### PR TITLE
SWBCore,SWBTaskConstruction,SWBTaskExecution,SWBTestSupport,SWBUtil: …

### DIFF
--- a/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
-public import SWBMacro
+private import SWBMacro
 
 public struct ToolchainRegistryExtensionPoint: ExtensionPoint, Sendable {
     public typealias ExtensionProtocol = ToolchainRegistryExtension

--- a/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
+++ b/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Windows)
+private import Foundation
+#else
 public import Foundation
+#endif
 
 import SwiftDriver
 import TSCBasic

--- a/Sources/SWBLLBuild/LowLevelBuildSystem.swift
+++ b/Sources/SWBLLBuild/LowLevelBuildSystem.swift
@@ -11,7 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
+#if os(Windows)
+private import SWBLibc
+#else
 public import SWBLibc
+#endif
 
 // Re-export all APIs from llbuild bindings.
 @_exported public import llbuild

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -14,7 +14,7 @@ package import SWBCore
 package import SWBUtil
 import struct SWBProtocol.BuildOperationTaskEnded
 import Foundation
-public import SWBMacro
+package import SWBMacro
 
 // Some things that should probably live in this task producer that might not be immediately obvious:
 //      Emitting an error if PGO is turned on for a target containing Swift files.

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/DevelopmentAssetsTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/DevelopmentAssetsTaskProducer.swift
@@ -12,7 +12,6 @@
 
 import SWBCore
 import SWBUtil
-import SWBTaskConstruction
 
 final class DevelopmentAssetsTaskProducer: StandardTaskProducer, TaskProducer {
     func generateTasks() async -> [any PlannedTask] {

--- a/Sources/SWBTaskExecution/Task.swift
+++ b/Sources/SWBTaskExecution/Task.swift
@@ -16,8 +16,8 @@ public import SWBUtil
 public import SWBCore
 import SWBCAS
 public import SWBMacro
-public import typealias SWBLLBuild.llbuild_pid_t
-public import protocol SWBLLBuild.ProcessDelegate
+package import typealias SWBLLBuild.llbuild_pid_t
+package import protocol SWBLLBuild.ProcessDelegate
 
 public import struct SWBProtocol.BuildOperationMetrics
 

--- a/Sources/SWBTestSupport/AssertMatch.swift
+++ b/Sources/SWBTestSupport/AssertMatch.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import SWBUtil
+package import SWBUtil
 package import Testing
 
 package indirect enum StringPattern: Sendable {

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Foundation
+private import Foundation
 @_spi(Testing) package import SWBCore
 package import SWBUtil
 import SWBTaskConstruction

--- a/Sources/SWBTestSupport/Projects/AppClips.swift
+++ b/Sources/SWBTestSupport/Projects/AppClips.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 package import SWBUtil
-package import SWBProtocol
+private import SWBProtocol
 
 extension TestProject {
     package static func appClip(sourceRoot: Path, fs: (any FSProxy)? = nil, appClipPlatformFilters: Set<PlatformFilter> = PlatformFilter.iOSFilters, appClipSupportsMacCatalyst: Bool = false, appDeploymentTarget: String? = nil) async throws -> TestProject {

--- a/Sources/SWBUtil/Dispatch+Async.swift
+++ b/Sources/SWBUtil/Dispatch+Async.swift
@@ -13,7 +13,7 @@
 // This file contains helpers used to bridge GCD and Swift Concurrency.
 // In the long term, these ideally all go away.
 
-public import Foundation
+private import Foundation
 
 /// Runs an async function and synchronously waits for the response.
 /// - warning: This function is extremely dangerous because it blocks the calling thread and may lead to deadlock, and should only be used as a temporary transitional aid.

--- a/Sources/SWBUtil/Lock.swift
+++ b/Sources/SWBUtil/Lock.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import SWBLibc
+private import SWBLibc
 
 // FIXME: Replace the contents of this file with the Swift standard library's Mutex type once it's available everywhere we deploy.
 


### PR DESCRIPTION
…narrow some imports

Narrow the scope of imports for some of the import statements across the package. This avoids some unnecessary warnings.