### PR TITLE
Tests: simplify some expectations (NFCI)

### DIFF
--- a/Tests/SWBCorePerfTests/SerializationPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SerializationPerfTests.swift
@@ -54,7 +54,6 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
 
                 for _ in 0..<numberOfTargets {
                     let sz = self.serializeMacroEvaluationScope(scope)
-                    #expect(sz != nil)
                     accumulatedBytes += Float64(sz.byteString.count)
                 }
 

--- a/Tests/SWBCoreTests/BuildRuleTests.swift
+++ b/Tests/SWBCoreTests/BuildRuleTests.swift
@@ -54,8 +54,7 @@ import SWBMacro
         let scope = MacroEvaluationScope(table: table)
 
         // Match the rules against the rule set.
-        let hAction = ruleSet.match(hFile, scope)
-        #expect(hAction != nil)
+        let _ = ruleSet.match(hFile, scope)
         let cAction = ruleSet.match(cFile, scope)
         #expect(cAction.action != nil)
         #expect(cAction.diagnostics.isEmpty)

--- a/Tests/SWBCoreTests/PIFLoadingTests.swift
+++ b/Tests/SWBCoreTests/PIFLoadingTests.swift
@@ -1365,10 +1365,10 @@ private final class ProjectModelItemClass: ProjectModelItem {
 
         // Check that the build files and the target dependency resolved.
         #expect(appTarget!.dependencies.map { $0.guid } == [frameworkTarget!.guid])
-        #expect(((appTarget!.buildPhases[0] as! SourcesBuildPhase).buildFiles[0] === classOneFileRef!) != nil)
-        #expect(((appTarget!.buildPhases[1] as! FrameworksBuildPhase).buildFiles[0] === cocoaFwkFileRef!) != nil)
-        #expect(((frameworkTarget!.buildPhases[0] as! SourcesBuildPhase).buildFiles[0] === classTwoFileRef!) != nil)
-        #expect(((frameworkTarget!.buildPhases[1] as! FrameworksBuildPhase).buildFiles[0] === classTwoFileRef!) != nil)
+        #expect((appTarget!.buildPhases[0] as! SourcesBuildPhase).buildFiles[0] === classOneFileRef!)
+        #expect((appTarget!.buildPhases[1] as! FrameworksBuildPhase).buildFiles[0] === cocoaFwkFileRef!)
+        #expect((frameworkTarget!.buildPhases[0] as! SourcesBuildPhase).buildFiles[0] === classTwoFileRef!)
+        #expect((frameworkTarget!.buildPhases[1] as! FrameworksBuildPhase).buildFiles[0] === classTwoFileRef!)
         #expect(appTarget?.productReference.target == appTarget)
         #expect(frameworkTarget?.productReference.target == frameworkTarget)
     }

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -4236,7 +4236,7 @@ import SWBMacro
 
         let parameters = BuildParameters(action: .build, configuration: "Debug")
         for (target, version) in expectations {
-            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: try #require(testWorkspace.target(for: target.guid)))
+            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testWorkspace.target(for: target.guid))
             let effectiveSwiftVersion = settings.globalScope.evaluate(BuiltinMacros.EFFECTIVE_SWIFT_VERSION)
             #expect(effectiveSwiftVersion == version)
         }

--- a/Tests/SWBMacroTests/MacroBasicTests.swift
+++ b/Tests/SWBMacroTests/MacroBasicTests.swift
@@ -23,20 +23,16 @@ import SWBMacro
         let namespace = MacroNamespace(debugDescription: "test")
 
         let firstBoolDecl = try namespace.declareBooleanMacro("SomeBooleanMacro")
-        #expect(firstBoolDecl != nil)
         #expect(firstBoolDecl.type == .boolean)
 
         let repeatedBoolDecl = try namespace.declareBooleanMacro("SomeBooleanMacro")
-        #expect(repeatedBoolDecl != nil)
         #expect(repeatedBoolDecl.type == .boolean)
         #expect(repeatedBoolDecl === firstBoolDecl)
 
         var didCatchExpectedException: Bool = false
         do {
-            let collidingStringDecl = try namespace.declareStringMacro("SomeBooleanMacro")
-            #expect(collidingStringDecl == nil)
-        }
-        catch {
+            _ = try namespace.declareStringMacro("SomeBooleanMacro")
+        } catch {
             didCatchExpectedException = true
         }
         #expect(didCatchExpectedException)
@@ -48,27 +44,21 @@ import SWBMacro
         let namespace = MacroNamespace(debugDescription: "test")
 
         let booleanDecl = try namespace.declareBooleanMacro("BooleanMacro")
