### PR TITLE
Prefer the copy of Swift Testing in the toolchain for importing and linking, if available

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -146,6 +146,6 @@ struct AndroidToolchainRegistryExtension: ToolchainRegistryExtension {
             return []
         }
 
-        return [Toolchain("android", "Android", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("bin")], fs: fs)]
+        return [Toolchain("android", "Android", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("bin")], testingLibraryPlatformNames: [], fs: fs)]
     }
 }

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4217,6 +4217,14 @@ private class SettingsBuilder {
             table.push(BuiltinMacros.LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "$(TEST_LIBRARY_SEARCH_PATHS$(TEST_BUILD_STYLE))"]))
             table.push(BuiltinMacros.SWIFT_INCLUDE_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "$(TEST_LIBRARY_SEARCH_PATHS$(TEST_BUILD_STYLE))"]))
 
+            // If the toolchain contains a copy of Swift Testing, prefer it.
+            let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
+            let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
+            let toolchainTestingLibraryDir = toolchainPath.join("usr/lib/swift/\(platformName)/testing")
+            if workspaceContext.fs.exists(toolchainTestingLibraryDir) {
+                table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", toolchainTestingLibraryDir.str]))
+            }
+
             if scope.evaluate(BuiltinMacros.ENABLE_PRIVATE_TESTING_SEARCH_PATHS) {
                 table.push(BuiltinMacros.SYSTEM_FRAMEWORK_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "$(TEST_PRIVATE_FRAMEWORK_SEARCH_PATHS$(TEST_BUILD_STYLE))"]))
             }

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4219,10 +4219,11 @@ private class SettingsBuilder {
 
             // If the toolchain contains a copy of Swift Testing, prefer it.
             let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
-            let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
-            let toolchainTestingLibraryDir = toolchainPath.join("usr/lib/swift/\(platformName)/testing")
-            if workspaceContext.fs.exists(toolchainTestingLibraryDir) {
-                table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", toolchainTestingLibraryDir.str]))
+            if let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }) {
+                let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
+                if let testingLibrarySearchPath = toolchain.testingLibrarySearchPath(forPlatformNamed: platformName) {
+                    table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", testingLibrarySearchPath.str]))
+                }
             }
 
             if scope.evaluate(BuiltinMacros.ENABLE_PRIVATE_TESTING_SEARCH_PATHS) {

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -295,12 +295,13 @@ public final class Toolchain: Hashable, Sendable {
         ])
 
         // Testing library platform names
-        var testingLibraryPlatformNames = Set<String>()
-        if let platformRegistry {
-            let testingLibrarySearchDir = path.join("usr").join("lib").join("swift")
-            testingLibraryPlatformNames = Set(try fs.listdir(testingLibrarySearchDir).filter {
+        let testingLibrarySearchDir = path.join("usr").join("lib").join("swift")
+        let testingLibraryPlatformNames: Set<String> = if let platformRegistry, fs.exists(testingLibrarySearchDir) {
+            Set(try fs.listdir(testingLibrarySearchDir).filter {
                 platformRegistry.lookup(name: $0) != nil && fs.exists(testingLibrarySearchDir.join($0).join("testing"))
             })
+        } else {
+            []
         }
 
         // Construct the toolchain

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -128,6 +128,6 @@ struct QNXToolchainRegistryExtension: ToolchainRegistryExtension {
             return []
         }
 
-        return [Toolchain("qnx", "QNX", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("usr").join("bin")], fs: fs)]
+        return [Toolchain("qnx", "QNX", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("usr").join("bin")], testingLibraryPlatformNames: [], fs: fs)]
     }
 }

--- a/Tests/SWBCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SWBCoreTests/ToolchainRegistryTests.swift
@@ -63,6 +63,10 @@ import SWBUtil
                 }
 
                 var pluginManager: PluginManager
+
+                var platformRegistry: PlatformRegistry? {
+                    nil
+                }
             }
 
             let core = try await Self.makeCore(skipLoadingPluginsNamed: ["com.apple.dt.SWBAndroidPlatformPlugin"])


### PR DESCRIPTION
This adds a special case to the logic which configures additional build settings when `ENABLE_TESTING_SEARCH_PATHS` is enabled so that it inserts an additional library search path to locate Swift Testing from the toolchain if it's present.

Motivation: This is one step towards a larger goal of ensuring that if a user installs an open source Swift.org toolchain and selects it in Xcode, the copy of Swift Testing in that toolchain will be preferred over the analogous copy (`Testing.framework`) built in to Xcode. This matches existing precedent with other Swift standard libraries, which are used from the toolchain when available.

Fixes rdar://145689942
