### PR TITLE
[SE-0458] Add SWIFT_STRICT_MEMORY_SAFETY build setting

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -563,6 +563,19 @@
             },
 
             {
+                Name = "SWIFT_STRICT_MEMORY_SAFETY";
+                Type = Boolean;
+                DefaultValue = "NO";
+                CommandLineArgs = {
+                    YES = ( "-strict-memory-safety" );
+                    NO = ();
+                };
+                DisplayName = "Strict Memory Safety";
+                Category = "Language";
+                Description = "Enable strict memory safety checking. This will produce warnings for each use of an unsafe language construct or API that isn't acknowledged with `unsafe` or `@unsafe`.";
+            },
+
+            {
                 Name = "SWIFT_ENABLE_BARE_SLASH_REGEX";
                 Type = Boolean;
                 DefaultValue = "YES";


### PR DESCRIPTION
Introduce a default-off build setting that allows one to enable the opt-in strict memory safety checking introduced by SE-0458.
