### PR TITLE
Remove -index-store-path for clang vendor is not Apple

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -612,7 +612,15 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         var commandLine = Array<String>()
 
         // Add the arguments from the specification.
-        commandLine += self.commandLineFromOptions(producer, scope: scope, inputFileType: inputFileType, optionContext: optionContext).map(\.asString)
+        commandLine += self.commandLineFromOptions(producer, scope: scope, inputFileType: inputFileType, optionContext: optionContext,lookup: { declaration in
+            if declaration.name == "CLANG_INDEX_STORE_ENABLE" && optionContext is DiscoveredClangToolSpecInfo {
+                let clangToolInfo = optionContext as! DiscoveredClangToolSpecInfo
+                if !clangToolInfo.isAppleClang {
+                    return BuiltinMacros.namespace.parseString("NO")
+                }
+            }
+            return nil
+        }).map(\.asString)
 
         // Add the common header search paths.
         let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(producer, scope, usesModules: scope.evaluate(BuiltinMacros.CLANG_ENABLE_MODULES))
@@ -652,19 +660,6 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         // Add search paths for sparse SDKs.
         let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
         commandLine += sparseSDKSearchPaths.searchPathArguments(for: self, scope: scope)
-
-        if let clangInfo = optionContext as? DiscoveredClangToolSpecInfo, !clangInfo.isAppleClang {
-            var filteredCommandLine: [String] = []
-            var iterator = commandLine.makeIterator()
-            while let arg = iterator.next() {
-                if arg == "-index-store-path" {
-                    _ = iterator.next()
-                } else {
-                    filteredCommandLine.append(arg)
-                }
-            }
-            commandLine = filteredCommandLine
-        }
 
         if scope.evaluate(BuiltinMacros.CLANG_USE_RESPONSE_FILE) && (optionContext?.toolPath.basenameWithoutSuffix == "clang" || optionContext?.toolPath.basenameWithoutSuffix == "clang++") {
             var responseFileCommandLine: [String] = []

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -653,6 +653,19 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
         commandLine += sparseSDKSearchPaths.searchPathArguments(for: self, scope: scope)
 
+        if let clangInfo = optionContext as? DiscoveredClangToolSpecInfo, !clangInfo.isAppleClang {
+            var filteredCommandLine: [String] = []
+            var iterator = commandLine.makeIterator()
+            while let arg = iterator.next() {
+                if arg == "-index-store-path" {
+                    _ = iterator.next()
+                } else {
+                    filteredCommandLine.append(arg)
+                }
+            }
+            commandLine = filteredCommandLine
+        }
+
         if scope.evaluate(BuiltinMacros.CLANG_USE_RESPONSE_FILE) && (optionContext?.toolPath.basenameWithoutSuffix == "clang" || optionContext?.toolPath.basenameWithoutSuffix == "clang++") {
             var responseFileCommandLine: [String] = []
             var regularCommandLine: [String] = []

--- a/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
+++ b/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
@@ -118,13 +118,16 @@ public func discoveredClangToolInfo(
                 // "8.1.0 (clang-802.1.38)"
                 // "12.0.0 (clang-1200.0.22.5) [ptrauth objc isa mode: sign-and-strip]"
                 if macroName == "__clang_version__" {
-                    isAppleClang = macroValue.contains("Apple")
                     if let match: RegEx.MatchResult = clangVersionRe.firstMatch(in: macroValue) {
                         llvmVersion = match["llvm"].map { try? Version($0) } ?? nil
                         clangVersion = match["clang"].map { try? Version($0) } ?? nil
                     } else if let match = try? swiftOSSToolchainClangVersionRe.firstMatch(in: macroValue) {
                         llvmVersion = try? Version(String(match.llvm))
                     }
+                }
+
+                if macroName == "__apple_build_version__" {
+                    isAppleClang = true
                 }
             }
         }


### PR DESCRIPTION
Closes #24

This update removes -index-store-path when the Clang vendor is not Apple.

Feedback on the implementation would be greatly appreciated! Please note that I haven't tested this on Linux or within a Docker environment.


cc: @jakepetroules 