### PR TITLE
easier doc access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ xcuserdata
 /.full-build
 /.swiftpm
 Package.resolved
+
+# Ignore docc preview build dir
+*/.docc-build/

--- a/README.md
+++ b/README.md
@@ -19,11 +19,21 @@ Documentation
 
 [SwiftBuild.docc](SwiftBuild.docc) contains additional technical documentation.
 
+To view the documentation in browser, run the following command at the root of the project:
+```bash
+docc preview SwiftBuild.docc
+```
+
+in MacOS, use:
+```bash
+xcrun docc preview SwiftBuild.docc
+```
+
 Testing
 -------------
 Before submitting the pull request, please make sure you have tested your changes. You can run the full test suite by running `swift test` from the root of the repository. The test suite is organized into a number of different test targets, with each corresponding to a specific component. For example, `SWBTaskConstructionTests` contains tests for the `SWBTaskConstruction` module which plan builds and then inspect the resulting build graph. Many tests in Swift Build operate on test project model objects which emulate those constructed by a higher level client and validate behavior at different layers. You can learn more about how these tests are written and organized in [Project Tests](SwiftBuild.docc/Development/test-development-project-tests.md).
 
- 
+
 Contributing to Swift Build
 ------------
 
@@ -31,8 +41,8 @@ Contributions to Swift Build are welcomed and encouraged! Please see the
 [Contributing to Swift guide](https://swift.org/contributing/).
 
 Before submitting the pull request, please make sure that they follow the Swift project [guidelines for contributing
- code](https://swift.org/contributing/#contributing-code). Bug reports should be 
- filed in [the issue tracker](https://github.com/swiftlang/swift-build/issues) of 
+ code](https://swift.org/contributing/#contributing-code). Bug reports should be
+ filed in [the issue tracker](https://github.com/swiftlang/swift-build/issues) of
  `swift-build` repository on GitHub.
 
 To be a truly great community, [Swift.org](https://swift.org/) needs to welcome


### PR DESCRIPTION
I noticed the architecture documentation was a top-level DocC bundle, which Xcode doesn't "just show" when building documentation. To work around this, and make that documentation a smidge more accessible, I added a few lines to the README highlighting how to use `docc preview` command to view the content in a browser.

- **adds notes on how to view documentation in a browser**
- **adds DocC preview build directory ignore line**
