### PR TITLE
Unify cache locations and pruning strategies

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
@@ -299,17 +299,17 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
                     (macro == BuiltinMacros.ASSETCATALOG_COMPILER_INPUTS) ? cbc.scope.table.namespace.parseLiteralStringList(assetSymbolInputs.map { $0.path.str }) : lookup(macro)
                 }
 
-                let cachingEnabled = cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING)
                 let action: (any PlannedTaskAction)?
                 if let deferredAction = delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences) {
                     action = deferredAction
-                } else if cachingEnabled {
+                } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
                     action = delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                         enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                         enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),
                         sandboxDirectory: cbc.scope.evaluate(BuiltinMacros.TEMP_SANDBOX_DIR),
                         extraSandboxSubdirectories: [],
-                        developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR)
+                        developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR),
+                        casOptions: casOptions
                     )
                 } else {
                     action = nil
@@ -359,17 +359,17 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
             var ruleInfo = defaultRuleInfo(cbc, delegate, lookup: lookup)
             ruleInfo[0..<1] = ["CompileAssetCatalogVariant", variant.rawValue]
 
-            let cachingEnabled = cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING)
             let action: (any PlannedTaskAction)?
             if let deferredAction = delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences) {
                 action = deferredAction
-            } else if cachingEnabled {
+            } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
                 action = delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                     enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                     enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),
                     sandboxDirectory: cbc.scope.evaluate(BuiltinMacros.TEMP_SANDBOX_DIR),
                     extraSandboxSubdirectories: [Path("outputs/0/\(overrideDir.basename)")],
-                    developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR)
+                    developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR),
+                    casOptions: casOptions
                 )
             } else {
                 action = nil

--- a/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
@@ -158,13 +158,14 @@ public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentif
     }
 
     override public func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {
-        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING) {
+        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
             return delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                 enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                 enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),
                 sandboxDirectory: cbc.scope.evaluate(BuiltinMacros.TEMP_SANDBOX_DIR),
                 extraSandboxSubdirectories: [],
-                developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR))
+                developerDirectory: cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR),
+                casOptions: casOptions)
         } else {
             return nil
         }

