### PR TITLE
rdar://143411533 (Object files and module wrap output end up in the same location, stomping on each other)

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -12,6 +12,8 @@
 
 public import SWBUtil
 import SWBCore
+import SWBMacro
+import SWBProtocol
 import Foundation
 import SWBTaskConstruction
 
@@ -23,6 +25,7 @@ import SWBTaskConstruction
     manager.register(XCStringsInputFileGroupingStrategyExtension(), type: InputFileGroupingStrategyExtensionPoint.self)
     manager.register(TaskProducersExtension(), type: TaskProducerExtensionPoint.self)
     manager.register(MacCatalystInfoExtension(), type: SDKVariantInfoExtensionPoint.self)
+    manager.register(AppleSettingsBuilderExtension(), type: SettingsBuilderExtensionPoint.self)
 }
 
 struct TaskProducersExtension: TaskProducerExtension {
@@ -157,4 +160,27 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
         }
         return ["xcstrings": Factory()]
     }
+}
+
+struct AppleSettingsBuilderExtension: SettingsBuilderExtension {
+    func addSDKSettings(_ sdk: SDK, _ variant: SDKVariant?, _ sparseSDKs: [SDK]) throws -> [String : String] {
+        guard variant?.llvmTargetTripleVendor == "apple" else {
+            return [:]
+        }
+
+        return [
+            "PER_ARCH_MODULE_FILE_DIR": "$(PER_ARCH_OBJECT_FILE_DIR)",
+        ]
+    }
+
+    func addBuiltinDefaults(fromEnvironment environment: [String : String], parameters: BuildParameters) throws -> [String : String] { [:] }
+    func addOverrides(fromEnvironment: [String : String], parameters: BuildParameters) throws -> [String : String] { [:] }
+    func addProductTypeDefaults(productType: ProductTypeSpec) -> [String : String] { [:] }
+    func addSDKOverridingSettings(_ sdk: SDK, _ variant: SDKVariant?, _ sparseSDKs: [SDK], specLookupContext: any SWBCore.SpecLookupContext) throws -> [String : String] { [:] }
+    func addPlatformSDKSettings(_ platform: SWBCore.Platform?, _ sdk: SDK, _ sdkVariant: SDKVariant?) -> [String : String] { [:] }
+    func xcconfigOverrideData(fromParameters: BuildParameters) -> ByteString { ByteString() }
+    func getTargetTestingSwiftPluginFlags(_ scope: MacroEvaluationScope, toolchainRegistry: ToolchainRegistry, sdkRegistry: SDKRegistry, activeRunDestination: RunDestinationInfo?, project: SWBCore.Project?) -> [String] { [] }
+    func shouldSkipPopulatingValidArchs(platform: SWBCore.Platform) -> Bool { false }
+    func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool { false }
+    func overridingBuildSettings(_: MacroEvaluationScope, platform: SWBCore.Platform?, productType: ProductTypeSpec) -> [String : String] { [:] }
 }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -901,6 +901,7 @@ public final class BuiltinMacros {
     public static let PER_ARCH_CFLAGS = BuiltinMacros.declareStringListMacro("PER_ARCH_CFLAGS")
     public static let PER_ARCH_LD = BuiltinMacros.declareStringMacro("PER_ARCH_LD")
     public static let PER_ARCH_LDPLUSPLUS = BuiltinMacros.declareStringMacro("PER_ARCH_LDPLUSPLUS")
+    public static let PER_ARCH_MODULE_FILE_DIR = BuiltinMacros.declarePathMacro("PER_ARCH_MODULE_FILE_DIR")
     public static let PER_ARCH_OBJECT_FILE_DIR = BuiltinMacros.declarePathMacro("PER_ARCH_OBJECT_FILE_DIR")
     public static let PER_VARIANT_CFLAGS = BuiltinMacros.declareStringListMacro("PER_VARIANT_CFLAGS")
     public static let PER_VARIANT_OBJECT_FILE_DIR = BuiltinMacros.declareStringMacro("PER_VARIANT_OBJECT_FILE_DIR")
@@ -1978,6 +1979,7 @@ public final class BuiltinMacros {
         PER_ARCH_CFLAGS,
         PER_ARCH_LD,
         PER_ARCH_LDPLUSPLUS,
+        PER_ARCH_MODULE_FILE_DIR,
         PER_ARCH_OBJECT_FILE_DIR,
         PER_VARIANT_CFLAGS,
         PER_VARIANT_OBJECT_FILE_DIR,

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3000,6 +3000,11 @@ For more information on mergable libraries, see [Configuring your project to use
                 DefaultValue = "$(TEMP_ROOT)/UninstalledProducts";
             },
             {
+                Name = "PER_ARCH_MODULE_FILE_DIR";
+                Type = Path;
+                DefaultValue = "$(PER_ARCH_OBJECT_FILE_DIR)/Modules";
+            },
+            {
                 Name = "ENABLE_HEADER_DEPENDENCIES";
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
@@ -1355,9 +1355,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
     }
 
     static func getSwiftModuleFilePathInternal(_ scope: MacroEvaluationScope, _ mode: SwiftCompilationMode) -> Path {
-        let objectFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_OBJECT_FILE_DIR)
+        let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR)
         let moduleName = scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME)
