### PR TITLE
Standardize spelling of explicit modules options

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -568,11 +568,11 @@ final class WorkspaceSettings: Sendable {
         }
 
         if SWBFeatureFlag.enableClangExplicitModulesByDefault.value {
-            table.push(BuiltinMacros._EXPERIMENTAL_CLANG_EXPLICIT_MODULES, literal: true)
+            table.push(BuiltinMacros.CLANG_ENABLE_EXPLICIT_MODULES, literal: true)
         }
 
         if SWBFeatureFlag.enableSwiftExplicitModulesByDefault.value {
-            table.push(BuiltinMacros._EXPERIMENTAL_SWIFT_EXPLICIT_MODULES, literal: .enabled)
+            table.push(BuiltinMacros.SWIFT_ENABLE_EXPLICIT_MODULES, literal: .enabled)
         }
 
         if SWBFeatureFlag.enableClangCachingByDefault.value {

--- a/Sources/SWBCore/Specs/PropertyDomainSpec.swift
+++ b/Sources/SWBCore/Specs/PropertyDomainSpec.swift
@@ -108,6 +108,8 @@ private final class EnumBuildOptionType : BuildOptionType {
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<LTOSetting>
         case "_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES":
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
+        case "SWIFT_ENABLE_EXPLICIT_MODULES":
+            return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
         default:
             return try namespace.declareStringMacro(name)
         }

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -912,7 +912,7 @@
                 DefaultValue = YES;
             },
             {
-                Name = "_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES";
+                Name = "SWIFT_ENABLE_EXPLICIT_MODULES";
                 Type = Enumeration;
                 Values = (
                     YES,

--- a/Sources/SWBUniversalPlatform/Specs/en.lproj/Swift Compiler.strings
+++ b/Sources/SWBUniversalPlatform/Specs/en.lproj/Swift Compiler.strings
@@ -55,5 +55,5 @@
 "[SWIFT_OBJC_INTEROP_MODE]-value-[objcxx]" = "C++ / Objective-C++";
 "[SWIFT_OBJC_INTEROP_MODE]-value-[objc]" = "C / Objective-C";
 
-"[_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES]-value-[YES]" = "Yes";
-"[_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES]-value-[NO]" = "No";
+"[SWIFT_ENABLE_EXPLICIT_MODULES]-value-[YES]" = "Yes";
+"[SWIFT_ENABLE_EXPLICIT_MODULES]-value-[NO]" = "No";


### PR DESCRIPTION
- Deemphasize _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES in favor of SWIFT_ENABLE_EXPLICIT_MODULES
- Clean up settings used by a couple of defaults

Continue to honor both spellings