### PR TITLE
[SWBCore] Enhance spec tools code quality

### DIFF
--- a/Sources/SWBCore/Specs/Tools/AppIntentsMetadataCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/AppIntentsMetadataCompiler.swift
@@ -93,7 +93,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
         var sourceFileListFiles = [String]()
         var swiftConstValuesFileListFiles = [String]()
         var metadataDependencyFileListFiles = [String]()
-        var staticMetadataDepdencyFileListFiles = [String]()
+        var staticMetadataDependencyFileListFiles = [String]()
 
         func constructFileList(path: Path, inputs: [FileToBuild]) {
             let fileListContents = OutputByteStream()
@@ -112,7 +112,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
         }
         let staticMetadataFileListPath = cbc.scope.evaluate(BuiltinMacros.LM_AUX_INTENTS_STATIC_METADATA_FILES_LIST_PATH)
         if !staticMetadataFileListPath.isEmpty {
-            staticMetadataDepdencyFileListFiles.append(staticMetadataFileListPath.str)
+            staticMetadataDependencyFileListFiles.append(staticMetadataFileListPath.str)
             allInputs.append(delegate.createNode(staticMetadataFileListPath))
         }
 
@@ -196,7 +196,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
             case BuiltinMacros.LM_INTENTS_METADATA_FILES_LIST_PATH:
                 return cbc.scope.table.namespace.parseLiteralStringList(metadataDependencyFileListFiles)
             case BuiltinMacros.LM_INTENTS_STATIC_METADATA_FILES_LIST_PATH:
-                return cbc.scope.table.namespace.parseLiteralStringList(staticMetadataDepdencyFileListFiles)
+                return cbc.scope.table.namespace.parseLiteralStringList(staticMetadataDependencyFileListFiles)
             case BuiltinMacros.LM_NO_APP_SHORTCUT_LOCALIZATION:
                 return noLocalizationFiles ? cbc.scope.table.namespace.parseLiteralString("YES") : cbc.scope.table.namespace.parseLiteralString("NO")
             default:


### PR DESCRIPTION
The change appears to be backward compatible, as the variable is scoped locally within the function. However, to ensure full compatibility, please run the @swift-ci test.

Additionally, I noticed that the `FileListFiles` seems redundant. Consider renaming it to something more concise, like `FileList` or simply `Files`. This would improve readability and maintain consistency with similar variables. For example:
```
var swiftConstValuesFiles = [String]()
var metadataDependencyFiles = [String]()
var staticMetadataDependencyFiles = [String]()
```
Let me know your thoughts!