### PR TITLE
Build options for Metal Compiler & Linker are missing under Build Settings

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -27,7 +27,7 @@
             "$(MTLCOMPILER_OUTPUT_FILE)",
         );
         IsArchitectureNeutral = YES;
-        SynthesizeBuildRule = NO;
+        SynthesizeBuildRule = YES;
         CommandResultsPostprocessor = XCClangResultsPostprocessor;
         OptionConditionFlavors = (
             sdk,
@@ -327,52 +327,5 @@
                 DependencyDataFormat = makefile;
             },
         );
-        IncludeInUnionedToolDefaults = NO;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "default:com.apple.compilers.metal";
-        Domain = iphoneos;
-        SynthesizeBuildRule = YES;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "iphoneos:com.apple.compilers.metal";
-        Domain = iphonesimulator;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "default:com.apple.compilers.metal";
-        Domain = macosx;
-        SynthesizeBuildRule = YES;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "default:com.apple.compilers.metal";
-        Domain = appletvos;
-        SynthesizeBuildRule = YES;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "appletvos:com.apple.compilers.metal";
-        Domain = appletvsimulator;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "default:com.apple.compilers.metal";
-        Domain = xros;
-        SynthesizeBuildRule = YES;
-    },
-    {
-        Type = Compiler;
-        Identifier = "com.apple.compilers.metal";
-        BasedOn = "xros:com.apple.compilers.metal";
-        Domain = xrsimulator;
     },
 )


### PR DESCRIPTION
Stop special casing the domain setup of Metal specifications so that their build settings show correctly in the build settings editor.

rdar://140999292