### PR TITLE
Miscellaneous Windows test fixes

### DIFF
--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -66,11 +66,11 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
                         ],
                         customTasks: [
                             TestCustomTask(
-                                commandLine: ["$(CONFIGURATION_BUILD_DIR)/tool"],
+                                commandLine: ["$(CONFIGURATION_BUILD_DIR)/\(destination.imageFormat(core).executableName(basename: "tool"))"],
                                 environment: environment,
                                 workingDirectory: tmpDir.str,
                                 executionDescription: "My Custom Task",
-                                inputs: ["$(CONFIGURATION_BUILD_DIR)/tool"],
+                                inputs: ["$(CONFIGURATION_BUILD_DIR)/\(destination.imageFormat(core).executableName(basename: "tool"))"],
                                 outputs: [Path.root.join("output").str],
                                 enableSandboxing: false,
                                 preparesForIndexing: false)

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -178,7 +178,7 @@ import Foundation
         }
     }
 
-    @Test
+    @Test(.requireHostOS(.macOS))
     func toolchainLoading() async throws {
         // Validate that we loaded the default toolchain.
         let defaultToolchain = try #require(await getCore().toolchainRegistry.lookup("default"), "no default toolchain")

--- a/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
+++ b/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
@@ -157,7 +157,7 @@ import SWBTestSupport
     }
 
     /// Test that default and overriding build settings defined in a toolchain are exported.
-    @Test(.skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
+    @Test(.requireHostOS(.macOS), .skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
     func exportingToolchainSettings() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             // Toolchains are only loaded from the localFS, so we can't use a PseudoFS here.

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -3932,12 +3932,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "TargetName",
-                        type: .framework,
+                        type: .dynamicLibrary,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "SWIFT_WARNINGS_AS_WARNINGS_GROUPS": "Unsafe DeprecatedDeclaration",
                                 "SWIFT_EXEC": swiftCompilerPath.str,
-                                "CODE_SIGN_IDENTITY": "",
                                 "SDKROOT": "$(HOST_PLATFORM)",
                                 "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                             ]),
@@ -3978,12 +3977,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "TargetName",
-                        type: .framework,
+                        type: .dynamicLibrary,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "SWIFT_WARNINGS_AS_ERRORS_GROUPS": "UnknownWarningGroup PreconcurrencyImport",
                                 "SWIFT_EXEC": swiftCompilerPath.str,
-                                "CODE_SIGN_IDENTITY": "",
                                 "SDKROOT": "$(HOST_PLATFORM)",
                                 "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                             ]),

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -37,7 +37,7 @@ fileprivate struct ServiceConsoleTests {
             let output = String(decoding: data, as: UTF8.self)
 
             // Verify there were no errors.
-            #expect(output == "swbuild> \n")
+            #expect(output == "swbuild> \(String.newline)")
 
             // Assert the tool exited successfully.
             await #expect(try promise.value == .exit(0))


### PR DESCRIPTION
- Handle .exe extension in build tool plugin output parsing test
- require a macOS host in a couple of tests
- Switch a couple tests to use dylibs instead of frameworks
- fix a newline issue