### PR TITLE
Ensure build directories added as linker inputs are in a deterministic order

### DIFF
--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -673,7 +673,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
         // Add dependencies on any directories in our input search paths for which the build system is creating those directories.
         let ldSearchPaths = Set(cbc.scope.evaluate(BuiltinMacros.FRAMEWORK_SEARCH_PATHS) + cbc.scope.evaluate(BuiltinMacros.LIBRARY_SEARCH_PATHS))
-        let otherInputs = delegate.buildDirectories.compactMap { path in ldSearchPaths.contains(path.str) ? delegate.createBuildDirectoryNode(absolutePath: path) : nil } + cbc.commandOrderingInputs
+        let otherInputs = delegate.buildDirectories.sorted().compactMap { path in ldSearchPaths.contains(path.str) ? delegate.createBuildDirectoryNode(absolutePath: path) : nil } + cbc.commandOrderingInputs
 
         // Create the task.
         delegate.createTask(type: self, dependencyData: dependencyInfo, payload: payload, ruleInfo: defaultRuleInfo(cbc, delegate), commandLine: commandLine, environment: environment, workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs + otherInputs, outputs: outputs, action: delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences), execDescription: resolveExecutionDescription(cbc, delegate), enableSandboxing: enableSandboxing)

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/HeadermapVFSTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/HeadermapVFSTaskProducer.swift
@@ -49,7 +49,7 @@ final class HeadermapVFSTaskProducer: StandardTaskProducer, TaskProducer {
 
             for (vfsPath, contents) in vfsContentsByPath {
                 await appendGeneratedTasks(&tasks) { delegate in
-                    let orderingInputs = delegate.buildDirectories.filter { $0.isAncestor(of: vfsPath) }.map { delegate.createBuildDirectoryNode(absolutePath: $0) }
+                    let orderingInputs = delegate.buildDirectories.sorted().filter { $0.isAncestor(of: vfsPath) }.map { delegate.createBuildDirectoryNode(absolutePath: $0) }
                     context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: vfsPath, commandOrderingInputs: orderingInputs), delegate, contents: contents, permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate])
                 }
             }


### PR DESCRIPTION
Otherwise, when the build description is regenerated we may cause unnecessary signature changes and relinking rdar://145001400

