### PR TITLE
[TaskActions] Change `SwiftCachingKeyQueryTaskAction` to be detached or not based on a setting

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
@@ -26,9 +26,8 @@ public final class SwiftCachingKeyQueryTaskAction: TaskAction {
         super.init()
     }
 
-    /// Network task so avoid blocking or being restricted by the execution lanes.
     override public var shouldExecuteDetached: Bool {
-        return true
+        return key.casOptions.enableDetachedKeyQueries
     }
 
     override public func performTaskAction(


### PR DESCRIPTION
By default it will run as part of the execution lanes, having the same behavior as `ClangCachingKeyQueryTaskAction`.

rdar://145674013