### PR TITLE
docs: enhance SwiftBuild docc

### DIFF
--- a/SwiftBuild.docc/Architecture/indexing-support.md
+++ b/SwiftBuild.docc/Architecture/indexing-support.md
@@ -15,7 +15,7 @@ Index-while-Building is controlled via the `INDEX_ENABLE_DATA_STORE` build setti
 
 When enabled, the index data store is populated by the compilers during the build process. The `-index-store-path` flag (both for clang and swiftc) indicates the directory root in which raw index data should be placed. The individual data files written by the compilers are not considered part of the build intermediates or outputs and therefore are not tracked by the dependency system.
 
-> Note: The format and directory structure of the Index Data Store is an implementation detail of the compiler and indexing system. However, it's worth mentioning that the filenames of some of the files within the index data store are based on a hash of the absolute file path of the related translation unit. The compilers accept a `-index-unit-output-path` flag which can be used to base this hash on a relocatable path (which may or may not exist in the underyling filesystem). This is important for distributed systems where part of the raw index data may be generated on a remote server.
+> Note: The format and directory structure of the Index Data Store is an implementation detail of the compiler and indexing system. However, it's worth mentioning that the filenames of some of the files within the index data store are based on a hash of the absolute file path of the related translation unit. The compilers accept a `-index-unit-output-path` flag which can be used to base this hash on a relocatable path (which may or may not exist in the underlying filesystem). This is important for distributed systems where part of the raw index data may be generated on a remote server.
 
 ### Background Indexing
 


### PR DESCRIPTION
Fix a bunch of typos in the architecture directory of the docc