### PR TITLE
Remove TestStandardTarget's default product type argument

### DIFF
--- a/Sources/SWBTestSupport/Projects/AppClips.swift
+++ b/Sources/SWBTestSupport/Projects/AppClips.swift
@@ -53,6 +53,7 @@ extension TestProject {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: appBuildSettings)
                     ],

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -1072,7 +1072,7 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
     private let approvedByUser: Bool
 
     /// Create a test target
-    package init(_ name: String, guid: String? = nil, type: TargetType = .application, buildConfigurations: [TestBuildConfiguration]? = nil, buildPhases: [any TestBuildPhase] = [], buildRules: [TestBuildRule] = [], customTasks: [TestCustomTask] = [], dependencies: [TestTargetDependency] = [], productReferenceName: String? = nil, predominantSourceCodeLanguage: SWBCore.StandardTarget.SourceCodeLanguage = .undefined, provisioningSourceData: [ProvisioningSourceData] = [], dynamicTargetVariantName: String? = nil, approvedByUser: Bool = true) {
+    package init(_ name: String, guid: String? = nil, type: TargetType, buildConfigurations: [TestBuildConfiguration]? = nil, buildPhases: [any TestBuildPhase] = [], buildRules: [TestBuildRule] = [], customTasks: [TestCustomTask] = [], dependencies: [TestTargetDependency] = [], productReferenceName: String? = nil, predominantSourceCodeLanguage: SWBCore.StandardTarget.SourceCodeLanguage = .undefined, provisioningSourceData: [ProvisioningSourceData] = [], dynamicTargetVariantName: String? = nil, approvedByUser: Bool = true) {
         self.name = name
         self.overriddenGuid = guid
         self.type = type

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -537,6 +537,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                                 ]),
                             TestStandardTarget(
                                 "agg3",
+                                type: .application,
                                 buildConfigurations: [
                                     TestBuildConfiguration("Debug", buildSettings: ["BUILD_VARIANTS": "normal debug"])
                                 ],
@@ -3409,6 +3410,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                         targets: [
                             TestStandardTarget(
                                 "App",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([TestBuildFile("App.c")]),
                                 ]),
@@ -4398,6 +4400,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                         targets: [
                             TestStandardTarget(
                                 "App",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([
                                         "main.c",

--- a/Tests/SWBBuildSystemTests/EmbeddedBinaryValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/EmbeddedBinaryValidationTests.swift
@@ -47,6 +47,7 @@ fileprivate struct EmbeddedBinaryValidationTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase([
                                 "AppSource.m",

--- a/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
@@ -411,6 +411,7 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
                     targets: [
                         TestStandardTarget(
                             "App",
+                            type: .application,
                             buildPhases: [
                                 TestSourcesBuildPhase([
                                     "main.c",

--- a/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
+++ b/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
@@ -51,6 +51,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "Client-Default",
+                        type: .application,
                         buildConfigurations: [
                             // The default all-target-headers.hmap will make this setup fail.
                             TestBuildConfiguration("Debug", buildSettings: [
@@ -66,6 +67,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                         ]),
                     TestStandardTarget(
                         "Client-UseVFS",
+                        type: .application,
                         buildConfigurations: [
                             // Forcing HEADERMAP_USES_VFS will turn off all-target-headers.hmap,
                             // but its replacement all-non-framework-target-headers.hmap will
@@ -84,6 +86,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                         ]),
                     TestStandardTarget(
                         "Client-NoFrameworkEntries",
+                        type: .application,
                         buildConfigurations: [
                             // HEADERMAP_INCLUDES_FRAMEWORK_ENTRIES_FOR_TARGETS_NOT_BEING_BUILT
                             // will neuter all-non-framework-target-headers.hmap enough that this

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -52,6 +52,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                         targets: [
                             TestStandardTarget(
                                 "AppTarget",
+                                type: .application,
                                 buildConfigurations: [
                                     TestBuildConfiguration("Debug"),
                                 ],
@@ -264,6 +265,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug"),
                 ],
@@ -461,6 +463,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "iphonesimulator",
@@ -544,6 +547,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug")
                 ],
@@ -641,6 +645,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let macAppTarget = TestStandardTarget(
                 "macAppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -659,6 +664,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let iosAppTarget = TestStandardTarget(
                 "iOSAppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "iphonesimulator",
@@ -761,6 +767,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let appTarget1 = TestStandardTarget(
                 "AppTarget1",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -782,6 +789,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let appTarget2 = TestStandardTarget(
                 "AppTarget2",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -1169,6 +1177,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let conflictTarget1 = TestStandardTarget(
                 "conflictApp",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -1184,6 +1193,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let conflictTarget2 = TestStandardTarget(
                 "conflictApp",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",

--- a/Tests/SWBBuildSystemTests/OnDemandResourcesTests.swift
+++ b/Tests/SWBBuildSystemTests/OnDemandResourcesTests.swift
@@ -254,6 +254,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -308,6 +309,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -382,6 +384,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -666,6 +669,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -811,6 +815,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -877,6 +882,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("AssetPackManifest.plist"),
@@ -944,6 +950,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "Assets.xcassets",
@@ -1028,6 +1035,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),

--- a/Tests/SWBBuildSystemTests/SceneKitBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SceneKitBuildOperationTests.swift
@@ -41,7 +41,9 @@ fileprivate struct SceneKitBuildOperationTests: CoreBasedTests {
                         ]),
                 ],
                 targets: [
-                    TestStandardTarget("App", buildPhases: [
+                    TestStandardTarget("App",
+                                       type: .application,
+                                       buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dae", decompress: false),
                             TestBuildFile("B.dae", decompress: true),

--- a/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
+++ b/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
@@ -347,6 +347,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -371,6 +372,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -399,6 +401,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetA",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskA",
@@ -567,6 +570,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -588,6 +592,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetAB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskAB",
@@ -861,6 +866,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -877,6 +883,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -973,6 +980,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -992,6 +1000,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetA",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskA",
@@ -1012,6 +1021,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -1937,6 +1947,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                         targets: [
                             TestStandardTarget(
                                 "Calculate Checksum Target and a Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Description",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([
                                         "raw.fake-neutral",

--- a/Tests/SWBBuildSystemTests/SpriteKitBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SpriteKitBuildOperationTests.swift
@@ -39,7 +39,9 @@ fileprivate struct SpriteKitBuildOperationTests: CoreBasedTests {
                         ]),
                 ],
                 targets: [
-                    TestStandardTarget("App", buildPhases: [
+                    TestStandardTarget("App",
+                                       type: .application,
+                                       buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("assets.atlas"),
                         ]),

--- a/Tests/SWBCorePerfTests/SerializationPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SerializationPerfTests.swift
@@ -26,7 +26,7 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
             projects: [
                 TestProject("aProject",
                             groupTree: TestGroup("SomeFiles"),
-                            targets: [TestStandardTarget("Target1")]
+                            targets: [TestStandardTarget("Target1", type: .application)]
                            )
             ]).loadHelper(getCore())
         let project = helper.project

--- a/Tests/SWBCorePerfTests/SettingsPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SettingsPerfTests.swift
@@ -28,7 +28,7 @@ fileprivate struct SettingsPerfTests: CoreBasedTests, PerfTests {
                 projects: [
                     TestProject("aProject",
                                 groupTree: TestGroup("SomeFiles"),
-                                targets: [TestStandardTarget("Target1")]
+                                targets: [TestStandardTarget("Target1", type: .application)]
                                )
                 ]).loadHelper(getCore())
             let context = helper.workspaceContext

--- a/Tests/SWBCoreTests/BuildCommandTests.swift
+++ b/Tests/SWBCoreTests/BuildCommandTests.swift
@@ -23,8 +23,8 @@ import SWBCore
         let paths2: [Path] = [Path("")]
 
         let pifLoader = PIFLoader(data: .plArray([]), namespace: BuiltinMacros.namespace)
-        let target1 = try Target.create(TestStandardTarget("A").toProtocol(), pifLoader, signature: "MOCK1")
-        let target2 = try Target.create(TestStandardTarget("B").toProtocol(), pifLoader, signature: "MOCK2")
+        let target1 = try Target.create(TestStandardTarget("A", type: .application).toProtocol(), pifLoader, signature: "MOCK1")
+        let target2 = try Target.create(TestStandardTarget("B", type: .application).toProtocol(), pifLoader, signature: "MOCK2")
         let targets1 = [target1]
         let targets2 = [target2]
 

--- a/Tests/SWBCoreTests/FilePathResolverTests.swift
+++ b/Tests/SWBCoreTests/FilePathResolverTests.swift
@@ -205,7 +205,7 @@ import SWBMacro
 
     @Test
     func productReference() throws {
-        let model = try TestStandardTarget("anApp").toProtocol()
+        let model = try TestStandardTarget("anApp", type: .application).toProtocol()
         let target = try #require(Target.create(model, pifLoader, signature: "Mock") as? StandardTarget)
 
         // Get the absolute path for the productreference and test it.

--- a/Tests/SWBCoreTests/IncrementalPIFLoadingTests.swift
+++ b/Tests/SWBCoreTests/IncrementalPIFLoadingTests.swift
@@ -258,9 +258,11 @@ import SWBTestSupport
     func projectReferences() throws {
         let testTargetA = TestStandardTarget(
             "aTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["foo.c"])])
         let testTargetB = TestStandardTarget(
             "bTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["bar.c"])])
         let testProject = TestProject(
             "aProject",
@@ -305,6 +307,7 @@ import SWBTestSupport
         // Load with a new project but shared targetA.
         let testTargetB2 = TestStandardTarget(
             "bTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["baz.c"])])
         let testProject2 = TestProject(
             "aProject",

--- a/Tests/SWBCoreTests/IndexSelectConfiguredTargetTests.swift
+++ b/Tests/SWBCoreTests/IndexSelectConfiguredTargetTests.swift
@@ -24,6 +24,7 @@ import SWBUtil
 
         let appTarget = TestStandardTarget(
             "appTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",

--- a/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
@@ -24,6 +24,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -36,6 +37,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -48,6 +50,7 @@ import SWBUtil
 
         let macApp2 = TestStandardTarget(
             "macApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -64,6 +67,7 @@ import SWBUtil
 
         let iosApp2 = TestStandardTarget(
             "iosApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -164,6 +168,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -175,6 +180,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -477,6 +483,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -490,6 +497,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -503,6 +511,7 @@ import SWBUtil
 
         let macApp2 = TestStandardTarget(
             "macApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -515,6 +524,7 @@ import SWBUtil
 
         let iosApp2 = TestStandardTarget(
             "iosApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -612,6 +622,7 @@ import SWBUtil
         let core = try await getCore()
         let catalystAppTarget1 = TestStandardTarget(
             "catalystApp1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -627,6 +638,7 @@ import SWBUtil
 
         let catalystAppTarget2 = TestStandardTarget(
             "catalystApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -643,6 +655,7 @@ import SWBUtil
 
         let catalystAppTarget3 = TestStandardTarget(
             "catalystApp3",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -659,6 +672,7 @@ import SWBUtil
 
         let osxAppTarget = TestStandardTarget(
             "osxApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -673,6 +687,7 @@ import SWBUtil
 
         let osxAppTarget_iosmac = TestStandardTarget(
             "osxApp_iosmac",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -844,6 +859,7 @@ import SWBUtil
 
         let macAppTarget = TestStandardTarget(
             "macAppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -859,6 +875,7 @@ import SWBUtil
 
         let iosAppTarget = TestStandardTarget(
             "iOSAppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -944,6 +961,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -990,6 +1008,7 @@ import SWBUtil
         func createTarget(name: String, sdkRoot: String, archs: String) -> any TestTarget {
             return TestStandardTarget(
                 name,
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": sdkRoot,

--- a/Tests/SWBCoreTests/ProvisioningTests.swift
+++ b/Tests/SWBCoreTests/ProvisioningTests.swift
@@ -172,6 +172,7 @@ private func setupMacroEvaluationScope(_ settings: [MacroDeclaration:String] = [
                     targets: [
                         TestStandardTarget(
                             "AppTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration("Debug"),
                             ],

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -252,6 +252,7 @@ import SWBMacro
                                                                             ])],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Config1", buildSettings: [
                                                                                                     "BUILD_VARIANTS": "normal other",
@@ -433,6 +434,7 @@ import SWBMacro
                                                                      groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                      targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -479,6 +481,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -509,6 +512,7 @@ import SWBMacro
                                                                      ]),
                                                                      targets: [
                                                                         TestStandardTarget("macOSTarget",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -518,6 +522,7 @@ import SWBMacro
                                                                                                                    ])],
                                                                                            buildPhases: [TestSourcesBuildPhase(["Mock.cpp"])]),
                                                                         TestStandardTarget("iOSTarget",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -950,6 +955,7 @@ import SWBMacro
                                                                  ],
                                                                  targets: [
                                                                     TestStandardTarget("Target1",
+                                                                                       type: .application,
                                                                                        buildConfigurations: [
                                                                                         TestBuildConfiguration("Debug", buildSettings: [:]
                                                                                                               )],
@@ -1231,6 +1237,7 @@ import SWBMacro
                                                                     groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                     targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -1353,7 +1360,7 @@ import SWBMacro
                                 "__POPULATE_COMPATIBILITY_ARCH_MAP": "YES",
                             ])
                     ],
-                    targets: [TestStandardTarget("Target")]
+                    targets: [TestStandardTarget("Target", type: .application)]
                 )
             ]
         ).load(core)
@@ -1376,6 +1383,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: buildSettings)],
@@ -1606,6 +1614,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1646,6 +1655,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1902,6 +1912,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1935,7 +1946,9 @@ import SWBMacro
                                                         TestProject("aProject",
                                                                     groupTree: TestGroup("SomeFiles", children: []),
                                                                     targets: [
-                                                                        TestStandardTarget("Target1", buildConfigurations: [
+                                                                        TestStandardTarget("Target1",
+                                                                                           type: .application,
+                                                                                           buildConfigurations: [
                                                                             TestBuildConfiguration("Debug", buildSettings: [
                                                                                 "SYMROOT": "./build",
                                                                                 "DSTROOT": "build/foo/bar/something/../dst",
@@ -1996,6 +2009,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "Target",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -2072,6 +2086,7 @@ import SWBMacro
                             targets: [
                                 TestStandardTarget(
                                     "Target1",
+                                    type: .application,
                                     buildConfigurations: [
                                         TestBuildConfiguration(
                                             "Debug",
@@ -2275,6 +2290,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "SDKROOT": "macosx",
@@ -2408,6 +2424,7 @@ import SWBMacro
                                                                      ],
                                                                      targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug", buildSettings: [
                                                                                                 "SDKROOT": "linuxB",
@@ -2511,6 +2528,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "SDKROOT": "\(sdkPath.str)",
@@ -2581,6 +2599,7 @@ import SWBMacro
                                                                            ],
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "FRAMEWORK_SEARCH_PATHS": "$(inherited) onePath",
@@ -2657,6 +2676,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", baseConfig: "TargetSettings.xcconfig", buildSettings: [
                                                                                                     "SDKROOT": "\(sdkPath.str)",
@@ -2709,6 +2729,7 @@ import SWBMacro
                                                                                ],
                                                                                targets: [
                                                                                 TestStandardTarget("Target1",
+                                                                                                   type: .application,
                                                                                                    buildConfigurations: [
                                                                                                     TestBuildConfiguration("Debug", buildSettings: [
                                                                                                         "SDKROOT": "bogus",
@@ -3102,6 +3123,7 @@ import SWBMacro
                                                                                     ])],
                                                                                   targets: [
                                                                                     TestStandardTarget("Target1",
+                                                                                                       type: .application,
                                                                                                        buildConfigurations: [
                                                                                                         TestBuildConfiguration("Config1", buildSettings: [
                                                                                                             "BUILD_VARIANTS": "normal other",
@@ -3229,6 +3251,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one in the SDK.
                 (
                     TestStandardTarget("Target1",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3246,6 +3269,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target2",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3264,6 +3288,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target3",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3283,6 +3308,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one from the "trooper" SDK variant.
                 (
                     TestStandardTarget("Target4",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3301,6 +3327,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one defined in this target.
                 (
                     TestStandardTarget("Target5",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3319,6 +3346,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target6",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3338,6 +3366,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from defined in the target, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target7",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3358,6 +3387,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from defined in the target, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target8",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3377,6 +3407,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, both the iOS and macOS deployment targets defined in the target should be preserved.
                 (
                     TestStandardTarget("Target9",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3397,6 +3428,7 @@ import SWBMacro
                 // macCatalyst case: Since this is a zippered target, both the iOS and macOS deployment targets defined in the target should be preserved.
                 (
                     TestStandardTarget("Target10",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3418,6 +3450,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, the macOS deployment target defined in the target should be preserved, but the iOS deployment target should be set to the lower limit.
                 (
                     TestStandardTarget("Target11",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3438,6 +3471,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, the macOS deployment target defined in the target should be preserved, and the iOS deployment target should be derived from it.
                 (
                     TestStandardTarget("Target12",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3551,6 +3585,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3584,6 +3619,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3701,6 +3737,7 @@ import SWBMacro
                                                                 ],
                                                                 targets: [
                                                                     TestStandardTarget("AppTarget",
+                                                                                       type: .application,
                                                                                        buildConfigurations: [
                                                                                         TestBuildConfiguration("Debug", buildSettings: [
                                                                                             "SDKROOT[sdk=iphoneos*]": "\(ios16_0Path.str)",
@@ -3835,6 +3872,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3874,6 +3912,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -4098,6 +4137,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "SomeTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration("Debug")
                             ])
@@ -4185,6 +4225,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "SomeTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -4358,6 +4399,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Config", baseConfig: "Target.xcconfig", buildSettings: [
                                                                                                     "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -4775,6 +4817,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4807,6 +4850,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4859,6 +4903,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4892,6 +4937,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4925,6 +4971,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4955,7 +5002,9 @@ import SWBMacro
     func packagesAllowTestingSearchPathsAndBitcodeSimultaneously() async throws {
         let testWorkspace = try await TestWorkspace("Test", projects: [
             TestPackageProject("aPackageProject", groupTree: TestGroup("Sources", path: "Sources", children: [TestFile("best.swift"), TestFile("Info.plist"),]), targets: [
-                TestStandardTarget("Target", buildConfigurations: [
+                TestStandardTarget("Target",
+                                   type: .application,
+                                   buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "ENABLE_TESTING_SEARCH_PATHS": "YES",
                         "INFOPLIST_FILE": "Sources/Info.plist",
@@ -4981,7 +5030,9 @@ import SWBMacro
     func catalystDoesNotBreakOnlyActiveArch() async throws {
         let testWorkspace = TestWorkspace("Test", projects: [
             TestProject("Project", groupTree: TestGroup("Sources", path: "Sources", children: [TestFile("best.swift")]), targets: [
-                TestStandardTarget("Target", buildConfigurations: [
+                TestStandardTarget("Target",
+                                   type: .application,
+                                   buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "ONLY_ACTIVE_ARCH": "YES",
                         "SUPPORTS_MACCATALYST": "YES",
@@ -5035,6 +5086,7 @@ import SWBMacro
                     ],
                     targets: [
                         TestStandardTarget("TargetA",
+                                           type: .application,
                                            buildConfigurations: [
                                             TestBuildConfiguration("Debug", buildSettings: [
                                                 "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -5047,6 +5099,7 @@ import SWBMacro
                                            ]
                                           ),
                         TestStandardTarget("TargetB",
+                                           type: .application,
                                            buildConfigurations: [
                                             TestBuildConfiguration("Debug", buildSettings: [
                                                 "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -5441,7 +5494,7 @@ import SWBMacro
                         TestBuildConfiguration("Config1", baseConfig: "Test.xcconfig")
                     ],
                     targets: [
-                        TestStandardTarget("A")
+                        TestStandardTarget("A", type: .application)
                     ]),
                 TestProject(
                     "bProject",
@@ -5455,7 +5508,7 @@ import SWBMacro
                         TestBuildConfiguration("Config1", baseConfig: "Test.xcconfig")
                     ],
                     targets: [
-                        TestStandardTarget("B")
+                        TestStandardTarget("B", type: .application)
                     ])
             ]).load(getCore())
         let context = try await contextForTestData(testWorkspace, files: [

--- a/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
@@ -52,7 +52,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                                               projects: [TestProject("aProject",
                                                                      groupTree: TestGroup("SomeFiles"),
                                                                      targets: [
-                                                                        TestStandardTarget("anApp"),
+                                                                        TestStandardTarget("anApp", type: .application),
                                                                      ]
                                                                     )]
             ).load(core)
@@ -155,9 +155,9 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("anotherApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("aFramework")])]).load(core)
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("anotherApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("aFramework", type: .application)])]).load(core)
         let workspaceContext = WorkspaceContext(core: core, workspace: workspace, processExecutionCache: .sharedForTesting)
         let project = workspace.projects[0]
 
@@ -192,9 +192,9 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("anotherApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("aFramework")])]).load(core)
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("anotherApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("aFramework", type: .application)])]).load(core)
         let workspaceContext = WorkspaceContext(core: core, workspace: workspace, processExecutionCache: .sharedForTesting)
         let project = workspace.projects[0]
 
@@ -241,8 +241,8 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework", "Missing"]),
-                                                                    TestStandardTarget("aFramework"),
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework", "Missing"]),
+                                                                    TestStandardTarget("aFramework", type: .application),
                                                                  ]
                                                                 )]
         ).load(core)
@@ -721,6 +721,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                             targets: [
                                 TestStandardTarget(
                                     "Watchable",
+                                    type: .application,
                                     buildConfigurations: [
                                         TestBuildConfiguration(
                                             "Debug",
@@ -3188,8 +3189,8 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles", children: [TestFile("aFramework.framework")]),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", buildPhases: [TestFrameworksBuildPhase(["aFramework.framework"])]),
-                                                                    TestStandardTarget("aFramework", productReferenceName: "aFramework.framework"),
+                                                                    TestStandardTarget("anApp", type: .application, buildPhases: [TestFrameworksBuildPhase(["aFramework.framework"])]),
+                                                                    TestStandardTarget("aFramework", type: .application, productReferenceName: "aFramework.framework"),
                                                                  ]
                                                                 )]
         ).load(core)
@@ -3241,6 +3242,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ]),
                         TestStandardTarget(
                             "test0",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3253,6 +3255,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test1",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3263,6 +3266,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test2",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3273,6 +3277,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test3",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3283,6 +3288,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "testDisabled",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3294,10 +3300,10 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
 
                         // Ensure that more than one target has the same "stem" ("Dynamic"), so that we don't get an ambiguous match including the framework from a -lDynamic argument.
-                        TestStandardTarget("aFramework", productReferenceName: "aFramework.framework"),
-                        TestStandardTarget("aFramework2", productReferenceName: "Dynamic.framework"),
-                        TestStandardTarget("aDynamicLib", productReferenceName: "libDynamic.dylib"),
-                        TestStandardTarget("aStaticLib", productReferenceName: "libStatic.a"),
+                        TestStandardTarget("aFramework", type: .application, productReferenceName: "aFramework.framework"),
+                        TestStandardTarget("aFramework2", type: .application, productReferenceName: "Dynamic.framework"),
+                        TestStandardTarget("aDynamicLib", type: .application, productReferenceName: "libDynamic.dylib"),
+                        TestStandardTarget("aStaticLib", type: .application, productReferenceName: "libStatic.a"),
                     ]
                 ),
             ]

--- a/Tests/SWBCoreTests/WorkspaceDiffTests.swift
+++ b/Tests/SWBCoreTests/WorkspaceDiffTests.swift
@@ -24,7 +24,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -45,7 +45,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -64,7 +64,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -97,7 +97,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -119,7 +119,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -148,12 +148,12 @@ import SWBCore
             projects: [
                 TestProject("projectA",
                             groupTree: TestGroup("whatever"),
-                            targets: [TestStandardTarget("targetA")]),
+                            targets: [TestStandardTarget("targetA", type: .application)]),
                 TestProject("testProject",
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -166,8 +166,8 @@ import SWBCore
                             targets: []),
                 TestProject("projectB",
                             groupTree: TestGroup("whatever"),
-                            targets: [TestStandardTarget("targetB"),
-                                      TestStandardTarget("targetC")])
+                            targets: [TestStandardTarget("targetB", type: .application),
+                                      TestStandardTarget("targetC", type: .application)])
             ]).load(getCore())
 
         let diff = workspace.diff(against: otherWorkspace)
@@ -194,7 +194,7 @@ import SWBCore
                                                  guid: "G1234",
                                                  children: [extraFile]),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -205,7 +205,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root", guid: "G1234"),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -233,7 +233,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root", guid: "G1234"),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -246,7 +246,7 @@ import SWBCore
                                                  guid: "G1234",
                                                  children: [missingFile]),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 

--- a/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
@@ -39,6 +39,7 @@ fileprivate struct AppExtensionTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:])
                     ],

--- a/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
@@ -47,6 +47,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "INFOPLIST_FILE": "Info.plist",

--- a/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
@@ -47,6 +47,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.swift"]),
                             TestShellScriptBuildPhase(name: "Scripty McScriptface", originalObjectID: "", outputs: ["/foo/foo.txt"]),
@@ -100,6 +101,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestResourcesBuildPhase(["Image.png"]),
@@ -154,6 +156,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestShellScriptBuildPhase(name: "Bad Script", originalObjectID: "A", contents: "", inputs: [], outputs: [], alwaysOutOfDate: true),
@@ -209,6 +212,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestShellScriptBuildPhase(name: "S1", originalObjectID: "S1", contents: "", inputs: [], outputs: ["foo"], alwaysOutOfDate: false),
@@ -320,6 +324,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestCopyFilesBuildPhase(["f1.txt"], destinationSubfolder: .resources, onlyForDeployment: false),
@@ -382,6 +387,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestResourcesBuildPhase(["Image.png"]),

--- a/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
@@ -500,6 +500,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     targetName,
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug"),
                     ],

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -51,6 +51,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildPhases: [
                         // Whatever gets dragged into a Headers build phase will be unifdef'ed.
                         TestHeadersBuildPhase([
@@ -67,6 +68,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "CustomBuildRule",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -94,6 +96,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "NoApplyRules",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -170,6 +173,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                                                ])],
                                       targets: [
                                         TestStandardTarget("AppTarget",
+                                                           type: .application,
                                                            buildPhases: [
                                                             TestSourcesBuildPhase([
                                                                 "SourceFile1.fake-ext",
@@ -2847,6 +2851,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [

--- a/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
@@ -46,6 +46,7 @@ fileprivate struct ExportLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: ["INFOPLIST_FILE": "AppTarget/Info.plist"])
                     ],

--- a/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
@@ -43,6 +43,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -85,6 +86,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -132,6 +134,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -191,6 +194,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],

--- a/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
@@ -405,6 +405,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Application",
+                    type: .application,
                     buildConfigurations: [
                         buildConfiguration(withName: "ModulesOffVFSOffDefineModuleOff", extraSettings: [:]),
                         buildConfiguration(withName: "ModulesOnVFSOffDefineModuleOff", extraSettings: ["CLANG_ENABLE_MODULES": "YES"]),
@@ -505,6 +506,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Application",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Default", buildSettings: [
                             "GENERATE_INFOPLIST_FILE": "YES",

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -24,6 +24,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func multiPlatformTargets() async throws {
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -36,6 +37,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -509,6 +511,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -521,6 +524,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "AppTargetNoRemap",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -637,6 +641,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: buildSettings)
                     ],
@@ -670,6 +675,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         // EFFECTIVE_PLATFORM_NAME gets its own separate product directory.
         let target1 = TestStandardTarget(
             "Target1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "Mod",
@@ -679,6 +685,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         )
         let target2 = TestStandardTarget(
             "Target2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "Mod",
@@ -754,6 +761,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -766,6 +774,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "AppTargetNoRemap",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -850,6 +859,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["file.c"]),
                         ]),
@@ -937,6 +947,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["main.c"])
                         ]),
@@ -984,6 +995,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase(["main.c"]),
                         TestFrameworksBuildPhase(["Fwk.framework"]),
@@ -1028,6 +1040,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func scriptTargetWithoutOutputs() async throws {
         let appTarget = TestStandardTarget(
             "AppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -1069,6 +1082,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func aggregateScriptDependentByMacCatalyst() async throws {
         let catalystAppTarget = TestStandardTarget(
             "catalystApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -1086,6 +1100,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let appTarget = TestStandardTarget(
             "AppTarget1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -1162,6 +1177,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func macCatalystAppWithZipperedFramework() async throws {
         let catalystAppTarget = TestStandardTarget(
             "catalystApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -1342,12 +1358,14 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let multiVariantTarget = TestStandardTarget(
             "multiVariantTarget",
+            type: .application,
             buildPhases: [
                 TestSourcesBuildPhase(["main.swift"]),
             ])
 
         let singleIndexVariantTarget = TestStandardTarget(
             "singleIndexVariantTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "INDEX_BUILD_VARIANT": "dev",
@@ -1409,6 +1427,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let testTarget = TestStandardTarget(
             "testTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "RUN_CLANG_STATIC_ANALYZER": "YES",

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -60,6 +60,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "foo.xib",
@@ -171,6 +172,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "Foo.png",
@@ -242,6 +244,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release",
                                                buildSettings: [
@@ -426,6 +429,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Bundlable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release",
                                                buildSettings: [
@@ -568,6 +572,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase([
                                 "CoreFoo.framework",
@@ -672,6 +677,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -807,6 +813,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -917,6 +924,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase([
                                 "CoreFoo.framework",
@@ -1064,6 +1072,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "Settings.bundle"
@@ -1165,6 +1174,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase(["Settings.bundle"], destinationSubfolder: .resources, onlyForDeployment: false),
                         ])
@@ -1264,6 +1274,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "ReleaseSettings.bundle"
@@ -1341,6 +1352,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestShellScriptBuildPhase(name: "", shellPath: "/bin/bash", originalObjectID: "abc", contents: "env | sort", onlyForDeployment: false, emitEnvironment: true, alwaysOutOfDate: true)
                     ]
@@ -1496,6 +1508,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -1816,6 +1829,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "AppShortcuts.strings",

--- a/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
@@ -52,6 +52,7 @@ fileprivate struct OnDemandResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dat", assetTags: Set(["foo"])),

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -896,6 +896,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "tool",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase(["main.swift"]),
                         TestCopyFilesBuildPhase([TestBuildFile(.file("best.txt"), resourceRule: .embedInCode)], destinationSubfolder: .builtProductsDir),

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -48,6 +48,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -403,6 +404,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -50,6 +50,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release"),
                     ],
@@ -209,6 +210,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -336,6 +338,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -419,6 +422,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -508,6 +512,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -647,6 +652,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -788,6 +794,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -944,6 +951,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1163,6 +1171,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1325,6 +1334,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1430,6 +1440,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1965,7 +1976,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         // Single files which get copied rather than combined.
                         "Single.png",
@@ -2138,7 +2149,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestSourcesBuildPhase([
                         "Doubled@1x.png",
                         "Doubled@2x.png",
@@ -2180,7 +2191,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         "A.xcassets",
                         "B C.xcassets",
@@ -2224,7 +2235,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestSourcesBuildPhase([
                         "A.xcassets",
                         "B.xcassets",
@@ -2269,7 +2280,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         TestBuildFile("A.dae", decompress: false),
                         TestBuildFile("B.dae", decompress: true),
@@ -2364,6 +2375,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "Localizable.strings",
@@ -2458,6 +2470,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase([
                             "main.m",
@@ -2506,6 +2519,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestAppleScriptBuildPhase([
                                 "Foo.applescript",
@@ -2544,6 +2558,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestAppleScriptBuildPhase([
                             ]),

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -46,6 +46,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug"
@@ -132,6 +133,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2368,6 +2370,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2456,6 +2459,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2574,6 +2578,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2640,6 +2645,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2681,6 +2687,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2722,6 +2729,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2782,6 +2790,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug"

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -101,6 +101,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "INFOPLIST_FILE": "Sources/Info.plist",
@@ -1948,6 +1949,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "INFOPLIST_FILE": "Sources/Info.plist",
@@ -2983,6 +2985,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -4086,6 +4089,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         targetName,
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug"),
                         ],
@@ -4689,6 +4693,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: ["INFOPLIST_FILE": "Sources/Info.plist"]),
                         TestBuildConfiguration("Release", buildSettings: ["INFOPLIST_FILE": "Sources/Info.plist"]),
@@ -7660,6 +7665,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "GENERATE_PKGINFO_FILE": "YES",
@@ -8338,6 +8344,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"
@@ -8422,6 +8429,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"
@@ -8500,6 +8508,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -72,6 +72,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1272,6 +1273,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -747,7 +747,7 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
     func serializable() async throws {
         try await withTemporaryDirectory { tmpDirPath -> Void in
             let core = try await getCore()
-            let testWorkspace = try TestWorkspace("SomeName", sourceRoot: tmpDirPath, projects: [.init("Project1", groupTree: TestGroup.init("Empty"), targets: [TestStandardTarget("Target1")])]).load(core)
+            let testWorkspace = try TestWorkspace("SomeName", sourceRoot: tmpDirPath, projects: [.init("Project1", groupTree: TestGroup.init("Empty"), targets: [TestStandardTarget("Target1", type: .application)])]).load(core)
             let workspaceContext = WorkspaceContext(core: core, workspace: testWorkspace, processExecutionCache: .sharedForTesting)
 
             let diagnostics: [ConfiguredTarget?: [Diagnostic]] = [

--- a/Tests/SWBTestSupportTests/TestSupportTests.swift
+++ b/Tests/SWBTestSupportTests/TestSupportTests.swift
@@ -56,7 +56,7 @@ import SWBUtil
                             ]),
                     ],
                     targets: [
-                        TestStandardTarget("TestTarget", buildPhases: [
+                        TestStandardTarget("TestTarget", type: .application, buildPhases: [
                             TestSourcesBuildPhase([
                                 TestBuildFile("test.c")
                             ])

--- a/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
@@ -34,6 +34,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let macApp = TestStandardTarget(
                     "macApp",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "SDKROOT": "macosx",
@@ -155,6 +156,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let macApp = TestStandardTarget(
                     "macApp",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "SDKROOT": "macosx",
@@ -236,6 +238,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let appTarget1 = TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -297,7 +300,9 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                 // Simulate adding a file to the existing target and send new PIF data.
 
                 let appTarget2 = TestStandardTarget(
-                    "AppTarget", guid: appTarget1.guid,
+                    "AppTarget",
+                    guid: appTarget1.guid,
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],
@@ -370,6 +375,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let appTarget = TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],
@@ -422,6 +428,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                 let appTarget = TestStandardTarget(
                     "AppTarget",
                     guid: "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -118,8 +118,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                     groupTree: TestGroup("Foo", children: [TestFile("Test.c")]),
                     targets: [
                         TestAggregateTarget("All", dependencies: ["aFramework", "bFramework"]),
-                        TestStandardTarget("aFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
-                        TestStandardTarget("bFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                        TestStandardTarget("aFramework", type: .application, buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                        TestStandardTarget("bFramework", type: .application, buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
                     ])
                 let testWorkspace = TestWorkspace("aWorkspace",
                                                   sourceRoot: srcroot,

--- a/Tests/SwiftBuildTests/MacCatalystTests.swift
+++ b/Tests/SwiftBuildTests/MacCatalystTests.swift
@@ -44,6 +44,7 @@ fileprivate struct MacCatalystTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "Foo",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "SUPPORTS_MACCATALYST": "YES",

--- a/Tests/SwiftBuildTests/PIFTests.swift
+++ b/Tests/SwiftBuildTests/PIFTests.swift
@@ -71,7 +71,7 @@ fileprivate struct PIFTests {
                     projects: [
                         TestProject("aProject",
                                     groupTree: TestGroup("foo"),
-                                    targets: [TestStandardTarget("aTarget")])
+                                    targets: [TestStandardTarget("aTarget", type: .application)])
                     ])
 
                 let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
@@ -103,7 +103,7 @@ fileprivate struct PIFTests {
                     projects: [
                         TestProject("aProject",
                                     groupTree: TestGroup("foo"),
-                                    targets: [TestStandardTarget("aTarget")])
+                                    targets: [TestStandardTarget("aTarget", type: .application)])
                     ])
 
                 let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)


### PR DESCRIPTION
This makes it more obvious that a test target is an app at first glance, and makes our test infrastructure slightly less Apple-centric by ceasing to encode an implicit assumption of a default app product type.
