### PR TITLE
Add a command plugin and usage instructions to run Swift Build under xcodebuild

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -371,6 +371,13 @@ let package = Package(
                 verb: "launch-xcode",
                 description: "Launch the currently selected Xcode configured to use the just-built build service"
             ))
+        ),
+        .plugin(
+            name: "run-xcodebuild",
+            capability: .command(intent: .custom(
+                verb: "run-xcodebuild",
+                description: "Run xcodebuild from the currently selected Xcode configured to use the just-built build service"
+            ))
         )
     ],
     swiftLanguageModes: [.v6],

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ When building SwiftPM from sources which include Swift Build integration, passin
 
 ### With Xcode
 
-Changes to swift-build can also be tested in Xcode using the `launch-xcode` command plugin provided by the package. Run `swift package launch-xcode --disable-sandbox` from your checkout of swift-build to launch a copy of the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. This workflow is currently supported when using Xcode 16.2.
+Changes to swift-build can also be tested in Xcode using the `launch-xcode` command plugin provided by the package. Run `swift package --disable-sandbox launch-xcode` from your checkout of swift-build to launch a copy of the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. This workflow is currently supported when using Xcode 16.2.
+
+### With xcodebuild
+
+Changes to swift-build can also be tested in xcodebuild using the `run-xcodebuild` command plugin provided by the package. Run `swift package --disable-sandbox run-xcodebuild` from your checkout of swift-build to run xcodebuild from the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. Arguments followed by `--` will be forwarded to xcodebuild unmodified. This workflow is currently supported when using Xcode 16.2.
 
 Documentation
 -------------


### PR DESCRIPTION
This adds a new "run-xcodebuild" command plugin similar to "launch-xcode", which will run xcodebuild pointed to the just-built Swift Build service, forwarding along any arguments passed to the plugin.

Also includes some minor error handling improvements and doc tweaks to the existing launch-xcode plugin.

Closes #43