### PR TITLE
SWBUtil,SWBTaskExecution,SWBTestSupport: remove `@retroactive`

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
@@ -123,7 +123,7 @@ public final class AuxiliaryFileTaskAction: TaskAction {
     }
 }
 
-extension AuxiliaryFileTaskActionContext.Diagnostic: @retroactive Serializable {
+extension AuxiliaryFileTaskActionContext.Diagnostic: Serializable {
     public func serialize<T: Serializer>(to serializer: T) {
         serializer.beginAggregate(2)
         switch kind {

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -60,21 +60,6 @@ extension BuildRequest {
     }
 }
 
-extension TaskResult: @retroactive Equatable {
-    package static func == (lhs: TaskResult, rhs: TaskResult) -> Bool {
-        switch (lhs, rhs) {
-        case let (.exit(exitStatus1, metrics1), .exit(exitStatus2, metrics2)):
-            return exitStatus1 == exitStatus2 && metrics1 == metrics2
-        case (.failedSetup, .failedSetup):
-            return true
-        case (.skipped, .skipped):
-            return true
-        default:
-            return false
-        }
-    }
-}
-
 package protocol BuildRequestCheckingResult {
     var buildRequest: BuildRequest { get }
     var core: Core { get }
@@ -2191,7 +2176,7 @@ extension BuildKey {
     }
 }
 
-extension Registry: @retroactive BuildSystemCache where Key == Path, Value == SystemCacheEntry {
+extension Registry: BuildSystemCache where Key == Path, Value == SystemCacheEntry {
     package func clearCachedBuildSystem(for key: Path) {
         _ = removeValue(forKey: key)
     }

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -1542,7 +1542,7 @@ fileprivate extension stat {
     }
 }
 
-extension timespec: @retroactive Equatable {
+extension timespec: Equatable {
     public static func ==(lhs: timespec, rhs: timespec) -> Bool {
         return lhs.tv_sec == rhs.tv_sec && lhs.tv_nsec == rhs.tv_nsec
     }


### PR DESCRIPTION
Remove some retroactive conformances which triggered warnings as the types are defined within the package. Additionally, entirely remove a conformance which is now unused as the defining module would provide the conformance.