### PR TITLE
Fix some issues with extended attributes

### DIFF
--- a/Sources/SWBCore/WorkspaceContext.swift
+++ b/Sources/SWBCore/WorkspaceContext.swift
@@ -384,7 +384,12 @@ public final class WorkspaceContext: Sendable {
 
 extension FSProxy {
     private static var CreatedByBuildSystemAttribute: String {
+        #if os(Linux)
+        // On Linux, "the name [of an extended attribute] must be a null-terminated string prefixed by a namespace identifier and a dot character" and only the "user" namespace is available for unrestricted access.
+        "user.org.swift.swift-build.CreatedByBuildSystem"
+        #else
         "com.apple.xcode.CreatedByBuildSystem"
+        #endif
     }
 
     private static var CreatedByBuildSystemAttributeOnValue: String {

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -759,7 +759,10 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
     func listExtendedAttributes(_ path: Path) throws -> [String] {
         #if os(Windows)
-        // no xattrs on Windows
+        // Implement ADS on Windows? See also https://github.com/swiftlang/swift-foundation/issues/1166
+        return []
+        #elseif os(OpenBSD)
+        // OpenBSD no longer supports extended attributes
         return []
         #else
         #if canImport(Darwin)
@@ -797,7 +800,9 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
     func setExtendedAttribute(_ path: Path, key: String, value: ByteString) throws {
         #if os(Windows)
-        // no xattrs on Windows
+        // Implement ADS on Windows? See also https://github.com/swiftlang/swift-foundation/issues/1166
+        #elseif os(OpenBSD)
+        // OpenBSD no longer supports extended attributes
         #else
         try value.bytes.withUnsafeBufferPointer { buf throws -> Void in
             #if canImport(Darwin)
@@ -814,7 +819,11 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
     func getExtendedAttribute(_ path: Path, key: String) throws -> ByteString? {
         #if os(Windows)
-        return nil // no xattrs on Windows
+        // Implement ADS on Windows? See also https://github.com/swiftlang/swift-foundation/issues/1166
+        return nil
+        #elseif os(OpenBSD)
+        // OpenBSD no longer supports extended attributes
+        return nil
         #else
         var bufferSize = 4096
         repeat {

--- a/Tests/SWBUtilTests/FSProxyTests.swift
+++ b/Tests/SWBUtilTests/FSProxyTests.swift
@@ -544,64 +544,57 @@ import SWBTestSupport
         }
     }
 
-    @Test(.requireHostOS(.macOS))
+    @Test(.skipHostOS(.windows))
     func extendedAttributesSupport() throws {
         try withTemporaryDirectory { (tmpDir: Path) in
             let testDataPath = tmpDir.join("test-data.txt")
             try localFS.write(testDataPath, contents: ByteString("best-data"))
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.empty", value: [])
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.empty") == [])
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.empty", value: [])
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.empty") == [])
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.binary", value: [0x01, 0x02, 0x03])
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.binary") == [0x01, 0x02, 0x03])
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.binary", value: [0x01, 0x02, 0x03])
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.binary") == [0x01, 0x02, 0x03])
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.binary", value: [0x00, 0x01, 0x02, 0x03])
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.binary") == [0x00, 0x01, 0x02, 0x03])
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.binary", value: [0x00, 0x01, 0x02, 0x03])
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.binary") == [0x00, 0x01, 0x02, 0x03])
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.string", value: "true")
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "true")
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.string", value: "true")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") == "true")
 
-            // String.utf8CString *includes* the trailing null byte
-#if canImport(Darwin)
-            #expect(setxattr(testDataPath.str, "attr.string", "true", "true".utf8CString.count, 0, 0) == 0)
-#elseif !os(Windows)
-            #expect(setxattr(testDataPath.str, "attr.string", "true", "true".utf8CString.count, 0) == 0)
-#endif
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "true\0")
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") != "true")
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.string", value: "true\0")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") == "true\0")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") != "true")
 
-            // String.utf8CString *includes* the trailing null byte
-#if canImport(Darwin)
-            #expect(setxattr(testDataPath.str, "attr.string", "tr\0ue", "tr\0ue".utf8CString.count, 0, 0) == 0)
-#elseif !os(Windows)
-            #expect(setxattr(testDataPath.str, "attr.string", "tr\0ue", "tr\0ue".utf8CString.count, 0) == 0)
-#endif
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "tr\0ue\0")
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") != "tr\0ue")
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.string", value: "tr\0ue\0")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") == "tr\0ue\0")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") != "tr\0ue")
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.string", value: "tr\0ue")
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.string") == "tr\0ue")
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.string", value: "tr\0ue")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.string") == "tr\0ue")
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.binaryString", value: [0x00, 0x01, 0x02, 0x03])
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.binaryString") == "\u{0}\u{1}\u{2}\u{3}")
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.binaryString", value: [0x00, 0x01, 0x02, 0x03])
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.binaryString") == "\u{0}\u{1}\u{2}\u{3}")
 
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.binaryString", value: "\u{0}\u{1}\u{2}\u{3}")
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.binaryString") == [0x00, 0x01, 0x02, 0x03])
+            try localFS.setExtendedAttribute(testDataPath, key: "user.attr.binaryString", value: "\u{0}\u{1}\u{2}\u{3}")
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.binaryString") == [0x00, 0x01, 0x02, 0x03])
 
