### PR TITLE
Make PlannedNode conform to CustomStringConvertible.

### DIFF
--- a/Sources/SWBCore/PlannedNode.swift
+++ b/Sources/SWBCore/PlannedNode.swift
@@ -15,7 +15,7 @@ public import SWBUtil
 
 /// A node that represents an input or output of a task (often, but not necessarily, representing the path of a file system entity).  Every node has a name, even if it doesn’t have a path.  If it does have a path, the name will be the same as the last path component of a path.
 /// PlannedNode are AnyObject-type and all instances are interned to allow for reference equality.
-public protocol PlannedNode: AnyObject, Sendable {
+public protocol PlannedNode: AnyObject, Sendable, CustomStringConvertible {
     /// Node name (never empty, and constant through the lifetime of the node).
     var name: String { get }
 
@@ -33,6 +33,10 @@ public final class PlannedPathNode: PlannedNode {
         assert(path.normalize() == path)
         self.path = path
         self.name = path.basename
+    }
+
+    public var description: String {
+        return "<\(type(of: self)):\(path.str)>"
     }
 }
 
@@ -52,6 +56,10 @@ public final class PlannedDirectoryTreeNode: PlannedNode {
         self.name = path.basename + "/"
         self.exclusionPatterns = excluding
     }
+
+    public var description: String {
+        return "<\(type(of: self)):\(path.str)>"
+    }
 }
 
 /// A node that represents a conceptual entity that is not a path.
@@ -62,6 +70,10 @@ public final class PlannedVirtualNode: PlannedNode {
     fileprivate init(name: String) {
         assert(!name.isEmpty)
         self.name = name
+    }
+
+    public var description: String {
+        return "<\(type(of: self)):\(name)>"
     }
 }
 

--- a/Sources/SWBTestSupport/TaskConstructionTester.swift
+++ b/Sources/SWBTestSupport/TaskConstructionTester.swift
@@ -1198,7 +1198,7 @@ package extension PlannedTaskInputsOutputs {
     }
 
     private func checkNodes(nodes: [any PlannedNode], name: String, contain patterns: [NodePattern], sourceLocation: SourceLocation = #_sourceLocation) {
-        #expect(nodes.count >= patterns.count, "too many patterns (\(patterns.count) > \(nodes.count)) for \(name)", sourceLocation: sourceLocation)
+        #expect(nodes.count >= patterns.count, "too many patterns for \(name) (\(nodes) vs \(patterns))", sourceLocation: sourceLocation)
         if nodes.count >= patterns.count {
             for pattern in patterns {
                 var foundPattern = false


### PR DESCRIPTION
Some checking logic in the test infrastructure reports errors with lists of `PlannedNode`s, and it is much easier to triage those errors if the identity of the nodes are present in the error message.

Also changed one such method to include this information rather than raw counts.
