### PR TITLE
Set TOOLCHAIN_VERSION appropriately when a toolchain is primary

### DIFF
--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -274,6 +274,7 @@ public final class Toolchain: Hashable, Sendable {
             defaultSettingsWhenPrimary = settingsItems
         }
         defaultSettingsWhenPrimary["TOOLCHAIN_DIR"] = .plString(path.str)
+        defaultSettingsWhenPrimary["TOOLCHAIN_VERSION"] = .plString(version.description)
 
         var executableSearchPaths = [
             path.join("usr").join("bin"),


### PR DESCRIPTION
This allows us to pick up the right value in the Windows Swift spec needed to set PATH