### PR TITLE
Ensure Path _str takes UTF-8 String fast paths

### DIFF
--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -737,7 +737,11 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
         // FIXME: This enumerator has unclear error handling. Does nextObject() return nil on error? That's wrong.
         return try enumerator.compactMap { next in
-            let nextPath = path.join(next as? String)
+            // FileManager.DirectoryEnumerator produces Strings that are backed
+            // by NSPathStore2, which are slower to work with.
+            var next = (next as? String)
+            next?.makeContiguousUTF8()
+            let nextPath = path.join(next)
             return try f(nextPath)
         }
     }

--- a/Sources/SWBUtil/Path.swift
+++ b/Sources/SWBUtil/Path.swift
@@ -139,6 +139,11 @@ public struct Path: Serializable, Sendable {
 
     public static var homeDirectory: Path {
         var rawPath = NSHomeDirectory()
+        // NSHomeDirectory produces a NSPathStore2, which is not a contiguous
+        // UTF-8 layout. Most of Path's operations rely on efficient iteration
+        // of String, and we can dodge the -characterAtIndex: slow path by
+        // performing this conversion early.
+        rawPath.makeContiguousUTF8()
         #if os(Windows)
         if rawPath.hasPrefix("/") {
             rawPath.removeFirst()

--- a/Sources/SWBUtil/PropertyList.swift
+++ b/Sources/SWBUtil/PropertyList.swift
@@ -658,7 +658,12 @@ private func convertToPropertyListItem(_ item: Any) -> PropertyListItem {
         // Expected these to fall into the NSNumber/CFNumber case (except on non-Darwin), but leaving this here in case that implicit conversion changes unexpectedly.
         return .plDouble(asDouble)
 
-    case let asString as String:
+    case var asString as String:
+        // It is likely that property list decoding has produced a string that
+        // is not contiguous UTF-8. While this doesn't break anything, it is a
+        // performance footgun for most clients. Eagerly convert it to a native
+        // representation to ensure they hit the String fast paths.
+        asString.makeContiguousUTF8()
         return .plString(asString)
 
     case let asData as Data:


### PR DESCRIPTION
Some clients (*cough* *cough* Xcode) like to create Paths out of bridged NSStrings, which cannot be efficiently iterated. As most of our operations require doing this frequently, we might as well convert on construction to avoid the -characterAtIndex: slow path.