### PR TITLE
Force write updates to preparation nodes

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -42,13 +42,15 @@ public struct AuxiliaryFileTaskActionContext {
     public let output: Path
     public let input: Path
     public let permissions: Int?
+    public let forceWrite: Bool
     public let diagnostics: [Diagnostic]
     public let logContents: Bool
 
-    public init(output: Path, input: Path, permissions: Int?, diagnostics: [Diagnostic], logContents: Bool) {
+    public init(output: Path, input: Path, permissions: Int?, forceWrite: Bool, diagnostics: [Diagnostic], logContents: Bool) {
         self.output = output
         self.input = input
         self.permissions = permissions
+        self.forceWrite = forceWrite
         self.diagnostics = diagnostics
         self.logContents = logContents
     }

--- a/Sources/SWBCore/Specs/Tools/WriteFile.swift
+++ b/Sources/SWBCore/Specs/Tools/WriteFile.swift
@@ -25,11 +25,11 @@ public final class WriteFileSpec: CommandLineToolSpec, SpecImplementationType {
         fatalError("unexpected direct invocation")
     }
 
-    @discardableResult public func constructFileTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, ruleName: String? = nil, contents: ByteString, permissions: Int?, diagnostics: [AuxiliaryFileTaskActionContext.Diagnostic] = [], logContents: Bool = false, preparesForIndexing: Bool, additionalTaskOrderingOptions: TaskOrderingOptions) -> Path {
+    @discardableResult public func constructFileTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, ruleName: String? = nil, contents: ByteString, permissions: Int?, forceWrite: Bool = false, diagnostics: [AuxiliaryFileTaskActionContext.Diagnostic] = [], logContents: Bool = false, preparesForIndexing: Bool, additionalTaskOrderingOptions: TaskOrderingOptions) -> Path {
         let fileContentsPath = delegate.recordAttachment(contents: contents)
         let outputNode = delegate.createNode(cbc.output)
         let execDescription = resolveExecutionDescription(cbc, delegate)
-        let action = delegate.taskActionCreationDelegate.createAuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputNode.path, input: fileContentsPath, permissions: permissions, diagnostics: diagnostics, logContents: logContents))
+        let action = delegate.taskActionCreationDelegate.createAuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputNode.path, input: fileContentsPath, permissions: permissions, forceWrite: forceWrite, diagnostics: diagnostics, logContents: logContents))
         let ruleName = ruleName ?? "WriteAuxiliaryFile"
         delegate.createTask(type: self, ruleInfo: [ruleName, outputNode.path.str], commandLine: ["write-file", outputNode.path.str], environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: cbc.commandOrderingInputs, outputs: [ outputNode ], mustPrecede: [], action: action, execDescription: execDescription, preparesForIndexing: preparesForIndexing, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: additionalTaskOrderingOptions, priority: .unblocksDownstreamTasks)
         return fileContentsPath

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1265,7 +1265,7 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
             }
             await appendGeneratedTasks(&tasks, usePhasedOrdering: false) { delegate in
                 let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [], outputs: [preparedForIndexNode.path], commandOrderingInputs: prepareTargetForIndexInputs + moduleInputs)
-                context.writeFileSpec.constructFileTasks(cbc, delegate, ruleName: ProductPlan.preparedForIndexPreCompilationRuleName, contents: [], permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [])
+                context.writeFileSpec.constructFileTasks(cbc, delegate, ruleName: ProductPlan.preparedForIndexPreCompilationRuleName, contents: [], permissions: nil, forceWrite: true, preparesForIndexing: true, additionalTaskOrderingOptions: [])
             }
         }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TargetOrderTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TargetOrderTaskProducer.swift
@@ -115,7 +115,7 @@ final class TargetOrderTaskProducer: StandardTaskProducer, TaskProducer {
             await appendGeneratedTasks(&context.preparedForIndexModuleContentTasks) { delegate in
                 let outputPath = preparedForIndexModuleNode.path
                 let cbc = CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], outputs: [outputPath])
-                context.writeFileSpec.constructFileTasks(cbc, delegate, ruleName: ProductPlan.preparedForIndexModuleContentRuleName, contents: [], permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [])
+                context.writeFileSpec.constructFileTasks(cbc, delegate, ruleName: ProductPlan.preparedForIndexModuleContentRuleName, contents: [], permissions: nil, forceWrite: true, preparesForIndexing: true, additionalTaskOrderingOptions: [])
             }
         }
     }

