### PR TITLE
Add the .index-build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ xcuserdata
 /.build
 /Packages
 
+# Ignore indexing build dir.
+/.index-build
+
 # Ignore bootstrap build dir.
 /.xbuild
 /.DD


### PR DESCRIPTION
sourcekit-lsp uses this location for background indexing. In newer versions it's moved into .build but add it to the ignore list anyways as some users may still be using older Swift toolchains for now.