### PR TITLE
docs: fix spelling errors in `SWBUniversalPlatform` documentation

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/CopyPlistFile.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/CopyPlistFile.xcspec
@@ -49,7 +49,7 @@
                     {   Value = "binary";
                         CommandLineArgs = ("--convert", "binary1");
                     },
-                    {   Value = "Binary";   // deprecated -- backwards compatability
+                    {   Value = "Binary";   // deprecated -- backwards compatibility
                         CommandLineArgs = ("--convert", "binary1");
                     },
                 );

--- a/Sources/SWBUniversalPlatform/Specs/PBXCp.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/PBXCp.xcspec
@@ -25,7 +25,7 @@
         );
         RuleFormat = "$(pbxcp_rule_name:quote) $(Output:quote) $(Input:quote)";
         ExecDescription = "Copy $(InputFileName)";
-        /* This description is dynamically overriden for certain rule types. */
+        /* This description is dynamically overridden for certain rule types. */
         ProgressDescription = "Copying $(CommandProgressByType) files";
         DeeplyStatInputDirectories = YES;
         CaresAboutInclusionDependencies = NO;


### PR DESCRIPTION
All SWBUniversalPlatform files have been reviewed. All changes are backward compatible 