### PR TITLE
Add a convenience API for tests to get the image format of a run destination

### DIFF
--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -283,6 +283,19 @@ extension RunDestinationInfo {
         guard let sdk = try? core.sdkRegistry.lookup(sdk, activeRunDestination: self) else { return nil }
         return sdk.targetBuildVersionPlatform(sdkVariant: sdkVariant.map { sdkVariant in sdk.variant(for: sdkVariant) } ?? sdk.defaultVariant)
     }
+
+    package func imageFormat(_ core: Core) -> ImageFormat {
+        switch platform {
+        case "webassembly":
+            fatalError("not implemented")
+        case "windows":
+            return .pe
+        case _ where buildVersionPlatform(core) != nil:
+            return .macho
+        default:
+            return .elf
+        }
+    }
 }
 
 extension _RunDestinationInfo {

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -82,8 +82,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         type: .dynamicLibrary,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
-                                "DYLIB_INSTALL_NAME_BASE": "@rpath",
-                                "DYLIB_INSTALL_NAME_BASE[sdk=linux*]": "$ORIGIN",
+                                "DYLIB_INSTALL_NAME_BASE": "$ORIGIN",
+                                "DYLIB_INSTALL_NAME_BASE[sdk=macosx*]": "@rpath",
 
                                 // FIXME: Find a way to make these default
                                 "EXECUTABLE_PREFIX": "lib",
@@ -143,10 +143,10 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
             try await tester.checkBuild(runDestination: destination, signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs) { results in
                 results.checkNoErrors()
 
-                let toolchain = try #require(try await getCore().toolchainRegistry.defaultToolchain)
+                let toolchain = try #require(core.toolchainRegistry.defaultToolchain)
                 let environment: [String: String]
-                if destination.platform == "linux" {
-                    environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/linux").str]
+                if destination.imageFormat(core) == .elf {
+                    environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
                 } else {
                     environment = [:]
                 }


### PR DESCRIPTION
This is often semantically more appropriate than checking the platform, and helps reduce the amount of platform-specific checks needed as we port to more platforms. Immediately make use of this in a test.