--- a/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
@@ -45,11 +45,23 @@ public final class AuxiliaryFileTaskAction: TaskAction {
         }
 
         do {
-            let contents = try executionDelegate.fs.read(context.input)
-            if context.logContents {
-                outputDelegate.emitOutput(contents)
+            if context.forceWrite {
+                // If we're forcing a write, remove and then write regardless of content.
+                if context.logContents {
+                    let contents = try executionDelegate.fs.read(context.input)
+                    outputDelegate.emitOutput(contents)
+                }
+                try? executionDelegate.fs.remove(context.output)
+                try executionDelegate.fs.copy(context.input, to: context.output)
+                try executionDelegate.fs.touch(context.output)
+            } else {
+                // Otherwise read the content and check to see if it has changed.
+                let contents = try executionDelegate.fs.read(context.input)
+                if context.logContents {
+                    outputDelegate.emitOutput(contents)
+                }
+                _ = try executionDelegate.fs.writeIfChanged(context.output, contents: contents)
             }
-            _ = try executionDelegate.fs.writeIfChanged(context.output, contents: contents)
         } catch {
             outputDelegate.emitError("unable to write file '\(context.output.str)': \(error.localizedDescription)")
             return .failed
@@ -70,10 +82,11 @@ public final class AuxiliaryFileTaskAction: TaskAction {
     // MARK: Serialization
 
     public override func serialize<T: Serializer>(to serializer: T) {
-        serializer.serializeAggregate(6) {
+        serializer.serializeAggregate(7) {
             serializer.serialize(context.output)
             serializer.serialize(context.input)
             serializer.serialize(context.permissions)
+            serializer.serialize(context.forceWrite)
             serializer.serialize(context.diagnostics)
             serializer.serialize(context.logContents)
             super.serialize(to: serializer)
@@ -81,23 +94,25 @@ public final class AuxiliaryFileTaskAction: TaskAction {
     }
 
     public required init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(6)
+        try deserializer.beginAggregate(7)
         let output: Path = try deserializer.deserialize()
         let input: Path = try deserializer.deserialize()
         let permissions: Int? = try deserializer.deserialize()
+        let forceWrite: Bool = try deserializer.deserialize()
         let diagnostics: [AuxiliaryFileTaskActionContext.Diagnostic] = try deserializer.deserialize()
         let logContents: Bool = try deserializer.deserialize()
-        self.context = AuxiliaryFileTaskActionContext(output: output, input: input, permissions: permissions, diagnostics: diagnostics, logContents: logContents)
+        self.context = AuxiliaryFileTaskActionContext(output: output, input: input, permissions: permissions, forceWrite: forceWrite, diagnostics: diagnostics, logContents: logContents)
         try super.init(from: deserializer)
     }
 
     public override func computeInitialSignature() -> ByteString {
         let serializer = MsgPackSerializer()
-        serializer.serializeAggregate(6) {
+        serializer.serializeAggregate(7) {
             serializer.serialize(context.output)
             // We must not serialize the entire path of the 'input', because it will include the build description ID, which may change in cases when this task should not be invalidated.
             serializer.serialize(context.input.basename)
             serializer.serialize(context.permissions)
+            serializer.serialize(context.forceWrite)
             serializer.serialize(context.diagnostics)
             serializer.serialize(context.logContents)
             super.serialize(to: serializer)

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -759,7 +759,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
             try fs.write(tmpDir.path.join("foo"), contents: "Hello, world!")
 
             do {
-                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, diagnostics: [], logContents: false))
+                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
                 let (task, execTask) = createTask(ruleInfo: ["MOCK"], commandLine: ["builtin-mock"], inputs: [], outputs: [outputNode], mustPrecede: [], action: action)
 
                 // Execute a test build against the task set.
@@ -773,7 +773,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
             // Perform a build with a new, identical task set, and check for a null build.
             do {
-                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, diagnostics: [], logContents: false))
+                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
                 let (task, _) = createTask(ruleInfo: ["MOCK"], commandLine: ["builtin-mock"], inputs: [], outputs: [outputNode], mustPrecede: [], action: action)
 
                 // Execute a test build against the task set.
@@ -784,7 +784,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
             // Perform a build with a changed task.
             do {
                 try fs.write(tmpDir.path.join("bar"), contents: "Hello, alternate world!")
-                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("bar"), permissions: nil, diagnostics: [], logContents: false))
+                let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("bar"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
                 let (task, execTask) = createTask(ruleInfo: ["MOCK"], commandLine: ["builtin-mock"], inputs: [], outputs: [outputNode], mustPrecede: [], action: action)
 
                 // Execute a test build against the task set.
@@ -808,7 +808,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
             try fs.write(tmpDir.path.join("foo"), contents: "Hello, world!")
 
             do {
-                let context = AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, diagnostics: [.init(kind: .error, message: "Couldn't deal with this for some reason")], logContents: false)
+                let context = AuxiliaryFileTaskActionContext(output: outputPath, input: tmpDir.path.join("foo"), permissions: nil, forceWrite: false, diagnostics: [.init(kind: .error, message: "Couldn't deal with this for some reason")], logContents: false)
                 let action = AuxiliaryFileTaskAction(context)
                 let (task, execTask) = createTask(ruleInfo: ["MOCK"], commandLine: ["builtin-mock"], inputs: [], outputs: [outputNode], mustPrecede: [], action: action)
 

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -1100,6 +1100,12 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 results.checkError(.contains("PhaseScriptExecution failed"))
                 results.checkTask(.matchRuleType("SwiftDriver GenerateModule"), .matchTargetName(frameTarget.name)) { _ in }
                 let (_, resultInfo) = try #require(results.getPreparedForIndexResultInfo().only)
+                if tester.fs.fileSystemMode != .checksumOnly {
+                    // Make sure the timestamp has been updated. This is important
+                    // since clients rely on the timestamp changing when
+                    // preparation has changed.
+                    #expect(currPrepareResult.timestamp < resultInfo.timestamp)
+                }
                 currPrepareResult = resultInfo
             }
 
@@ -1113,6 +1119,9 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 results.checkTask(.matchRuleType("SwiftDriver GenerateModule"), .matchTargetName(frameTarget.name)) { _ in }
 
                 let (_, resultInfo) = try #require(results.getPreparedForIndexResultInfo().only)
+                if tester.fs.fileSystemMode != .checksumOnly {
+                    #expect(currPrepareResult.timestamp < resultInfo.timestamp)
+                }
                 currPrepareResult = resultInfo
             }
 
@@ -1125,6 +1134,9 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 results.checkError(.contains("PhaseScriptExecution failed"))
                 results.checkTask(.matchRuleType("SwiftDriver GenerateModule"), .matchTargetName(superframeTarget.name)) { _ in }
                 let (_, resultInfo) = try #require(results.getPreparedForIndexResultInfo().only)
+                if tester.fs.fileSystemMode != .checksumOnly {
+                    #expect(currPrepareResult.timestamp == resultInfo.timestamp)
+                }
                 #expect(currPrepareResult == resultInfo)
             }
 
@@ -1137,6 +1149,9 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 results.checkError(.contains("PhaseScriptExecution failed"))
 
                 let (_, resultInfo) = try #require(results.getPreparedForIndexResultInfo().only)
+                if tester.fs.fileSystemMode != .checksumOnly {
+                    #expect(currPrepareResult.timestamp < resultInfo.timestamp)
+                }
                 currPrepareResult = resultInfo
             }
         }

--- a/Tests/SWBTaskExecutionTests/AuxiliaryFileTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/AuxiliaryFileTaskTests.swift
@@ -26,7 +26,7 @@ fileprivate struct AuxiliaryFileTaskTests {
         let output = Path.root.join("output.txt")
         let input = Path.root.join("input")
         try executionDelegate.fs.write(input, contents: ByteString(encodingAsUTF8: "Hello, world!"))
-        let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: input, permissions: 0o755, diagnostics: [], logContents: false))
+        let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: input, permissions: 0o755, forceWrite: false, diagnostics: [], logContents: false))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["WriteAuxiliaryFile", output.basename], workingDirectory: .root, outputs: [MakePlannedPathNode(output)], action: action, execDescription: "")
 
         let result = await action.performTaskAction(
@@ -47,7 +47,7 @@ fileprivate struct AuxiliaryFileTaskTests {
         let output = Path.root.join("output.txt")
         let input = Path.root.join("input")
         try executionDelegate.fs.write(input, contents: ByteString(encodingAsUTF8: "Hello, world!"))
-        let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: input, permissions: 0o755, diagnostics: [], logContents: true))
+        let action = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: input, permissions: 0o755, forceWrite: false, diagnostics: [], logContents: true))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["WriteAuxiliaryFile", output.basename], workingDirectory: .root, outputs: [MakePlannedPathNode(output)], action: action, execDescription: "")
 
         let outputDelegate = MockTaskOutputDelegate()
