### PR TITLE
SWBApplePlatform - Adopt Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -199,7 +199,7 @@ let package = Package(
         .target(
             name: "SWBApplePlatform",
             dependencies: ["SWBCore", "SWBMacro", "SWBUtil", "SWBTaskConstruction"],
-            swiftSettings: swiftSettings(languageMode: .v5)),
+            swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBGenericUnixPlatform",
             dependencies: ["SWBCore", "SWBUtil"],


### PR DESCRIPTION
This target can now trivially adopt Swift 6