### PR TITLE
Ensure we parse diagnostics from CustomTasks in PIF

### DIFF
--- a/Sources/SWBCore/CustomTaskTypeDescription.swift
+++ b/Sources/SWBCore/CustomTaskTypeDescription.swift
@@ -52,7 +52,7 @@ public final class CustomTaskTypeDescription: TaskTypeDescription {
     }
     
     public func customOutputParserType(for task: any ExecutableTask) -> (any TaskOutputParser.Type)? {
-        nil
+        ShellScriptOutputParser.self
     }
     
     public func interestingPath(for task: any ExecutableTask) -> Path? {

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+import SWBBuildSystem
+import SWBCore
+import SWBTestSupport
+import SWBTaskExecution
+import SWBUtil
+
+@Suite
+fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
+
+    @Test(.requireSDKs(.host))
+    func outputParsing() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestProject(
+                "aProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("tool.swift"),
+                        TestFile("foo.c"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": try await swiftVersion,
+                            "SDKROOT": "auto",
+                            "CODE_SIGNING_ALLOWED": "NO",
+                            "MACOSX_DEPLOYMENT_TARGET": "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)"
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "CoreFoo", type: .dynamicLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["foo.c"])
+                        ],
+                        customTasks: [
+                            TestCustomTask(
+                                commandLine: ["$(BUILD_DIR)/$(CONFIGURATION)/tool"],
+                                environment: [:],
+                                workingDirectory: tmpDir.str,
+                                executionDescription: "My Custom Task",
+                                inputs: ["$(BUILD_DIR)/$(CONFIGURATION)/tool"],
+                                outputs: [Path.root.join("output").str],
+                                enableSandboxing: false,
+                                preparesForIndexing: false)
+                        ],
+                        dependencies: ["tool"]
+                    ),
+                    TestStandardTarget(
+                        "tool", type: .hostBuildTool,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["tool.swift"])
+                        ]
+                    ),
+                ])
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            let parameters = BuildParameters(action: .build, configuration: "Debug")
+
+            try await tester.fs.writeFileContents(tmpDir.join("Sources").join("tool.swift")) { stream in
+                stream <<<
+                    """
+                    @main
+                    struct Entry {
+                        static func main() {
+                            print("warning: this is a warning")
+                        }
+                    }
+                    """
+            }
+
+            try await tester.fs.writeFileContents(tmpDir.join("Sources").join("foo.c")) { stream in
+                stream <<<
+                    """
+                    void foo(void) {}
+                    """
+            }
+
+            try await tester.checkBuild(parameters: parameters) { results in
+                results.checkWarning(.contains("this is a warning"))
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+}


### PR DESCRIPTION
CustomTasks should use shell script style output parsing to ensure diagnostics prefixed with error:, warning:, etc. are picked up correctly. This is important for supporting build tool plugins.

rdar://142581108