### PR TITLE
Cache setup errors should be non-fatal

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1359,7 +1359,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
         } else {
             casPlugin = core.lookupCASPlugin()
         }
-        return try casPlugin?.createCAS(path: casOptions.casPath, options: [:])
+        return try? casPlugin?.createCAS(path: casOptions.casPath, options: [:])
     }
 
     /// Reset the operation for a new build.


### PR DESCRIPTION
We currently rely on this error being recoverable in various contexts, especially in build operations tests. I accidentally upgraded it to a user facing build error in a previous PR