### PR TITLE
Don't crash when attempting single-file builds with multiple targets in the build request

### DIFF
--- a/Sources/SWBCore/BuildRequestContext.swift
+++ b/Sources/SWBCore/BuildRequestContext.swift
@@ -134,8 +134,8 @@ extension BuildRequestContext {
         }
     }
 
-    /// Compute output paths for a list of source files in a specific target.
-    public func computeOutputPaths(for inputPaths: [Path], workspace: Workspace, target: BuildRequest.BuildTargetInfo, command: BuildCommand, parameters: BuildParameters? = nil) -> [String] {
+    /// Compute output paths for a source file in a specific target. There may be multiple results if the build is a multi-arch build.
+    public func computeOutputPaths(for inputPath: Path, workspace: Workspace, target: BuildRequest.BuildTargetInfo, command: BuildCommand, parameters: BuildParameters? = nil) -> [String] {
         let settings = getCachedSettings(parameters ?? target.parameters, target: target.target)
         let effectiveArchs = settings.globalScope.evaluate(BuiltinMacros.ARCHS)
 
@@ -166,7 +166,8 @@ extension BuildRequestContext {
         let sourceCodeBasenames = sourceCodeFileToBuildableReference.keys.map { $0.basenameWithoutSuffix }
         return usedArchs.map({ arch in
             let lookup = { return $0 == BuiltinMacros.CURRENT_ARCH ? settings.globalScope.namespace.parseLiteralString(arch) : nil }
-            return inputPaths.map { file in
+            do {
+                let file = inputPath
                 let ref = sourceCodeFileToBuildableReference[file]
                 let specLookupContext = SpecLookupCtxt(specRegistry: workspaceContext.core.specRegistry, platform: settings.platform)
                 let input: FileToBuild
@@ -184,7 +185,7 @@ extension BuildRequestContext {
                 }
                 return outputDir.join(file.basenameWithoutSuffix).str + "\(uniquingSuffix)\(outputSuffix)"
             }
-        }).reduce([], +)
+        })
     }
 
     /// Given the targets configured for multiple platforms, select the most appropriate one for the index service to use.

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -99,6 +99,64 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
+    func multiFileAssembleBuild() async throws {
+        try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
+            try await withAsyncDeferrable { deferrable in
+                let tmpDir = temporaryDirectory.path
+                let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let srcroot = tmpDir.join("Test")
+                let testProject = TestProject(
+                    "aProject",
+                    defaultConfigurationName: "Release",
+                    groupTree: TestGroup("Foo", children: [TestFile("Test.c")]),
+                    targets: [
+                        TestAggregateTarget("All", dependencies: ["aFramework", "bFramework"]),
+                        TestStandardTarget("aFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                        TestStandardTarget("bFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                    ])
+                let testWorkspace = TestWorkspace("aWorkspace",
+                                                  sourceRoot: srcroot,
+                                                  projects: [testProject])
+
+                try await testSession.sendPIF(testWorkspace)
+
+                // Run a test build.
+                var request = SWBBuildRequest()
+                request.parameters = SWBBuildParameters()
+                request.parameters.action = "build"
+                request.parameters.configurationName = "Debug"
+                request.configuredTargets = testProject.targets.dropFirst().map { SWBConfiguredTarget(guid: $0.guid) }
+                request.buildCommand = .buildFiles(paths: [srcroot.join("Test.c").str], action: .assemble)
+
+                let events = try await testSession.runBuildOperation(request: request, delegate: TestBuildOperationDelegate())
+
+                let pathMap = try #require(events.compactMap({ msg in
+                    switch msg {
+                    case let .reportPathMap(msg):
+                        return msg.generatedFilesPathMap
+                    default:
+                        return nil
+                    }
+                }).only)
+                #expect(pathMap.count == 4)
+                for arch in ["arm64", "x86_64"] {
+                    for target in ["aFramework", "bFramework"] {
+                        #expect(try pathMap[AbsolutePath(validating: "\(srcroot.str)/aProject/build/aProject.build/Debug/\(target).build/Objects-normal/\(arch)/Test.s")] == AbsolutePath(validating: "\(srcroot.str)/Test.c"))
+                    }
+                }
+
+                XCTAssertLastBuildEvent(events)
+            }
+        }
+    }
+
     /// Check the basic behavior of a build operation's messages.
     @Test(.requireSDKs(.macOS), .skipHostOS(.windows)) // relies on UNIX shell, consider adding Windows command shell support for script phases?
     func basics() async throws {


### PR DESCRIPTION
Instead, when a single file preprocess or assemble request is made, incorporate the results across multiple architectures and target contexts instead of erroring out. The client can then decide how to present the results. Previously, the client was expected to limit the request to a single target.

rdar://145323187