### PR TITLE
Change Windows linker to lld(llvm linker)

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -306,6 +306,7 @@ public final class Core: Sendable {
 
         // Search the default location first (unless directed not to), then search any extra locations we've been passed.
         var searchPaths: [Path]
+        let fs = localFS
         if let onlySearchAdditionalPlatformPaths = getEnvironmentVariable("XCODE_ONLY_EXTRA_PLATFORM_FOLDERS"), onlySearchAdditionalPlatformPaths.boolValue {
             searchPaths = []
         }
@@ -324,7 +325,7 @@ public final class Core: Sendable {
             }
         }
         searchPaths += UserDefaults.additionalPlatformSearchPaths
-        return PlatformRegistry(delegate: self.registryDelegate, searchPaths: searchPaths, hostOperatingSystem: hostOperatingSystem)
+        return PlatformRegistry(delegate: self.registryDelegate, searchPaths: searchPaths, hostOperatingSystem: hostOperatingSystem, fs: fs)
     }()
 
     @PluginExtensionSystemActor public var loadedPluginPaths: [Path] {

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1015,7 +1015,7 @@ extension WorkspaceContext {
             }
 
             // Add the platform search paths.
-            for path in platform?.executableSearchPaths ?? [] {
+            for path in platform?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
 

--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -1234,17 +1234,44 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
         let alternateLinker = scope.evaluate(BuiltinMacros.ALTERNATE_LINKER)
-
         // The ALTERNATE_LINKER is the 'name' of the linker not the executable name, clang will find the linker binary based on name passed via -fuse-ld, but we need to discover
-        // its properties by executing the actual binary. On unix based oses the linkers are installed as ld.<name> on windows its <name>.exe
+        // its properties by executing the actual binary. There is a common filename when the linker is not "ld" across all platforms using "ld.<ALTERNAME_LINKER>(.exe)"
+        // macOS (Xcode SDK)
+        // -----------------
+        // ld
+        // ld-classic
+        //
+        // macOS (Open Source)
+        // -----------
+        // ld.lld -> lld
+        // ld64.lld -> lld
+        // lld
+        // lld-link -> lld
+        //
+        // Linux
+        // ------
+        // /usr/bin/ld -> aarch64-linux-gnu-ld
+        // /usr/bin/ld.bfd -> aarch64-linux-gnu-ld.bfd
+        // /usr/bin/ld.gold -> aarch64-linux-gnu-ld.gold
+        // /usr/bin/ld.lld -> lld
+        // /usr/bin/ld64.lld -> lld
+        // /usr/bin/lld
+        // /usr/bin/lld-link -> lld
+        // /usr/bin/gold -> aarch64-linux-gnu-gold
+        //
+        // Windows
+        // -------
+        // ld.lld.exe
+        // ld64.lld.exe
+        // lld-link.exe
+        // lld.exe
+        // link.exe //In Visual Studio
+        //
+        // Note: On Linux you cannot invoke the llvm linker by the direct name for determining the version,
+        // you need to use ld.<ALTERNATE_LINKER>
         var linkerPath = Path("ld")
-        if alternateLinker != "" {
-            linkerPath =
-                switch producer.hostOperatingSystem {
-                        case .linux: Path("ld.\(alternateLinker)")
-                        case .windows: Path("\(alternateLinker).exe")
-                        default : Path("\(alternateLinker)")
-                }
+        if alternateLinker != "" && alternateLinker != "ld" {
+            linkerPath = Path(producer.hostOperatingSystem.imageFormat.executableName(basename: "ld.\(alternateLinker)"))
         }
         // Create the cache key.  This is just the path to the linker we would invoke if we were invoking the linker directly.
         guard let toolPath = producer.executableSearchPaths.lookup(linkerPath) else {

--- a/Sources/SWBCore/Specs/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/Specs/Tools/LinkerTools.swift
@@ -177,6 +177,7 @@ public struct DiscoveredLdLinkerToolSpecInfo: DiscoveredCommandLineToolSpecInfo 
     let undefinedSymbolCountLimit = 100
 
     override func parseLine<S: Collection>(_ lineBytes: S) -> Bool where S.Element == UInt8 {
+
         // Create a string that we can examine.  Use the non-failable constructor, so that we are robust against potentially invalid UTF-8.
         let lineString = String(decoding: lineBytes, as: Unicode.UTF8.self)
 
@@ -1234,9 +1235,18 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
         let alternateLinker = scope.evaluate(BuiltinMacros.ALTERNATE_LINKER)
 
-        let linkerPath = if alternateLinker != "" { Path(alternateLinker) } else { Path("ld") }
-
-        // Create the cache key.  This is just the path to the ld linker we would invoke if we were invoking the linker directly.
+        // The ALTERNATE_LINKER is the 'name' of the linker not the executable name, clang will find the linker binary based on name passed via -fuse-ld, but we need to discover
+        // its properties by executing the actual binary. On unix based oses the linkers are installed as ld.<name> on windows its <name>.exe
+        var linkerPath = Path("ld")
+        if alternateLinker != "" {
+            linkerPath =
+                switch producer.hostOperatingSystem {
+                        case .linux: Path("ld.\(alternateLinker)")
+                        case .windows: Path("\(alternateLinker).exe")
+                        default : Path("\(alternateLinker)")
+                }
+        }
+        // Create the cache key.  This is just the path to the linker we would invoke if we were invoking the linker directly.
         guard let toolPath = producer.executableSearchPaths.lookup(linkerPath) else {
             return nil
         }
@@ -1582,7 +1592,7 @@ public func discoveredLinkerToolsInfo(_ producer: any CommandProducer, _ delegat
             let vCommandLine = [toolPath.str, "-v"]
             return try await producer.discoveredCommandLineToolSpecInfo(delegate, nil, vCommandLine, { executionResult in
                 let lld = [
-                    #/LLD (?<version>[\d.]+) .*/#,
+                    #/LLD (?<version>[\d.]+).*/#,
                 ]
                 if let match = try lld.compactMap({ try $0.firstMatch(in: String(decoding: executionResult.stdout, as: UTF8.self)) }).first {
                     return DiscoveredLdLinkerToolSpecInfo(linker: .lld, toolPath: toolPath, toolVersion: try Version(String(match.output.version)), architectures: Set())
@@ -1591,7 +1601,7 @@ public func discoveredLinkerToolsInfo(_ producer: any CommandProducer, _ delegat
                 let versionCommandLine = [toolPath.str, "--version"]
                 return try await producer.discoveredCommandLineToolSpecInfo(delegate, nil, versionCommandLine, { executionResult in
                     let lld = [
-                        #/LLD (?<version>[\d.]+) .*/#,
+                        #/LLD (?<version>[\d.]+).*/#,
                     ]
                     if let match = try lld.compactMap({ try $0.firstMatch(in: String(decoding: executionResult.stdout, as: UTF8.self)) }).first {
                         return DiscoveredLdLinkerToolSpecInfo(linker: .lld, toolPath: toolPath, toolVersion: try Version(String(match.output.version)), architectures: Set())

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -256,6 +256,35 @@ extension CoreBasedTests {
             #endif
         }
     }
+
+    // Linkers
+    package var ldPath: Path {
+        get async throws {
+            let (core, defaultToolchain) = try await coreAndToolchain()
+            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld"), "couldn't find ld in default toolchain")
+        }
+    }
+    package var linkPath: Path {
+        get async throws {
+            let (core, defaultToolchain) = try await coreAndToolchain()
+            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link"), "couldn't find link in default toolchain")
+        }
+    }
+    package var lldPath: Path {
+        get async throws {
+            let (core, defaultToolchain) = try await coreAndToolchain()
+            return try #require(
+                defaultToolchain.executableSearchPaths.findExecutable(
+                    operatingSystem: core.hostOperatingSystem,
+                    basename: core.hostOperatingSystem == .windows ? "lld-link" : "ld.lld"), "couldn't find ld.ldd in default toolchain")
+        }
+    }
+    package var goldPath: Path {
+        get async throws {
+            let (core, defaultToolchain) = try await coreAndToolchain()
+            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold"), "couldn't find ld.gold in default toolchain")
+        }
+    }
 }
 
 /// Process-wide registry of inferior products paths to Core instances.

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -258,31 +258,32 @@ extension CoreBasedTests {
     }
 
     // Linkers
-    package var ldPath: Path {
+    package var ldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld"), "couldn't find ld in default toolchain")
+            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld")
         }
     }
-    package var linkPath: Path {
+    package var linkPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link"), "couldn't find link in default toolchain")
+            if core.hostOperatingSystem != .windows {
+                // Most unixes have a link executable, but that is not a linker
+                return nil
+            }
+            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link")
         }
     }
-    package var lldPath: Path {
+    package var lldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return try #require(
-                defaultToolchain.executableSearchPaths.findExecutable(
-                    operatingSystem: core.hostOperatingSystem,
-                    basename: core.hostOperatingSystem == .windows ? "lld-link" : "ld.lld"), "couldn't find ld.ldd in default toolchain")
+            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.lld")
         }
     }
-    package var goldPath: Path {
+    package var goldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold"), "couldn't find ld.gold in default toolchain")
+            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold")
         }
     }
 }

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -261,7 +261,15 @@ extension CoreBasedTests {
     package var ldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld")
+            if let executable = defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld") {
+                return executable
+            }
+            for platform in core.platformRegistry.platforms {
+                if let executable = platform.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld") {
+                    return executable
+                }
+            }
+            return nil
         }
     }
     package var linkPath: Path? {
@@ -271,19 +279,45 @@ extension CoreBasedTests {
                 // Most unixes have a link executable, but that is not a linker
                 return nil
             }
-            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link")
+            if let executable = defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link") {
+                return executable
+            }
+            for platform in core.platformRegistry.platforms {
+                if let executable = platform.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "link") {
+                    return executable
+                }
+            }
+            return nil
         }
     }
