### PR TITLE
Fix console tests after removal of readline dependency

### DIFF
--- a/Sources/SwiftBuild/SWBTerminal.swift
+++ b/Sources/SwiftBuild/SWBTerminal.swift
@@ -76,6 +76,7 @@ func swbuild_repl() async throws -> Bool {
                     break
                 }
 
+                print(line)
                 (shouldContinue, ok) = await swbuild_process_command(console: console, command: line)
             }
 

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -37,12 +37,7 @@ fileprivate struct ServiceConsoleTests {
             let output = String(decoding: data, as: UTF8.self)
 
             // Verify there were no errors.
-            #if os(Linux)
-            // something with terminal echo is different on macOS vs Linux
             #expect(output == "swbuild> \n")
-            #else
-            #expect(output == String.newline)
-            #endif
 
             // Assert the tool exited successfully.
             await #expect(try promise.value == .exit(0))


### PR DESCRIPTION
Fix some tests that regressed in https://github.com/swiftlang/swift-build/pull/34