### PR TITLE
Refactor most project model objects in XCBCore to be Sendable

### DIFF
--- a/Sources/SWBCore/ProjectModel/BuildConfiguration.swift
+++ b/Sources/SWBCore/ProjectModel/BuildConfiguration.swift
@@ -14,7 +14,7 @@ import SWBProtocol
 import SWBUtil
 public import SWBMacro
 
-public final class BuildConfiguration: ProjectModelItem, Encodable
+public final class BuildConfiguration: ProjectModelItem, Encodable, Sendable
 {
     public let name: String
 

--- a/Sources/SWBCore/ProjectModel/BuildPhase.swift
+++ b/Sources/SWBCore/ProjectModel/BuildPhase.swift
@@ -17,7 +17,7 @@ public import SWBMacro
 // MARK: Build phase abstract class
 
 
-public class BuildPhase: ProjectModelItem
+public class BuildPhase: ProjectModelItem, @unchecked Sendable
 {
     /// The name of the build phase, typically for reporting issues.
     public var name: String { fatalError("abstract \(type(of: self)) build phase asked for its name") }
@@ -88,7 +88,7 @@ public class BuildPhase: ProjectModelItem
 // MARK: Build phase with build files abstract class
 
 
-public class BuildPhaseWithBuildFiles: BuildPhase
+public class BuildPhaseWithBuildFiles: BuildPhase, @unchecked Sendable
 {
     public let buildFiles: [BuildFile]
 
@@ -134,7 +134,7 @@ public class BuildPhaseWithBuildFiles: BuildPhase
 // MARK: Sources build phase class
 
 
-public final class SourcesBuildPhase: BuildPhaseWithBuildFiles
+public final class SourcesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Compile Sources" }
 }
@@ -143,7 +143,7 @@ public final class SourcesBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Frameworks build phase class
 
 
-public final class FrameworksBuildPhase: BuildPhaseWithBuildFiles
+public final class FrameworksBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Link Binary" }
 }
@@ -152,7 +152,7 @@ public final class FrameworksBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Headers build phase class
 
 
-public final class HeadersBuildPhase: BuildPhaseWithBuildFiles
+public final class HeadersBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Copy Headers" }
 }
@@ -161,7 +161,7 @@ public final class HeadersBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Resources build phase class
 
 
-public final class ResourcesBuildPhase: BuildPhaseWithBuildFiles
+public final class ResourcesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Copy Bundle Resources" }
 }
@@ -170,7 +170,7 @@ public final class ResourcesBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Copy files build phase class
 
 
-public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles
+public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Copy Files" }
 
@@ -228,7 +228,7 @@ public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Shell script build phase class
 
 
-public final class ShellScriptBuildPhase: BuildPhase
+public final class ShellScriptBuildPhase: BuildPhase, @unchecked Sendable
 {
     public override var name: String { return _name.isEmpty ? "Run Script" : _name }
 
@@ -378,7 +378,7 @@ public final class ShellScriptBuildPhase: BuildPhase
 // MARK: Rez build phase class
 
 
-public final class RezBuildPhase: BuildPhaseWithBuildFiles
+public final class RezBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Build Carbon Resources" }
 }
@@ -387,7 +387,7 @@ public final class RezBuildPhase: BuildPhaseWithBuildFiles
 // MARK: AppleScript build phase class
 
 
-public final class AppleScriptBuildPhase: BuildPhaseWithBuildFiles
+public final class AppleScriptBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Compile AppleScript Files" }
 }
@@ -396,7 +396,7 @@ public final class AppleScriptBuildPhase: BuildPhaseWithBuildFiles
 // MARK: Java archive build phase class
 
 
-public final class JavaArchiveBuildPhase: BuildPhaseWithBuildFiles
+public final class JavaArchiveBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sendable
 {
     public override var name: String { return "Build Java Resources" }
 }

