### PR TITLE
Ensure environment variables defined in specs are loaded in a deterministic order

### DIFF
--- a/Sources/SWBCore/Specs/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/Specs/CommandLineToolSpec.swift
@@ -327,7 +327,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
     @_spi(Testing) public let outputs: [MacroStringExpression]?
 
     /// The additional environment variables to provide to instances of the tool.
-    let environmentVariables: [(String, MacroStringExpression)]?
+    @_spi(Testing) public let environmentVariables: [(String, MacroStringExpression)]?
 
     /// The path of the additional "generated Info.plist" content, if used.
     let generatedInfoPlistContent: MacroStringExpression?
@@ -547,7 +547,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         if let envVariables = parser.parseObject("EnvironmentVariables", inherited: false) {
             if case .plDict(let items) = envVariables {
                 var variables: [(String, MacroStringExpression)] = []
-                for (key,valueData) in items {
+                for (key,valueData) in items.sorted(by: \.0) {
                     guard case .plString(let value) = valueData else {
                         parser.error("invalid value for '\(key)' key in 'EnvironmentVariables' (expected string)")
                         continue

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -884,6 +884,13 @@ import SWBMacro
         XCTAssertMatch(errors[0], .prefix("unexpected item: \"arm64e\" while parsing key Architectures"))
     }
 
+    @Test
+    func environmentVariableConsistentOrdering() async throws {
+        let core = try await getCore()
+        let migSpec: CompilerSpec = try core.specRegistry.getSpec("com.apple.compilers.mig") as CompilerSpec
+        #expect(migSpec.environmentVariables?.map({ $0.0 }) == ["DEVELOPER_DIR", "SDKROOT", "TOOLCHAINS"])
+    }
+
     /// Test that loading concrete compiler specs in our Xcode install work as expected.
     @Test
     func concreteCompilerSpecLoading() async throws {


### PR DESCRIPTION
Otherwise, tasks signatures may change across relaunches of the build service and cause rebuilds.

rdar://141252371