### PR TITLE
Complete Sendability audit of Spec class hierarchy

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
@@ -16,7 +16,7 @@ public import SWBCore
 import SWBTaskConstruction
 public import SWBMacro
 
-public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType, IbtoolCompilerSupport {
+public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType, IbtoolCompilerSupport, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.assetcatalog"
 
     private func constructAssetPackOutputSpecificationsTask(catalogInputs inputs: [FileToBuild], _ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async -> Path? {

--- a/Sources/SWBApplePlatform/Specs/CopyTiffFile.swift
+++ b/Sources/SWBApplePlatform/Specs/CopyTiffFile.swift
@@ -12,7 +12,7 @@
 
 import SWBCore
 
-final class CopyTiffFileSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final class CopyTiffFileSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.build-tasks.copy-tiff-file"
 
     override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBApplePlatform/Specs/CoreDataCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/CoreDataCompiler.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBCore
 
-public final class CoreDataModelCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class CoreDataModelCompilerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.model.coredata"
 
     public override var supportsInstallHeaders: Bool {

--- a/Sources/SWBApplePlatform/Specs/CoreMLCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/CoreMLCompiler.swift
@@ -103,7 +103,7 @@ fileprivate enum CoreMLIndexingInfo: Serializable, SourceFileIndexingInfo, Encod
     }
 }
 
-public final class CoreMLCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class CoreMLCompilerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.coreml"
 
     public override var supportsInstallHeaders: Bool {

--- a/Sources/SWBApplePlatform/Specs/DittoTool.swift
+++ b/Sources/SWBApplePlatform/Specs/DittoTool.swift
@@ -12,7 +12,7 @@
 
 import SWBCore
 
-final class DittoToolSpec : CommandLineToolSpec, SpecIdentifierType {
+final class DittoToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.tools.ditto"
 
     required convenience init(_ parser: SpecParser, _ basedOnSpec: Spec?) {

--- a/Sources/SWBApplePlatform/Specs/ExtensionPointsCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/ExtensionPointsCompiler.swift
@@ -13,7 +13,7 @@
 import SWBCore
 import SWBProtocol
 
-final class CopyXCAppExtensionPointsFileSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final class CopyXCAppExtensionPointsFileSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.process-xcappextensionpoints"
 
     override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBApplePlatform/Specs/IIGCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/IIGCompiler.swift
@@ -19,7 +19,7 @@ public struct DiscoveredIiGToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
     public var toolVersion: Version?
 }
 
-public final class IIGCompilerSpec: GenericCompilerSpec, SpecIdentifierType {
+public final class IIGCompilerSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.iig"
 
     public override var supportsInstallHeaders: Bool {

--- a/Sources/SWBApplePlatform/Specs/InstrumentsPackageBuilderSpec.swift
+++ b/Sources/SWBApplePlatform/Specs/InstrumentsPackageBuilderSpec.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBCore
 
-public final class InstrumentsPackageBuilderSpec: GenericCompilerSpec, SpecIdentifierType {
+public final class InstrumentsPackageBuilderSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.instruments-package-builder"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBApplePlatform/Specs/IntentsCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/IntentsCompiler.swift
@@ -86,7 +86,7 @@ fileprivate enum IntentsIndexingInfo: Serializable, SourceFileIndexingInfo, Enco
     }
 }
 
-public final class IntentsCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class IntentsCompilerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.intents"
 
     public override var supportsInstallAPI: Bool {

--- a/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
@@ -14,7 +14,7 @@ import SWBUtil
 public import SWBCore
 public import SWBMacro
 
-public class IbtoolCompilerSpec : GenericCompilerSpec, IbtoolCompilerSupport {
+public class IbtoolCompilerSpec : GenericCompilerSpec, IbtoolCompilerSupport, @unchecked Sendable {
     /// The info object collects information across the build phase so that an ibtool task doesn't try to produce a ~device output which is already being explicitly produced from another input.
     private final class BuildPhaseInfo: BuildPhaseInfoForToolSpec {
         var allInputFilenames = Set<String>()
@@ -140,11 +140,11 @@ public class IbtoolCompilerSpec : GenericCompilerSpec, IbtoolCompilerSupport {
     }
 }
 
-public final class IbtoolCompilerSpecNIB: IbtoolCompilerSpec, SpecIdentifierType {
+public final class IbtoolCompilerSpecNIB: IbtoolCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.xcode.tools.ibtool.compiler"
 }
 
-public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentifierType {
+public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.xcode.tools.ibtool.storyboard.compiler"
 
     override public func environmentFromSpec(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [(String, String)] {

--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.swift
@@ -123,7 +123,7 @@ fileprivate struct MetalTaskPayload: TaskPayload, Encodable {
     }
 }
 
-public final class MetalCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class MetalCompilerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.metal"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
@@ -203,6 +203,6 @@ public final class MetalCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
     override public var payloadType: (any TaskPayload.Type)? { return MetalTaskPayload.self }
 }
 
-public final class MetalLinkerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class MetalLinkerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.metal-linker"
 }

--- a/Sources/SWBApplePlatform/Specs/MiGCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/MiGCompiler.swift
@@ -19,7 +19,7 @@ public struct DiscoveredMiGToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
     public var toolVersion: Version?
 }
 
-public final class MigCompilerSpec : CompilerSpec, SpecIdentifierType {
+public final class MigCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.mig"
 
     required override init(_ parser: SpecParser, _ basedOnSpec: Spec?, isGeneric: Bool) {

--- a/Sources/SWBApplePlatform/Specs/OpenCLCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/OpenCLCompiler.swift
@@ -14,7 +14,7 @@ import SWBUtil
 import SWBMacro
 import SWBCore
 
-final class OpenCLCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder {
+final class OpenCLCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder, @unchecked Sendable {
     static let identifier = "com.apple.compilers.opencl"
 
     private let openCLOutputs: [MacroStringExpression]?

--- a/Sources/SWBApplePlatform/Specs/RealityAssetsCompilerSpec.swift
+++ b/Sources/SWBApplePlatform/Specs/RealityAssetsCompilerSpec.swift
@@ -41,7 +41,7 @@ public struct ModuleWithDependencies: Codable, Equatable {
 //
 //---------------------
 
-package final class RealityAssetsCompilerSpec: GenericCompilerSpec, SpecIdentifierType {
+package final class RealityAssetsCompilerSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tasks.compile-rk-assets.xcplugin"
 
     private func environmentBindings(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> EnvironmentBindings {

--- a/Sources/SWBApplePlatform/Specs/ReferenceObjectCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/ReferenceObjectCompiler.swift
@@ -19,7 +19,7 @@ public struct DiscoveredReferenceObjectToolSpecInfo: DiscoveredCommandLineToolSp
     public var toolVersion: Version?
 }
 
-public final class ReferenceObjectCompilerSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class ReferenceObjectCompilerSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.referenceobject"
 
     public override var enableSandboxing: Bool {

--- a/Sources/SWBApplePlatform/Specs/ResMergerLinkerSpec.swift
+++ b/Sources/SWBApplePlatform/Specs/ResMergerLinkerSpec.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBCore
 
-public final class ResMergerLinkerSpec : GenericLinkerSpec, SpecIdentifierType {
+public final class ResMergerLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.pbx.linkers.resmerger"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBApplePlatform/Specs/SceneKitToolSpec.swift
+++ b/Sources/SWBApplePlatform/Specs/SceneKitToolSpec.swift
@@ -13,7 +13,7 @@
 public import SWBCore
 import SWBMacro
 
-public final class SceneKitToolSpec : GenericCompilerSpec, SpecIdentifierType {
+public final class SceneKitToolSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.scntool"
 
     /// Override construction to handle the custom RESOURCE_FLAG value.

--- a/Sources/SWBApplePlatform/Specs/StoryboardLinker.swift
+++ b/Sources/SWBApplePlatform/Specs/StoryboardLinker.swift
@@ -14,7 +14,7 @@ public import SWBUtil
 public import SWBCore
 public import SWBMacro
 
-public final class IBStoryboardLinkerCompilerSpec : GenericCompilerSpec, SpecIdentifierType, IbtoolCompilerSupport {
+public final class IBStoryboardLinkerCompilerSpec : GenericCompilerSpec, SpecIdentifierType, IbtoolCompilerSupport, @unchecked Sendable {
     public static let identifier = "com.apple.xcode.tools.ibtool.storyboard.linker"
 
     /// Override to compute the special arguments.

--- a/Sources/SWBApplePlatform/Specs/XCStringsCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/XCStringsCompiler.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBCore
 
-public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierType {
+public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.xcstrings"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/Specs/CommandLineToolSpec.swift
@@ -16,7 +16,7 @@ public import class Foundation.JSONDecoder
 public import SWBMacro
 
 /// Describes the type and other characterstics of a single kind of input file accepted by a build tool.
-struct InputFileTypeDescriptor: Encodable {
+struct InputFileTypeDescriptor: Encodable, Sendable {
     /// Identifier of the file type — this is unbound until the build tool is used, since the particular file type any given identifier maps to can depend on the context.
     let identifier: String
     /// FIXME: There will be others, but for now the identifier is the only one we use.
@@ -248,8 +248,8 @@ extension DiscoveredCommandLineToolSpecInfo {
     }
 }
 
-open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescription {
-    package enum CommandLineTemplateArg : Sendable{
+open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescription, @unchecked Sendable {
+    package enum CommandLineTemplateArg : Sendable {
         /// Placeholder for the dynamically computed executable path.
         //
         // FIXME: Note, this is only used by 'Ld.xcspec', there might be a simpler implementation.
@@ -1408,7 +1408,7 @@ extension CommandLineToolSpec.RuleInfoTemplateArg: ExpressibleByStringLiteral {
     }
 }
 
-open class GenericCommandLineToolSpec : CommandLineToolSpec {
+open class GenericCommandLineToolSpec : CommandLineToolSpec, @unchecked Sendable {
     required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         super.init(parser, basedOnSpec, isGeneric: true)
     }

--- a/Sources/SWBCore/Specs/CompilerSpec.swift
+++ b/Sources/SWBCore/Specs/CompilerSpec.swift
@@ -14,7 +14,7 @@ import Foundation
 public import SWBUtil
 import SWBMacro
 
-open class CompilerSpec : CommandLineToolSpec {
+open class CompilerSpec : CommandLineToolSpec, @unchecked Sendable {
     class public override var typeName: String {
         return "Compiler"
     }
@@ -123,7 +123,7 @@ extension ProjectFailuresBlockList {
     }
 }
 
-open class GenericCompilerSpec : CompilerSpec {
+open class GenericCompilerSpec : CompilerSpec, @unchecked Sendable {
     required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         super.init(parser, basedOnSpec, isGeneric: true)
     }

--- a/Sources/SWBCore/Specs/LinkerSpec.swift
+++ b/Sources/SWBCore/Specs/LinkerSpec.swift
@@ -15,7 +15,7 @@ public import SWBMacro
 
 public let reexportedBinariesDirectoryName = "ReexportedBinaries"
 
-open class LinkerSpec : CommandLineToolSpec {
+open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
     /// Specifier for an individual library to be linked.
     public struct LibrarySpecifier {
         public enum Kind: CaseIterable, CustomStringConvertible {
@@ -148,7 +148,7 @@ open class LinkerSpec : CommandLineToolSpec {
     }
 }
 
-open class GenericLinkerSpec : LinkerSpec {
+open class GenericLinkerSpec : LinkerSpec, @unchecked Sendable {
     required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         super.init(parser, basedOnSpec, isGeneric: true)
     }

--- a/Sources/SWBCore/Specs/ProductTypes.swift
+++ b/Sources/SWBCore/Specs/ProductTypes.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 public import SWBMacro
 
-public class ProductTypeSpec : Spec, SpecType {
+public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
     /// The level to elevate the deprecation message as.
     public enum DeprecationLevel {
         case warning
@@ -352,7 +352,7 @@ public class ProductTypeSpec : Spec, SpecType {
 // MARK: Bundle product types
 
 
-public class BundleProductTypeSpec : ProductTypeSpec, SpecClassType {
+public class BundleProductTypeSpec : ProductTypeSpec, SpecClassType, @unchecked Sendable {
     public class var className: String {
         return "PBXBundleProductType"
     }
@@ -366,7 +366,7 @@ public class BundleProductTypeSpec : ProductTypeSpec, SpecClassType {
 	}
 }
 
-public class ApplicationProductTypeSpec : BundleProductTypeSpec {
+public final class ApplicationProductTypeSpec : BundleProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXApplicationProductType"
     }
@@ -390,13 +390,13 @@ public class ApplicationProductTypeSpec : BundleProductTypeSpec {
     }
 }
 
-public class ApplicationExtensionProductTypeSpec: BundleProductTypeSpec {
+public final class ApplicationExtensionProductTypeSpec: BundleProductTypeSpec, @unchecked Sendable {
     public override class var className: String {
         return "PBXApplicationExtensionProductType"
     }
 }
 
-public class FrameworkProductTypeSpec : BundleProductTypeSpec {
+public class FrameworkProductTypeSpec : BundleProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXFrameworkProductType"
     }
@@ -570,20 +570,20 @@ public class FrameworkProductTypeSpec : BundleProductTypeSpec {
     }
 }
 
-public class StaticFrameworkProductTypeSpec : FrameworkProductTypeSpec {
+public final class StaticFrameworkProductTypeSpec : FrameworkProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "XCStaticFrameworkProductType"
     }
 }
 
-public class KernelExtensionProductTypeSpec : BundleProductTypeSpec {
+public final class KernelExtensionProductTypeSpec : BundleProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "XCKernelExtensionProductType"
     }
 }
 
 /// The product type for XCTest unit and UI test bundles.
-public class XCTestBundleProductTypeSpec : BundleProductTypeSpec {
+public final class XCTestBundleProductTypeSpec : BundleProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXXCTestBundleProductType"
     }
@@ -758,13 +758,13 @@ public class XCTestBundleProductTypeSpec : BundleProductTypeSpec {
 // MARK: Standalone binary Product types
 
 
-public class StandaloneExecutableProductTypeSpec : ProductTypeSpec, SpecClassType {
+public class StandaloneExecutableProductTypeSpec : ProductTypeSpec, SpecClassType, @unchecked Sendable {
     public class var className: String {
         return "XCStandaloneExecutableProductType"
     }
 }
 
-public class LibraryProductTypeSpec: StandaloneExecutableProductTypeSpec {
+public class LibraryProductTypeSpec: StandaloneExecutableProductTypeSpec, @unchecked Sendable {
     public override class var className: String {
         fatalError("This method is a subclass responsibility")
     }
@@ -774,7 +774,7 @@ public class LibraryProductTypeSpec: StandaloneExecutableProductTypeSpec {
     }
 }
 
-public class DynamicLibraryProductTypeSpec : LibraryProductTypeSpec {
+public final class DynamicLibraryProductTypeSpec : LibraryProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXDynamicLibraryProductType"
     }
@@ -795,7 +795,7 @@ public class DynamicLibraryProductTypeSpec : LibraryProductTypeSpec {
     }
 }
 
-public class StaticLibraryProductTypeSpec : LibraryProductTypeSpec {
+public final class StaticLibraryProductTypeSpec : LibraryProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXStaticLibraryProductType"
     }
@@ -807,7 +807,7 @@ public class StaticLibraryProductTypeSpec : LibraryProductTypeSpec {
     }
 }
 
-public class ToolProductTypeSpec : StandaloneExecutableProductTypeSpec {
+public final class ToolProductTypeSpec : StandaloneExecutableProductTypeSpec, @unchecked Sendable {
     class public override var className: String {
         return "PBXToolProductType"
     }

--- a/Sources/SWBCore/Specs/PropertyDomainSpec.swift
+++ b/Sources/SWBCore/Specs/PropertyDomainSpec.swift
@@ -212,11 +212,11 @@ private let buildOptionTypes: [String: any BuildOptionType] = [
 /// Descriptor for a possible value for a build option.
 //
 // FIXME: This should possibly be private, and we really want the compiler to be able to optimize it as much as possible. However, we currently depend on it only being internal for our unit tests.
-@_spi(Testing) public struct BuildOptionValue {
+@_spi(Testing) public struct BuildOptionValue: Sendable {
     /// Type describing the possible ways a value can be expanded into command line arguments.
     ///
     /// For list types, this template defines what to do *for each* option in the list.
-    @_spi(Testing) public enum CommandLineTemplateSpecifier {
+    @_spi(Testing) public enum CommandLineTemplateSpecifier: Sendable {
         /// Don’t add anything — this can be used to “block” default fallback templates.
         case empty
 
@@ -262,7 +262,7 @@ private let buildOptionTypes: [String: any BuildOptionType] = [
 }
 
 /// Represents an individual option that is part of a property domain spec.
-@_spi(Testing) public final class BuildOption: CustomStringConvertible {
+@_spi(Testing) public final class BuildOption: CustomStringConvertible, Sendable {
     /// Helper type for representing the type of command line argument specifier that was used for a build option.
     private enum CommandLineSpecifier {
     case arrayArgs(value: [String])
@@ -1624,7 +1624,7 @@ extension BuildOptionGenerationContext {
 }
 
 /// This is a shared base class, but cannot itself be a declared spec type.
-open class PropertyDomainSpec : Spec {
+open class PropertyDomainSpec : Spec, @unchecked Sendable {
     /// The ordered list of build options associated with this spec, not including any buildOptions from its BasedOn spec (see `flattenedBuildOptions` and `flattenedOrderedBuildOptions` instead).
     @_spi(Testing) public let buildOptions: [BuildOption]
 

--- a/Sources/SWBCore/Specs/Specs.swift
+++ b/Sources/SWBCore/Specs/Specs.swift
@@ -26,7 +26,7 @@ extension SpecParser {
 }
 
 /// Base class for all spec types.
-open class Spec {
+open class Spec: @unchecked Sendable {
     class var typeName: String {
         preconditionFailure("subclass responsibility")
     }
@@ -132,7 +132,7 @@ extension Spec: CustomStringConvertible {
     }
 }
 
-public class ArchitectureSpec : Spec, SpecType {
+public final class ArchitectureSpec : Spec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "Architecture"
     }
@@ -248,7 +248,7 @@ public class ArchitectureSpec : Spec, SpecType {
     }
 }
 
-public class ProjectOverridesSpec : Spec, SpecType {
+public final class ProjectOverridesSpec : Spec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "ProjectOverrides"
     }
@@ -369,7 +369,7 @@ public class FileTypeSpec : Spec, SpecType, @unchecked Sendable {
     }
 }
 
-public class PackageTypeSpec : Spec, SpecType {
+public final class PackageTypeSpec : Spec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "PackageType"
     }
@@ -410,7 +410,7 @@ public class PackageTypeSpec : Spec, SpecType {
     }
 
     /// Structure which encapsulates information about a product directory which we might want to create early in building a target.
-    public struct ProductStructureDirectoryInfo {
+    public struct ProductStructureDirectoryInfo: Sendable {
         public let buildSetting: PathMacroDeclaration
         public let dontCreateIfProducedByAnotherTask: Bool
 
@@ -443,7 +443,7 @@ public class PackageTypeSpec : Spec, SpecType {
     ]
 }
 
-public class PlatformSpec : Spec, SpecType {
+public final class PlatformSpec : Spec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "Platform"
     }
@@ -467,7 +467,7 @@ public final class BuildSystemSpec : PropertyDomainSpec, SpecType, @unchecked Se
     }
 }
 
-public class BuildPhaseSpec : Spec, SpecType {
+public final class BuildPhaseSpec : Spec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "BuildPhase"
     }

--- a/Sources/SWBCore/Specs/Specs.swift
+++ b/Sources/SWBCore/Specs/Specs.swift
@@ -452,13 +452,13 @@ public class PlatformSpec : Spec, SpecType {
     }
 }
 
-public class BuildSettingsSpec : PropertyDomainSpec, SpecType {
+public final class BuildSettingsSpec : PropertyDomainSpec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "BuildSettings"
     }
 }
 
-public class BuildSystemSpec : PropertyDomainSpec, SpecType {
+public final class BuildSystemSpec : PropertyDomainSpec, SpecType, @unchecked Sendable {
     class public override var typeName: String {
         return "BuildSystem"
     }

--- a/Sources/SWBCore/Specs/Tools/AppIntentsMetadataCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/AppIntentsMetadataCompiler.swift
@@ -64,7 +64,7 @@ private struct AppIntentsLocalizationPayload: TaskPayload {
     }
 }
 
-final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.appintentsmetadata"
     public func shouldConstructAppIntentsMetadataTask(_ cbc: CommandBuildContext) -> Bool {
         return cbc.scope.evaluate(BuiltinMacros.CURRENT_VARIANT) == "normal" &&

--- a/Sources/SWBCore/Specs/Tools/AppIntentsSSUTrainingCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/AppIntentsSSUTrainingCompiler.swift
@@ -14,7 +14,7 @@ import SWBUtil
 import Foundation
 import SWBMacro
 
-final public class AppIntentsSSUTrainingCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final public class AppIntentsSSUTrainingCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.appintents-ssu-training"
 
     private func shouldConstructSsuTrainingTask(_ cbc: CommandBuildContext) -> Bool {

--- a/Sources/SWBCore/Specs/Tools/AppShortcutStringsMetadataCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/AppShortcutStringsMetadataCompiler.swift
@@ -14,7 +14,7 @@ public import SWBUtil
 import Foundation
 import SWBMacro
 
-final public class AppShortcutStringsMetadataCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final public class AppShortcutStringsMetadataCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.appshortcutstringsmetadata"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/CCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/CCompiler.swift
@@ -15,7 +15,7 @@ public import SWBMacro
 
 
 /// Abstract C Compiler.  This is not a concrete implementation, but rather it uses various information in the command build context to choose a specific compiler and to call `constructTasks()` on that compiler.  This provides a level of indirection for projects that just want their source files compiled using the default C compiler.  Depending on the context, the default C compiler for any particular combination of platform, architecture, and other factors may be Clang, ICC, GCC, or some other compiler.
-class AbstractCCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder {
+class AbstractCCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder, @unchecked Sendable {
     static let identifier = "com.apple.compilers.gcc"
 
     override func resolveConcreteSpec(_ cbc: CommandBuildContext) -> CommandLineToolSpec {
@@ -525,7 +525,7 @@ public enum FlagPattern: Sendable {
 }
 
 
-public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder {
+public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCompilerCommandLineBuilder, @unchecked Sendable {
     /// Clang compiler data cache, used to cache constant flags.
     fileprivate final class DataCache: SpecDataCache {
         fileprivate struct ConstantFlagsKey: Hashable, Sendable {
@@ -1874,7 +1874,7 @@ extension ClangCompilerSpec {
     }
 }
 
-public final class ClangStaticAnalyzerSpec : ClangCompilerSpec {
+public final class ClangStaticAnalyzerSpec : ClangCompilerSpec, @unchecked Sendable {
     public class override var identifier: String {
         "com.apple.compilers.llvm.clang.1_0.analyzer"
     }
@@ -1944,7 +1944,7 @@ func createSpecParser(for proxy: SpecProxy, registry: SpecRegistry) -> SpecParse
     return SpecParser(delegate, proxy)
 }
 
-public final class ClangPreprocessorSpec : ClangCompilerSpec, SpecImplementationType {
+public final class ClangPreprocessorSpec : ClangCompilerSpec, SpecImplementationType, @unchecked Sendable {
     public class override var identifier: String {
         "com.apple.compilers.llvm.clang.1_0.preprocessor"
     }
@@ -1980,7 +1980,7 @@ public final class ClangPreprocessorSpec : ClangCompilerSpec, SpecImplementation
     }
 }
 
-public final class ClangAssemblerSpec : ClangCompilerSpec, SpecImplementationType {
+public final class ClangAssemblerSpec : ClangCompilerSpec, SpecImplementationType, @unchecked Sendable {
     public class override var identifier: String {
         "com.apple.compilers.llvm.clang.1_0.assembler"
     }
@@ -2016,7 +2016,7 @@ public final class ClangAssemblerSpec : ClangCompilerSpec, SpecImplementationTyp
     }
 }
 
-public final class ClangModuleVerifierSpec: ClangCompilerSpec, SpecImplementationType {
+public final class ClangModuleVerifierSpec: ClangCompilerSpec, SpecImplementationType, @unchecked Sendable {
     public class override var identifier: String {
         "com.apple.compilers.llvm.clang.1_0.verify_module"
     }

--- a/Sources/SWBCore/Specs/Tools/ClangModuleVerifierInputGenerator.swift
+++ b/Sources/SWBCore/Specs/Tools/ClangModuleVerifierInputGenerator.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ClangModuleVerifierInputGeneratorSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class ClangModuleVerifierInputGeneratorSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.module-verifier-input-generator"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/ClangStatCache.swift
+++ b/Sources/SWBCore/Specs/Tools/ClangStatCache.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-final public class ClangStatCacheSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final public class ClangStatCacheSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.clang-stat-cache"
 
     override public var enableSandboxing: Bool {

--- a/Sources/SWBCore/Specs/Tools/CodeSign.swift
+++ b/Sources/SWBCore/Specs/Tools/CodeSign.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 public import SWBMacro
 
-public final class CodesignToolSpec : CommandLineToolSpec, SpecIdentifierType {
+public final class CodesignToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.codesign"
 
     public override func computeExecutablePath(_ cbc: CommandBuildContext) -> String {

--- a/Sources/SWBCore/Specs/Tools/ConcatenateTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ConcatenateTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ConcatenateToolSpec : CommandLineToolSpec, SpecImplementationType {
+public final class ConcatenateToolSpec : CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.concatenate"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/ConstructStubExecutorFileListTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ConstructStubExecutorFileListTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ConstructStubExecutorFileListToolSpec: CommandLineToolSpec, SpecImplementationType {
+public final class ConstructStubExecutorFileListToolSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.construct-stub-executor-link-file-list"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/CopyTool.swift
+++ b/Sources/SWBCore/Specs/Tools/CopyTool.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 import SWBMacro
 
-public final class CopyToolSpec : CompilerSpec, SpecIdentifierType {
+public final class CopyToolSpec : CompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.pbxcp"
 
     /// Construct a `Copy` task to copy a source file to a destination with default behaviors.

--- a/Sources/SWBCore/Specs/Tools/CreateAssetPackManifestTool.swift
+++ b/Sources/SWBCore/Specs/Tools/CreateAssetPackManifestTool.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBMacro
 
-public final class CreateAssetPackManifestToolSpec : CommandLineToolSpec, SpecImplementationType {
+public final class CreateAssetPackManifestToolSpec : CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.odr.create-asset-pack-manifest"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/CreateBuildDirectory.swift
+++ b/Sources/SWBCore/Specs/Tools/CreateBuildDirectory.swift
@@ -12,7 +12,7 @@
 
 import SWBUtil
 
-public final class CreateBuildDirectorySpec: CommandLineToolSpec, SpecImplementationType {
+public final class CreateBuildDirectorySpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.create-build-directory"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/DocumentationCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/DocumentationCompiler.swift
@@ -15,7 +15,7 @@ public import SWBUtil
 public import SWBProtocol
 public import SWBMacro
 
-final public class DocumentationCompilerSpec: GenericCompilerSpec, SpecIdentifierType {
+final public class DocumentationCompilerSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.documentation"
 
     static public func shouldConstructSymbolGenerationTask(_ cbc: CommandBuildContext) -> Bool {

--- a/Sources/SWBCore/Specs/Tools/DsymutilTool.swift
+++ b/Sources/SWBCore/Specs/Tools/DsymutilTool.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 import SWBMacro
 
-public final class DsymutilToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class DsymutilToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.dsymutil"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/Gate.swift
+++ b/Sources/SWBCore/Specs/Tools/Gate.swift
@@ -13,7 +13,7 @@
 // This is a stub spec type, used for gate tasks.
 //
 // FIXME: We shouldn't need this, but there are some hard coded assumptions about being able to serialize task types currently.
-public final class GateSpec: CommandLineToolSpec, SpecImplementationType {
+public final class GateSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.gate"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/GenerateAppPlaygroundAssetCatalog.swift
+++ b/Sources/SWBCore/Specs/Tools/GenerateAppPlaygroundAssetCatalog.swift
@@ -12,7 +12,7 @@
 
 import SWBUtil
 
-public final class GenerateAppPlaygroundAssetCatalog: GenericCommandLineToolSpec, SpecIdentifierType {
+public final class GenerateAppPlaygroundAssetCatalog: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier: String = "com.apple.tools.generate-app-playground-asset-catalog"
 
     public override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBCore/Specs/Tools/InfoPlistTool.swift
+++ b/Sources/SWBCore/Specs/Tools/InfoPlistTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class InfoPlistToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class InfoPlistToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.info-plist-utility"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/LaunchServicesRegisterTool.swift
+++ b/Sources/SWBCore/Specs/Tools/LaunchServicesRegisterTool.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-final class LaunchServicesRegisterToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+final class LaunchServicesRegisterToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.build-tasks.ls-register-url"
 
     override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -235,7 +235,7 @@ public struct DiscoveredLdLinkerToolSpecInfo: DiscoveredCommandLineToolSpecInfo 
     }
 }
 
-public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType {
+public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.pbx.linkers.ld"
 
     public override func computeExecutablePath(_ cbc: CommandBuildContext) -> String {
@@ -1322,7 +1322,7 @@ public struct DiscoveredLibtoolLinkerToolSpecInfo: DiscoveredCommandLineToolSpec
     public let toolVersion: Version?
 }
 
-public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType {
+public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.pbx.linkers.libtool"
 
     override public var payloadType: (any TaskPayload.Type)? { return LibtoolLinkerTaskPayload.self }

--- a/Sources/SWBCore/Specs/Tools/Lipo.swift
+++ b/Sources/SWBCore/Specs/Tools/Lipo.swift
@@ -13,7 +13,7 @@
 import SWBProtocol
 import SWBUtil
 
-public final class LipoToolSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+public final class LipoToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
 
     // Custom override to erase the "linker" nature as specified in Xcode's xcspecs, which doesn't fit with how we model things.
 

--- a/Sources/SWBCore/Specs/Tools/MasterObjectLink.swift
+++ b/Sources/SWBCore/Specs/Tools/MasterObjectLink.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 
 /// Spec to use the linker to run `ld -r` to create a prelinked object file (a.k.a. "master object file").
-final class MasterObjectLinkSpec: CommandLineToolSpec, SpecImplementationType {
+final class MasterObjectLinkSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     static let identifier = "com.apple.build-tools.master-object-link"
 
     class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/MergeInfoPlist.swift
+++ b/Sources/SWBCore/Specs/Tools/MergeInfoPlist.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class MergeInfoPlistSpec: CommandLineToolSpec, SpecImplementationType {
+public final class MergeInfoPlistSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
         MergeInfoPlistSpec(registry, proxy, execDescription: registry.internalMacroNamespace.parseString("Merge preprocessed Info.plist variants"), ruleInfoTemplate: ["MergeInfoPlistFile", .output, .input], commandLineTemplate: [.execPath, .options, .output, .inputs])
     }

--- a/Sources/SWBCore/Specs/Tools/MkdirTool.swift
+++ b/Sources/SWBCore/Specs/Tools/MkdirTool.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class MkdirToolSpec : CommandLineToolSpec, SpecIdentifierType {
+public final class MkdirToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.mkdir"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/ModulesVerifierTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ModulesVerifierTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ModulesVerifierToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class ModulesVerifierToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.modules-verifier"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/PLUtilTool.swift
+++ b/Sources/SWBCore/Specs/Tools/PLUtilTool.swift
@@ -10,6 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-final class PLUtilToolSpec : CommandLineToolSpec, SpecIdentifierType {
+final class PLUtilToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.tools.plutil"
 }

--- a/Sources/SWBCore/Specs/Tools/ProcessSDKImports.swift
+++ b/Sources/SWBCore/Specs/Tools/ProcessSDKImports.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ProcessSDKImportsSpec: CommandLineToolSpec, SpecImplementationType {
+public final class ProcessSDKImportsSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.process-sdk-imports"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/ProcessXCFrameworkLibrary.swift
+++ b/Sources/SWBCore/Specs/Tools/ProcessXCFrameworkLibrary.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 import SWBMacro
 
-public final class ProcessXCFrameworkLibrarySpec: CommandLineToolSpec, SpecImplementationType {
+public final class ProcessXCFrameworkLibrarySpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier: String = "com.apple.build-tasks.process-xcframework-library"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/ProductPackaging.swift
+++ b/Sources/SWBCore/Specs/Tools/ProductPackaging.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 import SWBMacro
 
-public final class ProductPackagingToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class ProductPackagingToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.product-pkg-utility"
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/RegisterExecutionPolicyException.swift
+++ b/Sources/SWBCore/Specs/Tools/RegisterExecutionPolicyException.swift
@@ -14,7 +14,7 @@ import SWBProtocol
 import SWBUtil
 public import SWBMacro
 
-public final class RegisterExecutionPolicyExceptionToolSpec: CommandLineToolSpec, SpecImplementationType {
+public final class RegisterExecutionPolicyExceptionToolSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tasks.register-execution-policy-exception"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/SetAttributes.swift
+++ b/Sources/SWBCore/Specs/Tools/SetAttributes.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class SetAttributesSpec: CommandLineToolSpec, SpecImplementationType {
+public final class SetAttributesSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.set-attributes"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/ShellScriptTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ShellScriptTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class ShellScriptToolSpec : CommandLineToolSpec, SpecIdentifierType {
+public final class ShellScriptToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.commands.shell-script"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/SignatureCollection.swift
+++ b/Sources/SWBCore/Specs/Tools/SignatureCollection.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class SignatureCollectionSpec: CommandLineToolSpec, SpecImplementationType {
+public final class SignatureCollectionSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.signature-collection"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/StripTool.swift
+++ b/Sources/SWBCore/Specs/Tools/StripTool.swift
@@ -12,7 +12,7 @@
 
 import SWBMacro
 
-public final class StripToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class StripToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.strip"
 
     /// Custom override to inject an appropriate output path.

--- a/Sources/SWBCore/Specs/Tools/SwiftABICheckerTool.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftABICheckerTool.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 public import SWBMacro
 
-public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo {
+public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.swift-abi-checker"
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {

--- a/Sources/SWBCore/Specs/Tools/SwiftABIGenerationTool.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftABIGenerationTool.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 public import SWBMacro
 
-public final class SwiftABIGenerationToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo {
+public final class SwiftABIGenerationToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.swift-abi-generation"
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {

--- a/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
@@ -1104,7 +1104,7 @@ public struct SwiftMacroImplementationDescriptor: Hashable, Comparable, Sendable
     }
 }
 
-public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo {
+public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDiscoveredCommandLineToolSpecInfo, @unchecked Sendable {
     @_spi(Testing) public static let parallelismLevel = ProcessInfo.processInfo.activeProcessorCount
 
     public static let identifier = "com.apple.xcode.tools.swift.compiler"

--- a/Sources/SWBCore/Specs/Tools/SwiftHeaderTool.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftHeaderTool.swift
@@ -13,7 +13,7 @@
 public import SWBUtil
 public import SWBMacro
 
-public final class SwiftHeaderToolSpec : CommandLineToolSpec, SpecImplementationType {
+public final class SwiftHeaderToolSpec : CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.swift-header-tool"
 
     public override func resolveExecutionDescription(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String {

--- a/Sources/SWBCore/Specs/Tools/SwiftStdLibTool.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftStdLibTool.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBMacro
 
-public final class SwiftStdLibToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+public final class SwiftStdLibToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.swift-stdlib-tool"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/SwiftSymbolExtractor.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftSymbolExtractor.swift
@@ -14,7 +14,7 @@ import Foundation
 import SWBUtil
 import SWBMacro
 
-final class SwiftSymbolExtractor: GenericCompilerSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType {
+final class SwiftSymbolExtractor: GenericCompilerSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.documentation.swift-symbol-extract"
 
     static public func shouldConstructSymbolExtractionTask(_ cbc: CommandBuildContext) -> Bool {

--- a/Sources/SWBCore/Specs/Tools/SymlinkTool.swift
+++ b/Sources/SWBCore/Specs/Tools/SymlinkTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class SymlinkToolSpec : CommandLineToolSpec, SpecIdentifierType {
+public final class SymlinkToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.symlink"
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/TAPISymbolExtractor.swift
+++ b/Sources/SWBCore/Specs/Tools/TAPISymbolExtractor.swift
@@ -14,7 +14,7 @@ import Foundation
 public import SWBUtil
 public import SWBMacro
 
-final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType {
+final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.documentation.objc-symbol-extract"
 
     /// Return whether or not this documentation build should include a task for symbol extraction.

--- a/Sources/SWBCore/Specs/Tools/TAPITools.swift
+++ b/Sources/SWBCore/Specs/Tools/TAPITools.swift
@@ -18,7 +18,7 @@ public struct DiscoveredTAPIToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
     public let toolVersion: Version?
 }
 
-public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType {
+public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompilerCommandLineBuilder, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.tapi.installapi"
 
     public static let dSYMSupportRequiredVersion = try! FuzzyVersion("1500.*.7")
@@ -165,7 +165,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
     }
 }
 
-final class TAPIMergeToolSpec : CommandLineToolSpec, SpecImplementationType {
+final class TAPIMergeToolSpec : CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     static let identifier = "com.apple.build-tools.tapi.merge"
 
     class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/TiffUtilTool.swift
+++ b/Sources/SWBCore/Specs/Tools/TiffUtilTool.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 import SWBMacro
 
-final class TiffUtilToolSpec : GenericCompilerSpec, SpecIdentifierType {
+final class TiffUtilToolSpec : GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.tiffutil"
 
     private class func deferredSpec(_ cbc: CommandBuildContext) -> CommandLineToolSpec? {

--- a/Sources/SWBCore/Specs/Tools/TouchTool.swift
+++ b/Sources/SWBCore/Specs/Tools/TouchTool.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 import SWBMacro
 
-final class TouchToolSpec : CommandLineToolSpec, SpecIdentifierType {
+final class TouchToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.tools.touch"
 
     override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/Specs/Tools/UnifdefTool.swift
+++ b/Sources/SWBCore/Specs/Tools/UnifdefTool.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class UnifdefToolSpec : CommandLineToolSpec, SpecIdentifierType {
+public final class UnifdefToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "public.build-task.unifdef"
 
     public override func evaluatedOutputs(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate) -> [(path: Path, isDirectory: Bool)]? {

--- a/Sources/SWBCore/Specs/Tools/ValidateDevelopmentAssets.swift
+++ b/Sources/SWBCore/Specs/Tools/ValidateDevelopmentAssets.swift
@@ -13,7 +13,7 @@
 import SWBProtocol
 import SWBUtil
 
-public final class ValidateDevelopmentAssets: CommandLineToolSpec, SpecImplementationType {
+public final class ValidateDevelopmentAssets: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.validate-development-assets"
 
     public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBCore/Specs/Tools/ValidateEmbeddedBinaryTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ValidateEmbeddedBinaryTool.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 public import SWBMacro
 
-public final class ValidateEmbeddedBinaryToolSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+public final class ValidateEmbeddedBinaryToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.tools.validate-embedded-binary-utility"
 
     public func constructValidateEmbeddedBinaryTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) async {

--- a/Sources/SWBCore/Specs/Tools/ValidateProductTool.swift
+++ b/Sources/SWBCore/Specs/Tools/ValidateProductTool.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class ValidateProductToolSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+public final class ValidateProductToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.platform.validate"
 
     public override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBCore/Specs/Tools/WriteFile.swift
+++ b/Sources/SWBCore/Specs/Tools/WriteFile.swift
@@ -12,7 +12,7 @@
 
 public import SWBUtil
 
-public final class WriteFileSpec: CommandLineToolSpec, SpecImplementationType {
+public final class WriteFileSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     public static let identifier = "com.apple.build-tools.write-file"
 
     public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {

--- a/Sources/SWBMacro/MacroConditionExpression.swift
+++ b/Sources/SWBMacro/MacroConditionExpression.swift
@@ -16,7 +16,7 @@ import SWBUtil
 
 
 /// A parsed condition which can be evaluated in the context of a scope to return a boolean or string result.  This is used in build options to define conditions under which the option should contribute arguments to a command line.
-public class MacroConditionExpression: CustomStringConvertible
+public class MacroConditionExpression: CustomStringConvertible, @unchecked Sendable
 {
     /// Parse a ``MacroConditionExpression`` object from ``string``.
     ///
@@ -333,7 +333,7 @@ public class MacroConditionExpression: CustomStringConvertible
 
 
 /// Abstract base class for expressions that whose natural return type is a string.  These can still be converted to booleans using evaluateAsBoolean()
-private class MacroConditionStringExpression: MacroConditionExpression
+private class MacroConditionStringExpression: MacroConditionExpression, @unchecked Sendable
 {
     override func evaluateAsString(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String
     {
@@ -347,7 +347,7 @@ private class MacroConditionStringExpression: MacroConditionExpression
 }
 
 /// A constant string condition expression.
-private class MacroConditionStringConstantExpression: MacroConditionStringExpression
+private final class MacroConditionStringConstantExpression: MacroConditionStringExpression, @unchecked Sendable
 {
     let macroExpr: MacroStringExpression
 
@@ -368,7 +368,7 @@ private class MacroConditionStringConstantExpression: MacroConditionStringExpres
 }
 
 /// Abstract base class for expressions that whose natural return type is a boolean.  These can still be converted to strings using evaluateAsString().
-private class MacroConditionBooleanExpression: MacroConditionExpression
+private class MacroConditionBooleanExpression: MacroConditionExpression, @unchecked Sendable
 {
     override func evaluateAsString(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String
     {
@@ -383,7 +383,7 @@ private class MacroConditionBooleanExpression: MacroConditionExpression
 
 // True and False constant expressions are not presently used.
 @available(*, unavailable)
-private class MacroConditionTrueConstantExpression: MacroConditionBooleanExpression
+private final class MacroConditionTrueConstantExpression: MacroConditionBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -398,7 +398,7 @@ private class MacroConditionTrueConstantExpression: MacroConditionBooleanExpress
 
 // True and False constant expressions are not presently used.
 @available(*, unavailable)
-private class MacroConditionFalseConstantExpression: MacroConditionBooleanExpression
+private final class MacroConditionFalseConstantExpression: MacroConditionBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -412,7 +412,7 @@ private class MacroConditionFalseConstantExpression: MacroConditionBooleanExpres
 }
 
 /// Abstract base class for boolean expressions that operate on a single operand (either boolean or string).
-private class MacroConditionUnaryBooleanExpression: MacroConditionExpression
+private class MacroConditionUnaryBooleanExpression: MacroConditionExpression, @unchecked Sendable
 {
     let expr: MacroConditionExpression?
 
@@ -427,7 +427,7 @@ private class MacroConditionUnaryBooleanExpression: MacroConditionExpression
     }
 }
 
-private class MacroConditionLogicalNOTExpression: MacroConditionUnaryBooleanExpression
+private final class MacroConditionLogicalNOTExpression: MacroConditionUnaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -442,7 +442,7 @@ private class MacroConditionLogicalNOTExpression: MacroConditionUnaryBooleanExpr
 }
 
 /// Abstract base class for boolean expressions that operate on two operands (either booleans or strings).
-private class MacroConditionBinaryBooleanExpression: MacroConditionBooleanExpression
+private class MacroConditionBinaryBooleanExpression: MacroConditionBooleanExpression, @unchecked Sendable
 {
     let leftExpr: MacroConditionExpression?
     let rightExpr: MacroConditionExpression?
@@ -459,7 +459,7 @@ private class MacroConditionBinaryBooleanExpression: MacroConditionBooleanExpres
     }
 }
 
-private class MacroConditionEqualityExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionEqualityExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -475,7 +475,7 @@ private class MacroConditionEqualityExpression: MacroConditionBinaryBooleanExpre
     }
 }
 
-private class MacroConditionInequalityExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionInequalityExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -491,7 +491,7 @@ private class MacroConditionInequalityExpression: MacroConditionBinaryBooleanExp
     }
 }
 
-private class MacroConditionLogicalANDExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionLogicalANDExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -507,7 +507,7 @@ private class MacroConditionLogicalANDExpression: MacroConditionBinaryBooleanExp
     }
 }
 
-private class MacroConditionLogicalORExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionLogicalORExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -525,7 +525,7 @@ private class MacroConditionLogicalORExpression: MacroConditionBinaryBooleanExpr
 
 // XOR is not presently used.
 @available(*, unavailable)
-private class MacroConditionLogicalXORExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionLogicalXORExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -541,7 +541,7 @@ private class MacroConditionLogicalXORExpression: MacroConditionBinaryBooleanExp
     }
 }
 
-private class MacroConditionContainsExpression: MacroConditionBinaryBooleanExpression
+private final class MacroConditionContainsExpression: MacroConditionBinaryBooleanExpression, @unchecked Sendable
 {
     override func evaluateAsBoolean(_ scope: MacroEvaluationScope, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> Bool
     {
@@ -558,7 +558,7 @@ private class MacroConditionContainsExpression: MacroConditionBinaryBooleanExpre
 }
 
 /// A ternary conditional expression.
-private class MacroConditionTernaryConditionalExpression: MacroConditionExpression
+private final class MacroConditionTernaryConditionalExpression: MacroConditionExpression, @unchecked Sendable
 {
     let condExpr: MacroConditionExpression?
     let thenExpr: MacroConditionExpression?

--- a/Sources/SWBUniversalPlatform/Specs/CopyPlistFile.swift
+++ b/Sources/SWBUniversalPlatform/Specs/CopyPlistFile.swift
@@ -13,7 +13,7 @@
 import SWBMacro
 import SWBCore
 
-final class CopyPlistFileSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final class CopyPlistFileSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.build-tasks.copy-plist-file"
 
     override func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {

--- a/Sources/SWBUniversalPlatform/Specs/CopyStringsFile.swift
+++ b/Sources/SWBUniversalPlatform/Specs/CopyStringsFile.swift
@@ -14,7 +14,7 @@ import SWBUtil
 import SWBMacro
 import SWBCore
 
-final class CopyStringsFileSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+final class CopyStringsFileSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.build-tasks.copy-strings-file"
 
     override func lookup(_ macro: MacroDeclaration, _ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, _ lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> MacroExpression? {

--- a/Sources/SWBUniversalPlatform/Specs/CppTool.swift
+++ b/Sources/SWBUniversalPlatform/Specs/CppTool.swift
@@ -12,6 +12,6 @@
 
 import SWBCore
 
-final class CppToolSpec : GenericCommandLineToolSpec, SpecIdentifierType {
+final class CppToolSpec : GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.cpp"
 }

--- a/Sources/SWBUniversalPlatform/Specs/DiffTool.swift
+++ b/Sources/SWBUniversalPlatform/Specs/DiffTool.swift
@@ -12,7 +12,7 @@
 
 import SWBCore
 
-final class DiffToolSpec: CommandLineToolSpec, SpecImplementationType {
+final class DiffToolSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
     static let identifier = "com.apple.build-tools.diff"
 
     override var enableSandboxing: Bool {

--- a/Sources/SWBUniversalPlatform/Specs/LexCompiler.swift
+++ b/Sources/SWBUniversalPlatform/Specs/LexCompiler.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 import SWBCore
 
-final class LexCompilerSpec : CompilerSpec, SpecIdentifierType {
+final class LexCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.lex"
 
     static let extensionMappings = [

--- a/Sources/SWBUniversalPlatform/Specs/YaccCompiler.swift
+++ b/Sources/SWBUniversalPlatform/Specs/YaccCompiler.swift
@@ -13,7 +13,7 @@
 import SWBUtil
 import SWBCore
 
-final class YaccCompilerSpec : CompilerSpec, SpecIdentifierType {
+final class YaccCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "com.apple.compilers.yacc"
 
     static let extensionMappings = [

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1983,7 +1983,7 @@ import SWBMacro
         }
     }
 
-    final class ThingToolSpec: GenericCommandLineToolSpec, SpecIdentifierType {
+    final class ThingToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
         static let identifier = "com.apple.compilers.thing_processor"
 
         override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {


### PR DESCRIPTION
This mostly consists of more aggressively marking classes as final, applying unchecked Sendable where needed, and auditing some more of the macro infrastructure for Sendability.