### PR TITLE
Fix custom task output parsing test on linux

### DIFF
--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -17,6 +17,7 @@ import SWBCore
 import SWBTestSupport
 import SWBTaskExecution
 import SWBUtil
+import SWBProtocol
 
 @Suite
 fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
@@ -24,6 +25,16 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
     @Test(.requireSDKs(.host))
     func outputParsing() async throws {
         try await withTemporaryDirectory { tmpDir in
+            let destination: RunDestinationInfo = .host
+            let core = try await getCore()
+            let toolchain = try #require(core.toolchainRegistry.defaultToolchain)
+            let environment: [String: String]
+            if  destination.imageFormat(core) == .elf {
+                environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
+            } else {
+                environment = [:]
+            }
+
             let testProject = TestProject(
                 "aProject",
                 sourceRoot: tmpDir,
@@ -53,11 +64,11 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
                         ],
                         customTasks: [
                             TestCustomTask(
-                                commandLine: ["$(BUILD_DIR)/$(CONFIGURATION)/tool"],
-                                environment: [:],
+                                commandLine: ["$(CONFIGURATION_BUILD_DIR)/tool"],
+                                environment: environment,
                                 workingDirectory: tmpDir.str,
                                 executionDescription: "My Custom Task",
-                                inputs: ["$(BUILD_DIR)/$(CONFIGURATION)/tool"],
+                                inputs: ["$(CONFIGURATION_BUILD_DIR)/tool"],
                                 outputs: [Path.root.join("output").str],
                                 enableSandboxing: false,
                                 preparesForIndexing: false)
@@ -71,7 +82,6 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
                         ]
                     ),
                 ])
-            let core = try await getCore()
             let tester = try await BuildOperationTester(core, testProject, simulated: false)
 
             let parameters = BuildParameters(action: .build, configuration: "Debug")


### PR DESCRIPTION
This test needs a couple of path and env var fixes to successfully run on linux