### PR TITLE
Resolves #249 - Fix simple linking on Windows

### DIFF
--- a/Sources/SWBWindowsPlatform/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Windows.xcspec
@@ -48,6 +48,7 @@
         Identifier = com.apple.product-type.library.static;
         BasedOn = default:com.apple.product-type.library.static;
         DefaultBuildProperties = {
+            EXECUTABLE_PREFIX = "";
             EXECUTABLE_EXTENSION = "lib";
             PUBLIC_HEADERS_FOLDER_PATH = "";
             PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -251,11 +251,6 @@ fileprivate struct LinkerTests: CoreBasedTests {
                         }
                     }
                 }
-                if runDestination == .windows {
-                    // Issue: Linker cannot find dependent library
-                    results.checkError(.contains("Linker command failed with exit code 1"))
-                    results.checkError(.contains("LNK1181: cannot open input file 'Library.lib'"))
-                }
                 results.checkNoDiagnostics()
             }
 
@@ -327,9 +322,6 @@ fileprivate struct LinkerTests: CoreBasedTests {
                             #expect(output.asString.contains(linkLinkerPath.str))
                         }
                     }
-                    //Issue: Linker cannot find dependent library
-                    results.checkError(.contains("Linker command failed with exit code 1"))
-                    results.checkError(.contains("LINK : fatal error LNK1181: cannot open input file 'Library.lib'"))
                     results.checkNoDiagnostics()
                 }
             }

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -1744,7 +1744,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 let effectivePlatformName = results.builtProductsDirSuffix(target)
                 let targetBuildDir = Path("\(SRCROOT)/build/Debug\(effectivePlatformName)")
                 let targetObjectsPerArchBuildBaseDir = Path("\(SRCROOT)/build/aProject.build/Debug\(effectivePlatformName)/Support.build/Objects-normal/")
-                let libSupportFileName = "libSupport\(runDestination == .windows ? ".lib" : ".a")"
+                let libSupportFileName = runDestination == .windows ? "Support.lib" : "libSupport.a"
 
                 if versioningSupported {
                     results.checkTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("Support_vers.c")) { _ in }


### PR DESCRIPTION
Windows linking is failing to find a dependent static library.

When using the clang driver for linking a '-l Library' will be translated into an argument of 'Library.lib'.

The linker is unable to find 'Library.lib' as the static library is named 'libLibrary.lib'

- Remove the EXECUTABLE_PREFIX for static  libraries on the windows platform.
- Update the tests to not check for the link failures.