### PR TITLE
Make task actions extensible via plugins

### DIFF
--- a/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
+++ b/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+
+public struct BuiltinTaskActionsExtension: TaskActionExtension {
+    public init() {
+    }
+
+    public var taskActionImplementations: [SerializableTypeCode : any PolymorphicSerializable.Type] {
+        [
+            1: AuxiliaryFileTaskAction.self,
+            2: CopyPlistTaskAction.self,
+            3: CopyStringsFileTaskAction.self,
+            4: CopyTiffTaskAction.self,
+            5: FileCopyTaskAction.self,
+            6: InfoPlistProcessorTaskAction.self,
+            // 7: Removed
+            8: LSRegisterURLTaskAction.self,
+            9: EmbedSwiftStdLibTaskAction.self,
+            10: ProcessProductEntitlementsTaskAction.self,
+            11: ProcessProductProvisioningProfileTaskAction.self,
+            15: ValidateProductTaskAction.self,
+            16: CreateBuildDirectoryTaskAction.self,
+            17: ODRAssetPackManifestTaskAction.self,
+            18: SwiftHeaderToolTaskAction.self,
+            19: RegisterExecutionPolicyExceptionTaskAction.self,
+            20: ClangCompileTaskAction.self,
+            21: ProcessXCFrameworkTaskAction.self,
+            22: SwiftCompilationTaskAction.self,
+            23: SwiftDriverTaskAction.self,
+            24: SwiftDriverCompilationRequirementTaskAction.self,
+            26: ClangScanTaskAction.self,
+            28: ValidateDevelopmentAssetsTaskAction.self,
+            // 29: AppIntentsMetadataTaskAction.self, //removed
+            30: DeferredExecutionTaskAction.self,
+            31: LinkAssetCatalogTaskAction.self,
+            32: SignatureCollectionTaskAction.self,
+            33: CodeSignTaskAction.self,
+            34: MergeInfoPlistTaskAction.self,
+            35: ClangModuleVerifierInputGeneratorTaskAction.self,
+            36: ConstructStubExecutorInputFileListTaskAction.self,
+            37: ConcatenateTaskAction.self,
+            38: GenericCachingTaskAction.self,
+            39: ProcessSDKImportsTaskAction.self
+        ]
+    }
+}

--- a/Sources/SWBTaskExecution/TaskActionExtensionPoint.swift
+++ b/Sources/SWBTaskExecution/TaskActionExtensionPoint.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+
+public struct TaskActionExtensionPoint: ExtensionPoint {
+    public typealias ExtensionProtocol = TaskActionExtension
+
+    public static let name = "TaskActionExtensionPoint"
+
+    package init() {}
+
+    // MARK: - actual extension point
+
+    package static func taskActionImplementations(pluginManager: PluginManager) throws -> [SerializableTypeCode: any PolymorphicSerializable.Type] {
+        return try pluginManager.extensions(of: Self.self).reduce([:], { implementations, ext in
+            for (code, _) in ext.taskActionImplementations where implementations[code] != nil {
+                throw StubError.error("Multiple implementations for task action implementation type code: \(code)")
+            }
+            return implementations.addingContents(of: ext.taskActionImplementations)
+        })
+    }
+}
+
+public protocol TaskActionExtension: Sendable {
+    /// Provides a dictionary of additional task action implementations.
+    var taskActionImplementations: [SerializableTypeCode: any PolymorphicSerializable.Type] { get }
+}

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -131,42 +131,15 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
         self.serializedRepresentationSignature = try deserializer.deserialize()
     }
 
-    public static let implementations: [SerializableTypeCode: any PolymorphicSerializable.Type] = [
-        1: AuxiliaryFileTaskAction.self,
-        2: CopyPlistTaskAction.self,
-        3: CopyStringsFileTaskAction.self,
-        4: CopyTiffTaskAction.self,
-        5: FileCopyTaskAction.self,
-        6: InfoPlistProcessorTaskAction.self,
-        // 7: Removed
-        8: LSRegisterURLTaskAction.self,
-        9: EmbedSwiftStdLibTaskAction.self,
-        10: ProcessProductEntitlementsTaskAction.self,
-        11: ProcessProductProvisioningProfileTaskAction.self,
-        15: ValidateProductTaskAction.self,
-        16: CreateBuildDirectoryTaskAction.self,
-        17: ODRAssetPackManifestTaskAction.self,
-        18: SwiftHeaderToolTaskAction.self,
-        19: RegisterExecutionPolicyExceptionTaskAction.self,
-        20: ClangCompileTaskAction.self,
-        21: ProcessXCFrameworkTaskAction.self,
-        22: SwiftCompilationTaskAction.self,
-        23: SwiftDriverTaskAction.self,
-        24: SwiftDriverCompilationRequirementTaskAction.self,
-        26: ClangScanTaskAction.self,
-        28: ValidateDevelopmentAssetsTaskAction.self,
-        // 29: AppIntentsMetadataTaskAction.self, //removed
-        30: DeferredExecutionTaskAction.self,
-        31: LinkAssetCatalogTaskAction.self,
-        32: SignatureCollectionTaskAction.self,
-        33: CodeSignTaskAction.self,
-        34: MergeInfoPlistTaskAction.self,
-        35: ClangModuleVerifierInputGeneratorTaskAction.self,
-        36: ConstructStubExecutorInputFileListTaskAction.self,
-        37: ConcatenateTaskAction.self,
-        38: GenericCachingTaskAction.self,
-        39: ProcessSDKImportsTaskAction.self
-    ]
+    @TaskLocal internal static var taskActionImplementations: [SerializableTypeCode: any PolymorphicSerializable.Type] = [:]
+
+    public static var implementations: [SerializableTypeCode: any PolymorphicSerializable.Type] {
+        let implementations = TaskAction.taskActionImplementations
+        if implementations.isEmpty {
+            fatalError("Task action implementations task local is not set (did you forget to wrap the call stack in TaskActionRegistry.withSerializationContext?)")
+        }
+        return implementations
+    }
 }
 
 public enum DynamicTaskRequestReason: CustomStringConvertible {

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -14,6 +14,7 @@ private import Foundation
 @_spi(Testing) package import SWBCore
 package import SWBUtil
 import SWBTaskConstruction
+import SWBTaskExecution
 
 #if USE_STATIC_PLUGIN_INITIALIZATION
 private import SWBAndroidPlatform
@@ -79,8 +80,11 @@ extension Core {
             pluginManager.registerExtensionPoint(DiagnosticToolingExtensionPoint())
             pluginManager.registerExtensionPoint(SDKVariantInfoExtensionPoint())
             pluginManager.registerExtensionPoint(FeatureAvailabilityExtensionPoint())
+            pluginManager.registerExtensionPoint(TaskActionExtensionPoint())
 
             pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
+
+            pluginManager.register(BuiltinTaskActionsExtension(), type: TaskActionExtensionPoint.self)
 
             for path in pluginPaths {
                 pluginManager.load(at: path)


### PR DESCRIPTION
This is the first step towards decoupling task action implementations from being hardcoded in the task execution framework. It doesn't move any implementations yet, just adds the hooks to unblock doing so.