### PR TITLE
[swift] Always emit pch output path in OutputFileMap

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3076,6 +3076,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 let emitModuleDependenciesFilePath = objectFileDir.join(masterSwiftBaseName + "-emit-module.d")
                 fileMapEntry.emitModuleDependencies = emitModuleDependenciesFilePath.str
 
+                // The PCH file path for generatePCH job.
+                let bridgingHeaderPCHPath = objectFileDir.join(masterSwiftBaseName + "-Bridging-header.pch")
+                fileMapEntry.pch = bridgingHeaderPCHPath.str
+
                 // Add the global entry to the map.
                 mapDict[""] = fileMapEntry
             }
@@ -3115,11 +3119,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     fileMapEntry.constValues = objectFileDir.join(masterSwiftBaseName + ".swiftconstvalues").str
                 }
 
-                let objcBridgingHeaderPath = Path(cbc.scope.evaluate(BuiltinMacros.SWIFT_OBJC_BRIDGING_HEADER))
-                if !objcBridgingHeaderPath.isEmpty,
-                   await swiftExplicitModuleBuildEnabled(cbc.producer, cbc.scope, delegate) {
-                    fileMapEntry.pch = objectFileDir.join(masterSwiftBaseName + "-Bridging-header.pch").str
-                }
+                // The PCH file path for generatePCH job.
+                let bridgingHeaderPCHPath = objectFileDir.join(masterSwiftBaseName + "-Bridging-header.pch")
+                fileMapEntry.pch = bridgingHeaderPCHPath.str
 
                 // Add the global entry to the map.
                 mapDict[""] = fileMapEntry

--- a/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
@@ -687,6 +687,7 @@ fileprivate struct SwiftModuleOnlyTaskConstructionTests: CoreBasedTests {
                 "diagnostics": .plString(archBuildDir.join("\(tpc.targetName)\(platformSuffix)-master.dia").str),
                 "emit-module-diagnostics": .plString(archBuildDir.join("\(tpc.targetName)\(platformSuffix)-master-emit-module.dia").str),
                 "emit-module-dependencies": .plString(archBuildDir.join("\(tpc.targetName)\(platformSuffix)-master-emit-module.d").str),
+                "pch": .plString(archBuildDir.join("\(tpc.targetName)\(platformSuffix)-master-Bridging-header.pch").str),
             ]))
         }
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -301,6 +301,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             "diagnostics": .plString("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/AppTarget-master.dia"),
                             "emit-module-diagnostics": .plString("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/AppTarget-master-emit-module.dia"),
                             "emit-module-dependencies": .plString("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/AppTarget-master-emit-module.d"),
+                            "pch": .plString("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/AppTarget-master-Bridging-header.pch"),
                         ]))
                     }
                     else {


### PR DESCRIPTION
Always emit pch output path in OutputfileMap to support possible chained bridging header support. In the chained bridging header support mode, swift-driver can plan a generate PCH job even when there are no explicit bridging header is passed on command-line, and it needs the path in output file map to write the PCH file into desired location. Since having additional unused entries in the output file map is not an issue, just always generate output path for PCH in the output file map.

rdar://146409233
