### PR TITLE
Enable Windows linker discovery

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -100,9 +100,10 @@ public final class Core: Sendable {
 
             await core.initializeToolchainRegistry()
 
+            await core.initializePlatformRegistry()
+
             // Force loading SDKs.
             let sdkRegistry = core.sdkRegistry
-
             for `extension` in await pluginManager.extensions(of: SDKRegistryExtensionPoint.self) {
                 await sdkRegistry.registerSDKs(extension: `extension`, platformRegistry: core.platformRegistry)
             }
@@ -178,6 +179,7 @@ public final class Core: Sendable {
     public let connectionMode: ServiceHostConnectionMode
 
     @_spi(Testing) public init(delegate: any CoreDelegate, hostOperatingSystem: OperatingSystem, pluginManager: PluginManager, developerPath: String, inferiorProductsPath: Path?, additionalContentPaths: [Path], environment: [String:String], buildServiceModTime: Date, connectionMode: ServiceHostConnectionMode) async throws {
+
         self.delegate = delegate
         self.hostOperatingSystem = hostOperatingSystem
         self.pluginManager = pluginManager
@@ -301,31 +303,10 @@ public final class Core: Sendable {
     @_spi(Testing) public var toolchainPaths: [(Path, strict: Bool)]
 
     /// The platform registry.
-    public lazy var platformRegistry: PlatformRegistry = {
-        // FIXME: We should support building the platforms (with symlinks) locally (for `inferiorProductsPath`).
-
-        // Search the default location first (unless directed not to), then search any extra locations we've been passed.
-        var searchPaths: [Path]
-        if let onlySearchAdditionalPlatformPaths = getEnvironmentVariable("XCODE_ONLY_EXTRA_PLATFORM_FOLDERS"), onlySearchAdditionalPlatformPaths.boolValue {
-            searchPaths = []
-        }
-        else {
-            let platformsDir = self.developerPath.join("Platforms")
-            searchPaths = [platformsDir]
-            if hostOperatingSystem == .windows {
-                for dir in (try? localFS.listdir(platformsDir)) ?? [] {
-                    searchPaths.append(platformsDir.join(dir))
-                }
-            }
-        }
-        if let additionalPlatformSearchPaths = getEnvironmentVariable("XCODE_EXTRA_PLATFORM_FOLDERS") {
-            for searchPath in additionalPlatformSearchPaths.split(separator: ":") {
-                searchPaths.append(Path(searchPath))
-            }
-        }
-        searchPaths += UserDefaults.additionalPlatformSearchPaths
-        return PlatformRegistry(delegate: self.registryDelegate, searchPaths: searchPaths, hostOperatingSystem: hostOperatingSystem)
-    }()
+    let _platformRegistry: UnsafeDelayedInitializationSendableWrapper<PlatformRegistry> = .init()
+    public var platformRegistry: PlatformRegistry {
+        _platformRegistry.value
+    }
 
     @PluginExtensionSystemActor public var loadedPluginPaths: [Path] {
         pluginManager.pluginsByIdentifier.values.map(\.path)
@@ -421,6 +402,29 @@ public final class Core: Sendable {
         }
 
         _specRegistry = await SpecRegistry(self.pluginManager, self.registryDelegate, searchPaths, domainInclusions, [:])
+    }
+
+    private func initializePlatformRegistry() async {
+        var searchPaths: [Path]
+        let fs = localFS
+        if let onlySearchAdditionalPlatformPaths = getEnvironmentVariable("XCODE_ONLY_EXTRA_PLATFORM_FOLDERS"), onlySearchAdditionalPlatformPaths.boolValue {
+            searchPaths = []
+        } else {
+            let platformsDir = self.developerPath.join("Platforms")
+            searchPaths = [platformsDir]
+            if hostOperatingSystem == .windows {
+                for dir in (try? fs.listdir(platformsDir)) ?? [] {
+                    searchPaths.append(platformsDir.join(dir))
+                }
+            }
+        }
+        if let additionalPlatformSearchPaths = getEnvironmentVariable("XCODE_EXTRA_PLATFORM_FOLDERS") {
+            for searchPath in additionalPlatformSearchPaths.split(separator: ":") {
+                searchPaths.append(Path(searchPath))
+            }
+        }
+        searchPaths += UserDefaults.additionalPlatformSearchPaths
+        _platformRegistry.initialize(to: await PlatformRegistry(delegate: self.registryDelegate, searchPaths: searchPaths, hostOperatingSystem: hostOperatingSystem, fs: fs))
     }
 
     /// Force all specs to be loaded.

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -419,7 +419,7 @@ public final class Core: Sendable {
             }
         }
         if let additionalPlatformSearchPaths = getEnvironmentVariable("XCODE_EXTRA_PLATFORM_FOLDERS") {
-            for searchPath in additionalPlatformSearchPaths.split(separator: ":") {
+            for searchPath in additionalPlatformSearchPaths.split(separator: Path.pathEnvironmentSeparator) {
                 searchPaths.append(Path(searchPath))
             }
         }

--- a/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
+++ b/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
@@ -30,7 +30,7 @@ public protocol PlatformInfoExtension: Sendable {
 
     func additionalKnownTestLibraryPathSuffixes() -> [Path]
 
-    func additionalPlatformExecutableSearchPaths(platformName: String, platformPath: Path) -> [Path]
+    func additionalPlatformExecutableSearchPaths(platformName: String, platformPath: Path, fs: any FSProxy) async -> [Path]
 
     func additionalToolchainExecutableSearchPaths(toolchainIdentifier: String, toolchainPath: Path) -> [Path]
 
@@ -54,7 +54,7 @@ extension PlatformInfoExtension {
         []
     }
 
-    public func additionalPlatformExecutableSearchPaths(platformName: String, platformPath: Path) -> [Path] {
+    public func additionalPlatformExecutableSearchPaths(platformName: String, platformPath: Path, fs: any FSProxy) async -> [Path] {
         []
     }
 

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -811,6 +811,7 @@ public final class BuiltinMacros {
     public static let LIBTOOL_DEPENDENCY_INFO_FILE = BuiltinMacros.declarePathMacro("LIBTOOL_DEPENDENCY_INFO_FILE")
     public static let LINKER = BuiltinMacros.declareStringMacro("LINKER")
     public static let ALTERNATE_LINKER = BuiltinMacros.declareStringMacro("ALTERNATE_LINKER")
+    public static let _LINKER_EXEC = BuiltinMacros.declarePathMacro("_LINKER_EXEC")
     public static let LINK_OBJC_RUNTIME = BuiltinMacros.declareBooleanMacro("LINK_OBJC_RUNTIME")
     public static let LINK_WITH_STANDARD_LIBRARIES = BuiltinMacros.declareBooleanMacro("LINK_WITH_STANDARD_LIBRARIES")
     public static let LIPO = BuiltinMacros.declareStringMacro("LIPO")
@@ -1357,6 +1358,7 @@ public final class BuiltinMacros {
         ALL_SETTINGS,
         ALTERNATE_GROUP,
         ALTERNATE_LINKER,
+        _LINKER_EXEC,
         ALTERNATE_MODE,
         ALTERNATE_OWNER,
         ALTERNATE_PERMISSIONS_FILES,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1015,7 +1015,7 @@ extension WorkspaceContext {
             }
 
             // Add the platform search paths.
-            for path in platform?.executableSearchPaths ?? [] {
+            for path in platform?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
 

--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -1553,7 +1553,7 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
 public func discoveredLinkerToolsInfo(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, at toolPath: Path) async -> (any DiscoveredCommandLineToolSpecInfo)? {
     do {
         do {
-            let commandLine = [toolPath.str,  producer.hostOperatingSystem == .windows ? "/VERSION" : "-version_details"]
+            let commandLine = [toolPath.str] + (producer.hostOperatingSystem == .windows ? [] : ["-version_details"])
             return try await producer.discoveredCommandLineToolSpecInfo(delegate, nil, commandLine, { executionResult in
                 let gnuLD = [
                     #/GNU ld version (?<version>[\d.]+)-.*/#,
@@ -1569,7 +1569,7 @@ public func discoveredLinkerToolsInfo(_ producer: any CommandProducer, _ delegat
                 if let match = try goLD.compactMap({ try $0.firstMatch(in: String(decoding: executionResult.stdout, as: UTF8.self)) }).first {
                     return DiscoveredLdLinkerToolSpecInfo(linker: .gold, toolPath: toolPath, toolVersion: try Version(String(match.output.version)), architectures: Set())
                 }
-                // link.exe has no option to simply dump the version, but if you pass an invalid argument, the program will dump a header that contains the version.
+                // link.exe has no option to simply dump the version, running, the program will no arguments will dump a header that contains the version.
                 let linkExe = [
                     #/Microsoft \(R\) Incremental Linker Version (?<version>[\d.]+)/#
                 ]

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -56,7 +56,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
             for path in core.toolchainRegistry.defaultToolchain?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
-            for path in platform?.executableSearchPaths ?? [] {
+            for path in platform?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
             paths.append(core.developerPath.join("usr").join("bin"))

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -192,6 +192,7 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
 
     open func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
         let args = commandLine.dropFirst()
+        let commandBinary = commandLine.first.map(Path.init)?.basenameWithoutSuffix
         switch commandLine.first.map(Path.init)?.basenameWithoutSuffix {
         case "actool" where args == ["--version", "--output-format", "xml1"]:
             return .deferred
@@ -208,6 +209,8 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
         case "iig" where args == ["--version"]:
             return .deferred
         case "ld" where args == ["-version_details"]:
+             return .deferred
+        case "link" where args == ["/VERSION"]:
             return .deferred
         case "libtool" where args == ["-V"] || args == ["--version"]:
             return .deferred
@@ -219,6 +222,7 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
             return .deferred
         case "what":
             return .deferred
+
         default:
             break
         }

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -210,7 +210,7 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
             return .deferred
         case "ld" where args == ["-version_details"]:
              return .deferred
-        case "link" where args == ["/VERSION"]:
+        case "link":
             return .deferred
         case "libtool" where args == ["-V"] || args == ["--version"]:
             return .deferred

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -17,6 +17,7 @@ import Foundation
 @PluginExtensionSystemActor public func initializePlugin(_ manager: PluginManager) {
     manager.register(WindowsPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(WindowsEnvironmentExtension(), type: EnvironmentExtensionPoint.self)
+    manager.register(WindowsPlatformExtension(), type: PlatformInfoExtensionPoint.self)
 }
 
 struct WindowsPlatformSpecsExtension: SpecificationsExtension {
@@ -25,22 +26,40 @@ struct WindowsPlatformSpecsExtension: SpecificationsExtension {
     }
 }
 
-struct WindowsEnvironmentExtension: EnvironmentExtension {
-    func additionalEnvironmentVariables(fs: any FSProxy) async throws -> [String: String] {
-        if try ProcessInfo.processInfo.hostOperatingSystem() == .windows {
-            // Add the environment variable for the MSVC toolset for Swift and Clang to find it
-            let vcToolsInstallDir = "VCToolsInstallDir"
-            let installations = try await VSInstallation.findInstallations(fs: fs)
-                .sorted(by: { $0.installationVersion > $1.installationVersion })
-            if let latest = installations.first {
-                let msvcDir = latest.installationPath.join("VC").join("Tools").join("MSVC")
-                let versions = try fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
-                if let latestVersion = versions.first {
-                    let dir = msvcDir.join(latestVersion.description).str
-                    return [vcToolsInstallDir: dir]
-                }
+
+private func findLatestInstallDirectory(fs: any FSProxy) async throws -> Path? {
+    if try ProcessInfo.processInfo.hostOperatingSystem() == .windows {
+        let installations = try await VSInstallation.findInstallations(fs: fs)
+            .sorted(by: { $0.installationVersion > $1.installationVersion })
+        if let latest = installations.first {
+            let msvcDir = latest.installationPath.join("VC").join("Tools").join("MSVC")
+            let versions = try fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
+            if let latestVersion = versions.first {
+                let dir = msvcDir.join(latestVersion.description).str
+                return Path(dir)
             }
         }
-        return [:]
+    }
+    return nil
+}
+
+struct WindowsEnvironmentExtension: EnvironmentExtension {
+    func additionalEnvironmentVariables(fs: any FSProxy) async throws -> [String: String] {
+        // Add the environment variable for the MSVC toolset for Swift and Clang to find it
+        let vcToolsInstallDir = "VCToolsInstallDir"
+        guard let dir = try? await findLatestInstallDirectory(fs: fs) else {
+            return [:]
+        }
+        return [vcToolsInstallDir: dir.str]
     }
 }
+
+struct WindowsPlatformExtension: PlatformInfoExtension {
+    public func additionalPlatformExecutableSearchPaths(platformName: String, platformPath: Path, fs: any FSProxy) async -> [Path] {
+        guard let dir = try? await findLatestInstallDirectory(fs: fs) else {
+            return []
+        }
+        return [dir.join("bin/Hostarm64/arm64"), dir.join("bin/Hostx64/x64") ]
+   }
+}
+

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -59,7 +59,11 @@ struct WindowsPlatformExtension: PlatformInfoExtension {
         guard let dir = try? await findLatestInstallDirectory(fs: fs) else {
             return []
         }
-        return [dir.join("bin/Hostarm64/arm64"), dir.join("bin/Hostx64/x64") ]
+        if Architecture.hostStringValue == "aarch64" {
+            return [dir.join("bin/Hostarm64/arm64")]
+        } else {
+            return [dir.join("bin/Hostx64/x64")]
+        }
    }
 }
 

--- a/Tests/SWBCoreTests/CommandLineToolSpecDiscoveredInfoTests.swift
+++ b/Tests/SWBCoreTests/CommandLineToolSpecDiscoveredInfoTests.swift
@@ -141,7 +141,7 @@ import Testing
         }
     }
 
-    @Test(.skipHostOS(.windows, "Failed to obtain command line tool spec info but no errors were emitted"))
+    @Test(.skipHostOS(.windows), .requireSystemPackages(apt: "libtool", yum: "libtool"))
     func discoveredLdLinkerSpecInfo() async throws {
         try await withSpec(LdLinkerSpec.self, .deferred) { (info: DiscoveredLdLinkerToolSpecInfo) in
             #expect(!info.toolPath.isEmpty)
@@ -168,7 +168,24 @@ import Testing
         }
     }
 
-    @Test(.skipHostOS(.windows), .requireSystemPackages(apt: "libtool", yum: "libtool"))
+
+    @Test(.requireHostOS(.windows))
+    func discoveredLdLinkerSpecInfoWindows() async throws {
+        try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows") { (info: DiscoveredLdLinkerToolSpecInfo) in
+            #expect(!info.toolPath.isEmpty)
+            #expect(info.toolVersion != nil)
+            if let toolVersion = info.toolVersion {
+                #expect(toolVersion > Version(0, 0, 0))
+            }
+        }
+        try await withSpec(LdLinkerSpec.self, .result(status: .exit(0), stdout: Data("Microsoft (R) Incremental Linker Version 14.41.34120.0\n".utf8), stderr: Data()), platform: "windows") { (info: DiscoveredLdLinkerToolSpecInfo) in
+            #expect(!info.toolPath.isEmpty)
+            #expect(info.toolVersion == Version(14, 41, 34120))
+            #expect(info.architectures == Set())
+        }
+    }
+
+    @Test(.skipHostOS(.windows))
     func discoveredLibtoolSpecInfo() async throws {
         try await withSpec(LibtoolLinkerSpec.self, .deferred) { (info: DiscoveredLibtoolLinkerToolSpecInfo) in
             #expect(info.toolPath.basename == "libtool")

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -66,7 +66,7 @@ import SWBMacro
             }
 
             let delegate = await TestDataDelegate(pluginManager: PluginManager(skipLoadingPluginIdentifiers: []))
-            let registry = PlatformRegistry(delegate: delegate, searchPaths: [tmpDirPath], hostOperatingSystem: try ProcessInfo.processInfo.hostOperatingSystem())
+            let registry = await PlatformRegistry(delegate: delegate, searchPaths: [tmpDirPath], hostOperatingSystem: try ProcessInfo.processInfo.hostOperatingSystem(), fs: localFS)
             try await perform(registry, delegate)
         }
     }


### PR DESCRIPTION
- Enable Windows linker discovery to get linker type and version
- Make Platform Registry initialization async
- Change the function signature of additionalPlatformExecutableSearchPaths to allow passing of a filesystem for discovery.    Plugins will need to be updated to match new signatures
- Add the visual studio install directory to platform search paths for executables.
- Add Windows platform plugin extension to get install directory
- Add new internal build setting _LINKER_EXEC for testing purposes.
- Change the search paths of a Platform to a StackedSearchPath, as done with the Toolchain Registry
- Add test for discovery of windows linker