### PR TITLE
fix: a typo in `dependencyDataFormat`

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1078,7 +1078,7 @@ private class InProcessCommand: SWBLLBuild.ExternalCommand, SWBLLBuild.ExternalD
         return signature
     }
 
-    var depedencyDataFormat: SWBLLBuild.DependencyDataFormat {
+    var dependencyDataFormat: SWBLLBuild.DependencyDataFormat {
         switch task.dependencyData {
         case .makefile?, .makefiles?:
             return .makefile

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1078,6 +1078,11 @@ private class InProcessCommand: SWBLLBuild.ExternalCommand, SWBLLBuild.ExternalD
         return signature
     }
 
+    // temporary for compatibility
+    var depedencyDataFormat: SWBLLBuild.DependencyDataFormat {
+        dependencyDataFormat
+    }
+
     var dependencyDataFormat: SWBLLBuild.DependencyDataFormat {
         switch task.dependencyData {
         case .makefile?, .makefiles?:


### PR DESCRIPTION
I couldn't find any references to this property, so it should be safe to change. but please run @swift-ci test.
Please let me know if it needs a deprecation phase or maybe removing the variable entirely. 🤷🏻‍♂️
Thanks.