--- a/Sources/SWBCore/ProjectModel/Project.swift
+++ b/Sources/SWBCore/ProjectModel/Project.swift
@@ -96,7 +96,7 @@ public final class Project: ProjectModelItem, PIFObject, Hashable, Encodable
         self.xcodeprojPath = model.xcodeprojPath
         self.sourceRoot = model.sourceRoot
         self.targets = try model.targetSignatures.map{ try pifLoader.loadReference(signature: $0, type: Target.self) }
-        self.groupTree = try Reference.create(model.groupTree, pifLoader) as! FileGroup
+        self.groupTree = try Reference.create(model.groupTree, pifLoader, isRoot: true) as! FileGroup
         self.buildConfigurations = model.buildConfigurations.map{ BuildConfiguration($0, pifLoader) }
         self.defaultConfigurationName = model.defaultConfigurationName
         self.developmentRegion = model.developmentRegion
@@ -133,7 +133,7 @@ public final class Project: ProjectModelItem, PIFObject, Hashable, Encodable
         }
 
         // The top-level file group is required.  We load this early because our or our targets' build configurations can refer to files in here.
-        groupTree = try FileGroup.parsePIFDictAsReference(Self.parseValueForKeyAsPIFDictionary(PIFKey_Project_groupTree, pifDict: pifDict), pifLoader: pifLoader) as! FileGroup
+        groupTree = try FileGroup.parsePIFDictAsReference(Self.parseValueForKeyAsPIFDictionary(PIFKey_Project_groupTree, pifDict: pifDict), pifLoader: pifLoader, isRoot: true) as! FileGroup
 
         // The list of targets is required.
         targets = try Self.parseValueForKeyAsArrayOfIndirectObjects(PIFKey_Project_targets, pifDict: pifDict, pifLoader: pifLoader)

--- a/Sources/SWBCore/ProjectModel/Reference.swift
+++ b/Sources/SWBCore/ProjectModel/Reference.swift
@@ -19,19 +19,19 @@ public typealias SourceTree = SWBProtocol.SourceTree
 // MARK: Reference abstract class
 
 