--- a/Sources/SWBCAS/Errors.swift
+++ b/Sources/SWBCAS/Errors.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum ToolchainCASPluginError: Error, Sendable {
+public enum ToolchainCASPluginError: Error, Sendable, CustomStringConvertible {
     case missingRequiredSymbol(String)
     case settingCASOptionFailed(String?)
     case casCreationFailed(String?)
@@ -18,4 +18,35 @@ public enum ToolchainCASPluginError: Error, Sendable {
     case loadFailed(String?)
     case cacheInsertionFailed(String?)
     case cacheLookupFailed(String?)
+    case casSizeOperationUnsupported
+    case casSizeOperationFailed(String?)
+    case casPruneOperationUnsupported
+    case casPruneOperationFailed(String?)
+
+    public var description: String {
+        switch self {
+        case .missingRequiredSymbol(let symbol):
+            "missing required symbol: \(symbol)"
+        case .settingCASOptionFailed(let detail):
+            "setting CAS option failed: \(detail ?? "unknown error")"
+        case .casCreationFailed(let detail):
+            "creating CAS failed: \(detail ?? "unknown error")"
+        case .storeFailed(let detail):
+            "CAS store failed: \(detail ?? "unknown error")"
+        case .loadFailed(let detail):
+            "CAS load failed: \(detail ?? "unknown error")"
+        case .cacheInsertionFailed(let detail):
+            "cache insert failed: \(detail ?? "unknown error")"
+        case .cacheLookupFailed(let detail):
+            "cache lookup failed: \(detail ?? "unknown error")"
+        case .casSizeOperationUnsupported:
+            "CAS does not support size lookup"
+        case .casSizeOperationFailed(let detail):
+            "CAS size operation failed: \(detail ?? "unknown error")"
+        case .casPruneOperationUnsupported:
+            "CAS does not support pruning"
+        case .casPruneOperationFailed(let detail):
+            "CAS prune operation failed: \(detail ?? "unknown error")"
+        }
+    }
 }

--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -316,7 +316,7 @@ public protocol TaskActionCreationDelegate
     func createDeferredExecutionTaskAction() -> any PlannedTaskAction
     func createEmbedSwiftStdLibTaskAction() -> any PlannedTaskAction
     func createFileCopyTaskAction(_ context: FileCopyTaskActionContext) -> any PlannedTaskAction
-    func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path) -> any PlannedTaskAction
+    func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction
     func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction
     func createMergeInfoPlistTaskAction() -> any PlannedTaskAction
     func createLinkAssetCatalogTaskAction() -> any PlannedTaskAction

--- a/Sources/SWBCore/Settings/CASOptions.swift
+++ b/Sources/SWBCore/Settings/CASOptions.swift
@@ -12,8 +12,23 @@
 
 import protocol Foundation.LocalizedError
 public import SWBUtil
+public import SWBMacro
 
 public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
+
+    enum Errors: Error, CustomStringConvertible {
+        case invalidSizeLimit(sizeLimitString: String, origin: String)
+        case invalidPercentLimit(percentLimitString: String)
+
+        var description: String {
+            switch self {
+            case .invalidSizeLimit(sizeLimitString: let sizeLimitString, origin: let origin):
+                return "invalid \(origin): '\(sizeLimitString)'"
+            case .invalidPercentLimit(percentLimitString: let percentLimitString):
+                return "invalid COMPILATION_CACHE_LIMIT_PERCENT: '\(percentLimitString)'"
+            }
+        }
+    }
 
     public enum SizeLimitingStrategy: Hashable, Serializable, Encodable, Sendable {
         /// Cache directory is removed after the build is finished.
@@ -155,69 +170,68 @@ public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
         self.limitingStrategy = try deserializer.deserialize()
     }
 
-    public static func createFromBuildContext(
-        _ cbc: CommandBuildContext,
-        _ language: GCCCompatibleLanguageDialect,
-        _ delegate: any TaskGenerationDelegate
-    ) -> CASOptions {
+    public static func create(
+        _ scope: MacroEvaluationScope,
+        _ language: GCCCompatibleLanguageDialect?
+    ) throws -> CASOptions {
         func isLanguageSupportedForRemoteCaching() -> Bool {
-            let supportedLangs = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SUPPORTED_LANGUAGES)
+            let supportedLangs = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SUPPORTED_LANGUAGES)
             // If no specific list of languages is provided then all languages are supported.
             guard !supportedLangs.isEmpty else { return true }
+            // If we're  not compiling a specific language, assume support.
+            guard let language else { return true }
             return supportedLangs.contains(language.dialectNameForCompilerCommandLineArgument)
         }
 
         let casPath: Path
         let pluginPath: Path?
         let remoteServicePath: Path?
-        let enableIntegratedCacheQueries = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES)
-        let enableDiagnosticRemarks = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS)
-        let enableStrictCASErrors = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_STRICT_CAS_ERRORS)
-        let enableDetachedKeyQueries = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES)
-        if cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_PLUGIN) {
-            casPath = Path(cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH)).join("plugin")
-            pluginPath = Path(cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_PLUGIN_PATH))
-            let remoteServicePathSetting = Path(cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SERVICE_PATH))
+        let enableIntegratedCacheQueries = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES)
+        let enableDiagnosticRemarks = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS)
+        let enableStrictCASErrors = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_STRICT_CAS_ERRORS)
+        let enableDetachedKeyQueries = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_DETACHED_KEY_QUERIES)
+        if scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_PLUGIN) {
+            casPath = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH)).join("plugin")
+            pluginPath = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_PLUGIN_PATH))
+            let remoteServicePathSetting = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SERVICE_PATH))
             if !remoteServicePathSetting.isEmpty && isLanguageSupportedForRemoteCaching() {
                 remoteServicePath = remoteServicePathSetting
             } else {
                 remoteServicePath = nil
             }
         } else {
-            casPath = Path(cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH)).join("builtin")
+            casPath = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH)).join("builtin")
             pluginPath = nil
             remoteServicePath = nil
         }
 
