### PR TITLE
Enable more windows test and fix some failing ones

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -584,7 +584,7 @@ package final class BuildOperation: BuildSystemOperation {
                 if let buildOnlyTheseOutputs = buildOutputMap?.keys {
                     // Build selected outputs, the build fails if one operation failed.
                     result = await _Concurrency.Task.detachNewThread(name: "llb_buildsystem_build_node") {
-                        !buildOnlyTheseOutputs.map({ system.build(node: $0) }).contains(false)
+                        !buildOnlyTheseOutputs.map({ return system.build(node: Path($0).strWithPosixSlashes) }).contains(false)
                     }
                 } else if let buildOnlyTheseNodes = nodesToBuild {
                     // Build selected nodes, the build fails if one operation failed.

--- a/Sources/SWBWindowsPlatform/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Windows.xcspec
@@ -61,7 +61,6 @@
         BasedOn = default:com.apple.product-type.library.dynamic;
         HasInfoPlist = NO;
         DefaultBuildProperties = {
-            EXECUTABLE_EXTENSION = "$(DYNAMIC_LIBRARY_EXTENSION:default=dll)";
             PUBLIC_HEADERS_FOLDER_PATH = "";
             PRIVATE_HEADERS_FOLDER_PATH = "";
         };

--- a/Sources/SWBWindowsPlatform/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Windows.xcspec
@@ -49,6 +49,21 @@
         BasedOn = default:com.apple.product-type.library.static;
         DefaultBuildProperties = {
             EXECUTABLE_EXTENSION = "lib";
+            PUBLIC_HEADERS_FOLDER_PATH = "";
+            PRIVATE_HEADERS_FOLDER_PATH = "";
+        };
+    },
+
+    {
+        Domain = windows;
+        Type = ProductType;
+        Identifier = com.apple.product-type.library.dynamic;
+        BasedOn = default:com.apple.product-type.library.dynamic;
+        HasInfoPlist = NO;
+        DefaultBuildProperties = {
+            EXECUTABLE_EXTENSION = "$(DYNAMIC_LIBRARY_EXTENSION:default=dll)";
+            PUBLIC_HEADERS_FOLDER_PATH = "";
+            PRIVATE_HEADERS_FOLDER_PATH = "";
         };
     },
 

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -76,7 +76,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 results.checkTaskExists(.matchRule(["SwiftCompile", "normal", results.runDestinationTargetArchitecture, "Compiling \(swiftFile.basename)", swiftFile.str]))
                 results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
                 if core.hostOperatingSystem.imageFormat.requiresSwiftModulewrap  {
-                    let toolWrap = try #require(results.getTask(.matchTargetName("tool"), .matchRuleType("SwiftModuleWrap")))
+                    let toolWrap = try #require(results.getTask(.matchTargetName("aLibrary"), .matchRuleType("SwiftModuleWrap")))
                     try results.checkTask(.matchTargetName("tool"), .matchRuleType("Ld")) { task in
                         try results.checkTaskFollows(task, toolWrap)
                     }

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -105,7 +105,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             }
 
             if runDestination == .macOS {
-                // Check build ing just the Metal file.
+                // Check building just the Metal file.
                 try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [metalOutputPath: metalFile.str]) { results in
                     results.consumeTasksMatchingRuleTypes(excludedTypes)
                     results.checkTask(.matchRule(["CompileMetalFile", metalFile.str])) { _ in }

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -74,7 +74,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
 
             // Construct the output paths.
             let excludedTypes: Set<String> = ["Copy", "Gate", "MkDir", "SymLink", "WriteAuxiliaryFile", "CreateBuildDirectory", "SwiftDriver", "SwiftDriver Compilation Requirements", "SwiftDriver Compilation", "SwiftMergeGeneratedHeaders", "ClangStatCache", "SwiftExplicitDependencyCompileModuleFromInterface", "SwiftExplicitDependencyGeneratePcm", "ProcessSDKImports"]
-            let runDestination = RunDestinationInfo.macOS
+            let runDestination = RunDestinationInfo.host
             let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)
             let target = tester.workspace.allTargets.first(where: { _ in true })!
             let cOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [cFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
@@ -277,7 +277,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)
 
                 try await tester.checkBuild(parameters: parameters, runDestination: runDestination, buildCommand: .build(style: .buildOnly, skipDependencies: skipDependencies), persistent: true) { results in
-                    results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile", "GenerateTAPI", "ClangStatCache", "ProcessSDKImports"])
+                    results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile", "GenerateTAPI", "ClangStatCache", "ProcessSDKImports", "Libtool"])
 
                     results.consumeTasksMatchingRuleTypes(["CompileC", "Ld"], targetName: "aLibrary")
 

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -35,7 +35,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
             if  destination.imageFormat(core) == .elf {
                 environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
             } else {
-                environment = ProcessInfo.processInfo.environment.filter { $0.key.uppercased() == "PATH" }, // important to allow swift to be looked up in PATH on Windows/Linux
+                environment = ProcessInfo.processInfo.environment.filter { $0.key.uppercased() == "PATH" } // important to allow swift to be looked up in PATH on Windows/Linux
             }
 
             let testProject = TestProject(

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -20,6 +20,8 @@ import SWBTaskExecution
 import SWBUtil
 import SWBProtocol
 
+import class Foundation.ProcessInfo
+
 @Suite
 fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
 

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -35,7 +35,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
             if  destination.imageFormat(core) == .elf {
                 environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
             } else {
-                environment = [:]
+                environment = ProcessInfo.processInfo.environment.filter(keys: ["PATH"]), // important to allow swift to be looked up in PATH on Windows/Linux
             }
 
             let testProject = TestProject(

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 import SWBBuildSystem
 import SWBCore
+import SWBProtocol
 import SWBTestSupport
 import SWBTaskExecution
 import SWBUtil
@@ -86,7 +87,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
                 ])
             let tester = try await BuildOperationTester(core, testProject, simulated: false)
 
-            let parameters = BuildParameters(action: .build, configuration: "Debug")
+            let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .host)
 
             try await tester.fs.writeFileContents(tmpDir.join("Sources").join("tool.swift")) { stream in
                 stream <<<

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -35,7 +35,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
             if  destination.imageFormat(core) == .elf {
                 environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
             } else {
-                environment = ProcessInfo.processInfo.environment.filter(keys: ["PATH"]), // important to allow swift to be looked up in PATH on Windows/Linux
+                environment = ProcessInfo.processInfo.environment.filter { $0.key.uppercased() == "PATH" }, // important to allow swift to be looked up in PATH on Windows/Linux
             }
 
             let testProject = TestProject(

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -3939,6 +3939,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                 "SWIFT_EXEC": swiftCompilerPath.str,
                                 "SDKROOT": "$(HOST_PLATFORM)",
                                 "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                                 "CODE_SIGNING_ALLOWED": "NO",
                             ]),
                         ],
                         buildPhases: [
@@ -3984,6 +3985,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                 "SWIFT_EXEC": swiftCompilerPath.str,
                                 "SDKROOT": "$(HOST_PLATFORM)",
                                 "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                                "CODE_SIGNING_ALLOWED": "NO",
                             ]),
                         ],
                         buildPhases: [

--- a/Tests/SWBTaskExecutionTests/PBXCpTests.swift
+++ b/Tests/SWBTaskExecutionTests/PBXCpTests.swift
@@ -424,10 +424,10 @@ fileprivate struct PBXCpTests: CoreBasedTests {
                 #expect(result.output == (
                     "copying \(fwkName)/...\n"
                 ))
