### PR TITLE
Strip #if directives from xcspecs and strings files (rdar://144731866)

### DIFF
--- a/Plugins/SWBSpecificationsPlugin/SWBSpecificationsPlugin.swift
+++ b/Plugins/SWBSpecificationsPlugin/SWBSpecificationsPlugin.swift
@@ -20,7 +20,7 @@ import Foundation
         let enumerator = FileManager.default.enumerator(at: target.directoryURL.repaired, includingPropertiesForKeys: nil)
         var inputs: [URL] = []
         while let url = enumerator?.nextObject() as? URL {
-            if ["xcspec", "xcbuildrules"].contains(url.pathExtension) {
+            if ["xcspec", "xcbuildrules", "strings"].contains(url.pathExtension) {
                 inputs.append(url)
             }
         }


### PR DESCRIPTION
Some build configurations can contain `#if` directives in xcspecs and strings files.

Such configurations are responsible for doing their own unifdefing if they want but we still need to strip those out of the final files so that they can be properly parsed as plists.