-public class Reference: ProjectModelItem, Hashable, Equatable
+public class Reference: ProjectModelItem, Hashable, Equatable, @unchecked Sendable
 {
     /// The global ID within the PIF for this reference.
     public let guid: String
 
-    public static func create(_ model: SWBProtocol.Reference, _ pifLoader: PIFLoader) throws -> Reference {
+    public static func create(_ model: SWBProtocol.Reference, _ pifLoader: PIFLoader, isRoot: Bool) throws -> Reference {
         switch model {
-        case let model as SWBProtocol.VersionGroup: return try VersionGroup(model, pifLoader)
-        case let model as SWBProtocol.VariantGroup: return try VariantGroup(model, pifLoader)
-        case let model as SWBProtocol.FileGroup: return try FileGroup(model, pifLoader)
+        case let model as SWBProtocol.VersionGroup: return try VersionGroup(model, pifLoader, isRoot: isRoot)
+        case let model as SWBProtocol.VariantGroup: return try VariantGroup(model, pifLoader, isRoot: isRoot)
+        case let model as SWBProtocol.FileGroup: return try FileGroup(model, pifLoader, isRoot: isRoot)
         case let model as SWBProtocol.ProductReference: return try ProductReference(model, pifLoader)
             // NOTE: This comes last because it is both a concrete and base type.
-        case let model as SWBProtocol.FileReference: return try FileReference(model, pifLoader)
+        case let model as SWBProtocol.FileReference: return try FileReference(model, pifLoader, isRoot: isRoot)
         default:
             fatalError("unexpected model: \(model)")
         }
@@ -79,14 +79,23 @@ public class Reference: ProjectModelItem, Hashable, Equatable
 
 
 /// A GroupTreeReference is a reference which exists as part of a project's group tree.  ProductReference objects are not part of the group tree.
-public class GroupTreeReference: Reference
+public class GroupTreeReference: Reference, @unchecked Sendable
 {
     /// The parent of this reference in the group tree.  The root group's parent pointer will always be nil, but all other references should have backpointers once the PIF is fully loaded.
     ///
     /// The parent relationships are currently only used by the FilePath resolver.
     //
     // FIXME: <rdar://problem/27956865> Evaluate whether it is worth eliminating GroupTreeReference's parent property
-    public internal(set) unowned var parent: GroupTreeReference?
+    fileprivate final class Parent: Sendable {
+        init(value: GroupTreeReference?) {
+            self.value = value
+        }
+        unowned let value: GroupTreeReference?
+    }
+    fileprivate let _parent: UnsafeDelayedInitializationSendableWrapper<Parent>
+    public var parent: GroupTreeReference? {
+        _parent.value.value
+    }
 
     /// The source tree for the reference.
     public let sourceTree: SourceTree
@@ -94,16 +103,20 @@ public class GroupTreeReference: Reference
     /// The path for the reference, relative to its source tree.  If its path is absolute, then the source tree is not needed to resolve its absolute path.
     public let path: MacroStringExpression
 
-    init(_ model: SWBProtocol.GroupTreeReference, _ pifLoader: PIFLoader) throws {
+    init(_ model: SWBProtocol.GroupTreeReference, _ pifLoader: PIFLoader, isRoot: Bool) throws {
         #if canImport(Darwin)
         assert(type(of: model) !== SWBProtocol.GroupTreeReference.self, "unexpected concrete reference")
         #endif
         self.sourceTree = model.sourceTree
         self.path = pifLoader.userNamespace.parseString(model.path)
+        self._parent = .init()
+        if isRoot {
+            self._parent.initialize(to: .init(value: nil))
+        }
         try super.init(model, pifLoader)
     }
 
-    override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader) throws {
+    init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader, isRoot: Bool) throws {
         // Initialize stored properties.
         // Not all subclasses of GroupTreeReference define a source tree or path in their PIF representation, so we define default values for those which don't.
         switch try Self.parseOptionalValueForKeyAsStringEnum(PIFKey_Reference_sourceTree, pifDict: pifDict) as PIFReferenceSourceTreeValue? {
@@ -118,28 +131,32 @@ public class GroupTreeReference: Reference
         let pathString: String? = try Self.parseOptionalValueForKeyAsString(PIFKey_path, pifDict: pifDict)
         path = pifLoader.userNamespace.parseString(pathString ?? "")
 
+        self._parent = .init()
+        if isRoot {
+            self._parent.initialize(to: .init(value: nil))
+        }
         try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader)
     }
 
     /// Parses a ProjectModelItemPIF dictionary as an object of the appropriate subclass of GroupTreeReference.
-    public class func parsePIFDictAsReference(_ pifDict: ProjectModelItemPIF, pifLoader: PIFLoader) throws -> GroupTreeReference {
+    public class func parsePIFDictAsReference(_ pifDict: ProjectModelItemPIF, pifLoader: PIFLoader, isRoot: Bool) throws -> GroupTreeReference {
         // Delegate to protocol-based representation, if in use.
         if let data = try parseOptionalValueForKeyAsByteString("data", pifDict: pifDict) {
             let deserializer = MsgPackDeserializer(data)
             let model: SWBProtocol.Reference = try deserializer.deserialize()
-            return try Reference.create(model, pifLoader) as! GroupTreeReference
+            return try Reference.create(model, pifLoader, isRoot: isRoot) as! GroupTreeReference
         }
 
         // Get the type of the reference.  This is required, so if there isn't one then it will die.
         switch try parseValueForKeyAsStringEnum(PIFKey_type, pifDict: pifDict) as PIFReferenceTypeValue {
         case .file:
-            return try FileReference(fromDictionary: pifDict, withPIFLoader: pifLoader)
+            return try FileReference(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
         case .group:
-            return try FileGroup(fromDictionary: pifDict, withPIFLoader: pifLoader)
+            return try FileGroup(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
         case .versionGroup:
-            return try VersionGroup(fromDictionary: pifDict, withPIFLoader: pifLoader)
+            return try VersionGroup(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
         case .variantGroup:
-            return try VariantGroup(fromDictionary: pifDict, withPIFLoader: pifLoader)
+            return try VariantGroup(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
         case .product:
             throw PIFParsingError.custom("Product references should not be included in a project's group tree")
         }
@@ -147,19 +164,13 @@ public class GroupTreeReference: Reference
 
     /// Parses the value for an optional key in a PIF dictionary as an Array of Reference objects.
     /// - returns: An Array value if the key is present, nil if it is absent.
-    public class func parseOptionalValueForKeyAsArrayOfReferences(_ key: String, pifDict: ProjectModelItemPIF, pifLoader: PIFLoader) throws -> [GroupTreeReference]? {
+    public class func parseOptionalValueForKeyAsArrayOfChildReferences(_ key: String, pifDict: ProjectModelItemPIF, pifLoader: PIFLoader) throws -> [GroupTreeReference]? {
         return try parseOptionalValueForKeyAsArrayOfPropertyListItems(key, pifDict: pifDict)?.map { (plItem) -> GroupTreeReference in
             guard case .plDict(let pifDict) = plItem else {
                 throw PIFParsingError.incorrectTypeInArray(keyName: key, objectType: self, expectedType: "Dictionary")
             }
-            return try parsePIFDictAsReference(pifDict, pifLoader: pifLoader)
+            return try parsePIFDictAsReference(pifDict, pifLoader: pifLoader, isRoot: false)
         }
-    }
-
-    /// Parses the value for a required key in a PIF dictionary as an Array of Reference objects.
-    class func parseValueForKeyAsArrayOfReferences(_ key: String, pifDict: ProjectModelItemPIF, pifLoader: PIFLoader) throws -> [GroupTreeReference]
-    {
-        return try require(key) { try parseOptionalValueForKeyAsArrayOfReferences(key, pifDict: pifDict, pifLoader: pifLoader) }
     }
 }
 
@@ -168,7 +179,7 @@ public class GroupTreeReference: Reference
 
 
 /// A FileReference is the most common kind of Reference, representing a single concrete file on disk.
-public class FileReference: GroupTreeReference, BuildFileRepresentable
+public final class FileReference: GroupTreeReference, BuildFileRepresentable, @unchecked Sendable
 {
     public let fileTypeIdentifier: String
     public let regionVariantName: String?
@@ -176,15 +187,15 @@ public class FileReference: GroupTreeReference, BuildFileRepresentable
     public let fileTextEncoding: FileTextEncoding?
     public let expectedSignature: String?
 
-    init(_ model: SWBProtocol.FileReference, _ pifLoader: PIFLoader) throws {
+    init(_ model: SWBProtocol.FileReference, _ pifLoader: PIFLoader, isRoot: Bool) throws {
         self.fileTypeIdentifier = model.fileTypeIdentifier
         self.regionVariantName = model.regionVariantName
         self.fileTextEncoding = model.fileTextEncoding
         self.expectedSignature = model.expectedSignature
-        try super.init(model, pifLoader)
+        try super.init(model, pifLoader, isRoot: isRoot)
     }
 
-    @_spi(Testing) public override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader) throws {
+    @_spi(Testing) public override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader, isRoot: Bool) throws {
         // Initialize stored properties.
         fileTypeIdentifier = try Self.parseValueForKeyAsString(PIFKey_Reference_fileType, pifDict: pifDict)
         regionVariantName = try Self.parseOptionalValueForKeyAsString(PIFKey_Reference_regionVariantName, pifDict: pifDict)
@@ -195,7 +206,7 @@ public class FileReference: GroupTreeReference, BuildFileRepresentable
         }
         expectedSignature = try Self.parseOptionalValueForKeyAsString(PIFKey_Reference_expectedSignature, pifDict: pifDict)
 
-        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader)
+        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
     }
 
     override public var description: String
@@ -209,27 +220,27 @@ public class FileReference: GroupTreeReference, BuildFileRepresentable
 
 
 /// A VersionGroup is a file reference which contains multiple versions of itself as children.  It is possible (but unlikely, and possibly no longer actively promoted) that individual children may be represented by build files.
-public final class VersionGroup: GroupTreeReference, BuildFileRepresentable
+public final class VersionGroup: GroupTreeReference, BuildFileRepresentable, @unchecked Sendable
 {
     /// The children of this version group, if any.
     public let children: [GroupTreeReference]
 
-    init(_ model: SWBProtocol.VersionGroup, _ pifLoader: PIFLoader) throws {
-        self.children = try model.children.map { try Reference.create($0, pifLoader) as! GroupTreeReference }
-        try super.init(model, pifLoader)
+    init(_ model: SWBProtocol.VersionGroup, _ pifLoader: PIFLoader, isRoot: Bool) throws {
+        self.children = try model.children.map { try Reference.create($0, pifLoader, isRoot: false) as! GroupTreeReference }
+        try super.init(model, pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 
-    override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader) throws {
+    override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader, isRoot: Bool) throws {
         // Initialize stored properties.
-        children = try Self.parseOptionalValueForKeyAsArrayOfReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
+        children = try Self.parseOptionalValueForKeyAsArrayOfChildReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
 
-        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader)
+        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 }
 
@@ -238,29 +249,29 @@ public final class VersionGroup: GroupTreeReference, BuildFileRepresentable
 
 
 /// A FileGroup is an abstract grouper of references and groups.  It is commonly used either for conceptual grouping for the benefit of users working with a project (and in this case has no meaningful impact on the build), or to represent a directory on disk which its children are relative to.  In the future it might be able to contribute other meaningful content to the build by, for example, describing build settings which apply to all of its children.
-public final class FileGroup: GroupTreeReference
+public final class FileGroup: GroupTreeReference, @unchecked Sendable
 {
     public let name: String
     public let children: [GroupTreeReference]
 
-    init(_ model: SWBProtocol.FileGroup, _ pifLoader: PIFLoader) throws {
+    init(_ model: SWBProtocol.FileGroup, _ pifLoader: PIFLoader, isRoot: Bool) throws {
         self.name = model.name
-        self.children = try model.children.map { try Reference.create($0, pifLoader) as! GroupTreeReference }
-        try super.init(model, pifLoader)
+        self.children = try model.children.map { try Reference.create($0, pifLoader, isRoot: false) as! GroupTreeReference }
+        try super.init(model, pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 
-    @_spi(Testing) public override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader) throws {
+    @_spi(Testing) public override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader, isRoot: Bool) throws {
         // Initialize stored properties.
         name = try Self.parseValueForKeyAsString(PIFKey_name, pifDict: pifDict)
-        children = try Self.parseOptionalValueForKeyAsArrayOfReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
+        children = try Self.parseOptionalValueForKeyAsArrayOfChildReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
 
-        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader)
+        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 
     override public var description: String
@@ -274,32 +285,32 @@ public final class FileGroup: GroupTreeReference
 
 
 /// A VariantGroup represents multiple files which conceptually are different 'variants' (e.g., localized variants) of a single file.  This includes more complex groupings, such as a .xib file and its associated localized .strings files.
-public final class VariantGroup: GroupTreeReference, BuildFileRepresentable
+public final class VariantGroup: GroupTreeReference, BuildFileRepresentable, @unchecked Sendable
 {
     /// The name of this variant group - primarily for debugging purposes.
     public let name: String
     /// The children of this variant group, if any.
     public let children: [GroupTreeReference]
 
-    init(_ model: SWBProtocol.VariantGroup, _ pifLoader: PIFLoader) throws {
+    init(_ model: SWBProtocol.VariantGroup, _ pifLoader: PIFLoader, isRoot: Bool) throws {
         self.name = model.name
-        self.children = try model.children.map { try Reference.create($0, pifLoader) as! GroupTreeReference }
-        try super.init(model, pifLoader)
+        self.children = try model.children.map { try Reference.create($0, pifLoader, isRoot: false) as! GroupTreeReference }
+        try super.init(model, pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 
-    override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader) throws {
+    override init(fromDictionary pifDict: ProjectModelItemPIF, withPIFLoader pifLoader: PIFLoader, isRoot: Bool) throws {
         // Initialize stored properties.
         name = try Self.parseValueForKeyAsString(PIFKey_name, pifDict: pifDict)
         // FIXME: Is children really optional for variant groups?
-        children = try Self.parseOptionalValueForKeyAsArrayOfReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
+        children = try Self.parseOptionalValueForKeyAsArrayOfChildReferences(PIFKey_Reference_children, pifDict: pifDict, pifLoader: pifLoader) ?? []
 
-        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader)
+        try super.init(fromDictionary: pifDict, withPIFLoader: pifLoader, isRoot: isRoot)
 
         // Set parent backpointer on children.
-        for child in children { child.parent = self }
+        for child in children { child._parent.initialize(to: .init(value: self)) }
     }
 
     override public var description: String

--- a/Tests/SWBCorePerfTests/FilePathResolverPerfTests.swift
+++ b/Tests/SWBCorePerfTests/FilePathResolverPerfTests.swift
@@ -51,7 +51,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
     @Test
     func projectRelativeSourceTree_X100000() async throws {
         let model = try TestGroup("SomeProject", path: "", sourceTree: .buildSetting("PROJECT_DIR")).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
 
         await measure {
             // We do each iteration many times in order to samples that are more likely to be statistically significant.
@@ -70,7 +70,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
     @Test
     func projectRelativeSourceTree_Cached_X100000() async throws {
         let model = try TestGroup("SomeProject", sourceTree: .buildSetting("PROJECT_DIR")).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
 
         await measure {
             // We do each iteration many times in order to samples that are more likely to be statistically significant.
@@ -86,7 +86,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
     @Test
     func absoluteSourceTree_X100000() async throws {
         let model = try TestGroup("SomeProject", path: "/tmp/AbsolutePath", sourceTree: .absolute).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
 
         await measure {
             // We do each iteration many times in order to samples that are more likely to be statistically significant.
@@ -106,7 +106,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
     func groupRelativeSourceTree_1Level_X100000() async throws {
         let model = try TestGroup("SomeProject", path: "/tmp/SomeProject", sourceTree: .absolute,
                                   children: [TestGroup("AllFiles")]).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
         let childGroup = try #require(rootGroup.children[0] as? FileGroup)
 
         await measure {
@@ -128,7 +128,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
         let model = try TestGroup("SomeProject", path: "/tmp/SomeProject", sourceTree: .absolute,
                                   children: [TestGroup("AllFiles",
                                                        children: [TestGroup("SomeFiles")])]).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
         let childGroup = try #require(rootGroup.children[0] as? FileGroup)
         let grandchildGroup = try #require(childGroup.children[0] as? FileGroup)
 
@@ -151,7 +151,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
         let model = try TestGroup("SomeProject", path: "/tmp/SomeProject", sourceTree: .absolute,
                                   children: [TestGroup("AllFiles",
                                                        children: [TestGroup("SomeFiles")])]).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
         let childGroup = try #require(rootGroup.children[0] as? FileGroup)
         let grandchildGroup = try #require(childGroup.children[0] as? FileGroup)
 

--- a/Tests/SWBCoreTests/FilePathResolverTests.swift
+++ b/Tests/SWBCoreTests/FilePathResolverTests.swift
@@ -66,7 +66,7 @@ import SWBMacro
     @Test
     func absolutePath() throws {
         let model = try TestFile(Path.root.join("tmp/SomeProject/SomeProject/ClassOne.m").str, sourceTree: .absolute).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         let resolvedPath = resolver.resolveAbsolutePath(fileRef)
@@ -86,7 +86,7 @@ import SWBMacro
                                                          children: [TestFile("Base.lproj/View.xib"), TestFile("fr.lproj/View.strings", regionVariantName: "fr")])
                                     ])
                                   ]).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
 
         // Test the individual references.
         // We do all this twice in order to exercise the cache mechanism.
@@ -125,7 +125,7 @@ import SWBMacro
     @Test
     func relativeSourceTree() throws {
         let model = try TestFile("ClassTwo.m", sourceTree: .buildSetting("RELATIVE_SOURCE_TREE")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         let resolvedPath = resolver.resolveAbsolutePath(fileRef)
@@ -135,7 +135,7 @@ import SWBMacro
     @Test
     func emptySourceTree() throws {
         let model = try TestFile("ClassThree.m", sourceTree: .buildSetting("EMPTY_SOURCE_TREE")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         // An empty source tree is
@@ -146,7 +146,7 @@ import SWBMacro
     @Test
     func undefinedSourceTree() throws {
         let model = try TestFile("ClassFour.m", sourceTree: .buildSetting("UNDEFINED_SOURCE_TREE")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         let resolvedPath = resolver.resolveAbsolutePath(fileRef)
@@ -156,7 +156,7 @@ import SWBMacro
     @Test
     func nullSourceTree() throws {
         let model = try TestFile("ClassThree.m", sourceTree: .buildSetting("")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         // An empty source tree is
@@ -167,7 +167,7 @@ import SWBMacro
     @Test
     func buildSettingEmbeddedInPath() throws {
         let model = try TestFile("Sources/Arch_$(CURRENT_ARCH)/ClassFive.m", sourceTree: .buildSetting("PROJECT_DIR")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         let resolvedPath = resolver.resolveAbsolutePath(fileRef)
@@ -177,7 +177,7 @@ import SWBMacro
     @Test
     func dotDotEmbeddedInFileReferencePath() throws {
         let model = try TestFile("Sources/SubDir/../ClassSix.m", sourceTree: .buildSetting("PROJECT_DIR")).toProtocol()
-        let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+        let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
         let resolvedPath = resolver.resolveAbsolutePath(fileRef)
@@ -193,7 +193,7 @@ import SWBMacro
                 ]),
             ])
         ]).toProtocol()
-        let rootGroup = try #require(Reference.create(model, pifLoader) as? FileGroup)
+        let rootGroup = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileGroup)
 
         // Get the absolute path for the reference and test it.
         let childGroup = try #require(rootGroup.children[0] as? FileGroup)
@@ -224,7 +224,7 @@ import SWBMacro
 
         for (inputFile, expectedPathString) in testData {
             let model = try inputFile.toProtocol()
-            let fileRef = try #require(Reference.create(model, pifLoader) as? FileReference)
+            let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
             // Get the absolute path for the reference and test it.
             let resolvedPath = resolver.resolveAbsolutePath(fileRef)

--- a/Tests/SWBCoreTests/PIFLoadingTests.swift
+++ b/Tests/SWBCoreTests/PIFLoadingTests.swift
@@ -420,7 +420,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
         }
 
         // Test the required version.
-        let _ = try FileGroup.parseValueForKeyAsProjectModelItem("fileGroupKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader) })
+        let _ = try FileGroup.parseValueForKeyAsProjectModelItem("fileGroupKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader, isRoot: false) })
 
         // Test failure cases.
         #expect(performing: {
@@ -450,10 +450,10 @@ private final class ProjectModelItemClass: ProjectModelItem {
         }
 
         // Test the optional version.
-        let presentValue: FileGroup? = try FileGroup.parseOptionalValueForKeyAsProjectModelItem("fileGroupKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader) })
+        let presentValue: FileGroup? = try FileGroup.parseOptionalValueForKeyAsProjectModelItem("fileGroupKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader, isRoot: false) })
         #expect(presentValue != nil)
 
-        let absentValue: FileGroup? = try FileGroup.parseOptionalValueForKeyAsProjectModelItem("missingKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader) })
+        let absentValue: FileGroup? = try FileGroup.parseOptionalValueForKeyAsProjectModelItem("missingKey", pifDict: pifDict, pifLoader: pifLoader, construct: { try FileGroup(fromDictionary: $0, withPIFLoader: pifLoader, isRoot: false) })
         #expect(absentValue == nil)
 
         // Test failure cases.
@@ -630,7 +630,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             Issue.record("property list is not a dictionary")
             return
         }
-        let fileRef = try #require(GroupTreeReference.parsePIFDictAsReference(fileRefPIF, pifLoader: pifLoader) as? FileReference)
+        let fileRef = try #require(GroupTreeReference.parsePIFDictAsReference(fileRefPIF, pifLoader: pifLoader, isRoot: true) as? FileReference)
 
         // Examine the file reference.
         #expect(fileRef.guid == "some-fileReference-guid")
@@ -673,7 +673,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             Issue.record("property list is not a dictionary")
             return
         }
-        let fileGroup = try #require(GroupTreeReference.parsePIFDictAsReference(fileGroupPIF, pifLoader: pifLoader) as? FileGroup)
+        let fileGroup = try #require(GroupTreeReference.parsePIFDictAsReference(fileGroupPIF, pifLoader: pifLoader, isRoot: true) as? FileGroup)
 
         // Examine the file group.
         #expect(fileGroup.guid == "some-fileGroup-guid")
@@ -736,7 +736,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             Issue.record("property list is not a dictionary")
             return
         }
-        let versionGroup = try #require(try GroupTreeReference.parsePIFDictAsReference(versionGroupPIF, pifLoader: pifLoader) as? VersionGroup)
+        let versionGroup = try #require(try GroupTreeReference.parsePIFDictAsReference(versionGroupPIF, pifLoader: pifLoader, isRoot: true) as? VersionGroup)
 
         // Examine the file group.
         #expect(versionGroup.guid == "some-versionGroup-guid")
@@ -779,7 +779,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
         // Convert the test data into a property list, then read the file group from it.
         let versionGroupPlist = PropertyListItem(testVersionGroupData)
         let versionGroupPIF = try #require(versionGroupPlist.dictValue, "property list is not a dictionary")
-        let versionGroup = try #require(GroupTreeReference.parsePIFDictAsReference(versionGroupPIF, pifLoader: pifLoader) as? VersionGroup)
+        let versionGroup = try #require(GroupTreeReference.parsePIFDictAsReference(versionGroupPIF, pifLoader: pifLoader, isRoot: true) as? VersionGroup)
 
         // Examine the file group.
         #expect(versionGroup.guid == "some-versionGroup-guid")
@@ -824,7 +824,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
         ]
 
         // Convert the test data into a property list, then read the variant group from it.
-        let variantGroup = try #require(GroupTreeReference.parsePIFDictAsReference( variantGroupPIF, pifLoader: pifLoader ) as? VariantGroup)
+        let variantGroup = try #require(GroupTreeReference.parsePIFDictAsReference( variantGroupPIF, pifLoader: pifLoader, isRoot: true) as? VariantGroup)
 
         // Examine the variant group.
         #expect(variantGroup.guid == "some-variantGroup-guid")
@@ -873,7 +873,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
         ]
 
         // Convert the test data into a property list, then read the xcconfig file reference from it.
-        let xcconfigFileRef = try FileReference(fromDictionary: xcconfigFileRefPIF, withPIFLoader: pifLoader)
+        let xcconfigFileRef = try FileReference(fromDictionary: xcconfigFileRefPIF, withPIFLoader: pifLoader, isRoot: true)
 
         // Now we can perform our build configuration test.
         let buildConfigurationPIF: [String: PropertyListItem] = [
@@ -1177,7 +1177,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             ]
 
             // Convert the test data into a property list, then read the file reference from it.
-            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader)
+            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader, isRoot: true)
         }()
         let classTwoFileRef: FileReference = try {
             let fileRefPIF: [String: PropertyListItem] = [
@@ -1189,7 +1189,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             ]
 
             // Convert the test data into a property list, then read the file reference from it.
-            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader)
+            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader, isRoot: true)
         }()
         let cocoaFwkFileRef: FileReference = try {
             let fileRefPIF: [String: PropertyListItem] = [
@@ -1201,7 +1201,7 @@ private final class ProjectModelItemClass: ProjectModelItem {
             ]
 
             // Convert the test data into a property list, then read the file reference from it.
-            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader)
+            return try FileReference(fromDictionary: fileRefPIF, withPIFLoader: pifLoader, isRoot: true)
         }()
 
         // Load a framework target.


### PR DESCRIPTION
The last main missing piece not addressed here is the `target` backreference on `ProductReference`