### PR TITLE
Tests: repair the build on Windows

### DIFF
--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -116,11 +116,19 @@ fileprivate struct ServiceConsoleTests {
     }
 }
 
+#if os(Windows)
+private var SYNCHRONIZE: DWORD {
+    DWORD(WinSDK.SYNCHRONIZE)
+}
+
+extension HANDLE: @retroactive @unchecked Sendable {}
+#endif
+
 extension Processes {
     fileprivate static func exitPromise(pid: pid_t) throws -> Promise<Void, any Error> {
         let promise = Promise<Void, any Error>()
         #if os(Windows)
-        guard let proc = OpenProcess(DWORD(SYNCHRONIZE), false, DWORD(pid)) else {
+        guard let proc: HANDLE = OpenProcess(SYNCHRONIZE, false, DWORD(pid)) else {
             throw StubError.error("OpenProcess failed with error \(GetLastError())")
         }
         defer { CloseHandle(proc) }


### PR DESCRIPTION
The adoption of Swift 6 triggered a failure on Windows. `HANDLE` is a typealias for a pointer. This value is sendable. As this is a typealias to `UnsafePointer<VOID__>` we require that the sendable conformance is in the `Swift` module. However, that is not possible. Provide a retroactive conformance to make the capture concurrency safe.