### PR TITLE
Track cache purpose to avoid collisions between incompatible plugins

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.swift
@@ -302,7 +302,7 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
                 let action: (any PlannedTaskAction)?
                 if let deferredAction = delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences) {
                     action = deferredAction
-                } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
+                } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, .generic) {
                     action = delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                         enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                         enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),
@@ -362,7 +362,7 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
             let action: (any PlannedTaskAction)?
             if let deferredAction = delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences) {
                 action = deferredAction
-            } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
+            } else if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, .generic) {
                 action = delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                     enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                     enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),

--- a/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/Specs/InterfaceBuilderCompiler.swift
@@ -158,7 +158,7 @@ public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentif
     }
 
     override public func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {
-        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
+        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, .generic) {
             return delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                 enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                 enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),

--- a/Sources/SWBApplePlatform/Specs/RealityAssetsCompilerSpec.swift
+++ b/Sources/SWBApplePlatform/Specs/RealityAssetsCompilerSpec.swift
@@ -177,7 +177,7 @@ package final class RealityAssetsCompilerSpec: GenericCompilerSpec, SpecIdentifi
 
         let action: (any PlannedTaskAction)?
         let cachingEnabled: Bool
-        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, nil) {
+        if cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING), let casOptions = try? CASOptions.create(cbc.scope, .generic) {
             action = delegate.taskActionCreationDelegate.createGenericCachingTaskAction(
                 enableCacheDebuggingRemarks: cbc.scope.evaluate(BuiltinMacros.GENERIC_TASK_CACHE_ENABLE_DIAGNOSTIC_REMARKS),
                 enableTaskSandboxEnforcement: !cbc.scope.evaluate(BuiltinMacros.DISABLE_TASK_SANDBOXING),

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1352,11 +1352,14 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
 
     private static func setupCAS(core: Core, operation: BuildOperation) throws -> ToolchainCAS? {
         let settings = operation.requestContext.getCachedSettings(operation.request.parameters)
-        let casOptions = try CASOptions.create(settings.globalScope, nil)
-        guard let casPlugin = core.lookupCASPlugin() else { return nil }
-        guard let cas = try? casPlugin.createCAS(path: casOptions.casPath, options: [:]) else { return nil }
-
-        return cas
+        let casOptions = try CASOptions.create(settings.globalScope, .generic)
+        let casPlugin: ToolchainCASPlugin?
+        if let pluginPath = casOptions.pluginPath {
+            casPlugin = try? ToolchainCASPlugin(dylib: pluginPath)
+        } else {
+            casPlugin = core.lookupCASPlugin()
+        }
+        return try casPlugin?.createCAS(path: casOptions.casPath, options: [:])
     }
 
     /// Reset the operation for a new build.

--- a/Sources/SWBCore/Specs/Tools/CCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/CCompiler.swift
@@ -955,7 +955,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
                 let casOptions: CASOptions? = {
                     guard cachedBuild else { return nil }
                     do {
-                        var casOpts = try CASOptions.create(cbc.scope, language)
+                        var casOpts = try CASOptions.create(cbc.scope, .compiler(language))
                         if casOpts.enableIntegratedCacheQueries, let clangInfo {
                             if !clangInfo.toolFeatures.has(.libclangCacheQueries) {
                                 delegate.warning("COMPILATION_CACHE_ENABLE_INTEGRATED_QUERIES ignored because it's not supported by the toolchain")

--- a/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/Specs/Tools/SwiftCompiler.swift
@@ -1798,7 +1798,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // Add caching related configurations.
             let casOptions: CASOptions?
             do {
-                casOptions = isCachingEnabled ? (try CASOptions.create(cbc.scope, .other(dialectName: "swift"))) : nil
+                casOptions = isCachingEnabled ? (try CASOptions.create(cbc.scope, .compiler(.other(dialectName: "swift")))) : nil
                 if let casOpts = casOptions {
                     args.append("-cache-compile-job")
                     args += ["-cas-path", casOpts.casPath.str]


### PR DESCRIPTION
Avoid CAS plugin errors when different versions are used by different categories of tools.