### PR TITLE
Resolves #263 - Add all valid architectures for windows cross compilation

### DIFF
--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -664,7 +664,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
 
         let archs: PropertyListItem = switch operatingSystem {
             case .windows:
-                .plArray([.plString("x86_64"), .plString("aarch64")])
+                .plArray([.plString("x86_64"), .plString("i686"), .plString("aarch64"), .plString("thumbv7")])
             default:
                 .plArray([.plString(Architecture.hostStringValue ?? "unknown")])
         }

--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -662,6 +662,12 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
             tripleEnvironment = ""
         }
 
+        let archs: PropertyListItem = switch operatingSystem {
+            case .windows:
+                .plArray([.plString("x86_64"), .plString("aarch64")])
+            default:
+                .plArray([.plString(Architecture.hostStringValue ?? "unknown")])
+        }
         return try [
             "Type": .plString("SDK"),
             "Version": .plString(Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description),
@@ -672,7 +678,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
             ].merging(defaultProperties, uniquingKeysWith: { _, new in new })),
             "SupportedTargets": .plDict([
                 operatingSystem.xcodePlatformName: .plDict([
-                    "Archs": .plArray([.plString(Architecture.hostStringValue ?? "unknown")]),
+                    "Archs": archs,
                     "LLVMTargetTripleEnvironment": .plString(tripleEnvironment),
                     "LLVMTargetTripleSys": .plString(operatingSystem.xcodePlatformName),
                     "LLVMTargetTripleVendor": .plString("unknown"),

--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -19,7 +19,7 @@
         Description = "Standard architectures";
         ArchitectureSetting = "ARCHS_STANDARD";
         RealArchitectures = (
-            "$(VALID_ARCHS)"
+            "$(HOST_ARCH)"
         );
         SortNumber = 0;
     },


### PR DESCRIPTION
* The fallback SDK registration was only adding the host architecture as a valid architecture.  Add all valid architectures for Windows cross compilation.

