### PR TITLE
Add and apply a test trait for tests which require Xcode 16 tools

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -141,6 +141,11 @@ fileprivate struct PreOverridesSettings {
 
         table.push(BuiltinMacros.DIAGNOSE_MISSING_TARGET_DEPENDENCIES, literal: .yes)
 
+        // This is a hack to allow more tests to run in Swift CI when using older Xcode versions.
+        if core.xcodeProductBuildVersion < (try! ProductBuildVersion("16A242d")) {
+            table.push(BuiltinMacros.LM_SKIP_METADATA_EXTRACTION, BuiltinMacros.namespace.parseString("YES"))
+        }
+
         // Add the "calculated" settings.
         addCalculatedUniversalDefaults(&table)
 

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -50,6 +50,11 @@ extension Core {
         // This is a "well known" launch parameter set in Xcode's schemes.
         let developerPath = getEnvironmentVariable("XCODE_DEVELOPER_DIR_PATH").map(Path.init)
 
+        // Unset variables which may interfere with testing in Swift CI
+        for variable in ["SWIFT_EXEC", "SWIFT_DRIVER_SWIFT_FRONTEND_EXEC", "SWIFT_DRIVER_SWIFT_EXEC"] {
+            try POSIX.unsetenv(variable)
+        }
+
         // When this code is being loaded directly via unit tests *and* we detect the products directory we are running in is for Xcode, then we should run using inferior search paths.
         let inferiorProductsPath: Path? = self.inferiorProductsPath()
 

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -213,6 +213,12 @@ extension Trait where Self == Testing.ConditionTrait {
             getEnvironmentVariable(key) == value
         }
     }
+
+    package static func skipIfEnvironmentVariableSet(key: String) -> Self {
+        disabled("environment sets '\(key)'") {
+            getEnvironmentVariable(key) != nil
+        }
+    }
 }
 
 // MARK: Condition traits for Xcode and SDK version requirements