-   #if !os(Windows)
-                let dstPerm = try fs.getFilePermissions(dst.join(fwkName).join(fName))
-                #expect(dstPerm == 0o755) // files are created with u+rw, g+wr, o+rw (and +x if src is executable) permissions and umask will adjust
-    #endif
+                if try ProcessInfo.processInfo.hostOperatingSystem() != .windows {
+                    let dstPerm = try fs.getFilePermissions(dst.join(fwkName).join(fName))
+                    #expect(dstPerm == 0o755) // files are created with u+rw, g+wr, o+rw (and +x if src is executable) permissions and umask will adjust
+                }
             }
         }
     }

--- a/Tests/SWBTaskExecutionTests/PBXCpTests.swift
+++ b/Tests/SWBTaskExecutionTests/PBXCpTests.swift
@@ -424,8 +424,10 @@ fileprivate struct PBXCpTests: CoreBasedTests {
                 #expect(result.output == (
                     "copying \(fwkName)/...\n"
                 ))
+   #if !os(Windows)
                 let dstPerm = try fs.getFilePermissions(dst.join(fwkName).join(fName))
                 #expect(dstPerm == 0o755) // files are created with u+rw, g+wr, o+rw (and +x if src is executable) permissions and umask will adjust
+    #endif
             }
         }
     }
