### PR TITLE
Add a LIBTOOL_USE_RESPONSE_FILE build setting

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -809,6 +809,7 @@ public final class BuiltinMacros {
     public static let LIBRARY_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("LIBRARY_SEARCH_PATHS")
     public static let LIBTOOL = BuiltinMacros.declarePathMacro("LIBTOOL")
     public static let LIBTOOL_DEPENDENCY_INFO_FILE = BuiltinMacros.declarePathMacro("LIBTOOL_DEPENDENCY_INFO_FILE")
+    public static let LIBTOOL_USE_RESPONSE_FILE = BuiltinMacros.declareBooleanMacro("LIBTOOL_USE_RESPONSE_FILE")
     public static let LINKER = BuiltinMacros.declareStringMacro("LINKER")
     public static let ALTERNATE_LINKER = BuiltinMacros.declareStringMacro("ALTERNATE_LINKER")
     public static let LINK_OBJC_RUNTIME = BuiltinMacros.declareBooleanMacro("LINK_OBJC_RUNTIME")
@@ -1863,6 +1864,7 @@ public final class BuiltinMacros {
         LIBRARY_SEARCH_PATHS,
         LIBTOOL,
         LIBTOOL_DEPENDENCY_INFO_FILE,
+        LIBTOOL_USE_RESPONSE_FILE,
         LINKER,
         LINK_OBJC_RUNTIME,
         LINK_WITH_STANDARD_LIBRARIES,

--- a/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
+++ b/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
@@ -56,11 +56,17 @@
                 Name = __INPUT_FILE_LIST_PATH__;
                 Type = Path;
                 // this is set up for us as a read-only property
+                Condition = "$(LIBTOOL_USE_RESPONSE_FILE)";
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";
                 CommandLineArgs = (
                     "@$(value)",
                 );
                 IsInputDependency = Yes;
+            },
+            {
+                Name = "LIBTOOL_USE_RESPONSE_FILE";
+                Type = Boolean;
+                DefaultValue = YES;
             },
         );
     },

--- a/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
@@ -61,6 +61,7 @@
             // Input file lists
             {   Name = __INPUT_FILE_LIST_PATH__;
                 Type = Path;
+                Condition = "$(LIBTOOL_USE_RESPONSE_FILE)";
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";      // this is set up for us as a read-only property
                 CommandLineFlag = "-filelist";
                 IsInputDependency = Yes;
@@ -104,6 +105,11 @@
                 DefaultValue = "$(OBJECT_FILE_DIR_$(CURRENT_VARIANT))/$(CURRENT_ARCH)/$(PRODUCT_NAME)_libtool_dependency_info.dat";
             },
 
+            {
+                Name = "LIBTOOL_USE_RESPONSE_FILE";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
         );
     }
 )

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1472,6 +1472,7 @@ import SWBMacro
         // Create the mock table.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         table.push(try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("LIBTOOL") as? PathMacroDeclaration), literal: "libtool")
+        table.push(BuiltinMacros.LIBTOOL_USE_RESPONSE_FILE, literal: true)
         table.push(BuiltinMacros.arch, literal: "x86_64")
         table.push(BuiltinMacros.variant, literal: "normal")
 


### PR DESCRIPTION
This will be used to control whether response files are used when invoking libtool, as some platforms' implementations (like FreeBSD) may not support response files.