### PR TITLE
Enable some more tests for windows/linux

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -584,7 +584,7 @@ package final class BuildOperation: BuildSystemOperation {
                 if let buildOnlyTheseOutputs = buildOutputMap?.keys {
                     // Build selected outputs, the build fails if one operation failed.
                     result = await _Concurrency.Task.detachNewThread(name: "llb_buildsystem_build_node") {
-                        !buildOnlyTheseOutputs.map({ system.build(node: $0) }).contains(false)
+                        !buildOnlyTheseOutputs.map({ return system.build(node: Path($0).strWithPosixSlashes) }).contains(false)
                     }
                 } else if let buildOnlyTheseNodes = nodesToBuild {
                     // Build selected nodes, the build fails if one operation failed.

--- a/Sources/SWBWindowsPlatform/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Windows.xcspec
@@ -49,6 +49,20 @@
         BasedOn = default:com.apple.product-type.library.static;
         DefaultBuildProperties = {
             EXECUTABLE_EXTENSION = "lib";
+            PUBLIC_HEADERS_FOLDER_PATH = "";
+            PRIVATE_HEADERS_FOLDER_PATH = "";
+        };
+    },
+
+    {
+        Domain = windows;
+        Type = ProductType;
+        Identifier = com.apple.product-type.library.dynamic;
+        BasedOn = default:com.apple.product-type.library.dynamic;
+        HasInfoPlist = NO;
+        DefaultBuildProperties = {
+            PUBLIC_HEADERS_FOLDER_PATH = "";
+            PRIVATE_HEADERS_FOLDER_PATH = "";
         };
     },
 

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -14,7 +14,6 @@ import SWBCore
 import SWBProtocol
 import SWBTestSupport
 import SwiftBuildTestSupport
-import SwiftBuild
 import SWBUtil
 import Testing
 
@@ -83,7 +82,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             // Check building just the C file.
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [cOutputPath: cFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
-                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(SWBRunDestinationInfo.host.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CFile.o").str, cFile.str, "normal", results.runDestinationTargetArchitecture, "c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
+                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(runDestination.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CFile.o").str, cFile.str, "normal", results.runDestinationTargetArchitecture, "c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
                 if runDestination == .linux {
                     results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
                 }
@@ -93,7 +92,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             // Check building just the ObjC file.
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [objcOutputPath: objcFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
-                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(SWBRunDestinationInfo.host.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/ObjCFile.o").str, objcFile.str, "normal", results.runDestinationTargetArchitecture, "objective-c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
+                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(runDestination.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/ObjCFile.o").str, objcFile.str, "normal", results.runDestinationTargetArchitecture, "objective-c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
                 results.checkNoTask()
             }
 

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -73,7 +73,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
                 results.checkTaskExists(.matchRule(["SwiftCompile", "normal", results.runDestinationTargetArchitecture, "Compiling \(swiftFile.basename)", swiftFile.str]))
                 results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
-                if runDestination == .linux {
+                if runDestination == .linux {  // FIXME: This needs to be investigated... We should be able to use core.hostOperatingSystem.imageFormat.requiresSwiftModulewrap to test for this, but on Windows using this causes the test to fail as the SwiftModuleWrap does not seem to be added.
                     results.checkTaskExists(.matchRule(["SwiftModuleWrap", "normal", results.runDestinationTargetArchitecture,  "Wrapping Swift module aLibrary"]))
                 }
                 results.checkNoTask()
@@ -83,7 +83,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [cOutputPath: cFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
                 results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(runDestination.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CFile.o").str, cFile.str, "normal", results.runDestinationTargetArchitecture, "c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
-                if runDestination == .linux {
+                if runDestination == .linux {  // FIXME: This needs to be investigated... iIs not clear why this task is added when building a C file, and only on Linux.
                     results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
                 }
                 results.checkNoTask()

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -13,6 +13,8 @@
 import SWBCore
 import SWBProtocol
 import SWBTestSupport
+import SwiftBuildTestSupport
+import SwiftBuild
 import SWBUtil
 import Testing
 
@@ -20,7 +22,7 @@ import Testing
 @Suite
 fileprivate struct BuildCommandTests: CoreBasedTests {
     /// Check compilation of a single file in C, ObjC and Swift, including the `uniquingSuffix` behaviour.
-    @Test(.requireSDKs(.macOS), .requireXcode16())
+    @Test(.requireSDKs(.host))
     func singleFileCompile() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = try await TestWorkspace(
@@ -29,12 +31,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 projects: [
                     TestProject(
                         "aProject",
-                        groupTree: TestGroup("Sources", children: [
-                            TestFile("CFile.c"),
-                            TestFile("SwiftFile.swift"),
-                            TestFile("ObjCFile.m"),
-                            TestFile("Metal.metal"),
-                        ]),
+                        groupTree: TestGroup("Sources", children: [TestFile("CFile.c"), TestFile("SwiftFile.swift"), TestFile("ObjCFile.m")]),
                         buildConfigurations: [TestBuildConfiguration(
                             "Debug",
                             buildSettings: ["PRODUCT_NAME": "$(TARGET_NAME)",
@@ -42,11 +39,14 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                                             "SWIFT_VERSION": swiftVersion])],
                         targets: [
                             TestStandardTarget(
-                                "aFramework", type: .framework,
+                                "aLibrary", type: .staticLibrary,
                                 buildConfigurations: [TestBuildConfiguration("Debug")],
-                                buildPhases: [
-                                    TestSourcesBuildPhase(["CFile.c", "SwiftFile.swift", "ObjCFile.m", "Metal.metal"]),
-                                ])])])
+                                buildPhases: [TestSourcesBuildPhase(["CFile.c", "SwiftFile.swift", "ObjCFile.m"])]
+                            )
+                        ]
+                    )
+                ]
+            )
             let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
 
             // Create the input files.
@@ -56,52 +56,48 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
             try await tester.fs.writeFileContents(swiftFile) { stream in }
             let objcFile = testWorkspace.sourceRoot.join("aProject/ObjCFile.m")
             try await tester.fs.writeFileContents(objcFile) { stream in }
-            let metalFile = testWorkspace.sourceRoot.join("aProject/Metal.metal")
-            try await tester.fs.writeFileContents(metalFile) { stream in }
 
             // Create a build request context to compute the output paths - can't use one from the tester because it's an _output_ of checkBuild.
             let buildRequestContext = BuildRequestContext(workspaceContext: tester.workspaceContext)
 
             // Construct the output paths.
             let excludedTypes: Set<String> = ["Copy", "Gate", "MkDir", "SymLink", "WriteAuxiliaryFile", "CreateBuildDirectory", "SwiftDriver", "SwiftDriver Compilation Requirements", "SwiftDriver Compilation", "SwiftMergeGeneratedHeaders", "ClangStatCache", "SwiftExplicitDependencyCompileModuleFromInterface", "SwiftExplicitDependencyGeneratePcm", "ProcessSDKImports"]
-            let runDestination = RunDestinationInfo.macOS
+            let runDestination = RunDestinationInfo.host
             let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)
             let target = tester.workspace.allTargets.first(where: { _ in true })!
             let cOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [cFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
             let objcOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [objcFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
             let swiftOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [swiftFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
-            let metalOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [metalFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
 
             // Check building just the Swift file.
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [swiftOutputPath: swiftFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
                 results.checkTaskExists(.matchRule(["SwiftCompile", "normal", results.runDestinationTargetArchitecture, "Compiling \(swiftFile.basename)", swiftFile.str]))
-                results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aFramework"]))
+                results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
+                if runDestination == .linux {
+                    results.checkTaskExists(.matchRule(["SwiftModuleWrap", "normal", results.runDestinationTargetArchitecture,  "Wrapping Swift module aLibrary"]))
+                }
                 results.checkNoTask()
             }
 
             // Check building just the C file.
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [cOutputPath: cFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
-                results.checkTaskExists(.matchRule(["CompileC", "\(tmpDirPath.str)/Test/aProject/build/aProject.build/Debug/aFramework.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CFile.o", cFile.str, "normal", results.runDestinationTargetArchitecture, "c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
+                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(SWBRunDestinationInfo.host.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CFile.o").str, cFile.str, "normal", results.runDestinationTargetArchitecture, "c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
+                if runDestination == .linux {
+                    results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
+                }
                 results.checkNoTask()
             }
 
             // Check building just the ObjC file.
             try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [objcOutputPath: objcFile.str]) { results in
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
-                results.checkTaskExists(.matchRule(["CompileC", "\(tmpDirPath.str)/Test/aProject/build/aProject.build/Debug/aFramework.build/Objects-normal/\(results.runDestinationTargetArchitecture)/ObjCFile.o", objcFile.str, "normal", results.runDestinationTargetArchitecture, "objective-c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
+                results.checkTaskExists(.matchRule(["CompileC", tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(SWBRunDestinationInfo.host.builtProductsDirSuffix)/aLibrary.build/Objects-normal/\(results.runDestinationTargetArchitecture)/ObjCFile.o").str, objcFile.str, "normal", results.runDestinationTargetArchitecture, "objective-c", "com.apple.compilers.llvm.clang.1_0.compiler"]))
                 results.checkNoTask()
             }
 
-            // Check building just the Metal file.
-            try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [metalOutputPath: metalFile.str]) { results in
-                results.consumeTasksMatchingRuleTypes(excludedTypes)
-                results.checkTask(.matchRule(["CompileMetalFile", metalFile.str])) { _ in }
-                results.checkNoTask()
-            }
-
-            try await tester.checkBuild(persistent: true) { results in
+            try await tester.checkBuild(runDestination: runDestination, persistent: true) { results in
                 results.checkNoDiagnostics()
             }
         }
@@ -153,9 +149,9 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
     }
 
     /// Check analyze of a single file.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.host))
     func singleFileAnalyze() async throws {
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, _, _ in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, _, _ in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             results.checkTask(.matchRuleType("AnalyzeShallow"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { _ in }
             results.checkNoTask()
@@ -163,9 +159,9 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
     }
 
     /// Check preprocessing of a single file.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.host))
     func preprocessSingleFile() async throws {
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Preprocess"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -175,7 +171,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         // Ensure that files with a non-default type work too
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.cpp", fileType: "sourcecode.cpp.objcpp") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.cpp", fileType: "sourcecode.cpp.objcpp") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Preprocess"), .matchRuleItemBasename("File.cpp"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c++"])
@@ -185,7 +181,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         // Ensure that RUN_CLANG_STATIC_ANALYZER=YES doesn't interfere with the preprocess build command
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .generatePreprocessedFile(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Preprocess"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -198,7 +194,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
     /// Check assembling of a single file.
     @Test(.requireSDKs(.macOS))
     func assembleSingleFile() async throws {
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -210,7 +206,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         // Ensure that RUN_CLANG_STATIC_ANALYZER=YES doesn't interfere with the assemble build command
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .host, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -223,7 +219,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
     }
 
     /// Check behavior of the skip dependencies flag.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.host))
     func skipDependenciesFlag() async throws {
         func runTest(skipDependencies: Bool, checkAuxiliaryTarget: (_ results: BuildOperationTester.BuildResults) throws -> Void) async throws {
             try await withTemporaryDirectory { tmpDirPath async throws -> Void in
@@ -241,14 +237,14 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                                 buildSettings: ["PRODUCT_NAME": "$(TARGET_NAME)"])],
                             targets: [
                                 TestStandardTarget(
-                                    "aFramework", type: .framework,
+                                    "aLibrary", type: .staticLibrary,
                                     buildConfigurations: [TestBuildConfiguration("Debug")],
                                     buildPhases: [
                                         TestSourcesBuildPhase(["CFile.c"]),
                                     ],
-                                    dependencies: ["aFrameworkDep"]),
+                                    dependencies: ["aLibraryDep"]),
                                 TestStandardTarget(
-                                    "aFrameworkDep", type: .framework,
+                                    "aLibraryDep", type: .staticLibrary,
                                     buildConfigurations: [TestBuildConfiguration("Debug")],
                                     buildPhases: [
                                         TestSourcesBuildPhase(["CFile.c"]),
@@ -261,13 +257,13 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 let cFile = testWorkspace.sourceRoot.join("aProject/CFile.c")
                 try await tester.fs.writeFileContents(cFile) { stream in }
 
-                let runDestination = RunDestinationInfo.macOS
+                let runDestination = RunDestinationInfo.host
                 let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)
 
                 try await tester.checkBuild(parameters: parameters, runDestination: runDestination, buildCommand: .build(style: .buildOnly, skipDependencies: skipDependencies), persistent: true) { results in
-                    results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile", "GenerateTAPI", "ClangStatCache", "ProcessSDKImports"])
+                    results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile", "GenerateTAPI", "ClangStatCache", "ProcessSDKImports", "Libtool"])
 
-                    results.consumeTasksMatchingRuleTypes(["CompileC", "Ld"], targetName: "aFramework")
+                    results.consumeTasksMatchingRuleTypes(["CompileC", "Ld"], targetName: "aLibrary")
 
                     try checkAuxiliaryTarget(results)
 
@@ -278,11 +274,64 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         try await runTest(skipDependencies: true) { results in
-            results.checkNoTask(.matchTargetName("aFrameworkDep"))
+            results.checkNoTask(.matchTargetName("aLibraryDep"))
         }
 
         try await runTest(skipDependencies: false) { results in
-            results.consumeTasksMatchingRuleTypes(["CompileC", "Ld"], targetName: "aFrameworkDep")
+            results.consumeTasksMatchingRuleTypes(["CompileC", "Ld"], targetName: "aLibraryDep")
+        }
+    }
+
+    @Test(.requireSDKs(.macOS), .requireXcode16())
+    func singleFileCompileMetal() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = try await TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup("Sources", children: [TestFile("Metal.metal")]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: ["PRODUCT_NAME": "$(TARGET_NAME)",
+                                            "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
+                                            "SWIFT_VERSION": swiftVersion])],
+                        targets: [
+                            TestStandardTarget(
+                                "aLibrary", type: .staticLibrary,
+                                buildConfigurations: [TestBuildConfiguration("Debug")],
+                                buildPhases: [TestSourcesBuildPhase(["Metal.metal"])]
+                            )
+                        ]
+                    )
+                ]
+            )
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            let metalFile = testWorkspace.sourceRoot.join("aProject/Metal.metal")
+            try await tester.fs.writeFileContents(metalFile) { stream in }
+
+            // Create a build request context to compute the output paths - can't use one from the tester because it's an _output_ of checkBuild.
+            let buildRequestContext = BuildRequestContext(workspaceContext: tester.workspaceContext)
+
+            // Construct the output paths.
+            let excludedTypes: Set<String> = ["Copy", "Gate", "MkDir", "SymLink", "WriteAuxiliaryFile", "CreateBuildDirectory", "SwiftDriver", "SwiftDriver Compilation Requirements", "SwiftDriver Compilation", "SwiftMergeGeneratedHeaders", "ClangStatCache", "SwiftExplicitDependencyCompileModuleFromInterface", "SwiftExplicitDependencyGeneratePcm", "ProcessSDKImports"]
+            let runDestination = RunDestinationInfo.host
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)
+            let target = tester.workspace.allTargets.first(where: { _ in true })!
+            let metalOutputPath = try #require(buildRequestContext.computeOutputPaths(for: [metalFile], workspace: tester.workspace, target: BuildRequest.BuildTargetInfo(parameters: parameters, target: target), command: .singleFileBuild(buildOnlyTheseFiles: [Path("")]), parameters: parameters).only)
+
+            // Check building just the Metal file.
+            try await tester.checkBuild(parameters: parameters, runDestination: runDestination, persistent: true, buildOutputMap: [metalOutputPath: metalFile.str]) { results in
+                results.consumeTasksMatchingRuleTypes(excludedTypes)
+                results.checkTask(.matchRule(["CompileMetalFile", metalFile.str])) { _ in }
+                results.checkNoTask()
+            }
+
+            try await tester.checkBuild(runDestination: runDestination, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
         }
     }
 }

--- a/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
@@ -17,7 +17,6 @@ import Testing
 import SWBCore
 import SWBProtocol
 import SWBTestSupport
-import SwiftBuild
 @_spi(Testing) import SWBUtil
 
 import SWBTaskExecution
@@ -236,7 +235,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
             let tester = try await BuildOperationTester(getCore(), testProject, simulated: true)
 
             try await tester.checkBuildDescription(runDestination: .host) { results in
-                let buildProductsDirSuffix = SWBRunDestinationInfo.host.builtProductsDirSuffix
+                let buildProductsDirSuffix = RunDestinationInfo.host.builtProductsDirSuffix
                 results.checkWarning(.equal("duplicate output file '\(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str)' on task: CpHeader \(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str) \(tmpDir.join("Subdir/Fwk.h", normalize: true).str) (in target 'lib1' from project 'aProject')"))
                 results.checkWarning(.equal("duplicate output file '\(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str)' on task: CpHeader \(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str) \(tmpDir.join("Fwk.h", normalize: true).str) (in target 'lib2' from project 'aProject')"))
                 results.checkWarning(.equal("duplicate output file '\(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str)' on task: CpHeader \(tmpDir.join("build/Debug\(buildProductsDirSuffix)/foo/bar/Fwk.h", normalize: true).str) \(tmpDir.join("Subdir/Fwk.h", normalize: true).str) (in target 'lib2' from project 'aProject')"))

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -1137,7 +1137,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationBeforeStarting() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1208,7 +1208,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationImmediatelyAfterStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1280,7 +1280,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test(.requireSDKs(.macOS))
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationAfterStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1362,7 +1362,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func cancellationAfterTaskStart() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1442,7 +1442,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check some cancellation related semantics.
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func repeatedCancellation() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -1591,7 +1591,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Test session destruction
-    @Test
+    @Test(.skipHostOS(.windows, "requires /usr/bin/yes"))
     func sessionDestructionCancellation() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -49,15 +49,17 @@ fileprivate struct ServiceConsoleTests {
         // Test against command line arguments.
         let executionResult = try await Process.getOutput(url: try CLIConnection.swiftbuildToolURL, arguments: ["isAlive"], environment: CLIConnection.environment)
 
+        let output = String(decoding: executionResult.stdout, as: UTF8.self)
+        
         // Verify there were no errors.
-        #expect(String(decoding: executionResult.stdout, as: UTF8.self) == "is alive? yes" + String.newline)
+        #expect(output == "is alive? yes\(String.newline)")
 
         // Assert the tool exited successfully.
         #expect(executionResult.exitStatus == .exit(0))
     }
 
     /// Test that the build service shuts down if the host dies.
-    @Test(.skipHostOS(.windows)) // PTY not supported on Windows
+    @Test(.skipHostOS(.windows, "PTY not supported on Windows"))
     func serviceShutdown() async throws {
         try await withCLIConnection { cli in
             // Find the service pid.
@@ -95,7 +97,7 @@ fileprivate struct ServiceConsoleTests {
     }
 
     /// Tests that the serializedDiagnostics console command is able to print human-readable serialized diagnostics from a .dia file.
-    @Test(.skipHostOS(.windows)) // PTY not supported on Windows
+    @Test(.skipHostOS(.windows, "PTY not supported on Windows"))
     func dumpSerializedDiagnostics() async throws {
         // Generate and compile a C source file that will generate a compiler warning.
         try await withTemporaryDirectory { tmp in


### PR DESCRIPTION
- fixed issue where a request to build a single output would fail on windows due to path separator differences used in llbuild manifest. (see singleFileCompile test)
- fix ServiceConsoleTests for windows
- fix BuildDescriptionConstructionTests for windows
- 
