### PR TITLE
Filter `MemberImportVisibility` notes if present

### DIFF
--- a/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
+++ b/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
@@ -206,5 +206,9 @@ package func _filterDiagnostic(message: String) -> String? {
         return nil
     }
 
+    if message.hasPrefix("Learn more about 'MemberImportVisibility' by visiting") {
+        return nil
+    }
+
     return message
 }


### PR DESCRIPTION
This is a follow-up to #247 which also covers an additional note that can be emitted here and that is relevant for some test cases to pass (e.g. some of the performance tests that don't run by default).
