### PR TITLE
Add a workspace for local co-development of Swift Build and swift-driver

### DIFF
--- a/Utilities/SwiftBuild+Deps.xcworkspace/contents.xcworkspacedata
+++ b/Utilities/SwiftBuild+Deps.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:../../swift-build">
+   </FileRef>
+   <FileRef
+      location = "container:../../swift-driver">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
This is useful for local development of the two projects together on a macOS host. In the future we could consider including some of the other relevant repos as well