### PR TITLE
Don't emit a note if previews is disabled in the build system <rdar://145843881>

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3165,10 +3165,8 @@ private class SettingsBuilder {
 
         var shouldLog: Bool {
             switch self {
-            case .swiftNotEnabled, .action:
+            case .swiftNotEnabled, .action, .swiftOptimizationLevel:
                 false
-            case .swiftOptimizationLevel:
-                true
             }
         }
 


### PR DESCRIPTION
This is already detected at higher levels. The machinery to emit the note is still here in case we need to come back to it or add to it, though.