+
     package var lldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.lld")
+            if let executable = defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.ld") {
+                return executable
+            }
+            for platform in core.platformRegistry.platforms {
+                if let executable = platform.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.ld") {
+                    return executable
+                }
+            }
+            return nil
         }
     }
+
     package var goldPath: Path? {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
-            return defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold")
+            if let executable = defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold") {
+                return executable
+            }
+            for platform in core.platformRegistry.platforms {
+                if let executable = platform.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld.gold") {
+                    return executable
+                }
+            }
+            return nil
         }
     }
 }

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -56,7 +56,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
             for path in core.toolchainRegistry.defaultToolchain?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
-            for path in platform?.executableSearchPaths ?? [] {
+            for path in platform?.executableSearchPaths.paths ?? [] {
                 paths.append(path)
             }
             paths.append(core.developerPath.join("usr").join("bin"))

--- a/Sources/SWBWindowsPlatform/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/WindowsLd.xcspec
@@ -133,6 +133,17 @@
                 );
                 IsInputDependency = Yes;
             },
+            {
+                Name = "ALTERNATE_LINKER";
+                Type = String;
+                DefaultValue = "lld-link";
+                CommandLineArgs = {
+                    "" = ();
+                    "<<otherwise>>" = (
+                        "-fuse-ld=$(value)"
+                    );
+                };
+            },
         );
     },
 )

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -170,16 +170,7 @@ fileprivate struct LinkerTests: CoreBasedTests {
     ///       a capaitalized error snippet, so this needs to be handled.
     @Test(.requireSDKs(.host))
     func alternateLinkerSelection() async throws {
-
-        // struct Linker {
-        //     let name: String
-        //     let exec: Path
-        //     let validOn: [RunDestinationInfo]
-        // }
-
         let runDestination: RunDestinationInfo = .host
-        // let defaultLinker = try await runDestination == .windows ? Linker(name: "link", exec: self.linkExePath, validOn: [.windows]) : Linker(name: "ld", exec: self.ldPath, validOn: [.macOS, .linux])
-
         let swiftVersion = try await self.swiftVersion
         try await withTemporaryDirectory { tmpDir in
             let testProject = try await TestProject(

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -66,7 +66,7 @@ import SWBMacro
             }
 
             let delegate = await TestDataDelegate(pluginManager: PluginManager(skipLoadingPluginIdentifiers: []))
-            let registry = PlatformRegistry(delegate: delegate, searchPaths: [tmpDirPath], hostOperatingSystem: try ProcessInfo.processInfo.hostOperatingSystem())
+            let registry = PlatformRegistry(delegate: delegate, searchPaths: [tmpDirPath], hostOperatingSystem: try ProcessInfo.processInfo.hostOperatingSystem(), fs: localFS)
             try await perform(registry, delegate)
         }
     }


### PR DESCRIPTION
Force ALTERNATE_LINKER to lld-link for the Windows platform.

* Add linker tests for setting ALTERNATE_LINKER.  Test a few different combinations, default, invalid and specific linkers.
* Tests expose some linking issues (Windows) that will need to be fixed.
* Fix the regular expression for detecting lld linker version as windows does not have a space. i.e. 
`LLD 17.0.6` 
`LLD 17.0.0 (compatible with GNU linkers)`