### PR TITLE
Fallback toolchain: locate in /usr/local prefixes in addition to /usr

### DIFF
--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -440,10 +440,23 @@ public final class ToolchainRegistry: @unchecked Sendable {
             return
         }
 
-        if let swift = StackedSearchPath(environment: ProcessInfo.processInfo.cleanEnvironment, fs: fs).lookup(Path("swift")), fs.exists(swift) && swift.normalize().str.hasSuffix("/usr/bin/swift") {
-            let path = swift.dirname.dirname.dirname
-            let llvmDirectories = try fs.listdir(Path("/usr/lib")).filter { $0.hasPrefix("llvm-") }.sorted().reversed()
-            try register(Toolchain(Self.defaultToolchainIdentifier, "Default", Version(), [], path, [], llvmDirectories.map { "/usr/lib/\($0)/lib" } + ["/usr/lib64"], [:], [:], [:], executableSearchPaths: [path.join("usr").join("bin"), path.join("usr").join("local").join("bin"),  path.join("usr").join("libexec")], fs: fs))
+        if let swift = StackedSearchPath(environment: ProcessInfo.processInfo.cleanEnvironment, fs: fs).lookup(Path("swift")), fs.exists(swift) {
+            let hasUsrBin = swift.normalize().str.hasSuffix("/usr/bin/swift")
+            let hasUsrLocalBin = swift.normalize().str.hasSuffix("/usr/local/bin/swift")
+            let path: Path
+            switch (hasUsrBin, hasUsrLocalBin) {
+            case (true, false):
+                path = swift.dirname.dirname.dirname
+            case (false, true):
+                path = swift.dirname.dirname.dirname.dirname
+            case (false, false):
+                return
+            case (true, true):
+                preconditionFailure()
+            }
+            let llvmDirectories = try Array(fs.listdir(Path("/usr/lib")).filter { $0.hasPrefix("llvm-") }.sorted().reversed())
+            let llvmDirectoriesLocal = try Array(fs.listdir(Path("/usr/local")).filter { $0.hasPrefix("llvm") }.sorted().reversed())
+            try register(Toolchain(Self.defaultToolchainIdentifier, "Default", Version(), [], path, [], llvmDirectories.map { "/usr/lib/\($0)/lib" } + llvmDirectoriesLocal.map { "/usr/local/\($0)/lib" } + ["/usr/lib64"], [:], [:], [:], executableSearchPaths: [path.join("usr").join("bin"), path.join("usr").join("local").join("bin"),  path.join("usr").join("libexec")], fs: fs))
         }
     }
 


### PR DESCRIPTION
It's common for some platforms (like FreeBSD, and possibly some Linux distributions) to place non-system content at a "local" subdirectory of "usr". Allow finding the host toolchain there as well. This code path currently only applies to Linux.