### PR TITLE
Fix link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@ _[Put a one line description of your change into the PR title, please be specifi
 
 _[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_
 
-_[Tests can be run by commenting `@swift-ci` test on the pull request, for more information see [this](README.md#testing)]_
+_[Tests can be run by commenting `@swift-ci` test on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_


### PR DESCRIPTION
Turns out the URL needs to be absolute, relative URLs will be relative to `/compare` on the PR page.