### PR TITLE
Use llvm-ar as the linux archiver

### DIFF
--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -759,6 +759,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
                 "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
                 "CHOWN": "/usr/bin/chown",
+                "AR": "llvm-ar",
             ]
         case .windows:
             defaultProperties = [

--- a/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
+++ b/Sources/SWBGenericUnixPlatform/UnixLibtool.xcspec
@@ -46,6 +46,11 @@
                 Type = String;
                 DefaultValue = "ar";
             },
+            // Used to lookup tool info
+            {   Name = LIBTOOL;
+                Type = Path;
+                DefaultValue = "$(AR)";
+            },
             // Input file lists
             {
                 Name = __INPUT_FILE_LIST_PATH__;

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -220,7 +220,9 @@ extension CoreBasedTests {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
             let fallbacklibtool = Path("/usr/bin/libtool")
-            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "libtool") ?? (localFS.exists(fallbacklibtool) ? fallbacklibtool : nil), "couldn't find libtool in default toolchain")
+            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "libtool")
+                                ?? defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "llvm-ar")
+                                ?? (localFS.exists(fallbacklibtool) ? fallbacklibtool : nil), "couldn't find libtool in default toolchain")
         }
     }
 

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -1785,7 +1785,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                                    "-o", targetObjectsPerArchBuildDir.join("Binary/\(libSupportFileName)").str
                                                   ])
                         case .linux:
-                            task.checkCommandLine(["ar", "rcs", targetBuildDir.join(libSupportFileName).str, "@\(targetObjectsPerArchBuildDir.join("Support.LinkFileList").str)"])
+                            task.checkCommandLine(["llvm-ar", "rcs", targetBuildDir.join(libSupportFileName).str, "@\(targetObjectsPerArchBuildDir.join("Support.LinkFileList").str)"])
                         case .windows:
                             task.checkCommandLine(["llvm-lib.exe",
                                                    "/out:\(architectures.count > 1 ? targetObjectsPerArchBuildDir.join("Binary/\(libSupportFileName)").str : targetBuildDir.join(libSupportFileName).str)",


### PR DESCRIPTION
This is consistent with SwiftPM, and llvm-ar, unlike libtool/ar, is included in Swift.org toolchains