### PR TITLE
build: update the dependencies for the plugins

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -190,31 +190,31 @@ let package = Package(
 
         .target(
             name: "SWBAndroidPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBApplePlatform",
-            dependencies: ["SWBCore", "SWBTaskConstruction"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil", "SWBTaskConstruction"],
             swiftSettings: swiftSettings(languageMode: .v5)),
         .target(
             name: "SWBGenericUnixPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBQNXPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBUniversalPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBWebAssemblyPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBWindowsPlatform",
-            dependencies: ["SWBCore"],
+            dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
             swiftSettings: swiftSettings(languageMode: .v6)),
 
         // Helper targets for SwiftPM


### PR DESCRIPTION
The plugins now depend on a wider variety of modules. Reflect that into the build definition. SPM gets away with it as it emits the modules into a common directory and the current scheduling seems to allow it to build. The CMake based build system identified the missing dependencies.