### PR TITLE
Refactor TaskStore/Task to control mutability when interning stored strings

### DIFF
--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -559,7 +559,7 @@ package final class BuildDescriptionManager: Sendable {
         let delegate = BuildDescriptionDeserializerDelegate(workspace: workspaceContext.workspace, platformRegistry: workspaceContext.core.platformRegistry, sdkRegistry: workspaceContext.core.sdkRegistry, specRegistry: workspaceContext.core.specRegistry)
         let taskStoreContents = try fs.read(path.join("task-store.msgpack"))
         let taskStoreDeserializer = MsgPackDeserializer(taskStoreContents, delegate: delegate)
-        let taskStore: TaskStore = try taskStoreDeserializer.deserialize()
+        let taskStore: FrozenTaskStore = try taskStoreDeserializer.deserialize()
         delegate.taskStore = taskStore
         let byteString = try fs.read(path.join("description.msgpack"))
         let deserializer = MsgPackDeserializer(byteString, delegate: delegate)

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -766,7 +766,7 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
 
             let deserializerDelegate = BuildDescriptionDeserializerDelegate(workspace: workspaceContext.workspace, platformRegistry: workspaceContext.core.platformRegistry, sdkRegistry: workspaceContext.core.sdkRegistry, specRegistry: workspaceContext.core.specRegistry)
             let taskStoreDeserializer = MsgPackDeserializer(serializedTaskStore, delegate: deserializerDelegate)
-            let taskStore: TaskStore = try! taskStoreDeserializer.deserialize()
+            let taskStore: FrozenTaskStore = try taskStoreDeserializer.deserialize()
             deserializerDelegate.taskStore = taskStore
             let deserializer = MsgPackDeserializer(serializedBuildDescription, delegate: deserializerDelegate)
             let deserializedDescription: BuildDescription = try deserializer.deserialize()


### PR DESCRIPTION
- Freeze arenas once we no longer need to mutate them
- Do the same for the TaskStore
- Rework environment bindings storage