### PR TITLE
ci: add auto spell check for any PRs and main branch changes

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,0 +1,11 @@
+name: 'Check spelling'
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+
+jobs:
+  spellcheck: # run the action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: streetsidesoftware/cspell-action@v6


### PR DESCRIPTION
Based on the discussion in [this PR](https://github.com/swiftlang/swift-build/pull/213#discussion_r1968123920), I’ve added cspell as a GitHub Action to automatically check for typos in PRs, making them harder to miss.

For now, it uses the tool’s default configuration, but we can adjust it as needed. It runs only on changed files, ignoring pre-existing issues, which should be reviewed manually to avoid unintended breaking changes (IMO).