### PR TITLE
Remove swift-crypto version constraint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -443,9 +443,7 @@ if useLocalDependencies {
     }
 } else {
     package.dependencies += [
-        // https://github.com/apple/swift-crypto/issues/262
-        // 3.7.1 introduced a regression which fails to link on aarch64-windows; revert to <4.0.0 for the upper bound when this is fixed
-        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0"..<"3.7.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-driver.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.4.1")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),


### PR DESCRIPTION
Now that the fix for apple/swift-crypto#262 has been included in a tagged release, we can safely upgrade to newer versions. This also pulls in fixes for FreeBSD that will unblock that platform bringup.