### PR TITLE
Add SWIFT_WARNINGS_AS_ERROR_GROUPS

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1015,6 +1015,8 @@ public final class BuiltinMacros {
     public static let SWIFT_LTO = BuiltinMacros.declareEnumMacro("SWIFT_LTO") as EnumMacroDeclaration<LTOSetting>
     public static let SWIFT_MODULE_NAME = BuiltinMacros.declareStringMacro("SWIFT_MODULE_NAME")
     public static let SWIFT_MODULE_ALIASES = BuiltinMacros.declareStringListMacro("SWIFT_MODULE_ALIASES")
+    public static let SWIFT_WARNINGS_AS_WARNINGS_GROUPS = BuiltinMacros.declareStringListMacro("SWIFT_WARNINGS_AS_WARNINGS_GROUPS")
+    public static let SWIFT_WARNINGS_AS_ERRORS_GROUPS = BuiltinMacros.declareStringListMacro("SWIFT_WARNINGS_AS_ERRORS_GROUPS")
     public static let SWIFT_OBJC_BRIDGING_HEADER = BuiltinMacros.declareStringMacro("SWIFT_OBJC_BRIDGING_HEADER")
     public static let SWIFT_OBJC_INTERFACE_HEADER_NAME = BuiltinMacros.declareStringMacro("SWIFT_OBJC_INTERFACE_HEADER_NAME")
     public static let SWIFT_OBJC_INTERFACE_HEADER_DIR = BuiltinMacros.declareStringMacro("SWIFT_OBJC_INTERFACE_HEADER_DIR")
@@ -2160,6 +2162,8 @@ public final class BuiltinMacros {
         SWIFT_LIBRARY_PATH,
         SWIFT_LTO,
         SWIFT_MODULE_ALIASES,
+        SWIFT_WARNINGS_AS_WARNINGS_GROUPS,
+        SWIFT_WARNINGS_AS_ERRORS_GROUPS,
         SWIFT_MODULE_NAME,
         SWIFT_MODULE_ONLY_ARCHS,
         SWIFT_MODULE_ONLY_MACOSX_DEPLOYMENT_TARGET,

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -1023,6 +1023,8 @@ public enum PIF {
         public var SWIFT_INSTALL_OBJC_HEADER: String?
         public var SWIFT_LOAD_BINARY_MACROS: [String]?
         public var SWIFT_MODULE_ALIASES: [String]?
+        public var SWIFT_WARNINGS_AS_WARNINGS_GROUPS: [String]?
+        public var SWIFT_WARNINGS_AS_ERRORS_GROUPS: [String]?
         public var SWIFT_OBJC_INTERFACE_HEADER_NAME: String?
         public var SWIFT_OBJC_INTERFACE_HEADER_DIR: String?
         public var SWIFT_OPTIMIZATION_LEVEL: String?

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -203,6 +203,24 @@
                 CommandLineFlag = "-module-alias";
             },
             {
+                Name = "SWIFT_WARNINGS_AS_WARNINGS_GROUPS";
+                Type = StringList;
+                DefaultValue = "";
+                Category = BuildOptions;
+                DisplayName = "Diagnostic Groups Remain Warnings";
+                Description = "Specify diagnostic groups that should remain warnings (format: '<group>')";
+                CommandLineFlag = "-Wwarning";
+            },
+            {
+                Name = "SWIFT_WARNINGS_AS_ERRORS_GROUPS";
+                Type = StringList;
+                DefaultValue = "";
+                Category = BuildOptions;
+                DisplayName = "Diagnostic Groups Treated as Errors";
+                Description = "Specify diagnostic groups that should be treated as errors (format: '<group>')";
+                CommandLineFlag = "-Werror";
+            },
+            {
                 Name = "SWIFT_OBJC_BRIDGING_HEADER";
                 Type = String;
                 DefaultValue = "";

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -124,6 +124,8 @@ extension ProjectModel {
             case SWIFT_ACTIVE_COMPILATION_CONDITIONS
             case SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES
             case SWIFT_MODULE_ALIASES
+            case SWIFT_WARNINGS_AS_WARNINGS_GROUPS
+            case SWIFT_WARNINGS_AS_ERRORS_GROUPS
         }
 
         public enum Declaration: String, Hashable, CaseIterable, Sendable {


### PR DESCRIPTION
Implements SWIFT_WARNINGS_AS_ERROR_GROUPS as discussed in #8.

Please note that while I believe the core implementation is complete, I haven't finished developer testing, and the test cases might still need adjustments. I'm actively working on these and will update the pull request once it's ready for thorough review