-        return objectFileDir.join(moduleName + ".swiftmodule").appendingFileNameSuffix(mode.moduleBaseNameSuffix)
+        return moduleFileDir.join(moduleName + ".swiftmodule").appendingFileNameSuffix(mode.moduleBaseNameSuffix)
     }
 
     static public func getSwiftModuleFilePath(_ scope: MacroEvaluationScope) -> Path {
@@ -2976,8 +2976,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             let containsSources = (producer.configuredTarget?.target as? StandardTarget)?.sourcesBuildPhase?.buildFiles.filter { currentPlatformFilter.matches($0.platformFilters) }.isEmpty == false
             if containsSources && inputFileTypes.contains(where: { $0.conformsTo(identifier: "sourcecode.swift") }) && scope.evaluate(BuiltinMacros.GCC_GENERATE_DEBUGGING_SYMBOLS) {
                 let moduleName = scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME)
-                let objectFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_OBJECT_FILE_DIR)
-                let moduleFilePath = objectFileDir.join(moduleName + ".swiftmodule")
+                let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR)
+                let moduleFilePath = moduleFileDir.join(moduleName + ".swiftmodule")
                 args += [["-Xlinker", "-add_ast_path", "-Xlinker", moduleFilePath.str]]
                 if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) {
                     args += [["@\(Path(moduleFilePath.appendingFileNameSuffix("-linker-args").withoutSuffix + ".resp").str)"]]

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -399,10 +399,10 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
                         for arch in scope.evaluate(BuiltinMacros.ARCHS) {
                             let scope = settings.globalScope.subscope(binding: BuiltinMacros.archCondition, to: arch)
                             let moduleName = scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME)
-                            let objectFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_OBJECT_FILE_DIR)
-                            swiftModulePaths[arch] = objectFileDir.join(moduleName + ".swiftmodule")
+                            let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR)
+                            swiftModulePaths[arch] = moduleFileDir.join(moduleName + ".swiftmodule")
                             if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) {
-                                swiftModuleAdditionalLinkerArgResponseFilePaths[arch] = objectFileDir.join("\(moduleName)-linker-args.resp")
+                                swiftModuleAdditionalLinkerArgResponseFilePaths[arch] = moduleFileDir.join("\(moduleName)-linker-args.resp")
                             }
                         }
                     }


### PR DESCRIPTION
On non macho-o platforms, swift-driver will create an additional module-wrap task if debugging is enabled which has an object file as output that will be named like the module and placed next to it. Since Swift Build will emit the Swift module next to the object files of a target, there can be a naming conflict, leading to us only ending up with the module-wrap content and the actual object file being stomped on.

This introduces a new `PER_ARCH_MODULE_FILE_DIR` build setting that's the same as `PER_ARCH_OBJECT_FILE_DIR` by default that allows us to customize the output directory.