-        #expect(booleanDecl != nil)
         #expect(booleanDecl.type == .boolean)
 
         let stringDecl = try namespace.declareStringMacro("StringMacro")
-        #expect(stringDecl != nil)
         #expect(stringDecl.type == .string)
 
         let stringListDecl = try namespace.declareStringListMacro("StringListMacro")
-        #expect(stringListDecl != nil)
         #expect(stringListDecl.type == .stringList)
 
         let userDefinedDecl = try namespace.declareUserDefinedMacro("UserDefinedMacro")
-        #expect(userDefinedDecl != nil)
         #expect(userDefinedDecl.type == .userDefined)
 
         let pathDecl = try namespace.declarePathMacro("PathMacro")
-        #expect(pathDecl != nil)
         #expect(pathDecl.type == .path)
 
         let pathListDecl = try namespace.declarePathListMacro("PathListMacro")
-        #expect(pathListDecl != nil)
         #expect(pathListDecl.type == .pathList)
 
         var diags1 = Array<MacroExpressionDiagnostic>()
@@ -116,19 +106,16 @@ import SWBMacro
 
         // Declarate a string macro in the lower namespace.
         let lowerStringDecl = try lowerNamespace.declareStringMacro("StringMacro")
-        #expect(lowerStringDecl != nil)
         #expect(lowerStringDecl.type == .string)
 
         // Create the middle of the three namespaces, and make sure we can see the string macro declaration from the lower namespace.
         let middleNamespace = MacroNamespace(parent: lowerNamespace, debugDescription: "middle")
         let middleStringDecl = try middleNamespace.declareStringMacro("StringMacro")
-        #expect(middleStringDecl != nil)
         #expect(middleStringDecl.type == .string)
         #expect(middleStringDecl === lowerStringDecl)
 
         // Also declare a string list macro in the middle namespace.
         let middleStringListDecl = try middleNamespace.declareStringListMacro("StringListMacro")
-        #expect(middleStringListDecl != nil)
         #expect(middleStringListDecl.type == .stringList)
 
         // Make sure we cannot reach the middle-namespace string list macro declaration if we do the lookup from the lower namespace.
@@ -138,19 +125,16 @@ import SWBMacro
         // Create the upper of the three namespaces, and make sure we can see the string macro declaration from the lower namespace.
         let upperNamespace = MacroNamespace(parent: middleNamespace, debugDescription: "upper")
         let upperStringDecl = try upperNamespace.declareStringMacro("StringMacro")
-        #expect(upperStringDecl != nil)
         #expect(upperStringDecl.type == .string)
         #expect(upperStringDecl === lowerStringDecl)
 
         // Make sure we can also see the string list macro declaration from the middle namespace.
         let upperStringListDecl = try upperNamespace.declareStringListMacro("StringListMacro")
-        #expect(upperStringListDecl != nil)
         #expect(upperStringListDecl.type == .stringList)
         #expect(upperStringListDecl === middleStringListDecl)
 
         // Make sure we can also declare a boolean macro in the upper namespace.
         let upperBooleanDecl = try upperNamespace.declareBooleanMacro("BooleanMacro")
-        #expect(upperBooleanDecl != nil)
         #expect(upperBooleanDecl.type == .boolean)
 
         // Make sure we cannot reach the upper-namespace boolean macro declaration if we do the lookup from either the lower or the middle namespace.
@@ -161,7 +145,6 @@ import SWBMacro
 
         // Make sure we can also declare a path macro in the upper namespace.
         let upperPathDecl = try upperNamespace.declarePathMacro("PathMacro")
-        #expect(upperPathDecl != nil)
         #expect(upperPathDecl.type == .path)
 
         // Make sure we cannot reach the upper-namespace path macro declaration if we do the lookup from either the lower or the middle namespace.
@@ -173,7 +156,6 @@ import SWBMacro
 
         // Make sure we can also declare a path macro in the upper namespace.
         let upperPathListDecl = try upperNamespace.declarePathListMacro("PathListMacro")
-        #expect(upperPathListDecl != nil)
         #expect(upperPathListDecl.type == .pathList)
 
         // Make sure we cannot reach the upper-namespace path list macro declaration if we do the lookup from either the lower or the middle namespace.

--- a/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
@@ -374,7 +374,6 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
                 }
             }
         }
-        #expect(hmapContents != nil)
     }
 
     @Test(.requireSDKs(.macOS))

--- a/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
@@ -910,7 +910,7 @@ fileprivate struct SwiftModuleOnlyTaskConstructionTests: CoreBasedTests {
                     if tpc.isZippered {
                         try checkPlatform(
                             tpc.secondaryPlatform,
-                            deploymentTarget: try #require(tpc.zipperedModuleOnlyDeploymentTarget))
+                            deploymentTarget: tpc.zipperedModuleOnlyDeploymentTarget)
                     }
                 }
             }

