### PR TITLE
Filter `MemberImportVisibility` warnings if present

### DIFF
--- a/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
+++ b/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
@@ -36,32 +36,38 @@ package protocol DiagnosticsCheckingResult: AnyObject {
 }
 
 extension DiagnosticsCheckingResult {
+    private func getFilteredDiagnostics(_ forKind: DiagnosticKind) -> [String] {
+        return getDiagnostics(forKind).compactMap {
+            filterDiagnostic(message: $0)
+        }
+    }
+
     /// Get the list of all errors.
     /// - remark: If the test calls this method then it must perform all checking of errors itself, as calling this method will disable automatic checking in the tester.
     package func getErrors() -> [String] {
         checkedErrors = true
-        return getDiagnostics(.error)
+        return getFilteredDiagnostics(.error)
     }
 
     /// Get the list of all warnings.
     /// - remark: If the test calls this method then it must perform all checking of warnings itself, as calling this method will disable automatic checking in the tester.
     package func getWarnings() -> [String] {
         checkedWarnings = true
-        return getDiagnostics(.warning)
+        return getFilteredDiagnostics(.warning)
     }
 
     /// Get the list of all notes.
     /// - remark: If the test calls this method then it must perform all checking of notes itself, as calling this method will disable automatic checking in the tester.
     package func getNotes() -> [String] {
         checkedNotes = true
-        return getDiagnostics(.note)
+        return getFilteredDiagnostics(.note)
     }
 
     /// Get the list of all remarks.
     /// - remark: If the test calls this method then it must perform all checking of remarks itself, as calling this method will disable automatic checking in the tester.
     package func getRemarks() -> [String] {
         checkedRemarks = true
-        return getDiagnostics(.remark)
+        return getFilteredDiagnostics(.remark)
     }
 
     /// Find a particular error.
@@ -193,6 +199,10 @@ package func _filterDiagnostic(message: String) -> String? {
 
     // Workaround: rdar://141686644
     if message.contains("In-process dependency scan query failed due to incompatible libSwiftScan") {
+        return nil
+    }
+
+    if message.hasPrefix("Enabling the Swift language feature 'MemberImportVisibility' is recommended") {
         return nil
     }
 

--- a/Sources/SWBTestSupport/TaskConstructionTester.swift
+++ b/Sources/SWBTestSupport/TaskConstructionTester.swift
@@ -120,6 +120,9 @@ package final class TaskConstructionTester {
         package func getDiagnosticMessage(_ pattern: StringPattern, kind: DiagnosticKind, checkDiagnostic: (Diagnostic) -> Bool) -> String? {
             for (target, targetDiagnostics) in diagnostics {
                 for (index, event) in targetDiagnostics.enumerated() {
+                    guard filterDiagnostic(message: event.formatLocalizedDescription(.debugWithoutBehavior)) != nil else {
+                        continue
+                    }
                     guard event.behavior == kind else {
                         continue
                     }


### PR DESCRIPTION
These can occur in certain environments and will cause a large number of tests to fail which are asserting that there are no additional warnings.

rdar://146108156
