### PR TITLE
Infer [system] based on install path when generating clang modulemaps

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -851,6 +851,7 @@ public final class BuiltinMacros {
     public static let MODULEMAP_FILE_CONTENTS = BuiltinMacros.declareStringMacro("MODULEMAP_FILE_CONTENTS")
     public static let MODULEMAP_PATH = BuiltinMacros.declareStringMacro("MODULEMAP_PATH")
     public static let MODULEMAP_PRIVATE_FILE = BuiltinMacros.declareStringMacro("MODULEMAP_PRIVATE_FILE")
+    public static let GENERATED_MODULEMAPS_USE_SYSTEM = BuiltinMacros.declareBooleanMacro("GENERATED_MODULEMAPS_USE_SYSTEM")
     public static let MODULES_FOLDER_PATH = BuiltinMacros.declarePathMacro("MODULES_FOLDER_PATH")
     public static let MODULE_VERIFIER_KIND = BuiltinMacros.declareEnumMacro("MODULE_VERIFIER_KIND") as EnumMacroDeclaration<ModuleVerifierKind>
     public static let MODULE_VERIFIER_LSV = BuiltinMacros.declareBooleanMacro("MODULE_VERIFIER_LSV")
@@ -1916,6 +1917,7 @@ public final class BuiltinMacros {
         MODULEMAP_FILE_CONTENTS,
         MODULEMAP_PATH,
         MODULEMAP_PRIVATE_FILE,
+        GENERATED_MODULEMAPS_USE_SYSTEM,
         MODULES_FOLDER_PATH,
         MODULE_CACHE_DIR,
         MODULE_NAME,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2048,17 +2048,18 @@ private class SettingsBuilder {
         // FIXME: Arguably we should emit a warning if the optimization settings are out of sync, as the user may be getting weird results.  It's not clear if there are lots of old projects which might spuriously get such a warning, and this isn't a new state of affairs.
         table.push(BuiltinMacros.IS_UNOPTIMIZED_BUILD, literal: (scope.evaluate(BuiltinMacros.GCC_OPTIMIZATION_LEVEL) == "0" || scope.evaluate(BuiltinMacros.SWIFT_OPTIMIZATION_LEVEL) == "-Onone"))
 
+        let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
+        let publicInstallPaths = [
+            Path("/System/Library/Frameworks"),
+            Path("/System/Library/SubFrameworks"),
+            Path("/usr/lib"),
+            Path("/System/iOSSupport/System/Library/Frameworks"),
+            Path("/System/iOSSupport/System/Library/SubFrameworks"),
+            Path("/System/iOSSupport/usr/lib"),]
+
         // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.
         if scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).isEmpty &&
            scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib" {
-            let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
-            let publicInstallPaths = [
-                Path("/System/Library/Frameworks"),
-                Path("/System/Library/SubFrameworks"),
-                Path("/usr/lib"),
-                Path("/System/iOSSupport/System/Library/Frameworks"),
-                Path("/System/iOSSupport/System/Library/SubFrameworks"),
-                Path("/System/iOSSupport/usr/lib"),]
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
             if table.contains(BuiltinMacros.SKIP_INSTALL) {
@@ -2071,6 +2072,16 @@ private class SettingsBuilder {
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "api")
             }
             // Else, leave it to the compiler's default.
+        }
+
+        // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.
+        if scope.evaluateAsString(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM).isEmpty {
+            let systemInstallPaths = publicInstallPaths + privateInstallPaths
+            let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
+
+            if systemInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
+                table.push(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM, literal: true)
+            }
         }
 
         // Overrides specific to building for Mac Catalyst.

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
@@ -370,9 +370,10 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
             //
             // NOTE: This is unrelated to the "MODULE_NAME" build setting, which is much older and used by kexts.
             let moduleName = scope.evaluate(BuiltinMacros.PRODUCT_MODULE_NAME)
+            let isSystem = scope.evaluate(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM)
 
             // Create the trivial synthesized module map.
-            outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) {\n"
+            outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) \(isSystem ? "[system] " : ""){\n"
             outputStream <<< "  umbrella header \"\(umbrellaHeaderName.asCStringLiteralContent)\"\n"
             outputStream <<< "  export *\n"
             outputStream <<< "\n"
@@ -393,12 +394,13 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
 
             let interfaceHeaderName = scope.evaluate(BuiltinMacros.SWIFT_OBJC_INTERFACE_HEADER_NAME)
             assert(!interfaceHeaderName.isEmpty) // implied by exportsSwiftObjCAPI
+            let isSystem = scope.evaluate(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM)
 
             // Swift only module map contents is a top level framework module. Swift contents
             // for a mixed module map is a submodule of the top level framework module (whose
             // name had better be PRODUCT_MODULE_NAME or things are going to get weird).
             if moduleInfo.forSwiftOnly {
-                outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) {\n"
+                outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) \(isSystem ? "[system] " : ""){\n"
             } else {
                 outputStream <<< "\n"
                 outputStream <<< "module \(try moduleName.asModuleIdentifierString()).Swift {\n"


### PR DESCRIPTION
rdar://144797825

Modules intended to be installed to system locations should annotate their modules as [system]. Do this automatically when the module map is generated by the build system