### PR TITLE
Update README.md to mention Swift Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Swift Build
 =======
 
-Swift Build is a high-level build system based on [llbuild](https://github.com/swiftlang/swift-llbuild) with great support for building Swift. It is used by Xcode to build Xcode projects and Swift packages. It can also be used as the Swift Package Manager build system in preview form when passing `--build-system swiftbuild`.
+Swift Build is a high-level build system based on [llbuild](https://github.com/swiftlang/swift-llbuild) with great support for building Swift. It is used by Xcode to build Xcode projects and Swift packages, and by Swift Playground. It can also be used as the Swift Package Manager build system in preview form when passing `--build-system swiftbuild`.
 
 Usage
 -----


### PR DESCRIPTION
Add a note to the README that Swift Build is also used by Swift Playground.