### PR TITLE
Improve robustness of test code involving SDK imports

### DIFF
--- a/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
@@ -78,7 +78,8 @@ fileprivate struct DsymGenerationBuildOperationTests: CoreBasedTests {
                 results.checkTask(.matchRuleType("GenerateTAPI")) { _ in }
                 results.checkTask(.matchRuleType("GenerateDSYMFile")) { _ in }
                 results.checkTask(.matchRuleType("Strip")) { _ in }
-                if try await supportsSDKImports {
+                let sdkImportsEnabled = results.buildRequestContext.getCachedSettings(debug, target: try #require(tester.workspace.projects.first?.targets.first)).globalScope.evaluate(BuiltinMacros.ENABLE_SDK_IMPORTS)
+                if try await supportsSDKImports, sdkImportsEnabled {
                     results.checkTask(.matchRuleType("ProcessSDKImports")) { _ in }
                 }
                 results.checkNoTask()

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -164,7 +164,8 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 results.checkTask(.matchRule(["WriteAuxiliaryFile", "\(tmpDirPath.str)/Test/aProject/build/aProject.build/Debug/AppTarget.build/AppTarget.DependencyStaticMetadataFileList"])) { _ in }
                 results.checkTask(.matchRule(["WriteAuxiliaryFile", "\(tmpDirPath.str)/Test/aProject/build/aProject.build/Debug/FwkTarget.build/FwkTarget.DependencyStaticMetadataFileList"])) { _ in }
 
-                if try await supportsSDKImports {
+                let sdkImportsEnabled = results.buildRequestContext.getCachedSettings(parameters, target: try #require(buildTargets.first).target).globalScope.evaluate(BuiltinMacros.ENABLE_SDK_IMPORTS)
+                if try await supportsSDKImports, sdkImportsEnabled {
                     // SDK imports create a resource file, but since we don't actually link here, we're not producing it.
                     results.checkTask(.matchRule(["MkDir", "\(tmpDirPath.str)/Test/aProject/build/Debug/FwkTarget.framework/Versions/A/Resources"])) { _ in }
                     results.checkTask(.matchRule(["SymLink", "\(tmpDirPath.str)/Test/aProject/build/Debug/FwkTarget.framework/Resources", "Versions/Current/Resources"])) { _ in }


### PR DESCRIPTION
Some existing test code would only differentiate between SDK imports being available or not, but since right now they're off by default, they should also check whether they're enabled.