### PR TITLE
Add FreeBSD support

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -670,6 +670,6 @@ struct CoreRegistryDelegate : PlatformRegistryDelegate, SDKRegistryDelegate, Spe
 extension OperatingSystem {
     /// Whether the Core is allowed to create a fallback toolchain, SDK, and platform for this operating system in cases where no others have been provided.
     internal var createFallbackSystemToolchain: Bool {
-        return self == .linux
+        return self == .linux || self == .freebsd
     }
 }

--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -747,8 +747,10 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible {
     private func fallbackSystemSDKSettings(operatingSystem: OperatingSystem) throws -> [String: PropertyListItem] {
         let defaultProperties: [String: PropertyListItem]
         switch operatingSystem {
-        case .linux:
+        case .linux, .freebsd:
             defaultProperties = [
+                "LIBTOOL_USE_RESPONSE_FILE": .plString("NO"), // TODO: Need to make this specific to FreeBSD
+
                 // Workaround to avoid `-add_ast_path` on Linux, apparently this needs to perform some "swift modulewrap" step instead.
                 "GCC_GENERATE_DEBUGGING_SYMBOLS": .plString("NO"),
 
@@ -800,7 +802,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible {
                 operatingSystem.xcodePlatformName: .plDict([
                     "Archs": .plArray([.plString(Architecture.hostStringValue ?? "unknown")]),
                     "LLVMTargetTripleEnvironment": .plString(tripleEnvironment),
-                    "LLVMTargetTripleSys": .plString(operatingSystem.xcodePlatformName),
+                    "LLVMTargetTripleSys": .plString(operatingSystem.xcodePlatformName + "14.1"), // TODO: Need to get the FreeBSD version and plumb it through somehow
                     "LLVMTargetTripleVendor": .plString("unknown"),
                 ])
             ]),

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -806,6 +806,7 @@ public final class BuiltinMacros {
     public static let LIBRARY_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("LIBRARY_SEARCH_PATHS")
     public static let LIBTOOL = BuiltinMacros.declarePathMacro("LIBTOOL")
     public static let LIBTOOL_DEPENDENCY_INFO_FILE = BuiltinMacros.declarePathMacro("LIBTOOL_DEPENDENCY_INFO_FILE")
+    public static let LIBTOOL_USE_RESPONSE_FILE = BuiltinMacros.declareBooleanMacro("LIBTOOL_USE_RESPONSE_FILE")
     public static let LINKER = BuiltinMacros.declareStringMacro("LINKER")
     public static let ALTERNATE_LINKER = BuiltinMacros.declareStringMacro("ALTERNATE_LINKER")
     public static let LINK_OBJC_RUNTIME = BuiltinMacros.declareBooleanMacro("LINK_OBJC_RUNTIME")
@@ -1852,6 +1853,7 @@ public final class BuiltinMacros {
         LIBRARY_SEARCH_PATHS,
         LIBTOOL,
         LIBTOOL_DEPENDENCY_INFO_FILE,
+        LIBTOOL_USE_RESPONSE_FILE,
         LINKER,
         LINK_OBJC_RUNTIME,
         LINK_WITH_STANDARD_LIBRARIES,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -5262,6 +5262,8 @@ extension OperatingSystem {
                 return "windows"
             case .linux:
                 return "linux"
+            case .freebsd:
+                return "freebsd"
             case .android:
                 return "android"
             case .unknown:

--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -1419,17 +1419,22 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType {
 
     override public func constructLinkerTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, libraries: [LibrarySpecifier], usedTools: [CommandLineToolSpec: Set<FileTypeSpec>]) async {
         var inputPaths = cbc.inputs.map({ $0.absolutePath })
+        var specialArgs = [String]()
 
-        // Define the linker file list.
-        let fileListPath = cbc.scope.evaluate(BuiltinMacros.__INPUT_FILE_LIST_PATH__)
-        if !fileListPath.isEmpty {
-            let contents = cbc.inputs.map({ return $0.absolutePath.strWithPosixSlashes + "\n" }).joined(separator: "")
-            cbc.producer.writeFileSpec.constructFileTasks(CommandBuildContext(producer: cbc.producer, scope: cbc.scope, inputs: [], output: fileListPath), delegate, contents: ByteString(encodingAsUTF8: contents), permissions: nil, preparesForIndexing: false, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
-            inputPaths.append(fileListPath)
+        if cbc.scope.evaluate(BuiltinMacros.LIBTOOL_USE_RESPONSE_FILE) {
+            // Define the linker file list.
+            let fileListPath = cbc.scope.evaluate(BuiltinMacros.__INPUT_FILE_LIST_PATH__)
+            if !fileListPath.isEmpty {
+                let contents = cbc.inputs.map({ return $0.absolutePath.strWithPosixSlashes + "\n" }).joined(separator: "")
+                cbc.producer.writeFileSpec.constructFileTasks(CommandBuildContext(producer: cbc.producer, scope: cbc.scope, inputs: [], output: fileListPath), delegate, contents: ByteString(encodingAsUTF8: contents), permissions: nil, preparesForIndexing: false, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
+                inputPaths.append(fileListPath)
+            }
+        } else {
+            specialArgs.append(contentsOf: cbc.inputs.map { $0.absolutePath.str })
+            inputPaths.append(contentsOf: cbc.inputs.map { $0.absolutePath })
         }
 
         // Add arguments for the contents of the Link Binaries build phase.
-        var specialArgs = [String]()
         specialArgs.append(contentsOf: libraries.flatMap { specifier -> [String] in
             let basename = specifier.path.basename
 

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -24,6 +24,9 @@ struct GenericUnixPlatformSpecsExtension: SpecificationsExtension {
     }
 
     func specificationDomains() -> [String: [String]] {
-        ["linux": ["generic-unix"]]
+        [
+            "linux": ["generic-unix"],
+            "freebsd": ["generic-unix"],
+        ]
     }
 }

--- a/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
+++ b/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
@@ -51,6 +51,7 @@
                 Name = __INPUT_FILE_LIST_PATH__;
                 Type = Path;
                 // this is set up for us as a read-only property
+                Condition = "$(LIBTOOL_USE_RESPONSE_FILE) != NO";
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";
                 CommandLineArgs = (
                     "@$(value)",

--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -98,6 +98,8 @@ extension _RunDestinationInfo {
             windows
         case .linux:
             linux
+        case .freebsd:
+            freebsd
         case .android:
             android
         case .unknown:
@@ -257,6 +259,14 @@ extension _RunDestinationInfo {
             preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
         }
         return .init(platform: "linux", sdk: "linux", sdkVariant: "linux", targetArchitecture: arch, supportedArchitectures: ["x86_64", "aarch64"], disableOnlyActiveArch: false)
+    }
+
+    /// A run destination targeting FreeBSD generic device, using the public SDK.
+    package static var freebsd: Self {
+        guard let arch = Architecture.hostStringValue  else {
+            preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
+        }
+        return .init(platform: "freebsd", sdk: "freebsd", sdkVariant: "freebsd", targetArchitecture: arch, supportedArchitectures: ["x86_64", "aarch64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting Android generic device, using the public SDK.

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -48,6 +48,8 @@ extension KnownSDK {
             return windows
         case .success(.linux):
             return linux
+        case .success(.freebsd):
+            return freebsd
         case .success(.android):
             return android
         case .success(.unknown), .failure:
@@ -68,6 +70,7 @@ extension KnownSDK {
 extension KnownSDK {
     package static let windows: Self = "windows"
     package static let linux: Self = "linux"
+    package static let freebsd: Self = "freebsd"
     package static let android: Self = "android"
     package static let qnx: Self = "qnx"
 }

--- a/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
@@ -61,6 +61,7 @@
             // Input file lists
             {   Name = __INPUT_FILE_LIST_PATH__;
                 Type = Path;
+                Condition = "$(LIBTOOL_USE_RESPONSE_FILE) != NO";
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";      // this is set up for us as a read-only property
                 CommandLineFlag = "-filelist";
                 IsInputDependency = Yes;
@@ -104,6 +105,11 @@
                 DefaultValue = "$(OBJECT_FILE_DIR_$(CURRENT_VARIANT))/$(CURRENT_ARCH)/$(PRODUCT_NAME)_libtool_dependency_info.dat";
             },
 
+            {
+                Name = "LIBTOOL_USE_RESPONSE_FILE";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
         );
     }
 )

--- a/Sources/SWBUtil/Architecture.swift
+++ b/Sources/SWBUtil/Architecture.swift
@@ -98,7 +98,13 @@ public struct Architecture: Sendable {
             if uname(&buf) == 0 {
                 return withUnsafeBytes(of: &buf.machine) { buf in
                     let data = Data(buf)
-                    return String(decoding: data[0...(data.lastIndex(where: { $0 != 0 }) ?? 0)], as: UTF8.self)
+                    let value = String(decoding: data[0...(data.lastIndex(where: { $0 != 0 }) ?? 0)], as: UTF8.self)
+                    switch value {
+                    case "amd64":
+                        return "x86_64"
+                    default:
+                        return value
+                    }
                 }
             }
             #endif

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -758,7 +758,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
     }
 
     func listExtendedAttributes(_ path: Path) throws -> [String] {
-        #if os(Windows)
+        #if os(Windows) || os(FreeBSD) // FreeBSD blocked on https://github.com/swiftlang/swift/pull/77836
         // no xattrs on Windows
         return []
         #else
@@ -796,7 +796,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
     }
 
     func setExtendedAttribute(_ path: Path, key: String, value: ByteString) throws {
-        #if os(Windows)
+        #if os(Windows) || os(FreeBSD) // FreeBSD blocked on https://github.com/swiftlang/swift/pull/77836
         // no xattrs on Windows
         #else
         try value.bytes.withUnsafeBufferPointer { buf throws -> Void in
@@ -813,7 +813,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
     }
 
     func getExtendedAttribute(_ path: Path, key: String) throws -> ByteString? {
-        #if os(Windows)
+        #if os(Windows) || os(FreeBSD) // FreeBSD blocked on https://github.com/swiftlang/swift/pull/77836
         return nil // no xattrs on Windows
         #else
         var bufferSize = 4096

--- a/Sources/SWBUtil/GNUReadLine.swift
+++ b/Sources/SWBUtil/GNUReadLine.swift
@@ -13,14 +13,14 @@
 #if os(macOS)
 private import EditLine
 private import EditLine.readline
-#elseif !canImport(Darwin) && !os(Windows) && !os(Android)
+#elseif !canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD)
 private import readline
 #endif
 
 import SWBCSupport
 
 public func swb_readline(_ prompt: String?) -> String? {
-    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android))
+    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD))
     return prompt?.utf8CString.withUnsafeBufferPointer { bp -> String? in
         if let ptr = readline(bp.baseAddress) {
             defer { ptr.deallocate() }
@@ -34,7 +34,7 @@ public func swb_readline(_ prompt: String?) -> String? {
 }
 
 @discardableResult public func swb_add_history(_ string: String?) -> Int {
-    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android))
+    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD))
     return string?.utf8CString.withUnsafeBufferPointer { Int(add_history($0.baseAddress)) } ?? Int(add_history(nil))
     #else
     return 0
@@ -42,7 +42,7 @@ public func swb_readline(_ prompt: String?) -> String? {
 }
 
 @discardableResult public func swb_read_history(_ filename: String?) -> Int {
-    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android))
+    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD))
     return filename?.utf8CString.withUnsafeBufferPointer { Int(read_history($0.baseAddress)) } ?? Int(read_history(nil))
     #else
     return 0
@@ -50,7 +50,7 @@ public func swb_readline(_ prompt: String?) -> String? {
 }
 
 @discardableResult public func swb_write_history(_ filename: String?) -> Int {
-    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android))
+    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD))
     return filename?.utf8CString.withUnsafeBufferPointer { Int(write_history($0.baseAddress)) } ?? Int(write_history(nil))
     #else
     return 0
@@ -58,7 +58,7 @@ public func swb_readline(_ prompt: String?) -> String? {
 }
 
 @discardableResult public func swb_history_truncate_file(_ filename: String?, _ nlines: Int) -> Int {
-    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android))
+    #if os(macOS) || (!canImport(Darwin) && !os(Windows) && !os(Android) && !os(FreeBSD))
     return filename?.utf8CString.withUnsafeBufferPointer { Int(history_truncate_file($0.baseAddress, Int32(nlines))) } ?? Int(history_truncate_file(nil, Int32(nlines)))
     #else
     return 0

--- a/Sources/SWBUtil/Library.swift
+++ b/Sources/SWBUtil/Library.swift
@@ -43,7 +43,7 @@ public enum Library: Sendable {
         #else
         let flags = RTLD_LAZY
         #endif
-        guard let handle = path.withPlatformString({ dlopen($0, flags) }) else {
+        guard let handle = path.withPlatformString({ (p: UnsafePointer<CChar>) in dlopen(p, flags) }) else {
             #if os(Android)
             throw LibraryOpenError(message: String(cString: dlerror()!))
             #else

--- a/Sources/SWBUtil/Lock.swift
+++ b/Sources/SWBUtil/Lock.swift
@@ -28,7 +28,7 @@ public final class Lock: @unchecked Sendable {
     let mutex: UnsafeMutablePointer<SRWLOCK> = UnsafeMutablePointer.allocate(capacity: 1)
     #else
     @usableFromInline
-    let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
+    let mutex: UnsafeMutablePointer<pthread_mutex_t?> = UnsafeMutablePointer.allocate(capacity: 1)
     #endif
 
     public init() {

--- a/Sources/SWBUtil/ProcessInfo.swift
+++ b/Sources/SWBUtil/ProcessInfo.swift
@@ -97,6 +97,8 @@ extension ProcessInfo {
         return .windows
         #elseif os(Linux)
         return .linux
+        #elseif os(FreeBSD)
+        return .freebsd
         #else
         if try FileManager.default.isReadableFile(atPath: systemVersionPlistURL.filePath.str) {
             switch try systemVersion().productName {
@@ -125,6 +127,7 @@ public enum OperatingSystem: Hashable, Sendable {
     case visionOS(simulator: Bool)
     case windows
     case linux
+    case freebsd
     case android
     case unknown
 
@@ -153,7 +156,7 @@ public enum OperatingSystem: Hashable, Sendable {
             return .macho
         case .windows:
             return .pe
-        case .linux, .android, .unknown:
+        case .linux, .freebsd, .android, .unknown:
             return .elf
         }
     }

--- a/Tests/SWBUtilTests/FSProxyTests.swift
+++ b/Tests/SWBUtilTests/FSProxyTests.swift
@@ -565,7 +565,7 @@ import SWBTestSupport
             // String.utf8CString *includes* the trailing null byte
 #if canImport(Darwin)
             #expect(setxattr(testDataPath.str, "attr.string", "true", "true".utf8CString.count, 0, 0) == 0)
-#elseif !os(Windows)
+#elseif !os(Windows) && !os(FreeBSD) // FreeBSD blocked on https://github.com/swiftlang/swift/pull/77836
             #expect(setxattr(testDataPath.str, "attr.string", "true", "true".utf8CString.count, 0) == 0)
 #endif
             #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "true\0")
@@ -574,7 +574,7 @@ import SWBTestSupport
             // String.utf8CString *includes* the trailing null byte
 #if canImport(Darwin)
             #expect(setxattr(testDataPath.str, "attr.string", "tr\0ue", "tr\0ue".utf8CString.count, 0, 0) == 0)
-#elseif !os(Windows)
+#elseif !os(Windows) && !os(FreeBSD) // FreeBSD blocked on https://github.com/swiftlang/swift/pull/77836
             #expect(setxattr(testDataPath.str, "attr.string", "tr\0ue", "tr\0ue".utf8CString.count, 0) == 0)
 #endif
             #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "tr\0ue\0")

--- a/Tests/SWBUtilTests/MiscTests.swift
+++ b/Tests/SWBUtilTests/MiscTests.swift
@@ -25,7 +25,7 @@ import SWBUtil
             #expect(SWBUtil.userCacheDir().str.hasPrefix("/var/folders"))
         case .android:
             #expect(SWBUtil.userCacheDir().str.hasPrefix("/data/local/tmp"))
-        case .linux, .unknown:
+        case .linux, .freebsd, .unknown:
             #expect(SWBUtil.userCacheDir().str.hasPrefix("/tmp"))
         }
     }


### PR DESCRIPTION
This allows building Swift Build for FreeBSD hosts, as well as building for a FreeBSD target from a FreeBSD host.