### PR TITLE
docs: fix a typo in `connections`

### DIFF
--- a/Sources/SWBBuildService/BuildServiceEntryPoint.swift
+++ b/Sources/SWBBuildService/BuildServiceEntryPoint.swift
@@ -91,7 +91,7 @@ extension BuildService {
         }
     }
 
-    /// Common entry point to the build service for in-process and out-of-process connectons.
+    /// Common entry point to the build service for in-process and out-of-process connections.
     ///
     /// Called directly from the exported C entry point `swiftbuildServiceEntryPoint` for in-process connections, or from `BuildService.main()` (after some basic file descriptor setup) for out-of-process connections.
     fileprivate static func run(inputFD: FileDescriptor, outputFD: FileDescriptor, connectionMode: ServiceHostConnectionMode, pluginsDirectory: URL?, arguments: [String], pluginLoadingFinished: () throws -> Void) async throws {


### PR DESCRIPTION
All SWBBuildService files reviewed.
This was the only remaining issue which is safe to merge since it is a non-compiling change.