### PR TITLE
Mark a flaky test assertion

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -4192,7 +4192,9 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                 }
 
                 results.checkTasks(.matchRuleType("Libtool")) { tasks in
-                    #expect(tasks.count == 2)
+                    withKnownIssue("Sometimes the task count is 1", isIntermittent: true) {
+                        #expect(tasks.count == 2)
+                    }
                 }
 
                 results.checkNoTask()


### PR DESCRIPTION
This has been observed to be flaky on at least Windows and I believe also macOS.