### PR TITLE
Revert "Infer [system] based on install path when generating clang modulemaps

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -852,7 +852,6 @@ public final class BuiltinMacros {
     public static let MODULEMAP_FILE_CONTENTS = BuiltinMacros.declareStringMacro("MODULEMAP_FILE_CONTENTS")
     public static let MODULEMAP_PATH = BuiltinMacros.declareStringMacro("MODULEMAP_PATH")
     public static let MODULEMAP_PRIVATE_FILE = BuiltinMacros.declareStringMacro("MODULEMAP_PRIVATE_FILE")
-    public static let GENERATED_MODULEMAPS_USE_SYSTEM = BuiltinMacros.declareBooleanMacro("GENERATED_MODULEMAPS_USE_SYSTEM")
     public static let MODULES_FOLDER_PATH = BuiltinMacros.declarePathMacro("MODULES_FOLDER_PATH")
     public static let MODULE_VERIFIER_KIND = BuiltinMacros.declareEnumMacro("MODULE_VERIFIER_KIND") as EnumMacroDeclaration<ModuleVerifierKind>
     public static let MODULE_VERIFIER_LSV = BuiltinMacros.declareBooleanMacro("MODULE_VERIFIER_LSV")
@@ -1920,7 +1919,6 @@ public final class BuiltinMacros {
         MODULEMAP_FILE_CONTENTS,
         MODULEMAP_PATH,
         MODULEMAP_PRIVATE_FILE,
-        GENERATED_MODULEMAPS_USE_SYSTEM,
         MODULES_FOLDER_PATH,
         MODULE_CACHE_DIR,
         MODULE_NAME,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2048,18 +2048,17 @@ private class SettingsBuilder {
         // FIXME: Arguably we should emit a warning if the optimization settings are out of sync, as the user may be getting weird results.  It's not clear if there are lots of old projects which might spuriously get such a warning, and this isn't a new state of affairs.
         table.push(BuiltinMacros.IS_UNOPTIMIZED_BUILD, literal: (scope.evaluate(BuiltinMacros.GCC_OPTIMIZATION_LEVEL) == "0" || scope.evaluate(BuiltinMacros.SWIFT_OPTIMIZATION_LEVEL) == "-Onone"))
 
-        let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
-        let publicInstallPaths = [
-            Path("/System/Library/Frameworks"),
-            Path("/System/Library/SubFrameworks"),
-            Path("/usr/lib"),
-            Path("/System/iOSSupport/System/Library/Frameworks"),
-            Path("/System/iOSSupport/System/Library/SubFrameworks"),
-            Path("/System/iOSSupport/usr/lib"),]
-
         // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.
         if scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).isEmpty &&
            scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib" {
+            let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
+            let publicInstallPaths = [
+                Path("/System/Library/Frameworks"),
+                Path("/System/Library/SubFrameworks"),
+                Path("/usr/lib"),
+                Path("/System/iOSSupport/System/Library/Frameworks"),
+                Path("/System/iOSSupport/System/Library/SubFrameworks"),
+                Path("/System/iOSSupport/usr/lib"),]
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
             if table.contains(BuiltinMacros.SKIP_INSTALL) {
@@ -2072,16 +2071,6 @@ private class SettingsBuilder {
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "api")
             }
             // Else, leave it to the compiler's default.
-        }
-
-        // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.
-        if scope.evaluateAsString(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM).isEmpty {
-            let systemInstallPaths = publicInstallPaths + privateInstallPaths
-            let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
-
-            if systemInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
-                table.push(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM, literal: true)
-            }
         }
 
         // Overrides specific to building for Mac Catalyst.

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
@@ -370,10 +370,9 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
             //
             // NOTE: This is unrelated to the "MODULE_NAME" build setting, which is much older and used by kexts.
             let moduleName = scope.evaluate(BuiltinMacros.PRODUCT_MODULE_NAME)
-            let isSystem = scope.evaluate(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM)
 
             // Create the trivial synthesized module map.
-            outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) \(isSystem ? "[system] " : ""){\n"
+            outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) {\n"
             outputStream <<< "  umbrella header \"\(umbrellaHeaderName.asCStringLiteralContent)\"\n"
             outputStream <<< "  export *\n"
             outputStream <<< "\n"
@@ -394,13 +393,12 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
 
             let interfaceHeaderName = scope.evaluate(BuiltinMacros.SWIFT_OBJC_INTERFACE_HEADER_NAME)
             assert(!interfaceHeaderName.isEmpty) // implied by exportsSwiftObjCAPI
-            let isSystem = scope.evaluate(BuiltinMacros.GENERATED_MODULEMAPS_USE_SYSTEM)
 
             // Swift only module map contents is a top level framework module. Swift contents
             // for a mixed module map is a submodule of the top level framework module (whose
             // name had better be PRODUCT_MODULE_NAME or things are going to get weird).
             if moduleInfo.forSwiftOnly {
-                outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) \(isSystem ? "[system] " : ""){\n"
+                outputStream <<< "framework module \(try moduleName.asModuleIdentifierString()) {\n"
             } else {
                 outputStream <<< "\n"
                 outputStream <<< "module \(try moduleName.asModuleIdentifierString()).Swift {\n"

--- a/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
@@ -697,57 +697,6 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
-    func moduleMapGenerationSystemInference() async throws {
-        let testProject = TestProject(
-            "Project",
-            groupTree: TestGroup(
-                "Group",
-                children: [
-                    TestFile("CookieCutter.h"),
-                    TestFile("CSource.c"),
-                ]),
-            buildConfigurations: [
-                TestBuildConfiguration("Debug", buildSettings: [
-                    "DEFINES_MODULE": "YES",
-                    "PRODUCT_NAME": "$(TARGET_NAME)",
-                    "GENERATE_INFOPLIST_FILE": "YES",
-                    "INSTALL_PATH": "/System/Library/Frameworks",
-                ])
-            ],
-            targets: [
-                TestStandardTarget(
-                    "CookieCutter",
-                    type: .framework,
-                    buildPhases: [
-                        TestHeadersBuildPhase([
-                            TestBuildFile("CookieCutter.h", headerVisibility: .public),
-                        ]),
-                        TestSourcesBuildPhase([
-                            "CSource.c",
-                        ]),
-                    ]
-                ),
-            ])
-        let tester = try await TaskConstructionTester(getCore(), testProject)
-        let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-
-        await tester.checkBuild() { results in
-            results.checkTarget("CookieCutter") { target in
-                results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/Project.build/Debug/CookieCutter.build/module.modulemap"])) { task, contents in
-                    #expect(contents == (OutputByteStream()
-                                         <<< "framework module CookieCutter [system] {\n"
-                                         <<< "  umbrella header \"CookieCutter.h\"\n"
-                                         <<< "  export *\n"
-                                         <<< "\n"
-                                         <<< "  module * { export * }\n"
-                                         <<< "}\n").bytes)
-                }
-            }
-            results.checkNoDiagnostics()
-        }
-    }
-
-    @Test(.requireSDKs(.macOS))
     func staticModuleMapContents() async throws {
         let testProject = try await TestProject(
             "Project",


### PR DESCRIPTION
This reverts commit 0a658dd7ddac22fd3e9a1d4db3a1e064d6f6eda3.

This change proved to be too disruptive to apply automatically due to ClangImporter Int/UInt changes when changing the system-ness of a module

rdar://145658401