-        let limitingStrategy: CASOptions.SizeLimitingStrategy = {
-            guard cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_KEEP_CAS_DIRECTORY) else {
+        let limitingStrategy: CASOptions.SizeLimitingStrategy = try {
+            guard scope.evaluate(BuiltinMacros.COMPILATION_CACHE_KEEP_CAS_DIRECTORY) else {
                 return .discarded
             }
 
-            func parseSizeLimit(_ sizeLimitStr: String, origin: String) -> CASOptions.SizeLimitingStrategy {
+            func parseSizeLimit(_ sizeLimitStr: String, origin: String) throws -> CASOptions.SizeLimitingStrategy {
                 guard let sizeLimit = CASOptions.parseSizeLimit(sizeLimitStr) else {
-                    delegate.error("invalid \(origin): '\(sizeLimitStr)'")
-                    return .default
+                    throw Errors.invalidSizeLimit(sizeLimitString: sizeLimitStr, origin: origin)
                 }
                 return .maxSizeBytes(sizeLimit > 0 ? sizeLimit : nil)
             }
 
-            let sizeLimitStr = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_LIMIT_SIZE)
+            let sizeLimitStr = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_LIMIT_SIZE)
             if !sizeLimitStr.isEmpty {
-                return parseSizeLimit(sizeLimitStr, origin: "COMPILATION_CACHE_LIMIT_SIZE")
+                return try parseSizeLimit(sizeLimitStr, origin: "COMPILATION_CACHE_LIMIT_SIZE")
             }
 
-            let percentLimitStr = cbc.scope.evaluate(BuiltinMacros.COMPILATION_CACHE_LIMIT_PERCENT)
+            let percentLimitStr = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_LIMIT_PERCENT)
             if !percentLimitStr.isEmpty {
                 guard let percent = Int(percentLimitStr) else {
-                    delegate.error("invalid COMPILATION_CACHE_LIMIT_PERCENT: '\(percentLimitStr)'")
-                    return .default
+                    throw Errors.invalidPercentLimit(percentLimitString: percentLimitStr)
                 }
                 return .maxPercentageOfAvailableSpace(percent)
             }
 
             if let sizeLimitDefault = UserDefaults.compilationCachingDiskSizeLimit {
-                return parseSizeLimit(sizeLimitDefault, origin: "CompilationCachingDiskSizeLimit default")
+                return try parseSizeLimit(sizeLimitDefault, origin: "CompilationCachingDiskSizeLimit default")
             }
 
             return .default

--- a/Sources/SWBCore/Specs/Tools/CCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/CCompiler.swift
@@ -954,14 +954,19 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
                 let casOptions: CASOptions? = {
                     guard cachedBuild else { return nil }
-                    var casOpts = CASOptions.createFromBuildContext(cbc, language, delegate)
-                    if casOpts.enableIntegratedCacheQueries, let clangInfo {
-                        if !clangInfo.toolFeatures.has(.libclangCacheQueries) {
-                            delegate.warning("COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES ignored because it's not supported by the toolchain")
-                            casOpts.enableIntegratedCacheQueries = false
+                    do {
+                        var casOpts = try CASOptions.create(cbc.scope, language)
+                        if casOpts.enableIntegratedCacheQueries, let clangInfo {
+                            if !clangInfo.toolFeatures.has(.libclangCacheQueries) {
+                                delegate.warning("COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES ignored because it's not supported by the toolchain")
+                                casOpts.enableIntegratedCacheQueries = false
+                            }
                         }
+                        return casOpts
+                    } catch {
+                        delegate.error(error.localizedDescription)
+                        return nil
                     }
-                    return casOpts
                 }()
                 let explicitModulesPayload = ClangExplicitModulesPayload(
                     uniqueID: String(commandLine.hashValue),

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -777,8 +777,8 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return FileCopyTaskAction(context)
     }
 
-    func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path) -> any PlannedTaskAction {
-        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory)
+    func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction {
+        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory, casOptions: casOptions)
     }
 
     func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction {

--- a/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
@@ -234,7 +234,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
                 )
 
                 let casKey = ClangCachingPruneDataTaskKey(
-                    libclangPath: explicitModulesPayload.libclangPath,
+                    path: explicitModulesPayload.libclangPath,
                     casOptions: casOptions
                 )
                 dynamicExecutionDelegate.operationContext.compilationCachingDataPruner.pruneCAS(

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -156,8 +156,8 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return FileCopyTaskAction(context)
     }
 
