### PR TITLE
SWBCore,SWBUtil,Tests: avoid some deprecated Swift methods

### DIFF
--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -471,7 +471,7 @@ public final class LibSwiftDriver {
         if let scanOracle = oracle, let scanLib = try driver.getSwiftScanLibPath() {
             // Errors instantiating the scanner are potentially recoverable, so suppress them here. Truly fatal errors
             // will be diagnosed later.
-            try? scanOracle.verifyOrCreateScannerInstance(fileSystem: fileSystem, swiftScanLibPath: scanLib)
+            try? scanOracle.verifyOrCreateScannerInstance(swiftScanLibPath: scanLib)
         }
 #endif
     }

--- a/Sources/SWBUtil/POSIX.swift
+++ b/Sources/SWBUtil/POSIX.swift
@@ -31,7 +31,7 @@ public enum POSIX: Sendable {
                 if GetLastError() == ERROR_ENVVAR_NOT_FOUND {
                     return nil
                 }
-                throw POSIXError(errno, context: "GetEnvironmentVariableW", String(cString: name))
+                throw POSIXError(errno, context: "GetEnvironmentVariableW", name)
             }
             return try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) {
                 switch GetEnvironmentVariableW(wName, $0.baseAddress!, DWORD($0.count)) {
@@ -40,7 +40,7 @@ public enum POSIX: Sendable {
                 case 0 where GetLastError() == ERROR_ENVVAR_NOT_FOUND:
                     return nil
                 default:
-                    throw POSIXError(errno, context: "GetEnvironmentVariableW", String(cString: name))
+                    throw POSIXError(errno, context: "GetEnvironmentVariableW", name)
                 }
             }
         }

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -203,7 +203,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
                 try task.checkCommandLineContainsUninterrupted(["-S", #require(inputs.first).str, "-o", #require(outputs.first)])
-                let assembly = try String(contentsOfFile: #require(outputs.first))
+                let assembly = try String(contentsOfFile: #require(outputs.first), encoding: .utf8)
                 #expect(assembly.hasPrefix("\t.section\t__TEXT,__text,regular,pure_instructions"))
             }
             results.checkNoTask()
@@ -215,7 +215,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
                 try task.checkCommandLineContainsUninterrupted(["-S", #require(inputs.first).str, "-o", #require(outputs.first)])
-                let assembly = try String(contentsOfFile: #require(outputs.first))
+                let assembly = try String(contentsOfFile: #require(outputs.first), encoding: .utf8)
                 #expect(assembly.hasPrefix("\t.section\t__TEXT,__text,regular,pure_instructions"))
             }
             results.checkNoTask()

--- a/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
@@ -313,7 +313,7 @@ fileprivate func swiftRuntimePath() throws -> Path? {
     let name = "swiftCore.dll"
     return try name.withCString(encodedAs: CInterop.PlatformUnicodeEncoding.self) { wName in
         guard let handle = GetModuleHandleW(wName) else {
-            throw POSIXError(errno, context: "GetModuleHandleW", String(cString: name))
+            throw POSIXError(errno, context: "GetModuleHandleW", name)
         }
 
         var capacity = MAX_PATH


### PR DESCRIPTION
Update the calls here to avoid some deprecated signatures. Note that the `String(cString:)` initializer was unnecessary as `name` was already a Swift string and did not need to be converted.