@@ -65,17 +65,17 @@ fileprivate struct AuxiliaryFileTaskTests {
     @Test
     func signature() {
         let output = Path.root.join("output.txt")
-        let taskA = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsA"), permissions: nil, diagnostics: [], logContents: false))
+        let taskA = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsA"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
         do {
-            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsB"), permissions: nil, diagnostics: [], logContents: false))
+            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsB"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
             #expect(taskA.computeInitialSignature() != taskB.computeInitialSignature())
         }
         do {
-            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: Path("/output2.txt"), input: Path("ContentsA"), permissions: nil, diagnostics: [], logContents: false))
+            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: Path("/output2.txt"), input: Path("ContentsA"), permissions: nil, forceWrite: false, diagnostics: [], logContents: false))
             #expect(taskA.computeInitialSignature() != taskB.computeInitialSignature())
         }
         do {
-            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsA"), permissions: 0o755, diagnostics: [], logContents: false))
+            let taskB = AuxiliaryFileTaskAction(AuxiliaryFileTaskActionContext(output: output, input: Path("ContentsA"), permissions: 0o755, forceWrite: false, diagnostics: [], logContents: false))
             #expect(taskA.computeInitialSignature() != taskB.computeInitialSignature())
         }
     }


### PR DESCRIPTION
Make sure we always bump the mod time of a preparation node when it gets run since clients rely on the timestamp to know when the preparation has changed.

rdar://143757173