### PR TITLE
Skip RKAssetsIncrementalRebuild test in CI

### DIFF
--- a/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
@@ -174,7 +174,7 @@ fileprivate struct PackageBuildOperationTests: CoreBasedTests {
     }
 
     /// Check that an .rkassets bundle gets an incremental build.
-    @Test(.requireSDKs(.xrOS), .disabled(if: !ProcessInfo.processInfo.isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)), "rdar://129991610"))
+    @Test(.requireSDKs(.xrOS), .disabled(if: !ProcessInfo.processInfo.isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)), "rdar://129991610"), .disabled(if: getEnvironmentVariable("CI")?.isEmpty == false))
     func RKAssetsIncrementalRebuild() async throws {
         // FIXME: We should be able to test this in simulation. For that, we need BuildDescription support for knowing which tasks are safe to run in simulation.
         let core = try await getCore()


### PR DESCRIPTION
This test started failing due to a missing visionOS simulator runtime since the OS was updated past macOS 15.0 and the test stopped being skipped. Skip it again until we can figure out what's going on.