### PR TITLE
Track the reason for constructing the build graph.

### DIFF
--- a/Sources/SWBBuildService/DependencyGraphMessages.swift
+++ b/Sources/SWBBuildService/DependencyGraphMessages.swift
@@ -67,7 +67,8 @@ private func constructTargetBuildGraph(for targetGUIDs: [TargetGUID], in workspa
                                                                  useImplicitDependencies: includeImplicitDependencies,
                                                                  useDryRun: false),
                                       buildRequestContext: buildRequestContext,
-                                      delegate: delegate)
+                                      delegate: delegate,
+                                      purpose: .dependencyGraph)
     if delegate.hasErrors {
         throw StubError.error("unable to get target build graph:\n" + delegate.diagnostics.map { $0.formatLocalizedDescription(.debug) }.joined(separator: "\n"))
     }


### PR DESCRIPTION
If the reason for the graph is 'dependencyGraph', we don't want to error out immediately when a target is not approvedByUser. We need to get further in the process so a proper error diagnostic gets created.
