### PR TITLE
Filter dependency scan query warnings

### DIFF
--- a/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
+++ b/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
@@ -191,5 +191,10 @@ package func _filterDiagnostic(message: String) -> String? {
         return nil
     }
 
+    // Workaround: rdar://141686644
+    if message.contains("In-process dependency scan query failed due to incompatible libSwiftScan") {
+        return nil
+    }
+
     return message
 }


### PR DESCRIPTION
These can show up depending on the toolchain being used and will poison many test results, so for the time being we want to filter them out.
