### PR TITLE
Add workspace name and path to the optional SWIFTBUILD_TRACE file

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -738,11 +738,15 @@ package final class BuildOperation: BuildSystemOperation {
             struct SwiftDataTraceEntry: Codable {
                 let buildDescriptionSignature: String
                 let isTargetParallelizationEnabled: Bool
+                let name: String
+                let path: String
             }
             do {
                 let traceEntry  = SwiftDataTraceEntry(
                     buildDescriptionSignature: buildDescription.signature.asString,
-                    isTargetParallelizationEnabled: request.useParallelTargets
+                    isTargetParallelizationEnabled: request.useParallelTargets,
+                    name: workspace.name,
+                    path: workspace.path.str
                 )
                 let encoder = JSONEncoder(outputFormatting: .sortedKeys)
                 try fs.append(swiftBuildTraceFilePath, contents: ByteString(encoder.encode(traceEntry)) + "\n")

--- a/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
@@ -71,7 +71,8 @@ fileprivate struct SwiftBuildTraceTests: CoreBasedTests {
                 }
 
                 let trace = try tester.fs.read(tmpDirPath.join(".SWIFTBUILD_TRACE")).asString
-                #expect(try #/\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true\}\n\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true\}\n/#.wholeMatch(in: trace) != nil)
+                print(trace)
+                #expect(try #/\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true,\"name\":\"Test\",\"path\":\".*\"\}\n\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true,\"name\":\"Test\",\"path\":\".*\"\}\n/#.wholeMatch(in: trace) != nil)
             }
         }
     }


### PR DESCRIPTION
This can be used to identify the top level workspace/project/package referenced by a trace entry.

rdar://144816105