### PR TITLE
Update swift-system to 1.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -447,7 +447,7 @@ if useLocalDependencies {
         // 3.7.1 introduced a regression which fails to link on aarch64-windows; revert to <4.0.0 for the upper bound when this is fixed
         .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0"..<"3.7.1"),
         .package(url: "https://github.com/apple/swift-driver.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.4.0")),
+        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.4.1")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),
     ]
     if !useLLBuildFramework {


### PR DESCRIPTION
Pickup Windows 10 bug fix in swift-system related to GetTempPath2W