-    package func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path) -> any PlannedTaskAction {
-        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory)
+    package func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction {
+        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory, casOptions: casOptions)
     }
 
     package func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction {

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -382,8 +382,8 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return FileCopyTaskAction(context)
     }
 
-    package func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path) -> any PlannedTaskAction {
-        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory)
+    package func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction {
+        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory, casOptions: casOptions)
     }
 
     package func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction {

--- a/Tests/SWBBuildSystemTests/GenericTaskCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/GenericTaskCachingTests.swift
@@ -266,4 +266,72 @@ fileprivate struct GenericTaskCachingTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
+    func repeatedReplay() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestProject(
+                "aProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("Assets.xcassets"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "macosx",
+                            "CODE_SIGNING_ALLOWED": "NO",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "VERSIONING_SYSTEM": "apple-generic",
+                            "DSTROOT": tmpDir.join("dstroot").str,
+                            "ENABLE_GENERIC_TASK_CACHING": "YES",
+                            "GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS": "YES",
+                            "COMPILATION_CACHE_LIMIT_SIZE": "1"
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "FrameworkTarget",
+                        type: .framework,
+                        buildPhases: [
+                            TestResourcesBuildPhase([
+                                TestBuildFile("Assets.xcassets"),
+                            ]),
+                        ]
+                    ),
+                ])
+
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot
+            try await localFS.writeAssetCatalog(SRCROOT.join("Assets.xcassets"))
+
+            // Repeated replay of the task in incremental builds should successfully place outputs
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: ["CCHROOT": tmpDir.join("cchroot").str]), runDestination: .macOS) { results in
+                results.checkTaskExists(.matchRuleType("CompileAssetCatalogVariant"))
+                results.checkRemark(.prefix("caching result"))
+                results.checkNoErrors()
+            }
+
+            try tester.fs.touch(SRCROOT.join("Assets.xcassets"))
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: ["CCHROOT": tmpDir.join("cchroot").str]), runDestination: .macOS) { results in
+                results.checkTaskExists(.matchRuleType("CompileAssetCatalogVariant"))
+                results.checkRemark(.prefix("replaying cache hit"))
+                results.checkNoErrors()
+            }
+
+            try tester.fs.touch(SRCROOT.join("Assets.xcassets"))
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: ["CCHROOT": tmpDir.join("cchroot").str]), runDestination: .macOS) { results in
+                results.checkTaskExists(.matchRuleType("CompileAssetCatalogVariant"))
+                results.checkRemark(.prefix("replaying cache hit"))
+                results.checkNoErrors()
+            }
+        }
+    }
 }

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -150,8 +150,8 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return FileCopyTaskAction(context)
     }
 
-    public func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path) -> any PlannedTaskAction {
-        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory)
+    public func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction {
+        return GenericCachingTaskAction(enableCacheDebuggingRemarks: enableCacheDebuggingRemarks, enableTaskSandboxEnforcement: enableTaskSandboxEnforcement, sandboxDirectory: sandboxDirectory, extraSandboxSubdirectories: extraSandboxSubdirectories, developerDirectory: developerDirectory, casOptions: casOptions)
     }
 
     public func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction {


### PR DESCRIPTION
- Use the same cache path for all tools in the build.This is safe because it's versioned internally
- Wire up the cache pruning mechanism to generic task caching to ensure consistent behavior
- Improve test coverage of replay in incremental builds