-            // Test that the growth of the default-sized 4kb buffer in getExtendedAttribute is covered and works
-            let largeData = ByteString([UInt8](repeating: 0xff, count: 8193))
-            try localFS.setExtendedAttribute(testDataPath, key: "attr.large", value: largeData)
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.large") == largeData)
+            if try ProcessInfo.processInfo.hostOperatingSystem() == .macOS {
+                // Test that the growth of the default-sized 4kb buffer in getExtendedAttribute is covered and works. This is macOS-specific behavior. For the record, on Linux, "ext2/3/4 and btrfs impose much smaller limits, requiring all the attributes (names and values) of one file to fit in one "filesystem block" (usually 4 KiB)".
+                let largeData = ByteString([UInt8](repeating: 0xff, count: 8193))
+                try localFS.setExtendedAttribute(testDataPath, key: "user.attr.large", value: largeData)
+                #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.large") == largeData)
 
-            // Attribute name is too long
-            #expect {
-                try localFS.getExtendedAttribute(testDataPath, key: String(repeating: "hello", count: 100))
-            } throws: { error in
-                error as? SWBUtil.POSIXError == POSIXError(ENAMETOOLONG, context: "getxattr", testDataPath.str, String(repeating: "hello", count: 100))
+                // Attribute name is too long
+                // On Linux, lgetxattr keeps returning ERANGE when the name is out of range, leading to infinite allocation attempt, not sure about the best way to handle this.
+                #expect {
+                    try localFS.getExtendedAttribute(testDataPath, key: String(repeating: "hello", count: 100))
+                } throws: { error in
+                    error as? SWBUtil.POSIXError == POSIXError(ENAMETOOLONG, context: "getxattr", testDataPath.str, String(repeating: "hello", count: 100))
+                }
             }
 
-            #expect(try localFS.getExtendedAttribute(testDataPath, key: "attr.missing") == nil)
+            #expect(try localFS.getExtendedAttribute(testDataPath, key: "user.attr.missing") == nil)
         }
     }
 


### PR DESCRIPTION
On Linux, the name of an extended attribute "must be a null-terminated string prefixed by a namespace identifier and a dot character", and only the "user" namespace is available for unrestricted use.

This changes our use of extended attributes to prefer a Linux-compatible name where possible, and updates the unit tests to account for this restriction and enables that test on Linux.

This also clarifies the support situation for extended attributes on Windows and OpenBSD. The logical equivalent to xattrs on Windows is perhaps ADS; add a comment to that effect and a reference to the Foundation issue tracking potentially adding the support at that level. Compile out xattrs support on OpenBSD as they don't exist there at all.