### PR TITLE
Add ITSAppUsesNonExemptEncryption / ITSEncryptionExportComplianceCode build settings

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1186,6 +1186,8 @@ public final class BuiltinMacros {
     public static let INFOPLIST_KEY_NSPrincipalClass = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NSPrincipalClass")
 
     // Info.plist Keys - Usage Descriptions
+    public static let INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = BuiltinMacros.declareBooleanMacro("INFOPLIST_KEY_ITSAppUsesNonExemptEncryption")
+    public static let INFOPLIST_KEY_ITSEncryptionExportComplianceCode = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_ITSEncryptionExportComplianceCode")
     public static let INFOPLIST_KEY_NFCReaderUsageDescription = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NFCReaderUsageDescription")
     public static let INFOPLIST_KEY_NSAppleEventsUsageDescription = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NSAppleEventsUsageDescription")
     public static let INFOPLIST_KEY_NSAppleMusicUsageDescription = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NSAppleMusicUsageDescription")
@@ -2396,6 +2398,8 @@ public final class BuiltinMacros {
         INFOPLIST_KEY_NSPrincipalClass,
 
         // Info.plist Keys - Usage Descriptions
+        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption,
+        INFOPLIST_KEY_ITSEncryptionExportComplianceCode,
         INFOPLIST_KEY_NFCReaderUsageDescription,
         INFOPLIST_KEY_NSAppleEventsUsageDescription,
         INFOPLIST_KEY_NSAppleMusicUsageDescription,

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3659,6 +3659,26 @@ When this setting is enabled:
                 Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleDisplayName](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundledisplayname) key in the `Info.plist` file to the value of this build setting.";
             },
             {
+                Name = INFOPLIST_KEY_ITSAppUsesNonExemptEncryption;
+                Type = Boolean;
+                Category = "Info.plist Values";
+                ConditionFlavors = (
+                    sdk,
+                );
+                DisplayName = "App Uses Non-Exempt Encryption";
+                Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [ITSAppUsesNonExemptEncryption](https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption) key in the `Info.plist` file to the value of this build setting.";
+            },
+            {
+                Name = INFOPLIST_KEY_ITSEncryptionExportComplianceCode;
+                Type = String;
+                Category = "Info.plist Values";
+                ConditionFlavors = (
+                    sdk,
+                );
+                DisplayName = "App Encryption Export Compliance Code";
+                Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [ITSEncryptionExportComplianceCode](https://developer.apple.com/documentation/bundleresources/information_property_list/itsencryptionexportcompliancecode) key in the `Info.plist` file to the value of this build setting.";
+            },
+            {
                 Name = INFOPLIST_KEY_LSApplicationCategoryType;
                 Type = Enumeration;
                 Values = (

--- a/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
@@ -690,6 +690,8 @@ public final class InfoPlistProcessorTaskAction: TaskAction
 
             // Usage Descriptions
 
+            "ITSAppUsesNonExemptEncryption",
+            "ITSEncryptionExportComplianceCode",
             "NFCReaderUsageDescription",
             "NSAppleEventsUsageDescription",
             "NSAppleMusicUsageDescription",


### PR DESCRIPTION
Developers don't have a way to directly edit the shim target's Info.plist for Watch-only apps. App Processing checks the shim app bundle for the presence of this key, so it's getting missed for watch only apps. Add build settings to alleviate this.

rdar://134458144