### PR TITLE
Update index tests to use common build request

### DIFF
--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -726,12 +726,14 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                 """
             }
 
-            try await tester.checkIndexBuild(prepareTargets: testProject.targets.map(\.guid), runDestination: .host, persistent: true) { results in
+            try await tester.checkIndexBuild(prepareTargets: tester.workspace.targets(named: "Framework").map(\.guid), runDestination: .host, persistent: true) { results in
                 results.checkNoDiagnostics()
 
                 // The tool itself should compile and link.
                 results.checkTaskExists(.matchTargetName("Tool"), .matchRuleType("SwiftDriver Compilation"))
-                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { _ in }
+                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { task in
+                    task.checkCommandLineMatches(["-target", .contains("-apple-macos")])
+                }
 
                 try results.checkTask(.matchTargetName("Framework"), .matchRuleType(ProductPlan.preparedForIndexPreCompilationRuleName)) { task in
                     try results.checkTaskFollows(task, .matchTargetName("Tool"), .matchRuleType("Ld"))
@@ -809,12 +811,14 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                 """
             }
 
-            try await tester.checkIndexBuild(prepareTargets: testProject.targets.map(\.guid), runDestination: .host, persistent: true) { results in
+            try await tester.checkIndexBuild(prepareTargets: tester.workspace.targets(named: "Framework").map(\.guid), runDestination: .host, persistent: true) { results in
                 results.checkNoDiagnostics()
 
                 // The tool itself should compile and link.
                 results.checkTaskExists(.matchTargetName("Tool"), .matchRuleType("SwiftDriver Compilation"))
-                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { _ in }
+                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { task in
+                    task.checkCommandLineMatches(["-target", .contains("-apple-macos")])
+                }
 
                 try results.checkTask(.matchTargetName("Framework"), .matchRuleType(ProductPlan.preparedForIndexPreCompilationRuleName)) { task in
                     try results.checkTaskFollows(task, .matchTargetName("Tool"), .matchRuleType("Ld"))

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -1678,10 +1678,10 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             try await tester.fs.writeFileContents(SRCROOT.join("test.swift")) { $0 <<< "// test.swift" }
 
-            let arena = ArenaInfo.indexBuildArena(derivedDataRoot: tester.workspace.path.dirname)
-
-            try await tester.checkIndexBuild(prepareTargets: [app.guid], persistent: true) { results in
+            let arena = try await tester.checkIndexBuild(prepareTargets: [app.guid], persistent: true) { results in
+                let arena = try #require(results.buildRequest.parameters.arena)
                 #expect(tester.fs.exists(arena.buildProductsPath))
+                return arena
             }
 
             let buildRequest = BuildRequest(parameters: BuildParameters(action: .indexBuild, configuration: nil, arena: arena), buildTargets: [], continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false, buildCommand: .cleanBuildFolder(style: .regular))

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -145,7 +145,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS, .iOS))
-    func vFSAndHeaderMapContents() async throws {
+    func vfsAndHeaderMapContents() async throws {
 
         let fwkTarget1 = TestStandardTarget(
             "FrameworkTarget1",
@@ -1309,7 +1309,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        try await tester.checkIndexBuild { results in
+        try await tester.checkIndexBuild(workspaceOperation: false) { results in
             results.checkNoDiagnostics()
             results.checkTarget("tool") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in


### PR DESCRIPTION
Setting up the build request for the index arena description was spread across three separate testing helpers and:
  1. Used macOS as the run destination
  2. Added all targets from the given workspace

Update these to use a common request that is more similar to the workspace build description by default (ie. no run destination + skipping package targets).

Resolves rdar://142699583.