### PR TITLE
Workaround language mode issue in older versions of --build-system xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -399,7 +399,7 @@ let package = Package(
             ))
         )
     ],
-    swiftLanguageModes: [.v6],
+    swiftLanguageModes: [.v5, .v6],
     cxxLanguageStandard: .cxx20
 )
 


### PR DESCRIPTION
Workaround the issue fixed in https://github.com/swiftlang/swift-package-manager/pull/8313 to continue supporting older toolchains