### PR TITLE
Adjust skip criteria for 2 remaining linux test failures

### DIFF
--- a/Tests/SWBCoreTests/CommandLineToolSpecDiscoveredInfoTests.swift
+++ b/Tests/SWBCoreTests/CommandLineToolSpecDiscoveredInfoTests.swift
@@ -168,7 +168,7 @@ import Testing
         }
     }
 
-    @Test(.skipHostOS(.windows))
+    @Test(.skipHostOS(.windows), .requireSystemPackages(apt: "libtool", yum: "libtool"))
     func discoveredLibtoolSpecInfo() async throws {
         try await withSpec(LibtoolLinkerSpec.self, .deferred) { (info: DiscoveredLibtoolLinkerToolSpecInfo) in
             #expect(info.toolPath.basename == "libtool")

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -142,7 +142,7 @@ fileprivate struct ClangTests: CoreBasedTests {
         }
     }
 
-    @Test(.skipHostOS(.windows, "clang-cache is not available on Windows"), .requireSDKs(.host))
+    @Test(.skipHostOS(.windows, "clang-cache is not available on Windows"), .skipHostOS(.linux, "test is incompatible with linux fallback system toolchain mechanism"), .requireSDKs(.host))
     func clangCacheEnableLauncher() async throws {
         let runDestination: RunDestinationInfo = .host
         let clangCachePath: String = switch runDestination {


### PR DESCRIPTION
One expects libtool to be installed as a system package, the other requires additional work to support.