### PR TITLE
Eliminate print() debugging statements

### DIFF
--- a/Sources/SWBCore/Specs/PropertyDomainSpec.swift
+++ b/Sources/SWBCore/Specs/PropertyDomainSpec.swift
@@ -1283,11 +1283,6 @@ private let buildOptionTypes: [String: any BuildOptionType] = [
     /// Get the command line arguments to use for this option in the given context.
     func getArgumentsForCommand(_ producer: any CommandProducer, scope: MacroEvaluationScope, inputFileType: FileTypeSpec?, optionContext: (any BuildOptionGenerationContext)?, lookup: ((MacroDeclaration) -> MacroExpression?)?) -> [CommandLineArgument] {
         // Filter by supported architecture.
-
-        if self.name == "ASSETCATALOG_COMPILER_INPUTS" {
-            print()
-        }
-
         guard supportsArchitecture(scope.evaluate(BuiltinMacros.CURRENT_ARCH)) else {
             return []
         }

--- a/Sources/SWBTestSupport/PerfTestSupport.swift
+++ b/Sources/SWBTestSupport/PerfTestSupport.swift
@@ -48,3 +48,12 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 }
+
+// Used to make printing for debugging purposes easier.
+private let shouldPrint = getEnvironmentVariable("SWB_PERF_TESTS_ENABLE_DEBUG_PRINT")?.boolValue ?? false
+
+public func perfPrint(_ message: String) {
+    if shouldPrint {
+        print(message)
+    }
+}

--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -731,9 +731,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
 
                 // The tool itself should compile and link.
                 results.checkTaskExists(.matchTargetName("Tool"), .matchRuleType("SwiftDriver Compilation"))
-                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) {
-                    print(Array($0.commandLineAsStrings))
-                }
+                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { _ in }
 
                 try results.checkTask(.matchTargetName("Framework"), .matchRuleType(ProductPlan.preparedForIndexPreCompilationRuleName)) { task in
                     try results.checkTaskFollows(task, .matchTargetName("Tool"), .matchRuleType("Ld"))
@@ -816,9 +814,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
 
                 // The tool itself should compile and link.
                 results.checkTaskExists(.matchTargetName("Tool"), .matchRuleType("SwiftDriver Compilation"))
-                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) {
-                    print(Array($0.commandLineAsStrings))
-                }
+                results.checkTask(.matchTargetName("Tool"), .matchRuleType("Ld")) { _ in }
 
                 try results.checkTask(.matchTargetName("Framework"), .matchRuleType(ProductPlan.preparedForIndexPreCompilationRuleName)) { task in
                     try results.checkTaskFollows(task, .matchTargetName("Tool"), .matchRuleType("Ld"))

--- a/Tests/SWBCorePerfTests/MacroExpressionParsingPerfTests.swift
+++ b/Tests/SWBCorePerfTests/MacroExpressionParsingPerfTests.swift
@@ -145,7 +145,6 @@ fileprivate struct MacroExpressionParsingPerfTests: CoreBasedTests, PerfTests {
                 }
 
                 func handleDiagnostic(_ diagnostic: MacroExpressionDiagnostic, parser: MacroExpressionParser) {
-                    print(diagnostic)
                 }
             }
             for str in stringsToParseCopy {

--- a/Tests/SWBCorePerfTests/SerializationPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SerializationPerfTests.swift
@@ -42,8 +42,6 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
 
     func _testSerializingTargetScopePerf_XXX(numberOfTargets: Int) async throws {
         try await withTemporaryDirectory { tmpDirPath in
-            // Used to make printing for debugging purposes easier.
-            let shouldPrint = false
             let didEmitSerializedSize = SWBMutex(false)
 
             let scope = try await createTestScope(tmpDirPath: tmpDirPath)
@@ -60,8 +58,7 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
 
                 if !didEmitSerializedSize.withLock({ $0 }) {
                     let mb = accumulatedBytes / (1000.0 * 1000.0)
-                    if shouldPrint { print("Serialized \(mb) megabytes for \(numberOfTargets) targets") }
-                    _ = mb
+                    perfPrint("Serialized \(mb) megabytes for \(numberOfTargets) targets")
                     didEmitSerializedSize.withLock { $0 = true }
                 }
             }
@@ -91,8 +88,7 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
             let sz = self.serializeMacroEvaluationScope(scope)
 
             let mb = Float64(sz.byteString.bytes.count) / (1000.0 * 1000.0)
-            //print("Will deserialize \(mb) megabytes")
-            _ = mb
+            perfPrint("Will deserialize \(mb) megabytes")
 
             let delegate = MacroEvaluationScopeDeserializerDelegate(namespace: scope.namespace)
 
@@ -117,8 +113,7 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
             let sz = self.serializeMacroEvaluationScope(scope)
 
             let mb = Float64(sz.byteString.bytes.count) / (1000.0 * 1000.0)
-            //print("Will deserialize \(mb) megabytes")
-            _ = mb
+            perfPrint("Will deserialize \(mb) megabytes")
 
             let delegate = MacroEvaluationScopeDeserializerDelegate(namespace: scope.namespace)
 

--- a/Tests/SWBTaskConstructionTests/EagerLinkingTests.swift
+++ b/Tests/SWBTaskConstructionTests/EagerLinkingTests.swift
@@ -165,7 +165,6 @@ fileprivate struct EagerLinkingTests: CoreBasedTests {
     func objCLinkerInputsReadyDependsOnLipo() async throws {
         let tester = try await TaskConstructionTester(getCore(), objcTestProject)
         try await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac, overrides: ["ARCHS": "arm64 x86_64"])) { results in
-            print(results)
             let linkBTask = try #require(results.getTask(.matchTargetName("B"), .matchRuleItem("Ld"), .matchRuleItem("x86_64")))
             let linkBTask2 = try #require(results.getTask(.matchTargetName("B"), .matchRuleItem("Ld"), .matchRuleItem("x86_64")))
             let lipoBTask = try #require(results.getTask(.matchTargetName("B"), .matchRuleType("CreateUniversalBinary")))

--- a/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
@@ -146,10 +146,6 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             let arch = results.runDestinationTargetArchitecture
             results.checkNoDiagnostics()
 
-            for task in results.uncheckedTasks {
-                print(task.ruleInfo)
-            }
-
             results.checkTarget(targetName) { target in
                 results.checkTasks(.matchRuleType("VerifyModuleC")) {tasks in
                     #expect(tasks.count == 6)
@@ -367,10 +363,6 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             await tester.checkBuild() { results in
                 results.checkNoDiagnostics()
 
-                for task in results.uncheckedTasks {
-                    print(task.ruleInfo)
-                }
-
                 results.checkTarget(targetName) { target in
                     results.checkTask(.matchRuleType("VerifyModuleC")) { task in
                         task.checkCommandLineContains([
@@ -468,10 +460,6 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             // A regular build will just build the currect architecture.
             await tester.checkBuild() { results in
                 results.checkNoDiagnostics()
-
-                for task in results.uncheckedTasks {
-                    print(task.ruleInfo)
-                }
 
                 results.checkTarget(targetName) { target in
                     results.checkTasks(.matchRuleType("VerifyModuleC")) { tasks in
@@ -590,10 +578,6 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             await tester.checkBuild() { results in
                 results.checkNoDiagnostics()
 
-                for task in results.uncheckedTasks {
-                    print(task.ruleInfo)
-                }
-
                 results.checkTarget(targetName) { target in
                     results.checkTask(.matchRuleType("VerifyModuleC")) { task in
                         let targetVariant = task.ruleInfo[2]
@@ -658,10 +642,6 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         await tester.checkBuild() { results in
             let arch = results.runDestinationTargetArchitecture
             results.checkNoDiagnostics()
-
-            for task in results.uncheckedTasks {
-                print(task.ruleInfo)
-            }
 
             results.checkTarget(targetName) { target in
                 results.checkTasks(.matchRuleType("VerifyModuleC")) {tasks in

--- a/Tests/SWBUtilPerfTests/MsgPackSerializationPerfTests.swift
+++ b/Tests/SWBUtilPerfTests/MsgPackSerializationPerfTests.swift
@@ -306,7 +306,7 @@ fileprivate struct MsgPackSerializationPerfTests: PerfTests {
                 if !didEmitSerializedSize
                 {
                     let mb = Float64(sz.byteString.bytes.count) / (1000.0 * 1000.0)
-                    print("Serialized \(mb) megabytes")
+                    perfPrint("Serialized \(mb) megabytes")
                     didEmitSerializedSize = true
                 }
             }
@@ -322,7 +322,7 @@ fileprivate struct MsgPackSerializationPerfTests: PerfTests {
         let sz = serializeCustomElementHierarchy(log)
 
         let mb = Float64(sz.byteString.bytes.count) / (1000.0 * 1000.0)
-        print("Will deserialize \(mb) megabytes")
+        perfPrint("Will deserialize \(mb) megabytes")
 
         try await measure {
             for _ in 1...iterations {


### PR DESCRIPTION
Library and test code should not be printing to the console.