### PR TITLE
Previews thunk builds overwrite Swift stringsdata file (rdar://143817567)

### DIFF
--- a/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
@@ -3237,6 +3237,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // Avoids emitting the `.d`` file
             "-emit-dependencies",
 
+            // Avoids overwriting localized strings for the transformed source file.
+            "-emit-localized-strings",
+
             // Previews doesn't need a `.swiftmodule` for the thunk
             "-emit-module",
 
@@ -3325,6 +3328,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             "-emit-module-interface-path",
             "-emit-private-module-interface-path",
             "-emit-package-module-interface-path",
+            "-emit-localized-strings-path",
             "-pch-output-dir",
         ] {
             removeWithParameter(arg)

--- a/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
+++ b/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
@@ -50,6 +50,8 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                                 "SDK_STAT_CACHE_ENABLE": "NO",
+                                // Test that we strip the flag
+                                "SWIFT_EMIT_LOC_STRINGS": "YES",
                                 "SWIFT_VALIDATE_CLANG_MODULES_ONCE_PER_BUILD_SESSION": "NO",
                             ].merging(overrides, uniquingKeysWith: { _, new in new }))
                     ],
@@ -177,6 +179,8 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                         "-emit-dependencies",
                         "-emit-module",
                         "-emit-objc-header",
+                        "-emit-localized-strings",
+                        "-emit-localized-strings-path",
                         "-explicit-module-build",
                         "-output-file-map",
                         "-index-store-path",


### PR DESCRIPTION
We need to strip the flags used when `SWIFT_EMIT_LOC_STRINGS=YES`.