@@ -240,6 +246,15 @@ extension Trait where Self == Testing.ConditionTrait {
     /// Constructs a condition trait that causes a test to be disabled if not running against at least the given version of Xcode.
     package static func requireMinimumXcodeBuildVersion(_ version: String, sourceLocation: SourceLocation = #_sourceLocation) -> Self {
         requireXcodeBuildVersions(in: try ProductBuildVersion(version)..., sourceLocation: sourceLocation)
+    }
+
+    package static func requireXcode16(sourceLocation: SourceLocation = #_sourceLocation) -> Self {
+        enabled("Xcode version is not suitable", sourceLocation: sourceLocation, {
+            guard let installedVersion =  try? await InstalledXcode.currentlySelected().productBuildVersion() else {
+                return true
+            }
+            return installedVersion > (try ProductBuildVersion("16A242d"))
+        })
     }
 
     /// Constructs a condition trait that causes a test to be disabled if not running against at least the given version of Xcode.

--- a/Tests/SWBBuildSystemTests/AppIntentsNLTrainingTests.swift
+++ b/Tests/SWBBuildSystemTests/AppIntentsNLTrainingTests.swift
@@ -18,7 +18,7 @@ import SWBTestSupport
 import SWBTaskExecution
 import SWBUtil
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct AppIntentsNLTrainingTests: CoreBasedTests {
     let appShortcutsStringsFileName = "AppShortcuts.strings"
     let appIntentsSourceFileName = "source.swift"

--- a/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
@@ -18,7 +18,7 @@ import SWBTestSupport
 import SWBTaskExecution
 import SWBUtil
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct AppShortcutsStringsValidationTests: CoreBasedTests {
     let appShortcutsStringsFileName = "AppShortcuts.strings"
 

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -20,7 +20,7 @@ import Testing
 @Suite
 fileprivate struct BuildCommandTests: CoreBasedTests {
     /// Check compilation of a single file in C, ObjC and Swift, including the `uniquingSuffix` behaviour.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func singleFileCompile() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = try await TestWorkspace(

--- a/Tests/SWBBuildSystemTests/BuildOperationDescriptionTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationDescriptionTests.swift
@@ -140,7 +140,7 @@ fileprivate struct BuildOperationDescriptionTests: CoreBasedTests {
     }
 
     /// Generate a `BuildDescription` from our test workspace, build it, and check results.  Then try doing it again to make sure we can use the results loaded from the on-disk cache.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func onDiskBuildDescriptionCache() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = try await getTestWorkspace(in: tmpDirPath)
@@ -358,7 +358,7 @@ fileprivate struct BuildOperationDescriptionTests: CoreBasedTests {
     }
 
     /// Generate a `BuildDescription` from our test workspace, build it, and check results.  Then try doing it again to make sure we can use the results loaded from the on-disk cache.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func inMemoryBuildDescriptionCache() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = try await getTestWorkspace(in: tmpDirPath)
@@ -499,7 +499,7 @@ fileprivate struct BuildOperationDescriptionTests: CoreBasedTests {
     }
 
     /// Generate a `BuildDescription` from our test workspace, build it, and check results.  Then try doing it again to make sure we can use the cached build system object
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func buildDescriptionUseInBuildSystemCaching() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = try await getTestWorkspace(in: tmpDirPath)

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -28,7 +28,7 @@ import SWBTaskExecution
 @_spi(Testing) import SWBUtil
 import SWBTestSupport
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct BuildOperationTests: CoreBasedTests {
     @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
     func commandLineTool() async throws {
@@ -4612,57 +4612,57 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func frameworkInstallAPITBDSigning() async throws {
         try await checkTBDSigning(useStubify: false, productType: .framework)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func frameworkInstallAPITBDSigningWithBuildVariants() async throws {
         // FIXME: <rdar://problem/42261905> We should do this at the task construction tests layer, once we have good automatic cycle detection there.
         try await checkTBDSigning(useStubify: false, productType: .framework, buildVariants: ["normal", "profile"])
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func frameworkStubifyTBDSigning() async throws {
         try await checkTBDSigning(useStubify: true, productType: .framework)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticFrameworkInstallAPITBDSigning() async throws {
         try await checkTBDSigning(useStubify: false, productType: .staticFramework)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticFrameworkInstallAPITBDSigningWithBuildVariants() async throws {
         try await checkTBDSigning(useStubify: false, productType: .staticFramework, buildVariants: ["normal", "profile"])
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticFrameworkStubifyTBDSigning() async throws {
         try await checkTBDSigning(useStubify: true, productType: .staticFramework)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func dylibInstallAPITBDSigning() async throws {
         try await checkTBDSigning(useStubify: false, productType: .dynamicLibrary)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func dylibInstallAPITBDSigningWithBuildVariants() async throws {
         try await checkTBDSigning(useStubify: false, productType: .dynamicLibrary, buildVariants: ["normal", "profile"])
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func dylibStubifyTBDSigning() async throws {
         try await checkTBDSigning(useStubify: true, productType: .dynamicLibrary)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticlibInstallAPITBDSigning() async throws {
         try await checkTBDSigning(useStubify: false, productType: .staticLibrary)
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticlibInstallAPITBDSigningWithBuildVariants() async throws {
         try await checkTBDSigning(useStubify: false, productType: .staticLibrary, buildVariants: ["normal", "profile"])
     }
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func staticlibStubifyTBDSigning() async throws {
         try await checkTBDSigning(useStubify: true, productType: .staticLibrary)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func incrementalFwkTAPI() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let target = TestStandardTarget(

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -20,7 +20,7 @@ import SWBTestSupport
 import SWBUtil
 import SWBProtocol
 
-@Suite(.requireDependencyScanner)
+@Suite(.requireDependencyScanner, .requireXcode16())
 fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func explicitModulesBasic() async throws {

--- a/Tests/SWBBuildSystemTests/GenericTaskCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/GenericTaskCachingTests.swift
@@ -18,7 +18,7 @@ import SWBBuildSystem
 import SWBCore
 import SWBTestSupport
 
-@Suite(.disabled(if: getEnvironmentVariable("CI")?.isEmpty == false, "tests run too slowly in CI"))
+@Suite(.disabled(if: getEnvironmentVariable("CI")?.isEmpty == false, "tests run too slowly in CI"), .requireXcode16())
 fileprivate struct GenericTaskCachingTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
     func realityToolCachingBasics() async throws {

--- a/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
+++ b/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
@@ -17,7 +17,7 @@ import SWBBuildSystem
 import SWBCore
 import SWBTestSupport
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func implicitDependency() async throws {

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -27,7 +27,7 @@ import SWBUtil
 fileprivate struct IndexBuildOperationTests: CoreBasedTests {
     static let excludedStartTaskTypes = Set(["Gate", "CreateBuildDirectory", ProductPlan.preparedForIndexPreCompilationRuleName, ProductPlan.preparedForIndexModuleContentRuleName, "ClangStatCache", "SwiftExplicitDependencyCompileModuleFromInterface", "SwiftExplicitDependencyGeneratePcm"])
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func legacyPrebuild() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = try await TestWorkspace(

--- a/Tests/SWBBuildSystemTests/InstrumentsPackageBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/InstrumentsPackageBuildOperationTests.swift
@@ -17,7 +17,7 @@ import Testing
 
 import Testing
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct InstrumentsPackageBuildOperationTests: CoreBasedTests {
     /// An Instruments package target.
     @Test(.requireSDKs(.macOS))

--- a/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
@@ -19,7 +19,7 @@ import struct SWBProtocol.RunDestinationInfo
 import SWBCore
 import class SwiftBuild.SWBBuildService
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))
     func automaticMergedFrameworkCreation() async throws {

--- a/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
@@ -290,7 +290,7 @@ fileprivate struct PackageBuildOperationTests: CoreBasedTests {
     }
 
     /// Check that an .rkassets bundle produces a reasonable error when building for an unsupported platform.
-    @Test(.requireSDKs(.watchOS))
+    @Test(.requireSDKs(.watchOS), .requireXcode16())
     func RKAssetsWrongPlatform() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let packageResourceTarget = try await TestStandardTarget(

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -19,7 +19,7 @@ import SWBProtocol
 import SWBCore
 @_spi(Testing) import SWBBuildService
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))
     func previewXOJITBuilds() async throws {

--- a/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
+++ b/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
@@ -1211,7 +1211,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func legacyBlockUndeclaredInputOutputFromDiskWhenRecursiveScriptInputIsOn() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -20,7 +20,7 @@ import SWBLLBuild
 
 import SWBCore
 
-@Suite(.requireLLBuild(apiVersion: 12))
+@Suite(.requireLLBuild(apiVersion: 12), .requireXcode16())
 fileprivate struct SwiftDriverTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func swiftDriverPlanning() async throws {

--- a/Tests/SWBBuildSystemTests/TrackedDomainOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/TrackedDomainOperationTests.swift
@@ -25,7 +25,7 @@ import SWBTaskExecution
 import SWBUtil
 import SWBTestSupport
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct TrackedDomainOperationTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func basicTrackedDomainAggregation() async throws {

--- a/Tests/SWBBuildSystemTests/UnifdefTests.swift
+++ b/Tests/SWBBuildSystemTests/UnifdefTests.swift
@@ -17,7 +17,7 @@ import SWBCore
 import SWBUtil
 import SWBTestSupport
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct UnifdefTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func unifdefActionSignatureChange() async throws {

--- a/Tests/SWBCASTests/CASFSNodeTests.swift
+++ b/Tests/SWBCASTests/CASFSNodeTests.swift
@@ -15,7 +15,7 @@ import SWBCAS
 import SWBUtil
 import SWBTestSupport
 
-@Suite(.requireHostOS(.macOS, when: getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") == nil))
+@Suite(.requireHostOS(.macOS, when: getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") == nil), .requireXcode16())
 fileprivate struct CASFSNodeTests {
     private func pluginPath() async throws -> Path {
         if let pathString = getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") {

--- a/Tests/SWBCASTests/ToolchainCASPluginTests.swift
+++ b/Tests/SWBCASTests/ToolchainCASPluginTests.swift
@@ -15,7 +15,7 @@ import SWBCAS
 import SWBUtil
 import SWBTestSupport
 
-@Suite(.requireHostOS(.macOS, when: getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") == nil))
+@Suite(.requireHostOS(.macOS, when: getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") == nil), .requireXcode16())
 fileprivate struct ToolchainCASPluginTests {
     private func pluginPath() async throws -> Path {
         if let pathString = getEnvironmentVariable("TOOLCHAIN_CAS_PLUGIN_PATH") {

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -163,7 +163,7 @@ import SWBMacro
         }
     }
 
-    @Test(.requireHostOS(.macOS))
+    @Test(.requireHostOS(.macOS), .requireXcode16())
     func swiftTaskConstruction() async throws {
         let core = try await getCore()
         let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
@@ -319,7 +319,7 @@ import SWBMacro
         }
     }
 
-    @Test(.requireHostOS(.macOS), .requireLLBuild(apiVersion: 12))
+    @Test(.requireHostOS(.macOS), .requireLLBuild(apiVersion: 12), .requireXcode16())
     func swiftTaskConstruction_integratedDriver() async throws {
         let core = try await getCore()
         let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
@@ -502,7 +502,7 @@ import SWBMacro
     }
 
     // remove in rdar://53000820
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode16())
     func swiftTaskConstructionWithoutResponseFile() async throws {
         let core = try await getCore()
         let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -303,7 +303,7 @@ import Foundation
         }
     }
 
-    @Test
+    @Test(.skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
     func externalToolchainsDir() async throws {
         try await withTemporaryDirectory { tmpDir in
             let originalToolchain = try await toolchainPathsCount()

--- a/Tests/SWBCoreTests/PIFLoadingTests.swift
+++ b/Tests/SWBCoreTests/PIFLoadingTests.swift
@@ -1147,7 +1147,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
         }
     }
 
-    @Test
+    @Test(.requireXcode16())
     func loadingStandardTarget() throws {
         let classOneFileRef: FileReference? = try
         {

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -1113,7 +1113,7 @@ import SWBMacro
     }
 
     /// Tests that the recommended deployment target build settings have been properly set.
-    @Test
+    @Test(.requireXcode16())
     func recommendedDeploymentTargets() async throws {
         let core = try await getCore()
         let workspace = try TestWorkspace(

--- a/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
+++ b/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
@@ -157,7 +157,7 @@ import SWBTestSupport
     }
 
     /// Test that default and overriding build settings defined in a toolchain are exported.
-    @Test
+    @Test(.skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
     func exportingToolchainSettings() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             // Toolchains are only loaded from the localFS, so we can't use a PseudoFS here.

--- a/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
@@ -18,7 +18,7 @@ import SWBTaskConstruction
 import SWBTestSupport
 import SWBUtil
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
     let appShortcutsStringsFileName = "AppShortcuts.strings"
     let assistantIntentsStringsFileName = "AssistantIntents.strings"

--- a/Tests/SWBTaskConstructionTests/BuildActionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildActionTaskConstructionTests.swift
@@ -16,7 +16,7 @@ import SWBCore
 
 import SWBTestSupport
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func installApi() async throws {

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -1779,7 +1779,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.iOS))
+    @Test(.requireSDKs(.iOS), .requireXcode16())
     func installLocSSUAppIntents() async throws {
         let testProject = TestProject(
             "aProject",

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -21,7 +21,7 @@ import SWBUtil
 
 import SWBTaskConstruction
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func app() async throws {

--- a/Tests/SWBTaskConstructionTests/TrackedDomainTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TrackedDomainTaskConstructionTests.swift
@@ -19,7 +19,7 @@ import SWBUtil
 
 import SWBTaskConstruction
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct TrackedDomainTaskConstructionTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS, .iOS))
     func basicDomainAggregation() async throws {

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -16,7 +16,7 @@ import SWBProtocol
 import SWBTestSupport
 import SWBUtil
 
-@Suite
+@Suite(.requireXcode16())
 fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
 
     // MARK: Framework test target

--- a/Tests/SwiftBuildTests/DeferredExecutionTests.swift
+++ b/Tests/SwiftBuildTests/DeferredExecutionTests.swift
@@ -20,7 +20,7 @@ import SWBCore
 
 @Suite(.requireHostOS(.macOS))
 fileprivate struct DeferredExecutionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS), arguments: [true, false])
+    @Test(.requireSDKs(.macOS), .requireXcode16(), arguments: [true, false])
     func testDeferredExecution(isOn: Bool) async throws {
         try await withTemporaryDirectory { tmpDir in
             let fs: any FSProxy = localFS

--- a/Tests/SwiftBuildTests/ValidationTests.swift
+++ b/Tests/SwiftBuildTests/ValidationTests.swift
@@ -73,7 +73,7 @@ fileprivate struct ValidationTests: CoreBasedTests {
     }
 
     /// Tests that `xcodebuild` pointed at the built build service is still able to build projects. This can find incompatibilities introduced in the protocol between the older client framework and build service process.
-    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
+    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS), .requireXcode16())
     func selfBuild() async throws {
         let bundleResourceURL = try #require(Bundle.module.resourceURL)
         let projectPath = Path(bundleResourceURL.appendingPathComponent("TestData").appendingPathComponent("CommandLineTool").absoluteURL.path)


### PR DESCRIPTION
Some of the tests, if running on macOS, require tools from an install of Xcode 16. Swift CI is currently using Xcode 15.2, so make sure we skip the relevant tests there