### PR TITLE
Remove bogus categories from LD_NO_PIE build settings

### DIFF
--- a/Sources/SWBGenericUnixPlatform/UnixCompile.xcspec
+++ b/Sources/SWBGenericUnixPlatform/UnixCompile.xcspec
@@ -59,7 +59,6 @@
                     NO = ("-fPIE");
                 };
                 Condition = "$(MACH_O_TYPE) == mh_execute";
-                Category = Linking;
             },
             {
                 Name = "ENABLE_BLOCKS";

--- a/Sources/SWBQNXPlatform/QNXCompile.xcspec
+++ b/Sources/SWBQNXPlatform/QNXCompile.xcspec
@@ -86,7 +86,6 @@
                     NO = ("-fPIE");
                 };
                 Condition = "$(MACH_O_TYPE) == mh_execute";
-                Category = Linking;
             },
             {
                 Name = "ENABLE_BLOCKS";


### PR DESCRIPTION
The actual category is "Linking - General" as defined in CoreBuildSystem. The conflict blocks build settings documentation from being generated.