### PR TITLE
fix: a typo in `_OBSOLETE_MANUAL_BUILD_ORDER` everywhere

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -862,7 +862,7 @@ public final class BuiltinMacros {
     public static let OBJCC = BuiltinMacros.declarePathMacro("OBJCC")
     public static let OBJCPLUSPLUS = BuiltinMacros.declarePathMacro("OBJCPLUSPLUS")
     public static let OBJECT_FILE_DIR = BuiltinMacros.declarePathMacro("OBJECT_FILE_DIR")
-    public static let _OBSELETE_MANUAL_BUILD_ORDER = BuiltinMacros.declareBooleanMacro("_OBSELETE_MANUAL_BUILD_ORDER")
+    public static let _OBSOLETE_MANUAL_BUILD_ORDER = BuiltinMacros.declareBooleanMacro("_OBSELETE_MANUAL_BUILD_ORDER")
     public static let ONLY_ACTIVE_ARCH = BuiltinMacros.declareBooleanMacro("ONLY_ACTIVE_ARCH")
     public static let OPENCLC = BuiltinMacros.declareStringMacro("OPENCLC")
     public static let OPENCL_ARCHS = BuiltinMacros.declareStringListMacro("OPENCL_ARCHS")
@@ -1938,7 +1938,7 @@ public final class BuiltinMacros {
         OBJC_ABI_VERSION,
         OBJECT_FILE_DIR,
         OBJROOT,
-        _OBSELETE_MANUAL_BUILD_ORDER,
+        _OBSOLETE_MANUAL_BUILD_ORDER,
         ONLY_ACTIVE_ARCH,
         OPENCLC,
         OPENCL_ARCHS,

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -862,7 +862,7 @@ public final class BuiltinMacros {
     public static let OBJCC = BuiltinMacros.declarePathMacro("OBJCC")
     public static let OBJCPLUSPLUS = BuiltinMacros.declarePathMacro("OBJCPLUSPLUS")
     public static let OBJECT_FILE_DIR = BuiltinMacros.declarePathMacro("OBJECT_FILE_DIR")
-    public static let _OBSOLETE_MANUAL_BUILD_ORDER = BuiltinMacros.declareBooleanMacro("_OBSELETE_MANUAL_BUILD_ORDER")
+    public static let _OBSOLETE_MANUAL_BUILD_ORDER = BuiltinMacros.declareBooleanMacro("_OBSOLETE_MANUAL_BUILD_ORDER")
     public static let ONLY_ACTIVE_ARCH = BuiltinMacros.declareBooleanMacro("ONLY_ACTIVE_ARCH")
     public static let OPENCLC = BuiltinMacros.declareStringMacro("OPENCLC")
     public static let OPENCL_ARCHS = BuiltinMacros.declareStringListMacro("OPENCL_ARCHS")

--- a/Sources/SWBCore/TargetDependencyResolver.swift
+++ b/Sources/SWBCore/TargetDependencyResolver.swift
@@ -172,7 +172,7 @@ public struct TargetBuildGraph: TargetGraph, Sendable {
         } else {
             let behavior: Diagnostic.Behavior
             let suffix: String
-            let isError = allTargets.contains(where: { buildRequestContext.getCachedSettings($0.parameters, target: $0.target).globalScope.evaluate(BuiltinMacros._OBSELETE_MANUAL_BUILD_ORDER) })
+            let isError = allTargets.contains(where: { buildRequestContext.getCachedSettings($0.parameters, target: $0.target).globalScope.evaluate(BuiltinMacros._OBSOLETE_MANUAL_BUILD_ORDER) })
             if isError {
                 behavior = .error
                 suffix = "prohibited"


### PR DESCRIPTION
I’ve resolved the issue throughout the codebase. However, since it involves a public property, it might be wise to introduce an alias using `@available` to enable automatic renaming.

Let me know your thoughts.

Also, please remember to run the @swift-ci  test.