### PR TITLE
Allow using static plugin initialization outside the package build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,9 @@ func swiftSettings(languageMode: SwiftLanguageMode) -> [SwiftSetting] {
             .enableUpcomingFeature("ExistentialAny"),
             .enableUpcomingFeature("InternalImportsByDefault"),
 
-            .swiftLanguageMode(.v5)
+            .swiftLanguageMode(.v5),
+
+            .define("USE_STATIC_PLUGIN_INITIALIZATION")
         ]
     case .v6:
         return [
@@ -51,7 +53,9 @@ func swiftSettings(languageMode: SwiftLanguageMode) -> [SwiftSetting] {
             .enableUpcomingFeature("ExistentialAny"),
             .enableUpcomingFeature("InternalImportsByDefault"),
 
-            .swiftLanguageMode(.v6)
+            .swiftLanguageMode(.v6),
+
+            .define("USE_STATIC_PLUGIN_INITIALIZATION")
         ]
     default:
         fatalError("unexpected language mode")

--- a/Sources/SWBBuildService/BuildServiceEntryPoint.swift
+++ b/Sources/SWBBuildService/BuildServiceEntryPoint.swift
@@ -26,7 +26,7 @@ import System
 import SystemPackage
 #endif
 
-#if SWIFT_PACKAGE
+#if USE_STATIC_PLUGIN_INITIALIZATION
 private import SWBAndroidPlatform
 private import SWBApplePlatform
 private import SWBGenericUnixPlatform
@@ -122,7 +122,7 @@ extension BuildService {
 
             pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
 
-            #if SWIFT_PACKAGE
+            #if USE_STATIC_PLUGIN_INITIALIZATION
             // Statically initialize the plugins.
             SWBAndroidPlatform.initializePlugin(pluginManager)
             SWBApplePlatform.initializePlugin(pluginManager)

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -244,7 +244,7 @@ public final class Core: Sendable {
 
     /// The list of plugin search paths.
     @_spi(Testing) public lazy var pluginPaths: [Path] = {
-        #if SWIFT_PACKAGE
+        #if USE_STATIC_PLUGIN_INITIALIZATION
         // In a package context, plugins are statically linked into the build system.
         return []
         #else

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -15,7 +15,7 @@ package import Foundation
 package import SWBUtil
 import SWBTaskConstruction
 
-#if SWIFT_PACKAGE
+#if USE_STATIC_PLUGIN_INITIALIZATION
 private import SWBAndroidPlatform
 private import SWBApplePlatform
 private import SWBGenericUnixPlatform
@@ -86,7 +86,7 @@ extension Core {
                 pluginManager.load(at: path)
             }
 
-            #if SWIFT_PACKAGE
+            #if USE_STATIC_PLUGIN_INITIALIZATION
             if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBAndroidPlatformPlugin") {
                 SWBAndroidPlatform.initializePlugin(pluginManager)
             }


### PR DESCRIPTION
We may want to adopt this style of plugin loading in the CMake build, which does not define SWIFT_PACKAGE