### PR TITLE
Update macro usage bookkeeping when replacing a target with a dynamic variant

### DIFF
--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -81,13 +81,13 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
     }
 
     /// Maps targets to the set of macro implementations they should load when compiling Swift code.
-    let swiftMacroImplementationDescriptorsByTarget: [ConfiguredTarget: Set<SwiftMacroImplementationDescriptor>]
+    package private(set) var swiftMacroImplementationDescriptorsByTarget: [ConfiguredTarget: Set<SwiftMacroImplementationDescriptor>]
 
     /// The set of targets which must build during prepare-for-indexing.
-    package let targetsRequiredToBuildForIndexing: Set<ConfiguredTarget>
+    package private(set) var targetsRequiredToBuildForIndexing: Set<ConfiguredTarget>
 
     /// The set of targets which need to build a swiftmodule during installAPI
-    package let targetsWhichShouldBuildModulesDuringInstallAPI: Set<ConfiguredTarget>?
+    package private(set) var targetsWhichShouldBuildModulesDuringInstallAPI: Set<ConfiguredTarget>?
 
     /// All targets in the product plan.
     /// - remark: This property is preferred over the `TargetBuildGraph` in the `BuildPlanRequest` as it performs additional computations for Swift packages.
@@ -787,6 +787,17 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                     let impartedBuildProperties = self.impartedBuildPropertiesByTarget[matchingTarget]
                     self.impartedBuildPropertiesByTarget.removeValue(forKey: matchingTarget)
                     self.impartedBuildPropertiesByTarget[dynamicConfiguredTarget] = impartedBuildProperties
+
+                    let descriptors = self.swiftMacroImplementationDescriptorsByTarget.removeValue(forKey: matchingTarget)
+                    self.swiftMacroImplementationDescriptorsByTarget[dynamicConfiguredTarget] = descriptors
+
+                    if self.targetsRequiredToBuildForIndexing.remove(matchingTarget) != nil {
+                        self.targetsRequiredToBuildForIndexing.insert(dynamicConfiguredTarget)
+                    }
+
+                    if self.targetsWhichShouldBuildModulesDuringInstallAPI?.remove(matchingTarget) != nil {
+                        self.targetsWhichShouldBuildModulesDuringInstallAPI?.insert(dynamicConfiguredTarget)
+                    }
                 }
             }
 


### PR DESCRIPTION
Previously, we failed to update swiftMacroImplementationDescriptorsByTarget, targetsRequiredToBuildForIndexing, and targetsWhichShouldBuildModulesDuringInstallAPI when doing this replacement.

Resolves #73 