@@ -555,7 +557,7 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(try fs.read(dst) == "contents1")
             let modificationDate = try fs.getFileInfo(dst).modificationDate
 
-            try await Task.sleep(for: .milliseconds(100))
+            try await Task.sleep(for: .milliseconds(500))
             let result2 = await pbxcp(["builtin-copy", "-skip-copy-if-contents-equal", "-rename", "-v", src.str, dst.str], cwd: Path("/"))
             #expect(result2.success == true)
             #expect(result2.output == "note: skipping copy of '\(src.str)' because it has the same contents as '\(dst.str)'\n")
@@ -586,7 +588,7 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(try fs.read(dstFile) == "contents1")
             let modificationDate = try fs.getFileInfo(dstFile).modificationDate
 
-            try await Task.sleep(for: .milliseconds(100))
+            try await Task.sleep(for: .milliseconds(500))
             let result2 = await pbxcp(["builtin-copy", "-skip-copy-if-contents-equal", "-rename", "-v", src.str, dst.str], cwd: Path("/"))
             #expect(result2.success == true)
             #expect(result2.output == "note: skipping copy of '\(src.str)' because it has the same contents as '\(dst.str)'\n")

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -1137,7 +1137,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationBeforeStarting() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -1208,7 +1208,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationImmediatelyAfterStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1280,7 +1280,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test(.requireSDKs(.macOS))
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationAfterStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1362,7 +1362,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationAfterTaskStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1442,7 +1442,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func repeatedCancellation() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1591,7 +1591,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Test session destruction
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func sessionDestructionCancellation() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -49,15 +49,17 @@ fileprivate struct ServiceConsoleTests {
         // Test against command line arguments.
         let executionResult = try await Process.getOutput(url: try CLIConnection.swiftbuildToolURL, arguments: ["isAlive"], environment: CLIConnection.environment)
 
+        let output = String(decoding: executionResult.stdout, as: UTF8.self)
+        
         // Verify there were no errors.
-        #expect(String(decoding: executionResult.stdout, as: UTF8.self) == "is alive? yes" + String.newline)
+        #expect(output == "is alive? yes\(String.newline)")
 
         // Assert the tool exited successfully.
         #expect(executionResult.exitStatus == .exit(0))
     }
 
     /// Test that the build service shuts down if the host dies.
-    @Test(.skipHostOS(.windows)) // PTY not supported on Windows
+    @Test(.skipHostOS(.windows, "PTY not supported on Windows"))
     func serviceShutdown() async throws {
         try await withCLIConnection { cli in
             // Find the service pid.
@@ -95,7 +97,7 @@ fileprivate struct ServiceConsoleTests {
     }
 
     /// Tests that the serializedDiagnostics console command is able to print human-readable serialized diagnostics from a .dia file.
-    @Test(.skipHostOS(.windows)) // PTY not supported on Windows
+    @Test(.skipHostOS(.windows, "PTY not supported on Windows"))
     func dumpSerializedDiagnostics() async throws {
         // Generate and compile a C source file that will generate a compiler warning.
         try await withTemporaryDirectory { tmp in


### PR DESCRIPTION
Most changes are to the tests except one change in Sources/SWBBuildSystem/BuildOperation.swift where the path used needed to have posix paths separators also some update to the Windows.xcspec file

(rdar://142882894)