### PR TITLE
docs: fix all remaining comment typos in the source directory

### DIFF
--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -188,7 +188,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     package let targetsBuildInParallel: Bool
 
     /// `true` if builds using this description should emit frontend command lines. This setting is important for debugging workflows, so we want the ability to enable it conveniently via build setting.
-    /// However, it should be consistent across all tasks in a build to avoid introducing unnecesary variants of dynamic compile tasks. To address this, we store it as a bit on the build description.
+    /// However, it should be consistent across all tasks in a build to avoid introducing unnecessary variants of dynamic compile tasks. To address this, we store it as a bit on the build description.
     package let emitFrontendCommandLines: Bool
 
     /// Load a build description from the given path.

--- a/Sources/SWBUtil/Promise.swift
+++ b/Sources/SWBUtil/Promise.swift
@@ -30,7 +30,7 @@ public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
         }
     }
 
-    /// Fullfills the promise with the specified result.
+    /// Fulfills the promise with the specified result.
     ///
     /// - returns: Whether the promise was already fulfilled.
     @discardableResult
@@ -53,7 +53,7 @@ public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
         return alreadyFulfilled
     }
 
-    /// Fullfills the promise with the specified value.
+    /// Fulfills the promise with the specified value.
     ///
     /// - returns: Whether the promise was already fulfilled.
     @discardableResult
@@ -61,7 +61,7 @@ public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
         fulfill(with: .success(value))
     }
 
-    /// Fullfills the promise with the specified error.
+    /// Fulfills the promise with the specified error.
     ///
     /// - returns: Whether the promise was already fulfilled.
     @discardableResult
@@ -71,7 +71,7 @@ public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
 }
 
 extension Promise where Success == Void {
-    /// Fullfills the promise.
+    /// Fulfills the promise.
     ///
     /// - returns: Whether the promise was already fulfilled.
     @discardableResult


### PR DESCRIPTION
Changes are backward compatible and double checked with the spell-checker.