### PR TITLE
SWBTestSupport,SWBUtil,Tests: avoid some won't be executed warnings

### DIFF
--- a/Sources/SWBTestSupport/Misc.swift
+++ b/Sources/SWBTestSupport/Misc.swift
@@ -221,8 +221,10 @@ extension ProcessInfo {
                 return p[0] == 1
             }
         }
-        #endif
         return false
+        #else
+        return false
+        #endif
     }
 
     // Get memory usage of current process in bytes

--- a/Sources/SWBUtil/Architecture.swift
+++ b/Sources/SWBUtil/Architecture.swift
@@ -101,8 +101,8 @@ public struct Architecture: Sendable {
                     return String(decoding: data[0...(data.lastIndex(where: { $0 != 0 }) ?? 0)], as: UTF8.self)
                 }
             }
-            #endif
             return nil
+            #endif
         }()
     }
 

--- a/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
@@ -104,20 +104,19 @@ final class CLIConnection {
     }
 
     fileprivate init(currentDirectory: Path? = nil) async throws {
+        #if os(Windows)
+        throw StubError.error("PTY not supported on Windows")
+        #else
         temporaryDirectory = try NamedTemporaryDirectory()
 
         // Allocate a PTY we can use to talk to the tool.
         var monitorFD = Int32(0)
         var sessionFD = Int32(0)
-        #if !os(Windows)
         if openpty(&monitorFD, &sessionFD, nil, nil, nil) != 0 {
             throw POSIXError(errno, context: "openpty")
         }
         _ = fcntl(monitorFD, F_SETFD, FD_CLOEXEC)
         _ = fcntl(sessionFD, F_SETFD, FD_CLOEXEC)
-        #else
-        throw StubError.error("PTY not supported on Windows")
-        #endif
 
         monitorHandle = FileHandle(fileDescriptor: monitorFD, closeOnDealloc: true)
         let sessionHandle = FileHandle(fileDescriptor: sessionFD, closeOnDealloc: true)
@@ -141,6 +140,7 @@ final class CLIConnection {
 
         outputStream = monitorHandle._bytes(on: .global())
         outputStreamIterator = outputStream.cliResponses.makeAsyncIterator()
+        #endif
     }
 
     func shutdown() async {


### PR DESCRIPTION
This cleans up some warnings on Windows about code that will never be executed due to the earlier returns in the Windows paths.