--- a/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
@@ -377,7 +377,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platformName = "macosx"
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: try #require(core.platformRegistry.lookup(name: platformName)), sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: core.platformRegistry.lookup(name: platformName), sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-enforceminimumos", "-genpkginfo", "/tmp/PkgInfo", "-expandbuildsettings", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
             // Write the test files.
@@ -1161,7 +1161,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: productTypeSpec, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: productTypeSpec, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
             // Write the test files.
@@ -1210,7 +1210,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: core)
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "-requiredArchitecture", "arm64", "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1257,7 +1257,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "-requiredArchitecture", "arm64", "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1301,7 +1301,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "-requiredArchitecture", "arm64", "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1347,7 +1347,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: ["armv6", "armv7", "armv64"]), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: ["armv6", "armv7", "armv64"]), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "-requiredArchitecture", "arm64", "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1398,7 +1398,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1445,7 +1445,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
         try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
         try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1475,7 +1475,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
         try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
         try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1505,7 +1505,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), ["CFBundleIdentifier": bundleIdentifier])
@@ -1543,7 +1543,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist", "-genpkginfo", "/tmp/PkgInfo"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
         try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
         try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1582,7 +1582,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist", "-genpkginfo", "/tmp/PkgInfo"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -1621,7 +1621,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
         try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
         try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), ["CFBundleIdentifier": [1, 2, 3]])
@@ -1649,7 +1649,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
         try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
         try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), ["CFBundleIdentifier": "bar"])
@@ -1827,7 +1827,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1852,7 +1852,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1881,7 +1881,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1911,7 +1911,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -1941,7 +1941,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
             try executionDelegate.fs.createDirectory(Path.root.join("tmp"))
             try await executionDelegate.fs.writePlist(Path("/tmp/input.plist"), [
@@ -2040,7 +2040,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         let productType = try #require(core.specRegistry.getSpec(productTypeName, domain: platformName) as? ProductTypeSpec)
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: productType, platform: platform, sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: productType, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-expandbuildsettings", "-producttype", productTypeName, "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.
@@ -2121,7 +2121,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             let platformName = "macosx"
             let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: try #require(core.platformRegistry.lookup(name: platformName)), sdk: try #require(core.sdkRegistry.lookup(platformName)), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+            let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: core.platformRegistry.lookup(name: platformName), sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-enforceminimumos", "-genpkginfo", "/tmp/PkgInfo", "-expandbuildsettings", "-platform", platformName, "/tmp/input.plist", "-scanforprivacyfile", "/tmp/frameworkA.framework", "-scanforprivacyfile", "/tmp/frameworkB.framework", "-scanforprivacyfile", "/tmp/frameworkC.framework", "-o", "/tmp/output.plist"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
             var appPlist: PropertyListItem = .plDict([

--- a/Tests/SWBUtilPerfTests/MsgPackSerializationPerfTests.swift
+++ b/Tests/SWBUtilPerfTests/MsgPackSerializationPerfTests.swift
@@ -303,7 +303,6 @@ fileprivate struct MsgPackSerializationPerfTests: PerfTests {
             for _ in 1...iterations
             {
                 let sz = self.serializeCustomElementHierarchy(log)
-                #expect(sz != nil)
                 if !didEmitSerializedSize
                 {
                     let mb = Float64(sz.byteString.bytes.count) / (1000.0 * 1000.0)

--- a/Tests/SwiftBuildTests/DocumentationInfoTests.swift
+++ b/Tests/SwiftBuildTests/DocumentationInfoTests.swift
@@ -41,7 +41,6 @@ fileprivate struct DocumentationInfoTests: CoreBasedTests {
                 #expect(diagnostics.isEmpty)
                 let session = try result.get()
                 #expect(try await service.listSessions() == ["S0": "FOO"])
-                #expect(session != nil)
                 #expect(session.name == "FOO")
                 #expect(session.uid == "S0")
 

--- a/Tests/SwiftBuildTests/IndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/IndexingInfoTests.swift
@@ -40,7 +40,6 @@ fileprivate struct IndexingInfoTests: CoreBasedTests {
                 #expect(diagnostics.isEmpty)
                 let session = try result.get()
                 #expect(try await service.listSessions() == ["S0": "FOO"])
-                #expect(session != nil)
                 #expect(session.name == "FOO")
                 #expect(session.uid == "S0")
 


### PR DESCRIPTION
These expectations and requirements are unnecessary. The expectations are provably tautological. Simply remove them to reduce clutter and warnings from the compiler.