### PR TITLE
Remove TaskConstructionTester default run destination argument

### DIFF
--- a/Sources/SWBTestSupport/PlatformFilter.swift
+++ b/Sources/SWBTestSupport/PlatformFilter.swift
@@ -126,7 +126,7 @@ extension CoreBasedTests {
 
             let filtersString = platformFilters.sorted().map { $0.platform + ($0.environment.nilIfEmpty.map { "-\($0)"} ?? "") }.joined(separator: ", ") // Just for test logging.
 
-            try await TaskConstructionTester(core, testWorkspace).checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: runDestination), userPreferences: UserPreferences.defaultForTesting.with(enableDebugActivityLogs: true)) { results in
+            try await TaskConstructionTester(core, testWorkspace).checkBuild(BuildParameters(configuration: "Debug"), runDestination: runDestination, userPreferences: UserPreferences.defaultForTesting.with(enableDebugActivityLogs: true)) { results in
                 results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CreateUniversalBinary", "Gate", "GenerateDSYMFile", "Ld", "MkDir", "ProcessInfoPlistFile", "RegisterExecutionPolicyException", "RegisterWithLaunchServices", "SymLink", "Touch", "WriteAuxiliaryFile", "Validate"])
 
                 // We should always build this

--- a/Sources/SWBTestSupport/Projects/AppClips.swift
+++ b/Sources/SWBTestSupport/Projects/AppClips.swift
@@ -53,6 +53,7 @@ extension TestProject {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: appBuildSettings)
                     ],

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -1072,7 +1072,7 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
     private let approvedByUser: Bool
 
     /// Create a test target
-    package init(_ name: String, guid: String? = nil, type: TargetType = .application, buildConfigurations: [TestBuildConfiguration]? = nil, buildPhases: [any TestBuildPhase] = [], buildRules: [TestBuildRule] = [], customTasks: [TestCustomTask] = [], dependencies: [TestTargetDependency] = [], productReferenceName: String? = nil, predominantSourceCodeLanguage: SWBCore.StandardTarget.SourceCodeLanguage = .undefined, provisioningSourceData: [ProvisioningSourceData] = [], dynamicTargetVariantName: String? = nil, approvedByUser: Bool = true) {
+    package init(_ name: String, guid: String? = nil, type: TargetType, buildConfigurations: [TestBuildConfiguration]? = nil, buildPhases: [any TestBuildPhase] = [], buildRules: [TestBuildRule] = [], customTasks: [TestCustomTask] = [], dependencies: [TestTargetDependency] = [], productReferenceName: String? = nil, predominantSourceCodeLanguage: SWBCore.StandardTarget.SourceCodeLanguage = .undefined, provisioningSourceData: [ProvisioningSourceData] = [], dynamicTargetVariantName: String? = nil, approvedByUser: Bool = true) {
         self.name = name
         self.overriddenGuid = guid
         self.type = type

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -537,6 +537,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                                 ]),
                             TestStandardTarget(
                                 "agg3",
+                                type: .application,
                                 buildConfigurations: [
                                     TestBuildConfiguration("Debug", buildSettings: ["BUILD_VARIANTS": "normal debug"])
                                 ],
@@ -3409,6 +3410,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                         targets: [
                             TestStandardTarget(
                                 "App",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([TestBuildFile("App.c")]),
                                 ]),
@@ -4398,6 +4400,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                         targets: [
                             TestStandardTarget(
                                 "App",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([
                                         "main.c",

--- a/Tests/SWBBuildSystemTests/EmbeddedBinaryValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/EmbeddedBinaryValidationTests.swift
@@ -47,6 +47,7 @@ fileprivate struct EmbeddedBinaryValidationTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase([
                                 "AppSource.m",

--- a/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
@@ -411,6 +411,7 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
                     targets: [
                         TestStandardTarget(
                             "App",
+                            type: .application,
                             buildPhases: [
                                 TestSourcesBuildPhase([
                                     "main.c",

--- a/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
+++ b/Tests/SWBBuildSystemTests/HeadermapModuleCompatibilityTests.swift
@@ -51,6 +51,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "Client-Default",
+                        type: .application,
                         buildConfigurations: [
                             // The default all-target-headers.hmap will make this setup fail.
                             TestBuildConfiguration("Debug", buildSettings: [
@@ -66,6 +67,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                         ]),
                     TestStandardTarget(
                         "Client-UseVFS",
+                        type: .application,
                         buildConfigurations: [
                             // Forcing HEADERMAP_USES_VFS will turn off all-target-headers.hmap,
                             // but its replacement all-non-framework-target-headers.hmap will
@@ -84,6 +86,7 @@ fileprivate struct HeadermapModuleCompatibilityTests: CoreBasedTests {
                         ]),
                     TestStandardTarget(
                         "Client-NoFrameworkEntries",
+                        type: .application,
                         buildConfigurations: [
                             // HEADERMAP_INCLUDES_FRAMEWORK_ENTRIES_FOR_TARGETS_NOT_BEING_BUILT
                             // will neuter all-non-framework-target-headers.hmap enough that this

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -52,6 +52,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                         targets: [
                             TestStandardTarget(
                                 "AppTarget",
+                                type: .application,
                                 buildConfigurations: [
                                     TestBuildConfiguration("Debug"),
                                 ],
@@ -264,6 +265,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug"),
                 ],
@@ -461,6 +463,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "iphonesimulator",
@@ -544,6 +547,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
                 "AppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug")
                 ],
@@ -641,6 +645,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let macAppTarget = TestStandardTarget(
                 "macAppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -659,6 +664,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let iosAppTarget = TestStandardTarget(
                 "iOSAppTarget",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "iphonesimulator",
@@ -761,6 +767,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let appTarget1 = TestStandardTarget(
                 "AppTarget1",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -782,6 +789,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let appTarget2 = TestStandardTarget(
                 "AppTarget2",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -1169,6 +1177,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let conflictTarget1 = TestStandardTarget(
                 "conflictApp",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",
@@ -1184,6 +1193,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
 
             let conflictTarget2 = TestStandardTarget(
                 "conflictApp",
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "macosx",

--- a/Tests/SWBBuildSystemTests/OnDemandResourcesTests.swift
+++ b/Tests/SWBBuildSystemTests/OnDemandResourcesTests.swift
@@ -254,6 +254,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -308,6 +309,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -382,6 +384,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -666,6 +669,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -811,6 +815,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),
@@ -877,6 +882,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("AssetPackManifest.plist"),
@@ -944,6 +950,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "Assets.xcassets",
@@ -1028,6 +1035,7 @@ fileprivate struct OnDemandResourcesTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 TestBuildFile("A.dat", assetTags: Set(["foo"])),

--- a/Tests/SWBBuildSystemTests/SceneKitBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SceneKitBuildOperationTests.swift
@@ -41,7 +41,9 @@ fileprivate struct SceneKitBuildOperationTests: CoreBasedTests {
                         ]),
                 ],
                 targets: [
-                    TestStandardTarget("App", buildPhases: [
+                    TestStandardTarget("App",
+                                       type: .application,
+                                       buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dae", decompress: false),
                             TestBuildFile("B.dae", decompress: true),

--- a/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
+++ b/Tests/SWBBuildSystemTests/ShellScriptSandboxingTests.swift
@@ -347,6 +347,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -371,6 +372,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -399,6 +401,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetA",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskA",
@@ -567,6 +570,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -588,6 +592,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetAB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskAB",
@@ -861,6 +866,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -877,6 +883,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -973,6 +980,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetB",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskB",
@@ -992,6 +1000,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetA",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskA",
@@ -1012,6 +1021,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                             ),
                             TestStandardTarget(
                                 "TargetC",
+                                type: .application,
                                 buildPhases: [
                                     TestShellScriptBuildPhase(
                                         name: "TaskC",
@@ -1937,6 +1947,7 @@ fileprivate struct ShellScriptSandboxingTests: CoreBasedTests {
                         targets: [
                             TestStandardTarget(
                                 "Calculate Checksum Target and a Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Description",
+                                type: .application,
                                 buildPhases: [
                                     TestSourcesBuildPhase([
                                         "raw.fake-neutral",

--- a/Tests/SWBBuildSystemTests/SpriteKitBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SpriteKitBuildOperationTests.swift
@@ -39,7 +39,9 @@ fileprivate struct SpriteKitBuildOperationTests: CoreBasedTests {
                         ]),
                 ],
                 targets: [
-                    TestStandardTarget("App", buildPhases: [
+                    TestStandardTarget("App",
+                                       type: .application,
+                                       buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("assets.atlas"),
                         ]),

--- a/Tests/SWBCorePerfTests/SerializationPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SerializationPerfTests.swift
@@ -26,7 +26,7 @@ fileprivate struct SerializationPerfTests: CoreBasedTests, PerfTests {
             projects: [
                 TestProject("aProject",
                             groupTree: TestGroup("SomeFiles"),
-                            targets: [TestStandardTarget("Target1")]
+                            targets: [TestStandardTarget("Target1", type: .application)]
                            )
             ]).loadHelper(getCore())
         let project = helper.project

--- a/Tests/SWBCorePerfTests/SettingsPerfTests.swift
+++ b/Tests/SWBCorePerfTests/SettingsPerfTests.swift
@@ -28,7 +28,7 @@ fileprivate struct SettingsPerfTests: CoreBasedTests, PerfTests {
                 projects: [
                     TestProject("aProject",
                                 groupTree: TestGroup("SomeFiles"),
-                                targets: [TestStandardTarget("Target1")]
+                                targets: [TestStandardTarget("Target1", type: .application)]
                                )
                 ]).loadHelper(getCore())
             let context = helper.workspaceContext

--- a/Tests/SWBCoreTests/BuildCommandTests.swift
+++ b/Tests/SWBCoreTests/BuildCommandTests.swift
@@ -23,8 +23,8 @@ import SWBCore
         let paths2: [Path] = [Path("")]
 
         let pifLoader = PIFLoader(data: .plArray([]), namespace: BuiltinMacros.namespace)
-        let target1 = try Target.create(TestStandardTarget("A").toProtocol(), pifLoader, signature: "MOCK1")
-        let target2 = try Target.create(TestStandardTarget("B").toProtocol(), pifLoader, signature: "MOCK2")
+        let target1 = try Target.create(TestStandardTarget("A", type: .application).toProtocol(), pifLoader, signature: "MOCK1")
+        let target2 = try Target.create(TestStandardTarget("B", type: .application).toProtocol(), pifLoader, signature: "MOCK2")
         let targets1 = [target1]
         let targets2 = [target2]
 

--- a/Tests/SWBCoreTests/FilePathResolverTests.swift
+++ b/Tests/SWBCoreTests/FilePathResolverTests.swift
@@ -205,7 +205,7 @@ import SWBMacro
 
     @Test
     func productReference() throws {
-        let model = try TestStandardTarget("anApp").toProtocol()
+        let model = try TestStandardTarget("anApp", type: .application).toProtocol()
         let target = try #require(Target.create(model, pifLoader, signature: "Mock") as? StandardTarget)
 
         // Get the absolute path for the productreference and test it.

--- a/Tests/SWBCoreTests/IncrementalPIFLoadingTests.swift
+++ b/Tests/SWBCoreTests/IncrementalPIFLoadingTests.swift
@@ -258,9 +258,11 @@ import SWBTestSupport
     func projectReferences() throws {
         let testTargetA = TestStandardTarget(
             "aTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["foo.c"])])
         let testTargetB = TestStandardTarget(
             "bTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["bar.c"])])
         let testProject = TestProject(
             "aProject",
@@ -305,6 +307,7 @@ import SWBTestSupport
         // Load with a new project but shared targetA.
         let testTargetB2 = TestStandardTarget(
             "bTarget",
+            type: .application,
             buildPhases: [TestSourcesBuildPhase(["baz.c"])])
         let testProject2 = TestProject(
             "aProject",

--- a/Tests/SWBCoreTests/IndexSelectConfiguredTargetTests.swift
+++ b/Tests/SWBCoreTests/IndexSelectConfiguredTargetTests.swift
@@ -24,6 +24,7 @@ import SWBUtil
 
         let appTarget = TestStandardTarget(
             "appTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",

--- a/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
@@ -24,6 +24,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -36,6 +37,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -48,6 +50,7 @@ import SWBUtil
 
         let macApp2 = TestStandardTarget(
             "macApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -64,6 +67,7 @@ import SWBUtil
 
         let iosApp2 = TestStandardTarget(
             "iosApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -164,6 +168,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -175,6 +180,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -477,6 +483,7 @@ import SWBUtil
 
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -490,6 +497,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -503,6 +511,7 @@ import SWBUtil
 
         let macApp2 = TestStandardTarget(
             "macApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -515,6 +524,7 @@ import SWBUtil
 
         let iosApp2 = TestStandardTarget(
             "iosApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -612,6 +622,7 @@ import SWBUtil
         let core = try await getCore()
         let catalystAppTarget1 = TestStandardTarget(
             "catalystApp1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -627,6 +638,7 @@ import SWBUtil
 
         let catalystAppTarget2 = TestStandardTarget(
             "catalystApp2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -643,6 +655,7 @@ import SWBUtil
 
         let catalystAppTarget3 = TestStandardTarget(
             "catalystApp3",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -659,6 +672,7 @@ import SWBUtil
 
         let osxAppTarget = TestStandardTarget(
             "osxApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -673,6 +687,7 @@ import SWBUtil
 
         let osxAppTarget_iosmac = TestStandardTarget(
             "osxApp_iosmac",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -844,6 +859,7 @@ import SWBUtil
 
         let macAppTarget = TestStandardTarget(
             "macAppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -859,6 +875,7 @@ import SWBUtil
 
         let iosAppTarget = TestStandardTarget(
             "iOSAppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -944,6 +961,7 @@ import SWBUtil
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -990,6 +1008,7 @@ import SWBUtil
         func createTarget(name: String, sdkRoot: String, archs: String) -> any TestTarget {
             return TestStandardTarget(
                 name,
+                type: .application,
                 buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": sdkRoot,

--- a/Tests/SWBCoreTests/ProductTypesTests.swift
+++ b/Tests/SWBCoreTests/ProductTypesTests.swift
@@ -71,7 +71,7 @@ fileprivate struct ProductTypesTests: CoreBasedTests {
         let fs = PseudoFS()
 
         let tester = try TaskConstructionTester(core, testWorkspace)
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS, fs: fs) { results in
             results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "WriteAuxiliaryFile", "Gate", "RegisterExecutionPolicyException", "SetOwnerAndGroup", "SetMode", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "ProcessInfoPlist"])
 
             results.checkTarget("aFramework") { target in

--- a/Tests/SWBCoreTests/ProvisioningTests.swift
+++ b/Tests/SWBCoreTests/ProvisioningTests.swift
@@ -172,6 +172,7 @@ private func setupMacroEvaluationScope(_ settings: [MacroDeclaration:String] = [
                     targets: [
                         TestStandardTarget(
                             "AppTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration("Debug"),
                             ],

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -4191,7 +4191,7 @@ import SWBMacro
         let buildRequestContext = BuildRequestContext(workspaceContext: context)
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkNote("A script phase disables sandboxing, forcing `EAGER_COMPILATION_ALLOW_SCRIPTS` to off (in target \'A\' from project \'aProject\')")
 

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -252,6 +252,7 @@ import SWBMacro
                                                                             ])],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Config1", buildSettings: [
                                                                                                     "BUILD_VARIANTS": "normal other",
@@ -433,6 +434,7 @@ import SWBMacro
                                                                      groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                      targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -479,6 +481,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -509,6 +512,7 @@ import SWBMacro
                                                                      ]),
                                                                      targets: [
                                                                         TestStandardTarget("macOSTarget",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -518,6 +522,7 @@ import SWBMacro
                                                                                                                    ])],
                                                                                            buildPhases: [TestSourcesBuildPhase(["Mock.cpp"])]),
                                                                         TestStandardTarget("iOSTarget",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -950,6 +955,7 @@ import SWBMacro
                                                                  ],
                                                                  targets: [
                                                                     TestStandardTarget("Target1",
+                                                                                       type: .application,
                                                                                        buildConfigurations: [
                                                                                         TestBuildConfiguration("Debug", buildSettings: [:]
                                                                                                               )],
@@ -1231,6 +1237,7 @@ import SWBMacro
                                                                     groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                     targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug",
                                                                                                                    buildSettings: [
@@ -1353,7 +1360,7 @@ import SWBMacro
                                 "__POPULATE_COMPATIBILITY_ARCH_MAP": "YES",
                             ])
                     ],
-                    targets: [TestStandardTarget("Target")]
+                    targets: [TestStandardTarget("Target", type: .application)]
                 )
             ]
         ).load(core)
@@ -1376,6 +1383,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: buildSettings)],
@@ -1606,6 +1614,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1646,6 +1655,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1902,6 +1912,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -1935,7 +1946,9 @@ import SWBMacro
                                                         TestProject("aProject",
                                                                     groupTree: TestGroup("SomeFiles", children: []),
                                                                     targets: [
-                                                                        TestStandardTarget("Target1", buildConfigurations: [
+                                                                        TestStandardTarget("Target1",
+                                                                                           type: .application,
+                                                                                           buildConfigurations: [
                                                                             TestBuildConfiguration("Debug", buildSettings: [
                                                                                 "SYMROOT": "./build",
                                                                                 "DSTROOT": "build/foo/bar/something/../dst",
@@ -1996,6 +2009,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "Target",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -2072,6 +2086,7 @@ import SWBMacro
                             targets: [
                                 TestStandardTarget(
                                     "Target1",
+                                    type: .application,
                                     buildConfigurations: [
                                         TestBuildConfiguration(
                                             "Debug",
@@ -2275,6 +2290,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "SDKROOT": "macosx",
@@ -2408,6 +2424,7 @@ import SWBMacro
                                                                      ],
                                                                      targets: [
                                                                         TestStandardTarget("Target1",
+                                                                                           type: .application,
                                                                                            buildConfigurations: [
                                                                                             TestBuildConfiguration("Debug", buildSettings: [
                                                                                                 "SDKROOT": "linuxB",
@@ -2511,6 +2528,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "SDKROOT": "\(sdkPath.str)",
@@ -2581,6 +2599,7 @@ import SWBMacro
                                                                            ],
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", buildSettings: [
                                                                                                     "FRAMEWORK_SEARCH_PATHS": "$(inherited) onePath",
@@ -2657,6 +2676,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug", baseConfig: "TargetSettings.xcconfig", buildSettings: [
                                                                                                     "SDKROOT": "\(sdkPath.str)",
@@ -2709,6 +2729,7 @@ import SWBMacro
                                                                                ],
                                                                                targets: [
                                                                                 TestStandardTarget("Target1",
+                                                                                                   type: .application,
                                                                                                    buildConfigurations: [
                                                                                                     TestBuildConfiguration("Debug", buildSettings: [
                                                                                                         "SDKROOT": "bogus",
@@ -3102,6 +3123,7 @@ import SWBMacro
                                                                                     ])],
                                                                                   targets: [
                                                                                     TestStandardTarget("Target1",
+                                                                                                       type: .application,
                                                                                                        buildConfigurations: [
                                                                                                         TestBuildConfiguration("Config1", buildSettings: [
                                                                                                             "BUILD_VARIANTS": "normal other",
@@ -3229,6 +3251,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one in the SDK.
                 (
                     TestStandardTarget("Target1",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3246,6 +3269,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target2",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3264,6 +3288,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target3",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3283,6 +3308,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one from the "trooper" SDK variant.
                 (
                     TestStandardTarget("Target4",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3301,6 +3327,7 @@ import SWBMacro
                 // Non-macCatalyst case: The effective macOS deployment target should be the one defined in this target.
                 (
                     TestStandardTarget("Target5",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3319,6 +3346,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from the macCatalyst target info, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target6",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3338,6 +3366,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from defined in the target, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target7",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3358,6 +3387,7 @@ import SWBMacro
                 // macCatalyst case: The iOS deployment target should be the value from defined in the target, and the macOS deployment target should match it since we're building an unzippered target.
                 (
                     TestStandardTarget("Target8",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3377,6 +3407,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, both the iOS and macOS deployment targets defined in the target should be preserved.
                 (
                     TestStandardTarget("Target9",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3397,6 +3428,7 @@ import SWBMacro
                 // macCatalyst case: Since this is a zippered target, both the iOS and macOS deployment targets defined in the target should be preserved.
                 (
                     TestStandardTarget("Target10",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3418,6 +3450,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, the macOS deployment target defined in the target should be preserved, but the iOS deployment target should be set to the lower limit.
                 (
                     TestStandardTarget("Target11",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3438,6 +3471,7 @@ import SWBMacro
                 // Non-macCatalyst case: Since this is a zippered target, the macOS deployment target defined in the target should be preserved, and the iOS deployment target should be derived from it.
                 (
                     TestStandardTarget("Target12",
+                                       type: .application,
                                        buildConfigurations: [
                                         TestBuildConfiguration("Debug", buildSettings: [
                                             "SDKROOT": "\(sdkPath.str)",
@@ -3551,6 +3585,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3584,6 +3619,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: []),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3701,6 +3737,7 @@ import SWBMacro
                                                                 ],
                                                                 targets: [
                                                                     TestStandardTarget("AppTarget",
+                                                                                       type: .application,
                                                                                        buildConfigurations: [
                                                                                         TestBuildConfiguration("Debug", buildSettings: [
                                                                                             "SDKROOT[sdk=iphoneos*]": "\(ios16_0Path.str)",
@@ -3835,6 +3872,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -3874,6 +3912,7 @@ import SWBMacro
                                                                            groupTree: TestGroup("SomeFiles", children: [TestFile("Mock.cpp")]),
                                                                            targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Debug",
                                                                                                                        buildSettings: [
@@ -4098,6 +4137,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "SomeTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration("Debug")
                             ])
@@ -4185,6 +4225,7 @@ import SWBMacro
                     targets: [
                         TestStandardTarget(
                             "SomeTarget",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -4358,6 +4399,7 @@ import SWBMacro
                                                                          ],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
+                                                                                               type: .application,
                                                                                                buildConfigurations: [
                                                                                                 TestBuildConfiguration("Config", baseConfig: "Target.xcconfig", buildSettings: [
                                                                                                     "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -4775,6 +4817,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4807,6 +4850,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4859,6 +4903,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4892,6 +4937,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4925,6 +4971,7 @@ import SWBMacro
                 targets: [
                     TestStandardTarget(
                         "Target",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration(
                                 "Debug",
@@ -4955,7 +5002,9 @@ import SWBMacro
     func packagesAllowTestingSearchPathsAndBitcodeSimultaneously() async throws {
         let testWorkspace = try await TestWorkspace("Test", projects: [
             TestPackageProject("aPackageProject", groupTree: TestGroup("Sources", path: "Sources", children: [TestFile("best.swift"), TestFile("Info.plist"),]), targets: [
-                TestStandardTarget("Target", buildConfigurations: [
+                TestStandardTarget("Target",
+                                   type: .application,
+                                   buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "ENABLE_TESTING_SEARCH_PATHS": "YES",
                         "INFOPLIST_FILE": "Sources/Info.plist",
@@ -4981,7 +5030,9 @@ import SWBMacro
     func catalystDoesNotBreakOnlyActiveArch() async throws {
         let testWorkspace = TestWorkspace("Test", projects: [
             TestProject("Project", groupTree: TestGroup("Sources", path: "Sources", children: [TestFile("best.swift")]), targets: [
-                TestStandardTarget("Target", buildConfigurations: [
+                TestStandardTarget("Target",
+                                   type: .application,
+                                   buildConfigurations: [
                     TestBuildConfiguration("Debug", buildSettings: [
                         "ONLY_ACTIVE_ARCH": "YES",
                         "SUPPORTS_MACCATALYST": "YES",
@@ -5035,6 +5086,7 @@ import SWBMacro
                     ],
                     targets: [
                         TestStandardTarget("TargetA",
+                                           type: .application,
                                            buildConfigurations: [
                                             TestBuildConfiguration("Debug", buildSettings: [
                                                 "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -5047,6 +5099,7 @@ import SWBMacro
                                            ]
                                           ),
                         TestStandardTarget("TargetB",
+                                           type: .application,
                                            buildConfigurations: [
                                             TestBuildConfiguration("Debug", buildSettings: [
                                                 "CASCADING": "$(TARGET_SETTING) $(inherited)",
@@ -5441,7 +5494,7 @@ import SWBMacro
                         TestBuildConfiguration("Config1", baseConfig: "Test.xcconfig")
                     ],
                     targets: [
-                        TestStandardTarget("A")
+                        TestStandardTarget("A", type: .application)
                     ]),
                 TestProject(
                     "bProject",
@@ -5455,7 +5508,7 @@ import SWBMacro
                         TestBuildConfiguration("Config1", baseConfig: "Test.xcconfig")
                     ],
                     targets: [
-                        TestStandardTarget("B")
+                        TestStandardTarget("B", type: .application)
                     ])
             ]).load(getCore())
         let context = try await contextForTestData(testWorkspace, files: [

--- a/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
@@ -52,7 +52,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                                               projects: [TestProject("aProject",
                                                                      groupTree: TestGroup("SomeFiles"),
                                                                      targets: [
-                                                                        TestStandardTarget("anApp"),
+                                                                        TestStandardTarget("anApp", type: .application),
                                                                      ]
                                                                     )]
             ).load(core)
@@ -155,9 +155,9 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("anotherApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("aFramework")])]).load(core)
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("anotherApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("aFramework", type: .application)])]).load(core)
         let workspaceContext = WorkspaceContext(core: core, workspace: workspace, processExecutionCache: .sharedForTesting)
         let project = workspace.projects[0]
 
@@ -192,9 +192,9 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("anotherApp", dependencies: ["aFramework"]),
-                                                                    TestStandardTarget("aFramework")])]).load(core)
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("anotherApp", type: .application, dependencies: ["aFramework"]),
+                                                                    TestStandardTarget("aFramework", type: .application)])]).load(core)
         let workspaceContext = WorkspaceContext(core: core, workspace: workspace, processExecutionCache: .sharedForTesting)
         let project = workspace.projects[0]
 
@@ -241,8 +241,8 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles"),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", dependencies: ["aFramework", "Missing"]),
-                                                                    TestStandardTarget("aFramework"),
+                                                                    TestStandardTarget("anApp", type: .application, dependencies: ["aFramework", "Missing"]),
+                                                                    TestStandardTarget("aFramework", type: .application),
                                                                  ]
                                                                 )]
         ).load(core)
@@ -721,6 +721,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                             targets: [
                                 TestStandardTarget(
                                     "Watchable",
+                                    type: .application,
                                     buildConfigurations: [
                                         TestBuildConfiguration(
                                             "Debug",
@@ -3188,8 +3189,8 @@ fileprivate enum TargetPlatformSpecializationMode {
                                           projects: [TestProject("aProject",
                                                                  groupTree: TestGroup("SomeFiles", children: [TestFile("aFramework.framework")]),
                                                                  targets: [
-                                                                    TestStandardTarget("anApp", buildPhases: [TestFrameworksBuildPhase(["aFramework.framework"])]),
-                                                                    TestStandardTarget("aFramework", productReferenceName: "aFramework.framework"),
+                                                                    TestStandardTarget("anApp", type: .application, buildPhases: [TestFrameworksBuildPhase(["aFramework.framework"])]),
+                                                                    TestStandardTarget("aFramework", type: .application, productReferenceName: "aFramework.framework"),
                                                                  ]
                                                                 )]
         ).load(core)
@@ -3241,6 +3242,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ]),
                         TestStandardTarget(
                             "test0",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3253,6 +3255,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test1",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3263,6 +3266,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test2",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3273,6 +3277,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "test3",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3283,6 +3288,7 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
                         TestStandardTarget(
                             "testDisabled",
+                            type: .application,
                             buildConfigurations: [
                                 TestBuildConfiguration(
                                     "Debug",
@@ -3294,10 +3300,10 @@ fileprivate enum TargetPlatformSpecializationMode {
                         ),
 
                         // Ensure that more than one target has the same "stem" ("Dynamic"), so that we don't get an ambiguous match including the framework from a -lDynamic argument.
-                        TestStandardTarget("aFramework", productReferenceName: "aFramework.framework"),
-                        TestStandardTarget("aFramework2", productReferenceName: "Dynamic.framework"),
-                        TestStandardTarget("aDynamicLib", productReferenceName: "libDynamic.dylib"),
-                        TestStandardTarget("aStaticLib", productReferenceName: "libStatic.a"),
+                        TestStandardTarget("aFramework", type: .application, productReferenceName: "aFramework.framework"),
+                        TestStandardTarget("aFramework2", type: .application, productReferenceName: "Dynamic.framework"),
+                        TestStandardTarget("aDynamicLib", type: .application, productReferenceName: "libDynamic.dylib"),
+                        TestStandardTarget("aStaticLib", type: .application, productReferenceName: "libStatic.a"),
                     ]
                 ),
             ]

--- a/Tests/SWBCoreTests/WorkspaceDiffTests.swift
+++ b/Tests/SWBCoreTests/WorkspaceDiffTests.swift
@@ -24,7 +24,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -45,7 +45,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -64,7 +64,7 @@ import SWBCore
                 TestProject("testProject",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -97,7 +97,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -119,7 +119,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -148,12 +148,12 @@ import SWBCore
             projects: [
                 TestProject("projectA",
                             groupTree: TestGroup("whatever"),
-                            targets: [TestStandardTarget("targetA")]),
+                            targets: [TestStandardTarget("targetA", type: .application)]),
                 TestProject("testProject",
                             guid: "abcd",
                             groupTree: TestGroup("root"),
                             targets: [
-                                TestStandardTarget("testTarget")
+                                TestStandardTarget("testTarget", type: .application)
                             ])
             ]).load(getCore())
 
@@ -166,8 +166,8 @@ import SWBCore
                             targets: []),
                 TestProject("projectB",
                             groupTree: TestGroup("whatever"),
-                            targets: [TestStandardTarget("targetB"),
-                                      TestStandardTarget("targetC")])
+                            targets: [TestStandardTarget("targetB", type: .application),
+                                      TestStandardTarget("targetC", type: .application)])
             ]).load(getCore())
 
         let diff = workspace.diff(against: otherWorkspace)
@@ -194,7 +194,7 @@ import SWBCore
                                                  guid: "G1234",
                                                  children: [extraFile]),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -205,7 +205,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root", guid: "G1234"),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -233,7 +233,7 @@ import SWBCore
                             guid: "abcd",
                             groupTree: TestGroup("root", guid: "G1234"),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 
@@ -246,7 +246,7 @@ import SWBCore
                                                  guid: "G1234",
                                                  children: [missingFile]),
                             targets: [
-                                TestStandardTarget("testTarget", guid: "efgh")
+                                TestStandardTarget("testTarget", guid: "efgh", type: .application)
                             ])
             ]).load(getCore())
 

--- a/Tests/SWBTaskConstructionPerfTests/TaskConstructionPerfTests.swift
+++ b/Tests/SWBTaskConstructionPerfTests/TaskConstructionPerfTests.swift
@@ -52,7 +52,7 @@ fileprivate struct TaskConstructionPerfTests: CoreBasedTests, PerfTests {
             )
             let tester = try await TaskConstructionTester(self.getCore(), testWorkspace)
             await measure {
-                await tester.checkBuild(checkTaskGraphIntegrity: false) { tester in
+                await tester.checkBuild(runDestination: .macOS, checkTaskGraphIntegrity: false) { tester in
                     tester.checkTasks(.matchRuleType("CreateBuildDirectory")) { tasks in
                         #expect(tasks.count == 1503)
                     }

--- a/Tests/SWBTaskConstructionTests/AppClipTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppClipTaskConstructionTests.swift
@@ -25,7 +25,7 @@ fileprivate struct AppClipTaskConstructionTests: CoreBasedTests {
             let fs = PseudoFS()
             let tester = try await TaskConstructionTester(getCore(), TestProject.appClip(sourceRoot: tmpDir, fs: fs))
 
-            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
                 results.checkNoDiagnostics()
                 for variant in ["thinned", "unthinned"] {
                     results.checkTask(.matchTargetName("Foo"), .matchRuleType("CompileAssetCatalogVariant"), .matchRuleItem(variant)) { task in
@@ -40,14 +40,14 @@ fileprivate struct AppClipTaskConstructionTests: CoreBasedTests {
                 }
             }
 
-            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOSSimulator, fs: fs) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("Foo"), .matchRuleType("ValidateEmbeddedBinary")) { task in
                     task.checkCommandLine(["embeddedBinaryValidationUtility", "\(tmpDir.str)/build/Debug-iphonesimulator/Foo.app/AppClips/BarClip.app", "-info-plist-path", "\(tmpDir.str)/build/Debug-iphonesimulator/Foo.app/Info.plist"])
                 }
             }
 
-            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macCatalyst), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macCatalyst, fs: fs) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("Foo"), .matchRuleType("Ld")) { task in
                     task.checkCommandLineLastArgumentEqual("\(tmpDir.str)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/Foo.app/Contents/MacOS/Foo")

--- a/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
@@ -72,13 +72,13 @@ fileprivate struct AppExtensionTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchTargetName("Foo"), .matchRule(["Copy", "/tmp/Test/aProject/build/Debug/Foo.app/Contents/Extensions/Modern.appex", "/tmp/Test/aProject/build/Debug/Modern.appex"])) { task in }
             results.checkTask(.matchTargetName("Foo"), .matchRule(["Copy", "/tmp/Test/aProject/build/Debug/Foo.app/Contents/PlugIns/Legacy.appex", "/tmp/Test/aProject/build/Debug/Legacy.appex"])) { task in }
         }
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchTargetName("Foo"), .matchRule(["Copy", "/tmp/Test/aProject/build/Debug-iphoneos/Foo.app/Extensions/Modern.appex", "/tmp/Test/aProject/build/Debug-iphoneos/Modern.appex"])) { task in }
             results.checkTask(.matchTargetName("Foo"), .matchRule(["Copy", "/tmp/Test/aProject/build/Debug-iphoneos/Foo.app/PlugIns/Legacy.appex", "/tmp/Test/aProject/build/Debug-iphoneos/Legacy.appex"])) { task in }

--- a/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
@@ -39,6 +39,7 @@ fileprivate struct AppExtensionTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:])
                     ],

--- a/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
@@ -79,7 +79,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
             let defaultToolchain = try #require(core.toolchainRegistry.defaultToolchain)
             let tester = try TaskConstructionTester(core, testProject)
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -248,7 +248,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
             let defaultToolchain = try #require(core.toolchainRegistry.defaultToolchain)
             let tester = try TaskConstructionTester(core, testProject)
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -445,7 +445,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(action: .build, configuration: "Release", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(BuildParameters(action: .build, configuration: "Release"), runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("AppIntentsSSUTraining")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -455,7 +455,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
             }
-            await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("AppIntentsSSUTraining")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -465,7 +465,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
             }
-            await tester.checkBuild(BuildParameters(action: .archive, configuration: "Release", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(BuildParameters(action: .archive, configuration: "Release"), runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("AppIntentsSSUTraining")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -531,7 +531,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ValidateAppShortcutStringsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -614,7 +614,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .iOS) { results in
                 results.checkNoTask(.matchRuleType("ExtractAppIntentsMetadata"))
                 results.checkNoTask(.matchRuleType("ValidateAppShortcutStringsMetadata"))
                 results.checkNoTask(.matchRuleType("AppIntentsSSUTraining"))
@@ -673,7 +673,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS)) { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("LinkTest.SwiftConstValuesFileList"))) { task, contents in
                     task.checkRuleInfo(["WriteAuxiliaryFile", .suffix("LinkTest.SwiftConstValuesFileList")])
                     task.checkOutputs(contain: [.namePattern(.suffix("LinkTest.SwiftConstValuesFileList"))])
@@ -833,7 +833,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("AppIntentsSSUTraining")) { task in
                     results.checkNoDiagnostics()
                 }
@@ -893,7 +893,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkNoTask(.matchRuleType("AppIntentsSSUTraining"))
             }
         }
@@ -949,7 +949,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS)) { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkNoTask(.matchRuleType("AppIntentsSSUTraining"))
             }
         }
@@ -1005,7 +1005,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1068,7 +1068,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1127,7 +1127,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .iOS) { results in
                 results.checkNoTask(.matchRuleType("ExtractAppIntentsMetadata"))
                 results.checkNoTask(.matchRuleType("ValidateAppShortcutStringsMetadata"))
                 results.checkNoTask(.matchRuleType("AppIntentsSSUTraining"))
@@ -1184,7 +1184,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1245,7 +1245,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1306,7 +1306,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1372,7 +1372,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
             let defaultToolchain = try #require(core.toolchainRegistry.defaultToolchain)
             let tester = try TaskConstructionTester(core, testProject)
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1572,7 +1572,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkWriteAuxiliaryFileTask(.matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyMetadataFileList"])) { task, contents in
                     let inputFiles = [
                         "\(SRCROOT)/build/Debug-iphoneos/FrameworkTargetA.framework/Metadata.appintents/extract.actionsdata",
@@ -1643,7 +1643,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1705,7 +1705,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,
@@ -1769,7 +1769,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+            await tester.checkBuild(runDestination: .iOS) { results in
                 results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
                     let executableName = task.commandLine.first
                     if let executableName,

--- a/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
@@ -47,6 +47,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "INFOPLIST_FILE": "Info.plist",

--- a/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
@@ -90,7 +90,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Test building without bitcode.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS, overrides: ["ENABLE_BITCODE": "NO", "BITCODE_GENERATION_MODE": "bitcode"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_BITCODE": "NO", "BITCODE_GENERATION_MODE": "bitcode"]), runDestination: .iOS) { results in
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
 
@@ -128,7 +128,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
         }
 
         // Test building with the bitcode marker.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS, overrides: ["ENABLE_BITCODE": "YES", "BITCODE_GENERATION_MODE": "marker"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_BITCODE": "YES", "BITCODE_GENERATION_MODE": "marker"]), runDestination: .iOS) { results in
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
 
@@ -169,7 +169,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
         }
 
         // Test building with full bitcode.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS, overrides: ["ENABLE_BITCODE": "YES", "BITCODE_GENERATION_MODE": "bitcode"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_BITCODE": "YES", "BITCODE_GENERATION_MODE": "bitcode"]), runDestination: .iOS) { results in
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
 
@@ -270,7 +270,7 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(runDestination: .iOS) { results in
             results.checkWarning(.equal("Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode. (in target 'App' from project 'aProject')"))
             results.checkWarning(.equal("Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode. (in target 'Lib' from project 'aProject')"))
 

--- a/Tests/SWBTaskConstructionTests/BuildActionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildActionTaskConstructionTests.swift
@@ -83,7 +83,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check an installhdrs release build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release"), runDestination: .macOS) { results in
             results.checkTarget("FrameworkTarget") { target in
                 // There should be the expected number of mkdir and symlink tasks.
                 results.checkTasks(.matchTarget(target), .matchRuleType("MkDir"), body: { tasks in
@@ -142,7 +142,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         let overrides = [
             "INSTALLAPI_COPY_PHASE": "YES",
         ]
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release", overrides: overrides)) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release", overrides: overrides), runDestination: .macOS) { results in
             results.checkTarget("FrameworkTarget") { target in
                 // There should be the expected number of mkdir and symlink tasks.
                 results.checkTasks(.matchTarget(target), .matchRuleType("MkDir"), body: { tasks in
@@ -316,7 +316,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         let parameters = BuildParameters(action: .installAPI, configuration: "Release")
         let buildTargets = tester.workspace.allTargets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: buildTargets, dependencyScope: .workspace, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
-        await tester.checkBuild(buildRequest: buildRequest) { results in
+        await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTarget("DynamicLibraryTarget") { target in
                 // There should be one symlink task.
                 results.checkTask(.matchTarget(target), .matchRule(["SymLink", "/tmp/Test/aProject/build/Release/DynamicLibraryTarget.tbd", "../../../../aProject.dst/usr/local/lib/DynamicLibraryTarget.tbd"])) { _ in }
@@ -384,7 +384,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         let overrides = [
             "INSTALLAPI_COPY_PHASE": "YES",
         ]
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release", overrides: overrides)) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release", overrides: overrides), runDestination: .macOS) { results in
             results.checkTarget("DynamicLibraryTarget") { target in
                 // There should be one symlink task.
                 results.checkTask(.matchTarget(target), .matchRule(["SymLink", "/tmp/Test/aProject/build/Release/DynamicLibraryTarget.tbd", "../../../../aProject.dst/usr/local/lib/DynamicLibraryTarget.tbd"])) { _ in }
@@ -490,7 +490,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check an installhdrs release build.
-        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Release"), runDestination: .macOS) { results in
             results.checkTarget("FrameworkTarget") { target in
                 // There should be the expected number of mkdir and symlink tasks.
                 results.checkTasks(.matchTarget(target), .matchRuleType("MkDir"), body: { tasks in
@@ -574,7 +574,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
             "INSTALLHDRS_COPY_PHASE": "YES",
             "INSTALLHDRS_SCRIPT_PHASE": "YES",
         ]
-        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Release", overrides: overrides)) { results in
+        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Release", overrides: overrides), runDestination: .macOS) { results in
             results.checkTarget("FrameworkTarget") { target in
                 // There should be the expected number of mkdir and symlink tasks.
                 results.checkTasks(.matchTarget(target), .matchRuleType("MkDir"), body: { tasks in
@@ -749,7 +749,7 @@ fileprivate struct BuildActionTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("StubFramework.framework/Versions/A/StubFramework"), contents: "binary")
 
         // Check the Release build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS, fs: fs) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }

--- a/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
@@ -47,6 +47,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.swift"]),
                             TestShellScriptBuildPhase(name: "Scripty McScriptface", originalObjectID: "", outputs: ["/foo/foo.txt"]),
@@ -100,6 +101,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestResourcesBuildPhase(["Image.png"]),
@@ -154,6 +156,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestShellScriptBuildPhase(name: "Bad Script", originalObjectID: "A", contents: "", inputs: [], outputs: [], alwaysOutOfDate: true),
@@ -209,6 +212,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestShellScriptBuildPhase(name: "S1", originalObjectID: "S1", contents: "", inputs: [], outputs: ["foo"], alwaysOutOfDate: false),
@@ -320,6 +324,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestCopyFilesBuildPhase(["f1.txt"], destinationSubfolder: .resources, onlyForDeployment: false),
@@ -382,6 +387,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["SourceFile.c"]),
                             TestResourcesBuildPhase(["Image.png"]),

--- a/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildPhaseFusionTests.swift
@@ -57,7 +57,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results -> Void in
+            await tester.checkBuild(runDestination: .macOS) { results -> Void in
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
                     results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
@@ -110,7 +110,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results -> Void in
+            await tester.checkBuild(runDestination: .macOS) { results -> Void in
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
                     // The compile and copy tasks shouldn't be ordered with respect to each other.
@@ -166,7 +166,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results -> Void in
+            await tester.checkBuild(runDestination: .macOS) { results -> Void in
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
                     results.checkTask(.matchRuleType("PhaseScriptExecution")) { task in
@@ -228,7 +228,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Enabled")) { results -> Void in
+            await tester.checkBuild(BuildParameters(configuration: "Enabled"), runDestination: .macOS) { results -> Void in
                 results.checkWarning("Run script build phase 'S7' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking \"Based on dependency analysis\" in the script phase. (in target 'AppTarget' from project 'aProject')")
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
@@ -263,7 +263,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 }
             }
 
-            await tester.checkBuild(BuildParameters(configuration: "Disabled")) { results -> Void in
+            await tester.checkBuild(BuildParameters(configuration: "Disabled"), runDestination: .macOS) { results -> Void in
                 results.checkWarning("Run script build phase 'S7' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking \"Based on dependency analysis\" in the script phase. (in target 'AppTarget' from project 'aProject')")
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
@@ -337,7 +337,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results -> Void in
+            await tester.checkBuild(runDestination: .macOS) { results -> Void in
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
                     results.checkTask(.matchRuleType("Copy"), .matchRuleItemBasename("f1.txt")) { task in
@@ -396,7 +396,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results -> Void in
+            await tester.checkBuild(runDestination: .macOS) { results -> Void in
                 results.checkNoDiagnostics()
                 results.checkTarget("AppTarget") { target -> Void in
                     results.checkTask(.matchRuleType("CopyPNGFile")) { task in
@@ -439,7 +439,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
 
             // The header copy should be moved before compile, and should not depend on target-entry.
-            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild() { results in
+            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("CoreFoo"), .matchRuleType("CpHeader")) { headerTask in
                     headerTask.checkInputs([
@@ -488,7 +488,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
 
             // The header copy should not be relocated.
-            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild() { results in
+            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("CoreFoo"), .matchRuleType("CpHeader"), .matchRulePattern([.contains("CoreBar.h")])) { headerTask in
                     results.checkTaskFollows(headerTask, .matchTargetName("CoreFoo"), .matchRuleType("CompileC"))
@@ -533,7 +533,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
 
             // The header copy should be moved before compile, and should not depend on target-entry.
-            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild() { results in
+            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("CoreFoo"), .matchRuleType("CpHeader"), .matchRulePattern([.contains("CoreFoo.h")])) { headerTask in
                     headerTask.checkInputs([
@@ -582,7 +582,7 @@ fileprivate struct BuildPhaseFusionTests: CoreBasedTests {
                 ])
 
             // The header copy should not be relocated.
-            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild() { results in
+            try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(runDestination: .macOS) { results in
                 results.checkWarning("tasks in 'Copy Headers' are delayed by unsandboxed script phases; set ENABLE_USER_SCRIPT_SANDBOXING=YES to enable sandboxing (in target 'CoreFoo' from project 'aProject')")
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("CoreFoo"), .matchRuleType("CpHeader"), .matchRulePattern([.contains("CoreBar.h")])) { headerTask in

--- a/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
@@ -81,7 +81,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check the build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "Ld", "GenerateTAPI", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             results.checkTarget("SomeFwk") { target in
@@ -380,7 +380,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             // Check that the clang tasks which process the output of the .fake-lang task add the appropriate flags.
@@ -476,7 +476,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Release"), runDestination: .macOS) { results in
             results.checkError(.equal("shell script build rule for '\(SRCROOT)/Foo.fake-bar' must declare at least one output file (in target 'App' from project 'aProject')"))
         }
     }
@@ -518,7 +518,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { target in
                 // There should only be one task to process Multiple.fake-lang, since there are erroneously two build files for one file reference.
                 results.checkTask(.matchTarget(target), .matchRuleType("RuleScriptExecution"), .matchRuleItemBasename("Multiple.fake-lang")) { task in
@@ -573,7 +573,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
                 )])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkError(.equal("the file group with identifier '\(srcroot.str)/build/aProject.build/Debug/Tool.build/DerivedSources/error.c' has already been processed. (in target 'Tool' from project 'aProject')"))
             results.checkNoDiagnostics()
         }
@@ -621,7 +621,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check the build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "Ld", "GenerateTAPI", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             results.checkTarget("SomeFwk") { target in
@@ -677,7 +677,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: PseudoFS()) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: PseudoFS()) { results in
             results.checkWarning(.equal("The file \"/tmp/Test/aProject/test.c\" cannot be processed by the Compile Sources build phase using the \"PBXCp\" rule. (in target 'App' from project 'aProject')"))
             results.checkNoDiagnostics()
         }

--- a/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildRuleTaskConstructionTests.swift
@@ -500,6 +500,7 @@ fileprivate struct BuildRuleTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     targetName,
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug"),
                     ],

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -120,7 +120,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check the debug build.
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("AppTarget") { target in
                 // Check that we have an unifdef task.
                 results.checkTask(.matchTarget(target), .matchRule(["Unifdef", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/Headers/Header.h", "\(SRCROOT)/Sources/Header.h"])) { task in
@@ -138,7 +138,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(targetName: "CustomBuildRule") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "CustomBuildRule") { results in
             results.checkTarget("CustomBuildRule") { target in
                 results.checkTask(.matchTarget(target), .matchRule(["CpHeader", "\(SRCROOT)/build/Debug/CustomBuildRule.app/Contents/Headers/Header.h", "\(SRCROOT)/Sources/Header.h"])) { _ in }
 
@@ -148,7 +148,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(targetName: "NoApplyRules") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "NoApplyRules") { results in
             results.checkTarget("NoApplyRules") { target in
                 results.checkTask(.matchTarget(target), .matchRule(["Copy", "\(SRCROOT)/build/Debug/NoApplyRules.app/Contents/Resources/Header.h", "\(SRCROOT)/Sources/Header.h"])) { _ in }
                 results.checkTask(.matchTarget(target), .matchRule(["Copy", "\(SRCROOT)/build/Debug/NoApplyRules.app/Contents/Resources/ModuleMap.modulemap", "\(SRCROOT)/Sources/ModuleMap.modulemap"])) { _ in }
@@ -183,7 +183,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                       ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("AppTarget") { target in
                 // Check that we warned about the missing source file.
                 results.checkWarning(.prefix("no rule to process file"))
@@ -266,7 +266,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         func checkBuild(params: BuildParameters) async throws {
             // Check the debug build.
-            try await tester.checkBuild(params, clientDelegate: TestCoreDataCompilerTaskPlanningClientDelegate()) { results in
+            try await tester.checkBuild(params, runDestination: .macOS, clientDelegate: TestCoreDataCompilerTaskPlanningClientDelegate()) { results in
                 try results.checkTarget(targetName) { target in
 
                     if params.action == .build || params.action == .installAPI || params.action == .installHeaders {
@@ -389,7 +389,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         try await checkBuild(params: BuildParameters(action: .installHeaders, configuration: "Debug", overrides: ["EXPERIMENTAL_ALLOW_INSTALL_HEADERS_FILTERING": "YES"]))
 
         // Check a build which emits an error when trying to get the generated file paths for the model.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { _ in }
 
             // Check diagnostics.
@@ -643,7 +643,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                 let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
                 // Test generating for Swift via an explicit override.
-                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "Swift"])), fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
+                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "Swift"])), runDestination: .macOS, fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
 
                     try checkBuild(action: action, with: results, srcroot: SRCROOT, expectedVisibility: visibilityBeingTested, expectedCodegenLanguage: .swift) { results, target in
                         // There should be a CoreMLModelCodegen task.
@@ -725,7 +725,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                 }
 
                 // Test generating for Objective-C.
-                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "Objective-C"])), fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
+                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "Objective-C"])), runDestination: .macOS, fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
 
                     try checkBuild(action: action, with: results, srcroot: SRCROOT, expectedVisibility: visibilityBeingTested, expectedCodegenLanguage: .objectiveC) { results, target in
                         // There should be a CoreMLModelCodegen task.
@@ -843,7 +843,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                 }
 
                 // Test generating for Swift using the target's defined predominant source code language.
-                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides), fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
+                try await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides), runDestination: .macOS, fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
 
                     try checkBuild(action: action, with: results, srcroot: SRCROOT, expectedVisibility: visibilityBeingTested, expectedCodegenLanguage: .swift) { results, target in
                         // There should be a CoreMLModelCodegen task.
@@ -929,7 +929,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let tester = try await taskConstructionTesterForProject(with: .public)
 
             // Check some builds which emit errors when trying to get the generated file paths for the model.
-            await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_SWIFT_VERSION": ""])), fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
+            await tester.checkBuild(BuildParameters(action: action, configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_SWIFT_VERSION": ""])), runDestination: .macOS, fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
                 results.checkTarget(targetName) { _ in }
 
                 // Check diagnostics.
@@ -938,7 +938,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                 results.checkError(.prefix("SmartStuff3.mlmodel: No Swift version specified.  Set COREML_CODEGEN_SWIFT_VERSION to preferred Swift version."))
                 results.checkNoDiagnostics()
             }
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "C"])), fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides.addingContents(of: ["COREML_CODEGEN_LANGUAGE": "C"])), runDestination: .macOS, fs: fs, clientDelegate: TestCoreMLCompilerTaskPlanningClientDelegate()) { results in
                 results.checkTarget(targetName) { _ in }
 
                 // Check diagnostics.
@@ -1202,14 +1202,14 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         var SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Test passing the module name to intentbuilderc.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Swift", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "TestModule"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public, moduleName: "TestModule")) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Swift", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "TestModule"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public, moduleName: "TestModule")) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .public, codegenLanguage: .swift, moduleName: "TestModule")
         }
 
         // We should not pass module name to intentbuilderc when building the app target
         // even if it has DEFINES_MODULE = YES.
         let applicationTester = try await taskConstructionTesterForProject(with: .public, targetType: .application)
-        await applicationTester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "TestModule"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
+        await applicationTester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "TestModule"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("IntentDefinitionCodegen")) { task in
                     task.checkCommandLine(["intentbuilderc", "generate", "-input", "\(SRCROOT)/Intents.intentdefinition", "-output", "\(SRCROOT)/build/aProject.build/Debug/\(targetName).build/DerivedSources/IntentDefinitionGenerated/Intents", "-classPrefix", "XC", "-language", "Objective-C", "-visibility", "public"])
@@ -1218,22 +1218,22 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         }
 
         // Test generating for Swift via an explicit override.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Swift"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Swift"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .public, codegenLanguage: .swift)
         }
 
         // Test generating for Objective-C.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .public, codegenLanguage: .objectiveC)
         }
 
         // Test generating for Swift using the target's defined predominant source code language.
-        await tester.checkBuild(clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .public, codegenLanguage: .swift)
         }
 
         // Check some builds which emit errors when trying to get the generated file paths for the model.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "C"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "C"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .public)) { results in
             results.checkTarget(targetName) { _ in }
 
             // Check diagnostics.
@@ -1244,21 +1244,21 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         tester = try await taskConstructionTesterForProject(with: .private)
         SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .private)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .private)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .private, codegenLanguage: .objectiveC)
         }
 
         tester = try await taskConstructionTesterForProject(with: .project)
         SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .project)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .project)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .project, codegenLanguage: .objectiveC)
         }
 
         tester = try await taskConstructionTesterForProject(with: .noCodegen)
         SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .noCodegen)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INTENTS_CODEGEN_LANGUAGE": "Objective-C"]), runDestination: .macOS, clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate(visibility: .noCodegen)) { results in
             checkBuild(with: results, srcroot: SRCROOT, visibility: .noCodegen, codegenLanguage: .objectiveC)
         }
     }
@@ -1369,7 +1369,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let perFileFlagsAvailableWorkaround = try core.xcodeProductBuildVersion >= ProductBuildVersion("12A65")
 
         // Check the tasks.
-        try await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        try await tester.checkBuild(runDestination: .macOS) { results in
             try results.checkTarget(targetName) { target in
                 // There should be two CompileMetalFile tasks.
                 try results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("Some.metal")) { task in
@@ -1494,7 +1494,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("Foo.metal")) { task in
                     task.checkCommandLineContains(["\(SRCROOT)/build/aProject.build/Debug/MetalStuff.build/Metal/Foo-\(BuildPhaseWithBuildFiles.filenameUniquefierSuffixFor(path: Path(SRCROOT).join("Sources").join("Foo.metal"))).air"])
@@ -1535,7 +1535,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget(targetName) { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("foo.metal")) { task in
                         if languageRevision == "UseDeploymentTarget" {
@@ -1633,7 +1633,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget(targetName) { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("foo.metal")) { task in
                         if enableModules == "STDLIB" {
@@ -1682,7 +1682,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("foo.metal")) { task in
                     task.checkCommandLineNoMatch([.prefix("-O")])
@@ -1717,7 +1717,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("foo.metal")) { task in
                     task.checkCommandLineContains(["-Os"])
@@ -1752,7 +1752,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         let tester = try TaskConstructionTester(core, testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileMetalFile"), .matchRuleItemBasename("foo.metal")) { task in
                     task.checkCommandLineContains(expectedOptions)
@@ -2001,7 +2001,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(runDestination: .anyMac) { results in
             results.checkTarget("Foo") { target in
                 // There should be one OpenCL code generation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Compile")) { task in
@@ -2085,7 +2085,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2097,7 +2097,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ld", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2109,7 +2109,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path - has no effect here
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2154,7 +2154,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2166,7 +2166,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2178,7 +2178,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2223,7 +2223,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2235,7 +2235,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2247,7 +2247,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2291,7 +2291,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2303,7 +2303,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2315,7 +2315,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2360,7 +2360,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2372,7 +2372,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2384,7 +2384,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2430,7 +2430,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2442,7 +2442,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2454,7 +2454,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2500,7 +2500,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
             // Default build uses clang++.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2513,7 +2513,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LD to use a different linker path - has no effect here.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LD": "/usr/bin/ld"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["clang++", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2526,7 +2526,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             }
 
             // Override LDPLUSPLUS to use a different linker path
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["LDPLUSPLUS": "/usr/bin/ldplusplus"]), runDestination: .macOS) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(["/usr/bin/ldplusplus", "-o", "\(SRCROOT)/build/Debug/Application.app/Contents/MacOS/Application"])
@@ -2576,7 +2576,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("Application") { target in
@@ -2626,7 +2626,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         try fs.write(Path("/c.plist"), contents: "")
         try fs.write(Path("/e.plist"), contents: "")
 
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("Application") { target in
@@ -2691,7 +2691,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("Application") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileC"), .matchRuleItemBasename("CFile1.c")) { task in
                     task.checkCommandLineContains(["clang", "-x", "c"])
@@ -2764,7 +2764,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "Ld", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "RegisterExecutionPolicyException", "SetMode", "SetOwnerAndGroup", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             // Check there are no diagnostics.
@@ -2811,7 +2811,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyLibrary") { target in
@@ -2870,7 +2870,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("App") { target in
                 // Check the storyboard compiles.
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileStoryboard")) { task in

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -51,6 +51,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildPhases: [
                         // Whatever gets dragged into a Headers build phase will be unifdef'ed.
                         TestHeadersBuildPhase([
@@ -67,6 +68,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "CustomBuildRule",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -94,6 +96,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "NoApplyRules",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -170,6 +173,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                                                ])],
                                       targets: [
                                         TestStandardTarget("AppTarget",
+                                                           type: .application,
                                                            buildPhases: [
                                                             TestSourcesBuildPhase([
                                                                 "SourceFile1.fake-ext",
@@ -2847,6 +2851,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [

--- a/Tests/SWBTaskConstructionTests/ClangModulesTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangModulesTaskConstructionTests.swift
@@ -60,7 +60,7 @@ fileprivate struct ClangModulesTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("a.c"))) { compileTask in
                     compileTask.checkCommandLineContains(["-fmodules"])
                 }

--- a/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
@@ -57,7 +57,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            try await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            try await tester.checkBuild(runDestination: .host) { results in
                 try results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
                     let responseFilePath = try #require(task.outputs.only)
 
@@ -116,7 +116,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 results.checkNoTask(.matchRulePattern(["WriteAuxiliaryFile", .suffix(".resp")]))
                 results.checkNoDiagnostics()
             }
@@ -164,7 +164,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
                     let stringContents = contents.asString
                     #expect(stringContents.contains("-target"))
@@ -229,7 +229,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 var aResponseFile: Path? = nil
                 var bResponseFile: Path? = nil
                 var cResponseFile: Path? = nil
@@ -288,7 +288,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 var compileResponseFile: Path? = nil
                 var analyzeResponseFile: Path? = nil
                 results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("a.c"))) { compileTask in
@@ -347,7 +347,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host), runDestination: .host) { results in
+            await tester.checkBuild(runDestination: .host) { results in
                 results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
                     let stringContents = contents.asString
                     #expect(stringContents.contains("-Xclang -Wno-shorten-64-to-32"))

--- a/Tests/SWBTaskConstructionTests/ClangStatCacheTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangStatCacheTaskConstructionTests.swift
@@ -68,7 +68,7 @@ fileprivate struct ClangStatCacheTaskConstructionTests: CoreBasedTests {
 
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testWorkspace)
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRulePattern(["ClangStatCache", .any, .equal(core.loadSDK(.macOS).path.str)])) { task in
                 task.checkCommandLineMatches([.suffix("clang-stat-cache"), .equal(core.loadSDK(.macOS).path.str), .equal("-o"), .suffix(".sdkstatcache")])
@@ -145,7 +145,7 @@ fileprivate struct ClangStatCacheTaskConstructionTests: CoreBasedTests {
                     ])])
 
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
             // There should be no duplicate tasks error, and exactly one stat cache task.
             results.checkNoDiagnostics()
             results.checkTasks(.matchRulePattern(["ClangStatCache", .any, .any])) { tasks in
@@ -185,7 +185,7 @@ fileprivate struct ClangStatCacheTaskConstructionTests: CoreBasedTests {
 
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testWorkspace)
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRulePattern(["ClangStatCache", .any, .equal(core.loadSDK(.macOS).path.str)])) { task in
                 task.checkCommandLineMatches([.suffix("clang-stat-cache"), .equal(core.loadSDK(.macOS).path.str), .equal("-v"), .equal("-o"), .suffix(".sdkstatcache")])
@@ -221,16 +221,16 @@ fileprivate struct ClangStatCacheTaskConstructionTests: CoreBasedTests {
                     ])])
 
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
             results.checkTaskExists(.matchRuleType("ClangStatCache"))
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["SDK_STAT_CACHE_ENABLE": "NO"]), fs: localFS) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["SDK_STAT_CACHE_ENABLE": "NO"]), runDestination: .macOS, fs: localFS) { results in
             results.checkNoTask(.matchRuleType("ClangStatCache"))
         }
 
         await UserDefaults.withEnvironment(["EnableSDKStatCaching": "0"]) {
-            await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
                 results.checkNoTask(.matchRuleType("ClangStatCache"))
             }
         }

--- a/Tests/SWBTaskConstructionTests/ClangStaticAnalyzerTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangStaticAnalyzerTests.swift
@@ -101,7 +101,7 @@ fileprivate struct ClangStaticAnalyzerTests: CoreBasedTests {
                 "CLANG_STATIC_ANALYZER_MODE": "deep",
                 "VALID_ARCHS": architectures.joined(separator: " ")
             ]
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .host, overrides: overrides), runDestination: .host) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides), runDestination: .host) { results in
                 results.checkTarget("Lib") { target in
                     results.checkNoTask(.matchTarget(target), .matchRule(["Analyze", Path(SRCROOT).join("bar.s").str]))
 
@@ -140,7 +140,7 @@ fileprivate struct ClangStaticAnalyzerTests: CoreBasedTests {
                                             ])])])
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
 
-        try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(BuildParameters(configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES", "CLANG_ANALYZER_EXEC": "clang-custom"])) { results in
+        try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(BuildParameters(configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES", "CLANG_ANALYZER_EXEC": "clang-custom"]), runDestination: .macOS) { results in
             results.checkTarget("Lib") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("AnalyzeShallow")) { task in
                     task.checkCommandLineContains(["clang-custom"])
@@ -188,7 +188,7 @@ fileprivate struct ClangStaticAnalyzerTests: CoreBasedTests {
             ])
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
 
-        try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(BuildParameters(configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"])) { results in
+        try await TaskConstructionTester(getCore(), testWorkspace).checkBuild(BuildParameters(configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .macOS) { results in
             results.checkTarget("AnalyzedLib") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("AnalyzeShallow")) { _ in }
             }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -318,7 +318,7 @@ fileprivate struct ClangTests: CoreBasedTests {
             ])
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .host) { results in
+        await tester.checkBuild(runDestination: .host) { results in
             results.checkTask(.matchRuleType("CompileC")) { task in
                 #expect(task.workingDirectory == workingDirectory)
             }

--- a/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
@@ -87,7 +87,7 @@ fileprivate struct CompilationCachingTaskConstructionTests: CoreBasedTests {
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        try await tester.checkBuild { results in
+        try await tester.checkBuild(runDestination: .macOS) { results in
             try results.checkTarget("Tool") { target in
                 try results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
                     let casOpts = try #require((task.execTask.payload as? ClangTaskPayload)?.explicitModulesPayload?.casOptions)

--- a/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
@@ -92,7 +92,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
 
         let iigPath = try await self.iigPath
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: hasDriverKitPlatform ? .driverKit : .macOS), fs: fs) { results in
+        await tester.checkBuild(runDestination: hasDriverKitPlatform ? .driverKit : .macOS, fs: fs) { results in
             results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CodeSign", "Gate", "Ld", "GenerateTAPI", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             results.checkTarget("DextTarget") { target in
@@ -228,7 +228,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
             let iigPath = try await self.iigPath
 
             if trace {
-                await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Debug", overrides: ["EXPERIMENTAL_ALLOW_INSTALL_HEADERS_FILTERING": "YES"])) { results in
+                await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Debug", overrides: ["EXPERIMENTAL_ALLOW_INSTALL_HEADERS_FILTERING": "YES"]), runDestination: .macOS) { results in
                     results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CodeSign", "Gate", "Ld", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
                     results.checkTarget("LibraryTarget") { target in
@@ -261,7 +261,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
                 }
             } else {
                 // installhdrs and installapi should only install the iig files.
-                await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Debug", overrides: ["EXPERIMENTAL_ALLOW_INSTALL_HEADERS_FILTERING": "YES"])) { results in
+                await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: "Debug", overrides: ["EXPERIMENTAL_ALLOW_INSTALL_HEADERS_FILTERING": "YES"]), runDestination: .macOS) { results in
                     results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CodeSign", "Gate", "Ld", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
                     results.checkTarget("LibraryTarget") { target in
@@ -276,7 +276,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
                     // Check there are no diagnostics.
                     results.checkNoDiagnostics()
                 }
-                await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+                await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
                     results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CodeSign", "Gate", "GenerateTAPI", "Ld", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
                     results.checkTarget("LibraryTarget") { target in
@@ -334,7 +334,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
             try fs.writeSimulatedProvisioningProfile(uuid: "8db0e92c-592c-4f06-bfed-9d945841b78d")
 
             // Analyze for a generic destination should analyze arm64 + x86_64
-            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", activeRunDestination: .anyDriverKit, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .anyDriverKit, fs: fs) { results in
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "arm64"])) { _ in }
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "x86_64"])) { _ in }
                 results.checkNoTask(.matchRuleItem("AnalyzeShallow"))
@@ -342,13 +342,13 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
             }
 
             // Analyze for concrete destinations should only analyze those architectures
-            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", activeRunDestination: .driverKitAppleSilicon, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .driverKitAppleSilicon, fs: fs) { results in
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "arm64"])) { _ in }
                 results.checkNoTask(.matchRuleItem("AnalyzeShallow"))
                 results.checkNoDiagnostics()
             }
 
-            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", activeRunDestination: .driverKitIntel, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .driverKitIntel, fs: fs) { results in
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "x86_64"])) { _ in }
                 results.checkNoTask(.matchRuleItem("AnalyzeShallow"))
                 results.checkNoDiagnostics()

--- a/Tests/SWBTaskConstructionTests/EagerCompilationTests.swift
+++ b/Tests/SWBTaskConstructionTests/EagerCompilationTests.swift
@@ -125,7 +125,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             ("D", ["A", "B", "C"])
         ]
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             for (after, befores) in checks {
                 results.checkTask(.matchTargetName(after), .matchRuleType("CompileC")) { compileAfter in
                     // compilation should wait for dependencies to compile, but should not wait for linking.
@@ -168,7 +168,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             ("H", ["E", "F", "G"]),
         ]
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             for (after, befores) in checks {
                 results.checkTask(.matchTargetName(after), .matchRuleItemPattern(.or("CompileC", "SwiftDriver Compilation"))) { compileAfter in
                     for before in befores {
@@ -253,7 +253,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("CompileC"))
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("Ld"))
@@ -299,7 +299,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("CompileC"))
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("Ld"))
@@ -352,7 +352,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("Ld"))
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("PhaseScriptExecution"))
@@ -399,7 +399,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("Ld"))
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("PhaseScriptExecution"))
@@ -443,7 +443,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("Aggregate"), .matchRuleType("PhaseScriptExecution")) { task in
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("Gate"), .matchRuleItemPattern(.suffix("-end")))
             }
@@ -482,7 +482,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("Ld"))
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("PhaseScriptExecution"))
@@ -546,7 +546,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             try fs.write(frameworkPath, contents: ByteString(encodingAsUTF8: frameworkPath.basename))
         }
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest, fs: fs) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest, fs: fs) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("CompileC"))
             }
@@ -593,7 +593,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskDoesNotFollow(task, .matchTargetName("A"), .matchRuleType("CompileC"))
             }
@@ -646,7 +646,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkWarning(.contains("target 'B' requires eager compilation, but DEPLOYMENT_LOCATION is set and the build directory of 'A' encloses the build directory of 'B'."))
             results.checkNoDiagnostics()
         }
@@ -687,7 +687,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { task in
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("CompileC"))
                 results.checkTaskFollows(task, .matchTargetName("A"), .matchRuleType("Ld"))
@@ -745,7 +745,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkWarning(.contains("target 'B' has both required and disabled eager compilation"))
             results.checkNoDiagnostics()
         }
@@ -782,7 +782,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkWarning(.contains("target 'A' requires eager compilation, but build phase 'Run Script' is delaying eager compilation"))
             results.checkNoDiagnostics()
         }
@@ -823,7 +823,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let parameters = BuildParameters(configuration: "Debug")
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { compileAfter in
                 // compilation should not wait for dependencies to compile
                 results.checkTaskDoesNotFollow(compileAfter, .matchTargetName("A"), .matchRuleType("CompileC"))
@@ -880,7 +880,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkTask(.matchTargetName("B"), .matchRuleType("CompileC")) { compileAfter in
                     // compilation should not wait for dependencies to compile
                     results.checkTaskDoesNotFollow(compileAfter, .matchTargetName("A"), .matchRuleType("CompileC"))
@@ -946,7 +946,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkTask(.matchTargetName("A"), .matchRuleType("CompileC")) { compileAfter in
                     results.checkTaskFollows(compileAfter, .matchTargetName("A"), .matchRuleType("SwiftDriver Compilation Requirements"))
                 }
@@ -1024,7 +1024,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 func verifyDependencyChain(_ tasks: [[TaskCondition]], sourceLocation: SourceLocation = #_sourceLocation) {
                     // order doesn't matter for one or less tasks in a chain
                     guard tasks.count > 1 else { return }
@@ -1150,7 +1150,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkTask(.matchTargetName("A"), .matchRuleType("CompileC")) { compileAfter in
                     results.checkTaskFollows(compileAfter, .matchTargetName("A"), .matchRuleType("ProcessPCH"))
                 }
@@ -1303,7 +1303,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             try fs.createDirectory(toolchain.path.join("usr").join("bin"), recursive: true)
             try fs.write(toolchain.path.join("usr").join("bin").join("coremlc"), contents: ByteString())
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest, fs: fs, clientDelegate: Delegate()) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest, fs: fs, clientDelegate: Delegate()) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTask(.matchTargetName("A"), .matchRuleType("SwiftDriver Compilation")) { compilationTask in
@@ -1398,7 +1398,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTask(.matchTargetName("A"), .matchRuleType("SwiftDriver Compilation")) { compilationTask in
@@ -1489,7 +1489,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTask(.matchTargetName("A"), .matchRuleType("SwiftDriver Compilation")) { compilationTask in
@@ -1580,7 +1580,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-            await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTask(.matchTargetName("A"), .matchRuleType("SwiftDriver Compilation")) { compilationTask in
@@ -1647,7 +1647,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
 
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild(targetName: "A") { results in
+            await tester.checkBuild(runDestination: .macOS, targetName: "A") { results in
                 results.checkWarning(.prefix("tasks in 'Copy Headers' are delayed by unsandboxed script phases"))
                 results.checkNoDiagnostics()
 
@@ -1718,7 +1718,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
-            try await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            try await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 let compilationRequirementRuleInfoType = "SwiftDriver Compilation Requirements"
@@ -1820,7 +1820,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        try await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        try await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             try results.checkTarget("App") { target in
@@ -1895,7 +1895,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
-            try await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            try await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 let compilationRequirementRuleInfoType = "SwiftDriver Compilation Requirements"
@@ -2025,7 +2025,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
             let parameters = BuildParameters(configuration: "Debug")
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
-            try await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+            try await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
                 results.checkNoDiagnostics()
 
                 let compilationRequirementRuleInfoType = "SwiftDriver Compilation Requirements"

--- a/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
@@ -46,6 +46,7 @@ fileprivate struct ExportLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: ["INFOPLIST_FILE": "AppTarget/Info.plist"])
                     ],

--- a/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ExportLocTaskConstructionTests.swift
@@ -67,7 +67,7 @@ fileprivate struct ExportLocTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let localizedStringsPath = "/tmp/StringsPath"
         let swiftFeatures = try await self.swiftFeatures
-        await tester.checkBuild(BuildParameters(action: .exportLoc, configuration: "Debug", overrides: ["SWIFT_EMIT_LOC_STRINGS": "YES", "STRINGSDATA_DIR": localizedStringsPath])) { results in
+        await tester.checkBuild(BuildParameters(action: .exportLoc, configuration: "Debug", overrides: ["SWIFT_EMIT_LOC_STRINGS": "YES", "STRINGSDATA_DIR": localizedStringsPath]), runDestination: .macOS) { results in
             results.checkTarget("AppTarget") { target in
                 results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -106,7 +106,7 @@ fileprivate struct ExportLocTaskConstructionTests: CoreBasedTests {
         let testProject = try await getTestProject()
         let tester = try await TaskConstructionTester(getCore(), testProject)
         //Check normal build action and make sure that -emit-localized-strings and -emit-localized-strings-path flags aren't present
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTarget("AppTarget") { target in
                 results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
                 results.checkTask(.matchRuleItem("ProcessInfoPlistFile")) { _ in }
@@ -145,7 +145,7 @@ fileprivate struct ExportLocTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let localizedStringsPath = "/tmp/StringsPath"
         let swiftFeatures = try await self.swiftFeatures
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_EMIT_LOC_STRINGS": "YES", "STRINGSDATA_DIR": localizedStringsPath])) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_EMIT_LOC_STRINGS": "YES", "STRINGSDATA_DIR": localizedStringsPath]), runDestination: .macOS) { results in
             results.checkTarget("AppTarget") { target in
                 results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
                 results.checkTask(.matchRuleItem("ProcessInfoPlistFile")) { _ in }

--- a/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
@@ -56,7 +56,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkNoTask(.matchTargetName("Foo"), .matchRuleType("GenerateAppPlaygroundAssetCatalog"))
             results.checkNoTask(.matchTargetName("Foo"), .matchRuleType("CompileAssetCatalog"))
@@ -99,7 +99,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkNoTask(.matchTargetName("Foo"), .matchRuleType("GenerateAppPlaygroundAssetCatalog"))
             results.checkNoTask(.matchTargetName("Foo"), .matchRuleType("CompileAssetCatalog"))
@@ -147,7 +147,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchTargetName("Foo"), .matchRuleType("GenerateAppPlaygroundAssetCatalog")) { task in
                 task.checkNoInputs(contain: [.pathPattern(.suffix(".xcassets"))])
@@ -208,7 +208,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchTargetName("Foo"), .matchRuleType("GenerateAppPlaygroundAssetCatalog")) { task in
                 task.checkInputs(contain: [.pathPattern(.suffix("Assets.xcassets"))])

--- a/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/GenerateAppPlaygroundAssetCatalogTaskConstructionTests.swift
@@ -43,6 +43,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -85,6 +86,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -132,6 +134,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],
@@ -191,6 +194,7 @@ fileprivate struct GenerateAppPlaygroundAssetCatalogTaskConstructionTests: CoreB
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [:]),
                     ],

--- a/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
@@ -94,7 +94,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check the debug build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget(targetName) { target in
@@ -187,7 +187,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
         let buildRequest = BuildRequest(parameters: parameters, buildTargets: [buildTarget], continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
         // Check the debug build.
-        await tester.checkBuild(parameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
             results.checkNoDiagnostics()
             results.checkTarget("exec") { target in
                 results.checkHeadermapGenerationTask(.matchTarget(target), .matchRuleItemBasename("exec-project-headers.hmap")) { headermap in
@@ -299,7 +299,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
 
         // Check that the headermap contents are deterministic.
         var hmapContents: [[UInt8]] = []
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Tool") { target in
                 for basename in headermapBasenames {
@@ -363,7 +363,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
                 }
             }
         }
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("Tool") { target in
                 #expect(headermapBasenames.count == hmapContents.count)
                 for (basename, hmapContents) in zip(headermapBasenames, hmapContents) {
@@ -444,7 +444,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         func checkBuild(configurationName: String, clangUsesAllTargetHeaders: Bool, swiftUsesAllTargetHeaders: Bool, buildRequest: BuildRequest? = nil, sourceLocation: SourceLocation = #_sourceLocation) async {
             let targetName = (buildRequest == nil) ? "Application" : nil
-            await tester.checkBuild(BuildParameters(configuration: configurationName), targetName: targetName, buildRequest: buildRequest) { results in
+            await tester.checkBuild(BuildParameters(configuration: configurationName), runDestination: .macOS, targetName: targetName, buildRequest: buildRequest) { results in
                 results.checkTarget("Application") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
                         if clangUsesAllTargetHeaders {
@@ -545,7 +545,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         for configurationName in ["Default", "Off", "On"] {
-            await tester.checkBuild(BuildParameters(configuration: configurationName), targetName: "Application") { results in
+            await tester.checkBuild(BuildParameters(configuration: configurationName), runDestination: .macOS, targetName: "Application") { results in
                 results.checkTarget("Application") { target in
                     results.checkHeadermapGenerationTask(.matchTarget(target), .matchRuleItemBasename("Application-all-non-framework-target-headers.hmap")) { headermap in
                         if configurationName != "Off" {

--- a/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HeadermapTaskConstructionTests.swift
@@ -405,6 +405,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Application",
+                    type: .application,
                     buildConfigurations: [
                         buildConfiguration(withName: "ModulesOffVFSOffDefineModuleOff", extraSettings: [:]),
                         buildConfiguration(withName: "ModulesOnVFSOffDefineModuleOff", extraSettings: ["CLANG_ENABLE_MODULES": "YES"]),
@@ -505,6 +506,7 @@ fileprivate struct HeadermapTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Application",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Default", buildSettings: [
                             "GENERATE_INFOPLIST_FILE": "YES",

--- a/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
@@ -58,7 +58,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .anyMac, targetName: "Framework") { results in
+        await tester.checkBuild(runDestination: .anyMac, targetName: "Framework") { results in
             results.checkNoDiagnostics()
             results.checkTarget("Framework") { frameworkTarget in
                 results.checkTarget("HostTool") { hostTarget in
@@ -139,7 +139,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         let fs = PseudoFS()
         try fs.writeSimulatedProvisioningProfile(uuid: "8db0e92c-592c-4f06-bfed-9d945841b78d")
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .anyMac, targetName: "Framework", fs: fs) { results in
+        await tester.checkBuild(runDestination: .anyMac, targetName: "Framework", fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Framework") { frameworkTarget in
                 results.checkTasks(.matchTarget(frameworkTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
@@ -164,7 +164,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .anyiOSDevice, targetName: "Framework", fs: fs) { results in
+        await tester.checkBuild(runDestination: .anyiOSDevice, targetName: "Framework", fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Framework") { frameworkTarget in
                 results.checkTasks(.matchTarget(frameworkTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
@@ -279,7 +279,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
 
         let destinations: [RunDestinationInfo] = [.anyMac, .anyiOSDevice]
         for destination in destinations {
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: destination), targetName: "App", fs: fs) { results in
+            await tester.checkBuild(runDestination: destination, targetName: "App", fs: fs) { results in
                 results.checkNoDiagnostics()
 
                 // Framework and App compilation should both depend on and pass flags to load the macro plugin
@@ -376,7 +376,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
 
         let destinations: [RunDestinationInfo] = [.anyMac, .anyiOSDevice]
         for destination in destinations {
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: destination), targetName: "App", fs: fs) { results in
+            await tester.checkBuild(runDestination: destination, targetName: "App", fs: fs) { results in
                 results.checkNoDiagnostics()
 
                 // Framework and App compilation should both depend on and pass flags to load the macro plugin
@@ -440,7 +440,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
 
         let fs = PseudoFS()
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS), targetName: "HostTool", fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "HostTool", fs: fs) { results in
             results.checkNoDiagnostics()
 
             // Other targets should not pass the flag/have the input.

--- a/Tests/SWBTaskConstructionTests/InAppPurchaseContentTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InAppPurchaseContentTaskConstructionTests.swift
@@ -72,7 +72,7 @@ fileprivate struct InAppPurchaseContentTaskConstructionTests: CoreBasedTests {
         let fs = PseudoFS()
         try await fs.writePlist(srcRoot.join("MyIAP/ContentInfo.plist"), .plDict([:]))
 
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             results.consumeTasksMatchingRuleTypes(["CpResource", "CreateBuildDirectory", "Gate", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "Touch", "WriteAuxiliaryFile"])
 
             // Notably, should not be codesigned.

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -24,6 +24,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func multiPlatformTargets() async throws {
         let macApp = TestStandardTarget(
             "macApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -36,6 +37,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let iosApp = TestStandardTarget(
             "iosApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -509,6 +511,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -521,6 +524,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "AppTargetNoRemap",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -637,6 +641,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: buildSettings)
                     ],
@@ -670,6 +675,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         // EFFECTIVE_PLATFORM_NAME gets its own separate product directory.
         let target1 = TestStandardTarget(
             "Target1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "Mod",
@@ -679,6 +685,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         )
         let target2 = TestStandardTarget(
             "Target2",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "Mod",
@@ -754,6 +761,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -766,6 +774,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     ]),
                 TestStandardTarget(
                     "AppTargetNoRemap",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
@@ -850,6 +859,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["file.c"]),
                         ]),
@@ -937,6 +947,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildPhases: [
                             TestSourcesBuildPhase(["main.c"])
                         ]),
@@ -984,6 +995,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase(["main.c"]),
                         TestFrameworksBuildPhase(["Fwk.framework"]),
@@ -1028,6 +1040,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func scriptTargetWithoutOutputs() async throws {
         let appTarget = TestStandardTarget(
             "AppTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -1069,6 +1082,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func aggregateScriptDependentByMacCatalyst() async throws {
         let catalystAppTarget = TestStandardTarget(
             "catalystApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "iphoneos",
@@ -1086,6 +1100,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let appTarget = TestStandardTarget(
             "AppTarget1",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -1162,6 +1177,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     func macCatalystAppWithZipperedFramework() async throws {
         let catalystAppTarget = TestStandardTarget(
             "catalystApp",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "SDKROOT": "macosx",
@@ -1342,12 +1358,14 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let multiVariantTarget = TestStandardTarget(
             "multiVariantTarget",
+            type: .application,
             buildPhases: [
                 TestSourcesBuildPhase(["main.swift"]),
             ])
 
         let singleIndexVariantTarget = TestStandardTarget(
             "singleIndexVariantTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "INDEX_BUILD_VARIANT": "dev",
@@ -1409,6 +1427,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
         let testTarget = TestStandardTarget(
             "testTarget",
+            type: .application,
             buildConfigurations: [
                 TestBuildConfiguration("Debug", buildSettings: [
                     "RUN_CLANG_STATIC_ANALYZER": "YES",

--- a/Tests/SWBTaskConstructionTests/InfoPlistTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InfoPlistTaskConstructionTests.swift
@@ -95,7 +95,7 @@ fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Tool") { target in
                 // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
@@ -114,7 +114,7 @@ fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .anyMac) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Tool") { target in
                 for arch in ["arm64", "x86_64"] {

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -81,7 +81,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         try fs.write(tester.workspace.projects[0].sourceRoot.join("Info.plist"), contents: "<dict/>")
 
         // We should only try to sign valid API-able product types.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkError("Cannot code sign because the target does not have an Info.plist file and one is not being generated automatically. Apply an Info.plist file to the target using the INFOPLIST_FILE build setting or generate one automatically by setting the GENERATE_INFOPLIST_FILE build setting to YES (recommended). (in target 'FwkNoPlist' from project 'aProject')")
             results.checkError("Cannot code sign because the target does not have an Info.plist file and one is not being generated automatically. Apply an Info.plist file to the target using the INFOPLIST_FILE build setting or generate one automatically by setting the GENERATE_INFOPLIST_FILE build setting to YES (recommended). (in target 'FwkNoPlist' from project 'aProject')")
             results.checkError("Cannot code sign because the target does not have an Info.plist file and one is not being generated automatically. Apply an Info.plist file to the target using the INFOPLIST_FILE build setting or generate one automatically by setting the GENERATE_INFOPLIST_FILE build setting to YES (recommended). (in target 'FwkNoSrc' from project 'aProject')")
@@ -134,7 +134,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tapiToolPath = try await self.tapiToolPath
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             // There should be 3 interesting tasks (aside from symlink/touch tasks):
             // * CpHeader for umbrella header
             // * SymLink of the .tbd file
@@ -182,7 +182,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
             // There should be 4 interesting tasks (aside from symlink/touch tasks):
             // * CpHeader for umbrella header
             // * SymLink of the .tbd file
@@ -302,7 +302,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tapiToolPath = try await self.tapiToolPath
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             // There should be 3 interesting tasks (aside from symlink/touch tasks):
             // * CpHeader for umbrella header
             // * SymLink of the .tbd file
@@ -353,7 +353,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
             // There should be 4 interesting tasks (aside from symlink/touch tasks):
             // * CpHeader for umbrella header
             // * SymLink of the .tbd file
@@ -496,7 +496,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
 
 
         // Check the `installapi` build.
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("CpHeader")) { task in
                 task.checkCommandLineMatches([
@@ -553,7 +553,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
             // There should be 4 interesting tasks (aside from symlink/touch tasks):
             // * CpHeader for umbrella header
             // * SymLink of the .tbd file
@@ -637,7 +637,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `install` build performs the stubify step.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("GenerateTAPI")) { task in
                 // check TAPI options.
@@ -699,7 +699,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         ])
 
         // Check the `installapi` build.
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             // There should be 3 interesting tasks:
             // * CpHeader for header
             // * WriteAuxiliaryFile for JSON description
@@ -748,7 +748,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug")) { results in
+        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("CpHeader")) { task in
                 task.checkCommandLineMatches([
@@ -846,7 +846,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         ])
 
         // Check the `installapi` build.
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             try results.checkWriteAuxiliaryFileTask(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("Core.json")) { task, contents in
                 let data = try PropertyList.fromJSONData(contents)
@@ -891,7 +891,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug")) { results in
+        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("CpHeader")) { task in
                 task.checkCommandLineMatches([
@@ -970,7 +970,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `install` build performs the stubify step.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("GenerateTAPI")) { task in
                 // check TAPI options.
@@ -1050,7 +1050,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `install` build performs the stubify step.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
@@ -1232,7 +1232,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkError(.equal("Framework requested to generate API, but has not adopted SUPPORTS_TEXT_BASED_API (in target 'BadFwk' from project 'aProject')"))
             results.checkError(.equal("Dynamic Library requested to generate API, but has not adopted SUPPORTS_TEXT_BASED_API (in target 'BadDynamicLib' from project 'aProject')"))
             results.checkNoDiagnostics()
@@ -1294,7 +1294,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
                 task.checkCommandLineDoesNotContain("-emit-tbd")
             }
         }
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Release"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch", "CreateBuildDirectory"])
             // Check that the VFS is generated.
             results.checkTaskExists(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("all-product-headers.yaml"))
@@ -1335,7 +1335,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
                     ])
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             // Check that the VFS is generated.
             results.checkTaskExists(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("all-product-headers.yaml"))
             results.checkTarget("FooFramework") { target in
@@ -1400,7 +1400,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tapiVersion = try await discoveredTAPIToolInfo(at: tapiToolPath).toolVersion ?? Version()
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch", "CreateBuildDirectory"])
             // Check that the VFS is generated.
             results.checkTaskExists(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("all-product-headers.yaml"))
@@ -1529,7 +1529,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTarget("TargetName") { target in
                 results.checkNoTask(.matchRuleType("RuleScriptExecution"))
             }
@@ -1537,7 +1537,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let overrides = [
             "APPLY_RULES_IN_INSTALLAPI": "YES"
         ]
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", overrides: overrides)) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", overrides: overrides), runDestination: .macOS) { results in
             results.checkTarget("TargetName") { target in
                 results.checkTask(.matchRuleType("RuleScriptExecution")) { task in
                     task.checkCommandLineContains(["/bin/sh", "-c", "cp $INPUT_FILE_PATH /tmp/b"])
@@ -1587,7 +1587,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch", "CreateBuildDirectory"])
 
             // Check that the VFS is generated.
@@ -1684,7 +1684,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .anyiOSDevice)) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .anyiOSDevice) { results in
             results.checkNoDiagnostics()
 
             // Check that the VFS is generated.
@@ -1820,7 +1820,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .anyiOSDevice), clientDelegate: Delegate()) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .anyiOSDevice, clientDelegate: Delegate()) { results in
             results.checkNoDiagnostics()
 
             // Check that the VFS is generated.
@@ -1938,7 +1938,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             // It is an error to have Swift code and not enable InstallAPI.
             // Only applies to frameworks and dylibs.
             results.checkError(.equal("Dynamic Library requested to generate API, but has not adopted SUPPORTS_TEXT_BASED_API (in target 'BadDylib' from project 'aProject')"))
@@ -1947,7 +1947,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `installapi` build with ALLOW_UNSUPPORTED_TEXT_BASED_API set.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", overrides: ["ALLOW_UNSUPPORTED_TEXT_BASED_API": "YES"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", overrides: ["ALLOW_UNSUPPORTED_TEXT_BASED_API": "YES"]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
         }
     }
@@ -2004,7 +2004,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .iOS) { results in
             let arch = results.runDestinationTargetArchitecture
 
             // We should have a Swift invocation for FwkPrivate even though it's not installed.
@@ -2127,7 +2127,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch", "CreateBuildDirectory"])
             results.checkTarget("PackageProduct") { target in
                 results.checkNoDiagnostics()
@@ -2193,7 +2193,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             ])
         ])
         // Check the `installapi` build.
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("CpHeader")) { task in
                 task.checkCommandLineMatches([
@@ -2247,7 +2247,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("CpHeader")) { task in
                 task.checkCommandLineMatches([
@@ -2353,7 +2353,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             ])
         ])
 
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .macOS), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             try results.checkWriteAuxiliaryFileTask(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("Fwk.json")) { task, contents in
                 let data = try PropertyList.fromJSONData(contents)
@@ -2365,7 +2365,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             }
         }
 
-        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
             results.checkNoDiagnostics()
             try results.checkWriteAuxiliaryFileTask(.matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("Fwk.json")) { task, contents in
                 let data = try PropertyList.fromJSONData(contents)
@@ -2424,7 +2424,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         try await fs.writePlist(Path("/TEST/Info.plist"), .plDict([:]))
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("GenerateTAPI")) { task in
                 // check TAPI options.
@@ -2452,7 +2452,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
 
             // Validate that dSYM generation happens before GenerationTAPI task.
             results.checkNoDiagnostics()
@@ -2551,7 +2551,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         try await fs.writePlist(Path("/TEST/Info.plist"), .plDict([:]))
 
         // Check the `installapi` build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRuleType("GenerateTAPI")) { task in
                 // check TAPI options.
@@ -2579,7 +2579,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
 
         // Check the `install` build, which should run the same steps but also provide the binary for comparison purposes.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: fs) { results in
 
             // Validate that dSYM generation happens before GenerationTAPI task.
             results.checkNoDiagnostics()
@@ -2675,7 +2675,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
         // Even though SUPPORTS_TEXT_BASED_API=YES is global for the project, don't emit a swiftmodule for the app target because it doesn't emit a TBD, and isn't a dependency of any target which emits a TBD.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkWarning(.prefix("Skipping installAPI swiftmodule emission for target 'App'"))
             results.checkNoDiagnostics()
             results.checkTarget("App") { appTarget in

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -60,6 +60,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "foo.xib",
@@ -171,6 +172,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Foo",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "Foo.png",
@@ -242,6 +244,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release",
                                                buildSettings: [
@@ -426,6 +429,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Bundlable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release",
                                                buildSettings: [
@@ -568,6 +572,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase([
                                 "CoreFoo.framework",
@@ -672,6 +677,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -807,6 +813,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -917,6 +924,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase([
                                 "CoreFoo.framework",
@@ -1064,6 +1072,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "Settings.bundle"
@@ -1165,6 +1174,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestCopyFilesBuildPhase(["Settings.bundle"], destinationSubfolder: .resources, onlyForDeployment: false),
                         ])
@@ -1264,6 +1274,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestResourcesBuildPhase([
                                 "ReleaseSettings.bundle"
@@ -1341,6 +1352,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestShellScriptBuildPhase(name: "", shellPath: "/bin/bash", originalObjectID: "abc", contents: "env | sort", onlyForDeployment: false, emitEnvironment: true, alwaysOutOfDate: true)
                     ]
@@ -1496,6 +1508,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestCopyFilesBuildPhase([
                             "CoreFoo.framework",
@@ -1816,6 +1829,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "AppShortcuts.strings",

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -75,7 +75,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS) { results in
             // Ignore all Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -105,7 +105,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // INSTALLLOC_LANGUAGE set to "de" should only have de.lproj/foo.strings and not Base.lproj/foo.xib in the output.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "de"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "de"]), runDestination: .macOS) { results in
             // Ignore all Gate, build directory, MkDir, and SymLink tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -126,7 +126,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
         // INSTALLLOC_LANGUAGE can also be set to a string list of language codes
         // These would generally contain all languages other than English, but could differ.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "de ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "de ja"]), runDestination: .macOS) { results in
             // Ignore all Gate, build directory, MkDir, and SymLink tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -189,7 +189,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS) { results in
             // Ignore all Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -316,7 +316,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root"]), runDestination: .macOS) { results in
             // Ignore all Gate, build directory, SymLink, MkDir, and WriteAuxiliaryFile tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -346,7 +346,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // We shouldn't process any InfoPlist files if INSTALLLOC_LANGUAGE is set.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW"]), runDestination: .macOS) { results in
             // Ignore all Gate, build directory, SymLink, MkDir, and WriteAuxiliaryFile tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -371,7 +371,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
         // And check when INSTALLLOC_LANGUAGE is set to multiple languages.
         // Still shouldn't process any InfoPlist files.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW fr"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW fr"]), runDestination: .macOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -474,7 +474,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["DSTROOT": "/tmp/Root"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -499,7 +499,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // We shouldn't process any InfoPlist files if INSTALLLOC_LANGUAGE is set.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -520,7 +520,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // And same for multiple specified languages.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW fr"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["DSTROOT": "/tmp/Root", "INSTALLLOC_LANGUAGE": "zh_TW fr"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -591,7 +591,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 languageLprojPathPairs += [(lang, path)]
             }
 
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
                 // Ignore all Gate, build directory, SymLink, and MkDir tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -610,7 +610,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             }
 
             // INSTALLLOC_LANGUAGE set to "ja"
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .iOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -631,7 +631,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
             // INSTALLLOC_LANGUAGE set to "ja"
             let specificLangs = ["zh_TW", "ja"]
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": specificLangs.joined(separator: " ")]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": specificLangs.joined(separator: " ")]), runDestination: .iOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -688,7 +688,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -736,7 +736,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // When installing Japanese, we should only get Japanese content.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -752,7 +752,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // When a language is not specified, we should get all localizable content.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -771,7 +771,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // Or with multiple languages
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -838,7 +838,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -861,7 +861,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -881,7 +881,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -971,11 +971,11 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         ])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        let buildParameters = BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS)
+        let buildParameters = BuildParameters(action: .installLoc, configuration: "Debug")
         let target = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: buildParameters, target: $0) })
         let buildRequest = BuildRequest(parameters: buildParameters, buildTargets: target, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
 
-        await tester.checkBuild(buildParameters, buildRequest: buildRequest) { results in
+        await tester.checkBuild(buildParameters, runDestination: .iOS, buildRequest: buildRequest) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -998,11 +998,11 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        let japaneseBuildParameters = BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja"])
+        let japaneseBuildParameters = BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"])
         let japaneseTarget = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: japaneseBuildParameters, target: $0) })
         let japaneseBuildRequest = BuildRequest(parameters: japaneseBuildParameters, buildTargets: japaneseTarget, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
 
-        await tester.checkBuild(japaneseBuildParameters, buildRequest: japaneseBuildRequest) { results in
+        await tester.checkBuild(japaneseBuildParameters, runDestination: .iOS, buildRequest: japaneseBuildRequest) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1022,11 +1022,11 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        let multiLangBuildParameters = BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"])
+        let multiLangBuildParameters = BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"])
         let multiLangTarget = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: multiLangBuildParameters, target: $0) })
         let multiLangBuildRequest = BuildRequest(parameters: multiLangBuildParameters, buildTargets: multiLangTarget, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
 
-        await tester.checkBuild(multiLangBuildParameters, buildRequest: multiLangBuildRequest) { results in
+        await tester.checkBuild(multiLangBuildParameters, runDestination: .iOS, buildRequest: multiLangBuildRequest) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1089,7 +1089,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 languageLprojPathPairs += [(lang, path)]
             }
 
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, SymLink, and MkDir tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1108,7 +1108,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             }
 
             // INSTALLLOC_LANGUAGE set to "ja"
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1129,7 +1129,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
             // INSTALLLOC_LANGUAGE set to "ja fr"
             let langs = ["ja", "fr"]
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": langs.joined(separator: " ")]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": langs.joined(separator: " ")]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1189,7 +1189,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                 languageLprojPathPairs += [(lang, path)]
             }
 
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, SymLink, and MkDir tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1208,7 +1208,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             }
 
             // INSTALLLOC_LANGUAGE set to "ja"
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1229,7 +1229,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
             // INSTALLLOC_LANGUAGE set to "ja"
             let langs = ["ja", "de"]
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": langs.joined(separator: " ")]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": langs.joined(separator: " ")]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1287,7 +1287,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             try fs.createDirectory(path, recursive: true)
             try fs.write(path.join("Root.strings"), contents: "LocTest")
 
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, SymLink, and MkDir tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1305,7 +1305,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             }
 
             // INSTALLLOC_LANGUAGE set to "ja"
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1324,7 +1324,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             }
 
             // INSTALLLOC_LANGUAGE set to "ja fr"
-            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja fr"]), fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja fr"]), runDestination: .macOS, fs: fs) { results in
                 // Ignore all Gate, build directory, MkDir, and SymLink tasks.
                 results.checkTasks(.matchRuleType("Gate")) { _ in }
                 results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1360,7 +1360,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -1373,7 +1373,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // Shell Script tasks should be generated for an installloc build only if INSTALLLOC_SCRIPT_PHASE is enabled.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_SCRIPT_PHASE": "YES"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_SCRIPT_PHASE": "YES"]), runDestination: .macOS) { results in
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -1425,7 +1425,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
 
         // For localization builds, we expect all the necessary directories and localizable files to be created.
         // However, we should not generate the expected SymLink tasks for a FrameworkProductTypeSpec.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS) { results in
 
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1446,7 +1446,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // Same if multiple languages are specified as in _Loc_All builds.
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "ja it"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "ja it"]), runDestination: .macOS) { results in
 
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1468,7 +1468,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         }
 
         // Verify that an install build still creates the SymLinks we want to ignore in the installloc build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS) { results in
             results.checkTarget("FrameworkTarget") { target in
                 results.checkTasks(.matchTarget(target), .matchRule(["SymLink", "/tmp/Test/aProject/build/Release/FrameworkTarget.framework", "../../../../aProject.dst/Library/Frameworks/FrameworkTarget.framework"])) { _ in }
                 results.checkTasks(.matchTarget(target), .matchRule(["SymLink", "/tmp/aProject.dst/Library/Frameworks/FrameworkTarget.framework/Versions/Current", "A"])) { _ in }
@@ -1540,7 +1540,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug"), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1564,7 +1564,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1585,7 +1585,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja zh_TW"]), runDestination: .iOS) { results in
             // Ignore all Gate, build directory, SymLink, and MkDir tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1684,7 +1684,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
         try await fs.writePlist(baselineDir.join("Some-Test-Data.plist"), .plDict([:]))
 
         // Run installLoc on project
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS, fs: fs) { results in
 
             // Ignore all Gate, SymLink and CreateBuildDirectory tasks, as they are not relevant for this case
             results.checkTasks(.matchRuleType("Gate")) { _ in }
@@ -1777,7 +1777,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"])) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("app") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("FOO.bundle")) { task in

--- a/Tests/SWBTaskConstructionTests/InstallTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallTaskConstructionTests.swift
@@ -135,7 +135,7 @@ fileprivate struct InstallTaskConstructionTests: CoreBasedTests {
             "DSTROOT": "/tmp/dstroot",
             "USE_HIERARCHICAL_LAYOUT_FOR_COPIED_ASIDE_PRODUCTS": "YES",
         ]
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: overrides)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: overrides), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.consumeTasksMatchingRuleTypes(["Gate", "WriteAuxiliaryFile", "CreateBuildDirectory", "MkDir", "Strip", "SetOwnerAndGroup", "SetMode", "Touch", "RegisterWithLaunchServices"])
@@ -236,7 +236,7 @@ fileprivate struct InstallTaskConstructionTests: CoreBasedTests {
 
         // Check a build where the DSTROOT is a string-prefix of the SRCROOT.
         var DSTROOT = tester.workspace.projects[0].sourceRoot.dirname.join(projectNameRoot).str
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: ["DSTROOT": DSTROOT,])) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: ["DSTROOT": DSTROOT,]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.consumeTasksMatchingRuleTypes(["Gate", "WriteAuxiliaryFile", "CreateBuildDirectory", "MkDir", "Strip", "SetOwnerAndGroup", "SetMode", "Touch", "RegisterWithLaunchServices"])
@@ -249,7 +249,7 @@ fileprivate struct InstallTaskConstructionTests: CoreBasedTests {
 
         // Check a build where the DSTROOT is *not* a string-prefix of the SRCROOT.
         DSTROOT = tester.workspace.projects[0].sourceRoot.dirname.join("\(projectNameRoot).dst").str
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: ["DSTROOT": DSTROOT,])) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release", overrides: ["DSTROOT": DSTROOT,]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.consumeTasksMatchingRuleTypes(["Gate", "WriteAuxiliaryFile", "CreateBuildDirectory", "MkDir", "Strip", "SetOwnerAndGroup", "SetMode", "Touch", "RegisterWithLaunchServices"])

--- a/Tests/SWBTaskConstructionTests/IntermediateStubTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IntermediateStubTaskConstructionTests.swift
@@ -48,7 +48,7 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
             ])
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("GenerateTAPI")) { task in
                 task.checkInputs([.path("/tmp/Test/aProject/build/Debug/Fwk.framework/Versions/A/Fwk"),
                                   .namePattern(.suffix("-ProductPostprocessingTaskProducer")),
@@ -88,7 +88,7 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTask(.matchRule(["GenerateTAPI", "/tmp/Test/aProject/build/Debug/Fwk.framework/Versions/A/Fwk.tbd", "normal", "x86_64"])) { _ in }
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
@@ -122,7 +122,7 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
     }
@@ -156,7 +156,7 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS) { results in
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
             results.checkWarning(.contains("Building with bitcode is deprecated"))
         }
@@ -190,7 +190,7 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug")) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTask(.matchRule(["GenerateTAPI", "/tmp/Test/aProject/build/Debug/Fwk.framework/Versions/A/Fwk.tbd"])) { _ in }
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
@@ -223,11 +223,11 @@ fileprivate struct IntermediateStubTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["REEXPORTED_FRAMEWORK_NAMES": "Foundation"])) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["REEXPORTED_FRAMEWORK_NAMES": "Foundation"]), runDestination: .macOS) { results in
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["OTHER_LDFLAGS": "-reexport-lfoo"])) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["OTHER_LDFLAGS": "-reexport-lfoo"]), runDestination: .macOS) { results in
             results.checkNoTask(.matchRuleType("GenerateTAPI"))
         }
     }

--- a/Tests/SWBTaskConstructionTests/KernelExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/KernelExtensionTaskConstructionTests.swift
@@ -52,7 +52,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         for macro in ["$(ARCHS_STANDARD)", "$(ARCHS_STANDARD_64_BIT)", "$(ARCHS_STANDARD_INCLUDING_64_BIT)"] {
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac, overrides: ["ARCHS": macro])) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ARCHS": macro]), runDestination: .anyMac) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchRuleType("CompileC"), .matchRuleItem("arm64e")) { task in }
                 results.checkTask(.matchRuleType("CompileC"), .matchRuleItem("x86_64")) { task in }
@@ -95,7 +95,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        try await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        try await tester.checkBuild(runDestination: .anyMac) { results in
             results.checkNoDiagnostics()
 
             let writeTask: any PlannedTask = try results.checkTask(.matchRule(["WriteAuxiliaryFile", "/tmp/Test/aProject/build/aProject.build/Debug/aTarget.build/DerivedSources/KextTest_info.c"])) { task in task }
@@ -153,12 +153,12 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRule(["WriteAuxiliaryFile", "/tmp/Test/aProject/build/aProject.build/Debug/aTarget.build/DerivedSources/KextTest_info.c"])) { _ in }
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["GENERATE_KERNEL_MODULE_INFO_FILE": "NO"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["GENERATE_KERNEL_MODULE_INFO_FILE": "NO"]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             let writeRule = ["WriteAuxiliaryFile", "/tmp/Test/aProject/build/aProject.build/Debug/aTarget.build/DerivedSources/KextTest_info.c"]
@@ -209,7 +209,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
         let tester = try TaskConstructionTester(core, testProject)
 
         // Check the build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "Ld", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "RegisterExecutionPolicyException", "SetMode", "SetOwnerAndGroup", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             // Check there are no diagnostics.
@@ -262,7 +262,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check the build.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "Ld", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             results.checkTarget("SomeKext") { target in

--- a/Tests/SWBTaskConstructionTests/LibtoolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/LibtoolTaskConstructionTests.swift
@@ -61,7 +61,7 @@ fileprivate struct LibtoolTaskConstructionTests: CoreBasedTests {
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug")) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("Deterministic") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkRuleInfo(["Libtool", "\(SRCROOT)/build/Debug/libDeterministic.a", "normal"])

--- a/Tests/SWBTaskConstructionTests/MasterObjectFileTests.swift
+++ b/Tests/SWBTaskConstructionTests/MasterObjectFileTests.swift
@@ -62,7 +62,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check a debug build.
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -91,7 +91,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         }
 
         // Check an install build with RETAIN_RAW_BINARIES.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), fs: localFS) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: ["RETAIN_RAW_BINARIES": "YES"]), runDestination: .macOS, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -129,7 +129,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         }
 
         // Check an installapi build.
-        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), fs: localFS) { results in
+        await tester.checkBuild(BuildParameters(action: .installAPI, configuration: "Debug"), runDestination: .macOS, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -193,7 +193,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check a build for MacCatalyst.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macCatalyst), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .macCatalyst, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -263,7 +263,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check a debug build.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .iOS, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -344,7 +344,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check a debug build.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator, fs: localFS) { results in
             // Ignore all tasks we don't want to check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }

--- a/Tests/SWBTaskConstructionTests/MergeableLibraryTests.swift
+++ b/Tests/SWBTaskConstructionTests/MergeableLibraryTests.swift
@@ -163,7 +163,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -175,7 +175,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable targets were *not* build to be mergeable.
@@ -330,7 +330,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -343,7 +343,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable targets were built to be mergeable.
@@ -579,7 +579,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -591,7 +591,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable target was *not* build to be mergeable.
@@ -717,7 +717,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -730,7 +730,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable targets were *not* built to be mergeable.
@@ -970,7 +970,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: "Config", activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: "Config", overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -981,7 +981,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable target was *not* built to be mergeable.
@@ -1088,7 +1088,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: "Config", activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: "Config", overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1100,7 +1100,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable target was *not* built to be mergeable.
@@ -1284,7 +1284,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.iOS
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1299,7 +1299,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1379,7 +1379,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.iOSSimulator
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1394,7 +1394,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1457,7 +1457,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.iOS
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1473,7 +1473,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1527,7 +1527,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.iOS
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1544,7 +1544,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1606,7 +1606,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.iOSSimulator
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1622,7 +1622,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1761,7 +1761,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.macOS
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1776,7 +1776,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -1858,7 +1858,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let runDestination = RunDestinationInfo.macOS
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -1874,7 +1874,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let buildTargets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: buildTargets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request, fs: fs) { results in
+            await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request, fs: fs) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 results.checkTask(.matchRuleType("ProcessXCFramework"), .matchRuleItemBasename("\(fwkBaseName).xcframework")) { task in
@@ -2022,7 +2022,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Debug"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: "Config", activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: "Config", overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -2033,7 +2033,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the framework targets were *not* build to be mergeable.
@@ -2134,7 +2134,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
         do {
             let buildType = "Release"
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-            let parameters = BuildParameters(configuration: "Config", activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: "Config", overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -2146,7 +2146,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check that the mergeable targets were *not* built to be mergeable.
@@ -2326,7 +2326,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let CONFIGURATION = "Config"
             let buildVariants = ["normal", "profile"]
             let runDestination = RunDestinationInfo.iOS
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -2341,7 +2341,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
             let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check the mergeable target.
@@ -2510,7 +2510,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
             let CONFIGURATION = "Config"
             let runDestination = RunDestinationInfo.iOS
-            let parameters = BuildParameters(configuration: CONFIGURATION, activeRunDestination: .iOS, overrides: [
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
                 "SYMROOT": SYMROOT,
                 "OBJROOT": OBJROOT,
                 "DSTROOT": DSTROOT,
@@ -2522,7 +2522,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             let BUILT_PRODUCTS_DIR = "\(SYMROOT)/\(CONFIGURATION)" + (runDestination != .macOS ? "-\(runDestination.platform)" : "")
             let targets = [BuildRequest.BuildTargetInfo(parameters: parameters, target: tester.workspace.projects[0].targets[0])]
             let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-            await tester.checkBuild(parameters, buildRequest: request) { results in
+            await tester.checkBuild(parameters, runDestination: .iOS, buildRequest: request) { results in
                 results.consumeTasksMatchingRuleTypes()
 
                 // Check the normal framework target.
@@ -2700,7 +2700,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             for action: BuildAction in [.install, .installHeaders, .installAPI] {
                 let buildType = "Release"
                 let (SYMROOT, OBJROOT, DSTROOT) = buildDirs(in: Path("/tmp/buildDir"), for: buildType)
-                let parameters = BuildParameters(action: action, configuration: CONFIGURATION, activeRunDestination: runDestination, overrides: [
+                let parameters = BuildParameters(action: action, configuration: CONFIGURATION, overrides: [
                     "SYMROOT": SYMROOT,
                     "OBJROOT": OBJROOT,
                     "DSTROOT": DSTROOT,
@@ -2712,7 +2712,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
                 // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
                 let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
                 let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-                await tester.checkBuild(parameters, buildRequest: request) { results in
+                await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                     results.consumeTasksMatchingRuleTypes()
 
                     // Check the actions with a build component.
@@ -2934,7 +2934,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Test a debug build
             do {
                 let (SYMROOT, OBJROOT, DSTROOT) = ("/tmp/buildDir/\(runDestination.platform)/sym", "/tmp/buildDir/\(runDestination.platform)/obj", "/tmp/buildDir/\(runDestination.platform)/dst")
-                let parameters = BuildParameters(configuration: "Config", activeRunDestination: runDestination, overrides: [
+                let parameters = BuildParameters(configuration: "Config", overrides: [
                     "SYMROOT": SYMROOT,
                     "OBJROOT": OBJROOT,
                     "DSTROOT": DSTROOT,
@@ -2945,7 +2945,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
                 // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
                 let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
                 let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-                await tester.checkBuild(parameters, buildRequest: request) { results in
+                await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but AUTOMATICALLY_MERGE_DEPENDENCIES is assigned at level: target. (in target 'AutomaticApp' from project 'aProject')")
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but MERGE_LINKED_LIBRARIES is assigned at level: target. (in target 'ManualApp' from project 'aProject')")
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but MERGEABLE_LIBRARY is assigned at level: target. (in target 'ManualMergeableFwk' from project 'aProject')")
@@ -2962,7 +2962,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
             // Test a release build
             do {
                 let (SYMROOT, OBJROOT, DSTROOT) = ("/tmp/buildDir/\(runDestination.platform)/sym", "/tmp/buildDir/\(runDestination.platform)/obj", "/tmp/buildDir/\(runDestination.platform)/dst")
-                let parameters = BuildParameters(configuration: "Config", activeRunDestination: runDestination, overrides: [
+                let parameters = BuildParameters(configuration: "Config", overrides: [
                     "SYMROOT": SYMROOT,
                     "OBJROOT": OBJROOT,
                     "DSTROOT": DSTROOT,
@@ -2974,7 +2974,7 @@ fileprivate struct MergeableLibraryTests: CoreBasedTests {
                 // Add all the targets as top-level targets as this can shake out certain kinds of target dependency resolution bugs.
                 let targets = tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) })
                 let request = BuildRequest(parameters: parameters, buildTargets: targets, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-                await tester.checkBuild(parameters, buildRequest: request) { results in
+                await tester.checkBuild(parameters, runDestination: runDestination, buildRequest: request) { results in
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but AUTOMATICALLY_MERGE_DEPENDENCIES is assigned at level: target. (in target 'AutomaticApp' from project 'aProject')")
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but MERGE_LINKED_LIBRARIES is assigned at level: target. (in target 'ManualApp' from project 'aProject')")
                     results.checkError("Mergeable libraries are not supported for architecture 'armv7k', but MERGEABLE_LIBRARY is assigned at level: target. (in target 'ManualMergeableFwk' from project 'aProject')")

--- a/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
@@ -114,7 +114,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                       ("ObjCAndSwift", "ModuleContents", [didNotWriteModuleMapContents]),
         ]
         for (targetName, configurationName, warnings) in builds {
-            await tester.checkBuild(BuildParameters(configuration: configurationName), targetName: targetName) { results in
+            await tester.checkBuild(BuildParameters(configuration: configurationName), runDestination: .macOS, targetName: targetName) { results in
                 results.checkTarget(targetName) { target in
                     // The build directories are hard coded to "Debug" and don't use the configuration name being built.
                     let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/module.modulemap"
@@ -263,7 +263,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                       ("PrivateModuleInternalSwift", true),
         ]
         for (targetName, hasPrivateModuleMap) in builds {
-            await tester.checkBuild(targetName: targetName) { results in
+            await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
                 results.checkTarget(targetName) { target in
                     let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/module.modulemap"
                     let installedModuleMap = "\(SRCROOT)/build/Debug/\(targetName).framework/Versions/A/Modules/module.modulemap"
@@ -525,7 +525,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                                 ("Unifdef", "Unifdef.h", false),
         ]
         for (targetName, umbrellaHeader, hasSwiftSource) in targetParameters {
-            await tester.checkBuild(targetName: targetName) { results in
+            await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
                 results.checkTarget(targetName) { target in
                     let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/module.modulemap"
                     let unextendedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/unextended-module.modulemap"
@@ -571,7 +571,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(targetName: "SwiftOnly") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "SwiftOnly") { results in
             results.checkTarget("SwiftOnly") { target in
                 let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/SwiftOnly.build/module.modulemap"
                 let unextendedModuleMap = "\(SRCROOT)/build/Project.build/Debug/SwiftOnly.build/unextended-module.modulemap"
@@ -609,7 +609,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(targetName: "ObjCCompatibilityHeader") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "ObjCCompatibilityHeader") { results in
             results.checkTarget("ObjCCompatibilityHeader") { target in
                 let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/ObjCCompatibilityHeader.build/module.modulemap"
                 let unextendedModuleMap = "\(SRCROOT)/build/Project.build/Debug/ObjCCompatibilityHeader.build/unextended-module.modulemap"
@@ -763,7 +763,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                                 ("ObjCCompatibilityHeader", true),
         ]
         for (targetName, hasSwiftSource) in targetParameters {
-            await tester.checkBuild(targetName: targetName) { results in
+            await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
                 results.checkTarget(targetName) { target in
                     let generatedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/module.modulemap"
                     let unextendedModuleMap = "\(SRCROOT)/build/Project.build/Debug/\(targetName).build/unextended-module.modulemap"
@@ -948,7 +948,7 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                       ("ObjCAndSwift", "FilePublicWithPrivate", true, true, true, true, true),
         ]
         for (targetName, configurationName, copiesPublicModuleMap, hasSwiftExtension, copiesPrivateModuleMap, generatesSourceModuleMaps, copiesUseUnifdef) in builds {
-            await tester.checkBuild(BuildParameters(configuration: configurationName), targetName: targetName, fs: fs) { results in
+            await tester.checkBuild(BuildParameters(configuration: configurationName), runDestination: .macOS, targetName: targetName, fs: fs) { results in
                 results.checkTarget(targetName) { target in
                     // The build directories are hard coded to "Debug" and don't use the configuration name being built.
                     let sourceModuleMap = generatesSourceModuleMaps

--- a/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
@@ -71,7 +71,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                     ]),
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .anyMac) { results in
             results.checkError("No standard in \"gnu11\" is valid for language objective-c++")
             results.checkWarning("Duplicate target architectures found - x86_64-apple-macos14.0-macabi, x86_64-apple-macos14.0-macabi")
             results.checkWarning("No matching target for target variant - arm64e-apple-macos14.0-macabi")
@@ -142,7 +142,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             """)
 
         // A regular build will just build the correct architecture.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: ["OTHER_CFLAGS": "-DCLI_FLAG"], environmentConfigOverridesPath: xcconfig), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: ["OTHER_CFLAGS": "-DCLI_FLAG"], environmentConfigOverridesPath: xcconfig), runDestination: .macOS, fs: fs) { results in
             let arch = results.runDestinationTargetArchitecture
             results.checkNoDiagnostics()
 
@@ -259,7 +259,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         }
 
         // An install build will build all architectures, but invoke modules-verifier once with all of them specified.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .anyMac) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget(targetName) { target in
@@ -360,7 +360,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
             // A regular build will just build the correct architecture.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTarget(targetName) { target in
@@ -458,7 +458,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
             // A regular build will just build the correct architecture.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTarget(targetName) { target in
@@ -575,7 +575,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
             // A regular build will just build the correct architecture.
-            await tester.checkBuild() { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTarget(targetName) { target in
@@ -639,7 +639,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // A regular build will just build the correct architecture.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             let arch = results.runDestinationTargetArchitecture
             results.checkNoDiagnostics()
 
@@ -708,7 +708,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // A regular build will just build the correct architecture.
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             let arch = results.runDestinationTargetArchitecture
             results.checkNoDiagnostics()
 
@@ -760,7 +760,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         }
 
         // An install build will build all architectures, but invoke modules-verifier once with all of them specified.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .anyMac) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget(targetName) { target in
@@ -824,7 +824,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                                       ])
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(targetName: targetName) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
             results.checkNoDiagnostics()
             results.checkTarget(targetName) { target in
                 results.checkNoDiagnostics()
@@ -882,7 +882,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                                       ])
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        await tester.checkBuild(targetName: targetName) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
             results.checkNoDiagnostics()
             results.checkTarget(targetName) { target in
                 results.checkNoDiagnostics()
@@ -970,7 +970,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
             contents <<< "framework module Orange {}\n"
         }
 
-        await tester.checkBuild(targetName: targetName, fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: targetName, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTarget(targetName) { target in
                 let task = results.findOneMatchingTask([.matchTarget(target), .matchRuleType(verifierRuleName)])
@@ -1036,7 +1036,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(targetName: "B") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "B") { results in
             results.checkNoDiagnostics()
 
             func noDependency(from task1: [TaskCondition], to task2: [TaskCondition], sourceLocation: SourceLocation = #_sourceLocation) {
@@ -1101,7 +1101,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         for action in BuildAction.allCases.filter({ !$0.buildComponents.contains("build") }) {
-            await tester.checkBuild(BuildParameters(action: action, configuration: "Release")) { results in
+            await tester.checkBuild(BuildParameters(action: action, configuration: "Release"), runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
                 results.checkTarget(targetName) { target in
                     // Check that we DO NOT have a modules verifier task.
@@ -1168,7 +1168,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(targetName: "BBB") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "BBB") { results in
             results.checkNoDiagnostics()
 
             // Note checkTarget() removes the target from that list, but not all its tasks (which is what we want here)
@@ -1316,7 +1316,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(targetName: targetName) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
             results.checkNoDiagnostics()
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType(verifierInputRuleName)) { task in
@@ -1354,7 +1354,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         }
 
         // Make sure the right stuff happens for deployment postprocessing, i.e. an install build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: nil), targetName: targetName) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: nil), runDestination: .macOS, targetName: targetName) { results in
             results.checkNoDiagnostics()
             results.checkTarget(targetName) { target in
                 results.checkTask(.matchTarget(target), .matchRuleType(verifierInputRuleName)) { task in
@@ -1531,7 +1531,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
 
         let SRCROOT = sourceRoot.str
 
-        await tester.checkBuild(targetName: "OutputFiles", fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "OutputFiles", fs: fs) { results in
             results.checkNote(.contains("'OutputToPrivateHeadersSubFolder' will be run during every build because it does not specify any outputs."), failIfNotFound: false)
             results.checkNoDiagnostics()
             results.checkTarget("OutputFiles") { target in
@@ -1570,7 +1570,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         }
 
         // Make sure the right stuff happens for deployment postprocessing, i.e. an install build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: nil), targetName: "OutputFiles", fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: nil), runDestination: .macOS, targetName: "OutputFiles", fs: fs) { results in
             results.checkNote(.contains("'OutputToPrivateHeadersSubFolder' will be run during every build because it does not specify any outputs."), failIfNotFound: false)
             results.checkNoDiagnostics()
             results.checkTarget("OutputFiles") { target in
@@ -1589,7 +1589,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
             }
         }
 
-        await tester.checkBuild(targetName: "NoOutputFiles", fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "NoOutputFiles", fs: fs) { results in
             results.checkWarning(.contains("'NoOutputFiles' will be run during every build because it does not specify any outputs."), failIfNotFound: false)
             results.checkNoDiagnostics()
             results.checkTarget("NoOutputFiles") { target in
@@ -1698,7 +1698,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         for targetName in ["NoObjCCompatibilityHeader", "ObjCCompatibilityHeaderNotInstalled"] {
-            await tester.checkBuild(targetName: targetName) { results in
+            await tester.checkBuild(runDestination: .macOS, targetName: targetName) { results in
                 results.checkWarning(.prefix("[targetIntegrity] DEFINES_MODULE was set, but no umbrella header could be found to generate the module map"))
                 results.checkNoDiagnostics()
                 results.checkTarget(targetName) { target in
@@ -1707,7 +1707,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
             }
         }
 
-        await tester.checkBuild(targetName: "SwiftOnly") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "SwiftOnly") { results in
             results.checkNoDiagnostics()
             results.checkTarget("SwiftOnly") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType(verifierInputRuleName)) { task in
@@ -1728,7 +1728,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
             }
         }
 
-        await tester.checkBuild(targetName: "ObjCAndSwift") { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "ObjCAndSwift") { results in
             results.checkNoDiagnostics()
             results.checkTarget("ObjCAndSwift") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType(verifierInputRuleName)) { task in
@@ -1810,7 +1810,7 @@ extension ClangModuleVerifierTaskConstructionTestsProtocol {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(targetName: "Framework", clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate()) { results in
+        await tester.checkBuild(runDestination: .macOS, targetName: "Framework", clientDelegate: TestIntentsCompilerTaskPlanningClientDelegate()) { results in
             results.checkNoDiagnostics()
             results.checkTarget("Framework") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType(verifierInputRuleName)) { task in

--- a/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
@@ -396,7 +396,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
         let sharedFrameworkTarget = try #require(tester.workspace.target(named: "Shared Framework"))
         let macAppWithEmbeddedPhoneAppTarget = try #require(tester.workspace.target(named: "MacAppEmbeddingiOSApp"))
 
-        let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: destination)
+        let parameters = BuildParameters(action: .build, configuration: "Debug")
         let request = BuildRequest(parameters: parameters, buildTargets: targets.map { BuildRequest.BuildTargetInfo(parameters: BuildParameters(action: .build, configuration: "Debug"), target: $0) }, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: useImplicitDependencies, useDryRun: false)
 
         let macos = targets.contains(macosTarget) || targets.contains(macAppWithEmbeddedPhoneAppTarget)
@@ -407,7 +407,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
         let shared = targets.contains(sharedFrameworkTarget)
 
         // Check the debug build, for the device.
-        await tester.checkBuild(buildRequest: request, fs: fs) { results in
+        await tester.checkBuild(runDestination: destination, buildRequest: request, fs: fs) { results in
 
             func validateTargetCompiledForPlatform(_ partialTriple: String, tasks: GenericSequence<any PlannedTask>) {
                 #expect(tasks.count > 0)
@@ -796,11 +796,11 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
         let targets = tester.workspace.targets(named: "macCatalyst App")
         for destination in [RunDestinationInfo.macOS, RunDestinationInfo.macCatalyst] {
-            let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: destination)
+            let parameters = BuildParameters(action: .build, configuration: "Debug")
 
             let request = BuildRequest(parameters: parameters, buildTargets: targets.map { BuildRequest.BuildTargetInfo(parameters: BuildParameters(action: .build, configuration: "Debug"), target: $0) }, continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
 
-            await tester.checkBuild(buildRequest: request) { results in
+            await tester.checkBuild(runDestination: destination, buildRequest: request) { results in
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
@@ -52,6 +52,7 @@ fileprivate struct OnDemandResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             TestBuildFile("A.dat", assetTags: Set(["foo"])),

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -149,7 +149,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject, testPackage])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Release"), targetName: "Tool") { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Release"), runDestination: .macOS, targetName: "Tool") { results in
             results.checkWarning(.contains("missing target configuration for 'D' (in target 'D' from project 'aProject')"))
             results.checkNoDiagnostics()
             results.checkTarget("Tool") { target in
@@ -250,7 +250,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject, testPackage])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("DynamicJSON") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
@@ -273,7 +273,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                 "DEPLOYMENT_LOCATION": "YES",
             ])
 
-            await tester.checkBuild(parameters) { results in
+            await tester.checkBuild(parameters, runDestination: .macOS) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTarget("DynamicJSON") { target in
@@ -294,7 +294,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                 "ARCHS": "x86_64 x86_64h",
                 "VALID_ARCHS": "$(inherited) x86_64h",
             ]
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac, overrides: overrides)) { results in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides), runDestination: .anyMac) { results in
                 results.checkNoDiagnostics()
                 results.checkTarget("SwiftyJSON") { target in
                     results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
@@ -357,7 +357,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("clib") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("test.modulemap")) { task, contents in
@@ -441,7 +441,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         let testWorkspace = TestWorkspace("Test", projects: [testProject, testPackage])
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkError("[targetIntegrity] The package product 'SwiftyJSON' cannot be used as a dependency of this target because it uses unsafe build flags. (in target 'tool' from project 'aProject')")
         }
     }
@@ -502,7 +502,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         for destination in [RunDestinationInfo.iOS, .macOS, .macCatalyst] {
-            await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: destination)) { results in
+            await tester.checkBuild(runDestination: destination) { results in
                 results.checkNoDiagnostics()
                 results.checkTarget("SwiftJSONTests") { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("CompileSwiftSources")) { tasks in
@@ -612,25 +612,25 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS)) { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkError("[targetIntegrity] The package product 'SwiftyJSONImpl' requires minimum platform version 11.0 for the macOS platform, but this target supports 10.13 (in target 'fmwk' from project 'aProject')")
             results.checkError("[targetIntegrity] The package product 'SwiftyJSON' requires minimum platform version 10.14 for the macOS platform, but this target supports 10.13 (in target 'fmwk' from project 'aProject')")
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(runDestination: .iOS) { results in
             results.checkError("[targetIntegrity] The package product 'SwiftyJSONImpl' requires minimum platform version 13.2 for the iOS platform, but this target supports 13.0 (in target 'fmwk' from project 'aProject')")
             results.checkError("[targetIntegrity] The package product 'SwiftyJSON' requires minimum platform version 13.2 for the iOS platform, but this target supports 13.0 (in target 'fmwk' from project 'aProject')")
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator)) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator) { results in
             results.checkError("[targetIntegrity] The package product 'SwiftyJSONImpl' requires minimum platform version 13.2 for the iOS platform, but this target supports 13.0 (in target 'fmwk' from project 'aProject')")
             results.checkError("[targetIntegrity] The package product 'SwiftyJSON' requires minimum platform version 13.2 for the iOS platform, but this target supports 13.0 (in target 'fmwk' from project 'aProject')")
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macCatalyst)) { results in
+        await tester.checkBuild(runDestination: .macCatalyst) { results in
             results.checkError("[targetIntegrity] The package product 'SwiftyJSONImpl' requires minimum platform version 13.2 for the Mac Catalyst platform, but this target supports 13.1 (in target 'fmwk' from project 'aProject')")
             results.checkError("[targetIntegrity] The package product 'SwiftyJSON' requires minimum platform version 13.2 for the Mac Catalyst platform, but this target supports 13.1 (in target 'fmwk' from project 'aProject')")
             results.checkNoDiagnostics()
@@ -710,7 +710,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         let workspace = TestWorkspace("Workspace", projects: [TestProject("aProject", groupTree: TestGroup("SomeFiles", children: [TestFile("best.c")]), targets: allTargets), package])
         let tester = try await TaskConstructionTester(getCore(), workspace)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["EXCLUDED_ARCHS": "i386 x86_64 armv7 armv7k arm64_32 arm64e"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["EXCLUDED_ARCHS": "i386 x86_64 armv7 armv7k arm64_32 arm64e"]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTasks(.matchRuleType("Ld")) { tasks in
@@ -800,7 +800,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("SwiftyJSONTests") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
@@ -849,7 +849,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("foo") { target in
@@ -911,7 +911,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             try "hello world".write(to: URL(fileURLWithPath: "\(sourceRoot.str)/best.txt"), atomically: true, encoding: .utf8)
         }
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("tool") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("embedded_resources.swift")) { task, contents in
@@ -1051,7 +1051,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("tool") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in
@@ -1174,7 +1174,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("app") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("FOO.bundle")) { task in
@@ -1254,7 +1254,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(clientDelegate: TestCoreDataCompilerTaskPlanningClientDelegate()) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: TestCoreDataCompilerTaskPlanningClientDelegate()) { results in
             results.checkNoDiagnostics()
             results.checkTarget("SwiftyJSON") { target in
                 results.checkNoTask(.matchTarget(target), .matchRuleType("DataModelCompile"))

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -896,6 +896,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "tool",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase(["main.swift"]),
                         TestCopyFilesBuildPhase([TestBuildFile(.file("best.txt"), resourceRule: .embedInCode)], destinationSubfolder: .builtProductsDir),

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -254,7 +254,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
         }
 
         // Check the debug build, for the simulator.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator, fs: fs) { results in
             // Ignore tasks we don't want to specifically check.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
@@ -697,7 +697,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
         let macosOverrides = [
             "ARCHS": archs.joined(separator: " "),
         ]
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMacCatalyst, overrides: macosOverrides)) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: macosOverrides), runDestination: .anyMacCatalyst) { results in
             results.checkNoDiagnostics()
 
             // Match tasks we know we're not interested in.
@@ -769,7 +769,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
         let fs = PseudoFS()
         try fs.createDirectory(Path("/Users/whoever/Library/MobileDevice/Provisioning Profiles"), recursive: true)
         try fs.write(Path("/Users/whoever/Library/MobileDevice/Provisioning Profiles/8db0e92c-592c-4f06-bfed-9d945841b78d.mobileprovision"), contents: "profile")
-        await tester.checkBuild(BuildParameters(configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
 
             // Match tasks we know we're not interested in.
@@ -878,7 +878,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Test with the public SDK.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macCatalyst)) { results in
+        await tester.checkBuild(runDestination: .macCatalyst) { results in
             results.checkNoDiagnostics()
 
             // Match tasks we know we're not interested in.
@@ -1004,7 +1004,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try TaskConstructionTester(core, testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MacTarget") { target in

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -48,6 +48,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -403,6 +404,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [

--- a/Tests/SWBTaskConstructionTests/PostprocessingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PostprocessingTaskConstructionTests.swift
@@ -65,7 +65,7 @@ fileprivate struct PostprocessingTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         let installParameters = BuildParameters(action: .install, configuration: "Debug")
-        await tester.checkBuild(installParameters) { results in
+        await tester.checkBuild(installParameters, runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("Library") { target in
@@ -180,7 +180,7 @@ fileprivate struct PostprocessingTaskConstructionTests: CoreBasedTests {
                 )
             ])
 
-        try await TaskConstructionTester(getCore(), testProject).checkBuild() { results in
+        try await TaskConstructionTester(getCore(), testProject).checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("Application") { target in
@@ -272,7 +272,7 @@ fileprivate struct PostprocessingTaskConstructionTests: CoreBasedTests {
             ]
         )
 
-        try await TaskConstructionTester(getCore(), testProject).checkBuild() { results in
+        try await TaskConstructionTester(getCore(), testProject).checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             for targetName in ["Library", "Framework", "Executable", "Application", "ApplicationExtension"] {
@@ -326,7 +326,7 @@ fileprivate struct PostprocessingTaskConstructionTests: CoreBasedTests {
             "sysctl-requirements": .plString("hw.optional.f16c == 1"),
         ]))
 
-        try await TaskConstructionTester(getCore(), testProject).checkBuild(fs: fs) { results in
+        try await TaskConstructionTester(getCore(), testProject).checkBuild(runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
 
             results.checkTask(.matchRule(["Copy", "/tmp/Test/aProject/build/Debug/ProductDefinition.plist", "/tmp/Test/aProject/prod.plist"])) { _ in }

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -61,7 +61,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try TaskConstructionTester(core, testProject)
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac)) { results in
+        await tester.checkBuild(runDestination: .anyMac) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -140,7 +140,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
         // The localFS is used because we need a value for the swiftlang version in order for
         // -disable-previous-implementation-calls-in-dynamic-replacements to be inserted.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .anyMac, fs: localFS) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -342,7 +342,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         let fs = PseudoFS()
         try fs.writeSimulatedPreviewsJITStubExecutorLibraries(sdk: core.loadSDK(.iOSSimulator))
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator, fs: fs) { results in
             results.checkNoDiagnostics()
 
             results.checkTask(.matchRuleType("Ld"), .matchRuleItem("/tmp/Test/ProjectName/build/Debug-iphonesimulator/TargetName.app/TargetName.debug.dylib")) { task in
@@ -444,7 +444,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
         // The localFS is used because we need a value for the swiftlang version in order for
         // -disable-previous-implementation-calls-in-dynamic-replacements to be inserted.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .anyMac, fs: localFS) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -549,7 +549,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
         // The localFS is used because we need a value for the swiftlang version in order for
         // -disable-previous-implementation-calls-in-dynamic-replacements to be inserted.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .anyMac, fs: localFS) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -621,7 +621,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
         // The localFS is used because we need a value for the swiftlang version in order for
         // -disable-previous-implementation-calls-in-dynamic-replacements to be inserted.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .anyMac, fs: localFS) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -692,7 +692,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
         // The localFS is used because we need a value for the swiftlang version in order for
         // -disable-previous-implementation-calls-in-dynamic-replacements to be inserted.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anyMac), fs: localFS) { results in
+        await tester.checkBuild(runDestination: .anyMac, fs: localFS) { results in
             results.checkNoDiagnostics()
 
             for arch in archs {
@@ -788,7 +788,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let tester = try TaskConstructionTester(core, testProject)
 
             // Concrete iOS simulator destination with overrides for an iPhone 14 Pro
-            let buildParameters = BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator, overrides: [
+            let buildParameters = BuildParameters(configuration: "Debug", overrides: [
                 "ASSETCATALOG_FILTER_FOR_DEVICE_MODEL": "iPhone15,2",
                 "ASSETCATALOG_FILTER_FOR_DEVICE_OS_VERSION": core.loadSDK(.iOSSimulator).defaultDeploymentTarget,
                 "ASSETCATALOG_FILTER_FOR_THINNING_DEVICE_CONFIGURATION": "iPhone15,2",
@@ -820,7 +820,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
 
             let actoolPath = try await self.actoolPath
 
-            await tester.checkBuild(buildParameters, fs: fs, clientDelegate: ClientDelegate()) { results in
+            await tester.checkBuild(buildParameters, runDestination: .iOSSimulator, fs: fs, clientDelegate: ClientDelegate()) { results in
                 results.checkNoDiagnostics()
                 results.checkNoNotes()
 
@@ -973,7 +973,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let core = try await self.getCore()
             let tester = try TaskConstructionTester(core, testProject)
 
-            let buildParameters = BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator, overrides: [
+            let buildParameters = BuildParameters(configuration: "Debug", overrides: [
                 // XOJIT previews enabled, which should be passed when the workspace setting is on
                 "ENABLE_XOJIT_PREVIEWS": "YES",
                 "ENABLE_DEBUG_DYLIB": "YES",
@@ -995,7 +995,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let fs = PseudoFS()
             try fs.writeSimulatedPreviewsJITStubExecutorLibraries(sdk: core.loadSDK(.iOSSimulator))
 
-            await tester.checkBuild(buildParameters, fs: fs, clientDelegate: ClientDelegate()) { results in
+            await tester.checkBuild(buildParameters, runDestination: .iOSSimulator, fs: fs, clientDelegate: ClientDelegate()) { results in
                 results.checkNoDiagnostics()
                 results.checkNoNotes()
 
@@ -1063,7 +1063,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let core = try await self.getCore()
             let tester = try TaskConstructionTester(core, testProject)
 
-            let buildParameters = BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator, overrides: [
+            let buildParameters = BuildParameters(configuration: "Debug", overrides: [
                 // XOJIT previews enabled, which should be passed when the workspace setting is on
                 "ENABLE_XOJIT_PREVIEWS": "YES",
                 "ENABLE_DEBUG_DYLIB": "YES",
@@ -1085,7 +1085,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let fs = PseudoFS()
             try fs.writeSimulatedPreviewsJITStubExecutorLibraries(sdk: core.loadSDK(.iOSSimulator))
 
-            await tester.checkBuild(buildParameters, fs: fs, clientDelegate: ClientDelegate()) { results in
+            await tester.checkBuild(buildParameters, runDestination: .iOSSimulator, fs: fs, clientDelegate: ClientDelegate()) { results in
                 results.checkTasks(.matchRuleItemPattern(.prefix("Swift"))) { _ in }
                 results.consumeTasksMatchingRuleTypes(["Copy", "CopySwiftLibs", "ExtractAppIntentsMetadata", "Gate", "GenerateDSYMFile", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "ClangStatCache", "RegisterExecutionPolicyException", "AppIntentsSSUTraining", "ProcessInfoPlistFile", "Touch", "Validate", "LinkAssetCatalogSignature", "CodeSign", "ProcessProductPackaging", "ProcessProductPackagingDER", "ConstructStubExecutorLinkFileList"])
 
@@ -1164,7 +1164,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let core = try await self.getCore()
             let tester = try TaskConstructionTester(core, testProject)
 
-            let buildParameters = BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator, overrides: [
+            let buildParameters = BuildParameters(configuration: "Debug", overrides: [
                 // XOJIT previews enabled, which should be passed when the workspace setting is on
                 "ENABLE_XOJIT_PREVIEWS": "YES",
                 "ENABLE_DEBUG_DYLIB": "YES",
@@ -1186,7 +1186,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             let fs = PseudoFS()
             try fs.writeSimulatedPreviewsJITStubExecutorLibraries(sdk: core.loadSDK(.iOSSimulator))
 
-            await tester.checkBuild(buildParameters, fs: fs, clientDelegate: ClientDelegate()) { results in
+            await tester.checkBuild(buildParameters, runDestination: .iOSSimulator, fs: fs, clientDelegate: ClientDelegate()) { results in
                 results.checkTask(.matchRule(["Ld", "\(srcRoot.str)/build/Debug-iphonesimulator/Tool", "normal"])) { task in
                     task.checkCommandLineContains([
                         "-Xlinker", "-rpath", "-Xlinker", "@executable_path",

--- a/Tests/SWBTaskConstructionTests/ReadOnlySettingsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ReadOnlySettingsTaskConstructionTests.swift
@@ -67,7 +67,7 @@ fileprivate struct ReadOnlySettingsTaskConstructionTests: CoreBasedTests {
             let testProject = getTestProject(productSpecificLdFlagsSetting: "")
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(fs: fs) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
                 results.checkError(.equal("PRODUCT_SPECIFIC_LDFLAGS assigned at level: project. This setting is append-only and cannot be overridden without prepending $(inherited). (in target 'AppTarget' from project 'aProject')"))
                 results.checkNoDiagnostics()
             }
@@ -79,7 +79,7 @@ fileprivate struct ReadOnlySettingsTaskConstructionTests: CoreBasedTests {
             let testProject = getTestProject(productSpecificLdFlagsSetting: "-e _foo")
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(fs: fs) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
                 results.checkError(.equal("PRODUCT_SPECIFIC_LDFLAGS assigned at level: project. This setting is append-only and cannot be overridden without prepending $(inherited). (in target 'AppTarget' from project 'aProject')"))
                 results.checkNoDiagnostics()
             }
@@ -91,7 +91,7 @@ fileprivate struct ReadOnlySettingsTaskConstructionTests: CoreBasedTests {
             let testProject = getTestProject(productSpecificLdFlagsSetting: "-e _foo $(inherited)")
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(fs: fs) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
                 results.checkError(.equal("PRODUCT_SPECIFIC_LDFLAGS assigned at level: project. This setting is append-only and cannot be overridden without prepending $(inherited). (in target 'AppTarget' from project 'aProject')"))
                 results.checkNoDiagnostics()
             }
@@ -103,7 +103,7 @@ fileprivate struct ReadOnlySettingsTaskConstructionTests: CoreBasedTests {
             let testProject = getTestProject(productSpecificLdFlagsSetting: "$(inherited) -e _foo")
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(fs: fs) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
                 results.checkNoDiagnostics()
             }
         }
@@ -114,7 +114,7 @@ fileprivate struct ReadOnlySettingsTaskConstructionTests: CoreBasedTests {
             let testProject = getTestProject(productSpecificLdFlagsSetting: "$(inherited)")
             let tester = try TaskConstructionTester(core, testProject)
 
-            await tester.checkBuild(fs: fs) { results in
+            await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -50,6 +50,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Release"),
                     ],
@@ -209,6 +210,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -336,6 +338,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -419,6 +422,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -508,6 +512,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -647,6 +652,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -788,6 +794,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -944,6 +951,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1163,6 +1171,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1325,6 +1334,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1430,6 +1440,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1965,7 +1976,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         // Single files which get copied rather than combined.
                         "Single.png",
@@ -2138,7 +2149,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestSourcesBuildPhase([
                         "Doubled@1x.png",
                         "Doubled@2x.png",
@@ -2180,7 +2191,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         "A.xcassets",
                         "B C.xcassets",
@@ -2224,7 +2235,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestSourcesBuildPhase([
                         "A.xcassets",
                         "B.xcassets",
@@ -2269,7 +2280,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                     ]),
             ],
             targets: [
-                TestStandardTarget("App", buildPhases: [
+                TestStandardTarget("App", type: .application, buildPhases: [
                     TestResourcesBuildPhase([
                         TestBuildFile("A.dae", decompress: false),
                         TestBuildFile("B.dae", decompress: true),
@@ -2364,6 +2375,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestResourcesBuildPhase([
                             "Localizable.strings",
@@ -2458,6 +2470,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildPhases: [
                         TestSourcesBuildPhase([
                             "main.m",
@@ -2506,6 +2519,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestAppleScriptBuildPhase([
                                 "Foo.applescript",
@@ -2544,6 +2558,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "App",
+                        type: .application,
                         buildPhases: [
                             TestAppleScriptBuildPhase([
                             ]),

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -70,13 +70,13 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let configuration = "Release"
 
-        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: configuration)) { results in
+        await tester.checkBuild(BuildParameters(action: .installHeaders, configuration: configuration), runDestination: .macOS) { results in
             results.checkTarget("App") { target in
                 results.checkNoTask(.matchTarget(target), .matchRuleType("Rez"))
             }
         }
 
-        await tester.checkBuild(BuildParameters(configuration: configuration), fs: fs) { results -> Void in
+        await tester.checkBuild(BuildParameters(configuration: configuration), runDestination: .macOS, fs: fs) { results -> Void in
             results.checkWarning(.equal("Build Carbon Resources build phases are no longer supported.  Rez source files should be moved to the Copy Bundle Resources build phase. (in target 'App' from project 'aProject')"))
 
             results.checkTarget("App") { target -> Void in
@@ -230,7 +230,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let actoolPath = try await self.actoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -441,7 +441,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let actoolPath = try await self.actoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -536,7 +536,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -676,7 +676,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -817,7 +817,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -974,7 +974,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -1196,7 +1196,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -1356,7 +1356,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.
@@ -1467,7 +1467,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let ibtoolPath = try await self.ibtoolPath
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("App") { target in
                 // Check the xib compiles, in particular the output files.
                 results.checkTask(.matchTarget(target), .matchRule(["CompileXIB", "\(SRCROOT)/Sources/foo.xib"])) { task in
@@ -1604,7 +1604,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("CoreFoo") { target in
                 // We should have a RuleScriptExecution task to process directly into the Resources directory.
                 results.checkTask(.matchTarget(target), .matchRuleType("RuleScriptExecution"), .matchRuleItemBasename("Foo.fake-xcspec-direct")) { task in
@@ -1670,7 +1670,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("CoreFoo") { target in
                 // We should have a Debug task to process directly into framework.
                 results.checkTask(.matchTarget(target), .matchRuleType("CopyPNGFile"), .matchRuleItemBasename("Foo.png")) { task in
@@ -1771,7 +1771,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check that setting VERSION_INFO_EXPORT_DECL to 'export' generates the expected file contents.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSION_INFO_EXPORT_DECL": "export"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSION_INFO_EXPORT_DECL": "export"]), runDestination: .macOS) { results in
             // There should be a WriteAuxiliaryFile task to create the versioning file.
             results.checkWriteAuxiliaryFileTask(.matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources/AppTarget_vers.c"])) { task, contents in
                 task.checkInputs([
@@ -1788,7 +1788,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
 
         // Check that setting VERSION_INFO_EXPORT_DECL to 'static' generates the expected file contents, omitting the 'extern' lines.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSION_INFO_EXPORT_DECL": "static"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSION_INFO_EXPORT_DECL": "static"]), runDestination: .macOS) { results in
             // There should be a WriteAuxiliaryFile task to create the versioning file.
             results.checkWriteAuxiliaryFileTask(.matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources/AppTarget_vers.c"])) { task, contents in
                 task.checkInputs([
@@ -1805,7 +1805,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
 
         // Check that setting apple-generic-hidden generates the expected file contents.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSIONING_SYSTEM": "apple-generic-hidden"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSIONING_SYSTEM": "apple-generic-hidden"]), runDestination: .macOS) { results in
             // There should be a WriteAuxiliaryFile task to create the versioning file.
             results.checkWriteAuxiliaryFileTask(.matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources/AppTarget_vers.c"])) { task, contents in
                 task.checkInputs([
@@ -1823,7 +1823,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         // Check that setting apple-generic-hidden works with VERSION_INFO_EXPORT_DECL and generates the expected file contents.
         await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["VERSIONING_SYSTEM": "apple-generic-hidden",
-                                                                                    "VERSION_INFO_EXPORT_DECL": "somedeclattr"])) { results in
+                                                                                    "VERSION_INFO_EXPORT_DECL": "somedeclattr"]), runDestination: .macOS) { results in
             // There should be a WriteAuxiliaryFile task to create the versioning file.
             results.checkWriteAuxiliaryFileTask(.matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources/AppTarget_vers.c"])) { task, contents in
                 task.checkInputs([
@@ -1867,7 +1867,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check behavior with dSYMs disabled.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["DEBUG_INFORMATION_FORMAT": "dwarf"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["DEBUG_INFORMATION_FORMAT": "dwarf"]), runDestination: .macOS) { results in
             // There shouldn't be a dSYM task.
             results.checkNoTask(.matchRuleType("GenerateDSYMFile"))
 
@@ -1876,7 +1876,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
 
         // Check behavior with dSYMs enabled.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"]), runDestination: .macOS) { results in
             // Check the expected dSYM task.
             results.checkTask(.matchRuleType("GenerateDSYMFile")) { task in
                 task.checkRuleInfo(["GenerateDSYMFile", "/tmp/Test/aProject/build/Debug/CoreFoo.framework.dSYM", "/tmp/Test/aProject/build/Debug/CoreFoo.framework/Versions/A/CoreFoo"])
@@ -1909,7 +1909,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check default behavior (should honor the flag).
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Copy"), .matchRuleItemBasename("Thing-1.txt")) { task in
                 task.checkRuleInfo(["Copy", "/tmp/Test/aProject/build/Debug/Thing-1.txt", "/tmp/Test/aProject/Sources/Thing-1.txt"])
                 task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-exclude", "Headers", "-exclude", "PrivateHeaders", "-exclude", "Modules", "-exclude", "*.tbd", "-strip-unsigned-binaries", "-strip-deterministic", "-strip-tool", "strip", "-resolve-src-symlinks", "-remove-static-executable", "/tmp/Test/aProject/Sources/Thing-1.txt", "/tmp/Test/aProject/build/Debug"])
@@ -1924,7 +1924,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
 
         // Check global disabling override.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["REMOVE_HEADERS_FROM_EMBEDDED_BUNDLES": "NO"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["REMOVE_HEADERS_FROM_EMBEDDED_BUNDLES": "NO"]), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Copy"), .matchRuleItemBasename("Thing-1.txt")) { task in
                 task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-strip-unsigned-binaries", "-strip-deterministic", "-strip-tool", "strip", "-resolve-src-symlinks", "-remove-static-executable", "/tmp/Test/aProject/Sources/Thing-1.txt", "/tmp/Test/aProject/build/Debug"])
             }
@@ -2005,7 +2005,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         // Check behavior when combining.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "YES", "APPLY_RULES_IN_COPY_FILES": "YES"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "YES", "APPLY_RULES_IN_COPY_FILES": "YES"]), runDestination: .macOS) { results in
             // There should be an individual copy of each single image, using the appropriate tool.
             do {
                 let rule = "CopyPNGFile", name = "Single.png"
@@ -2105,7 +2105,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
 
         // Check behavior when not combining.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "NO"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "NO"]), runDestination: .macOS) { results in
             // There should be a CopyPNGFile or CopyTiffFile task for each file, as appropriate.
             for name in ["Single.png", "Missing1x@2x.png", "Doubled.png", "Doubled@2x.png", "MixedType.png", "MixedType@2x.tiff"] {
                 let rule = Path(name).fileExtension == "png" ? "CopyPNGFile" : "CopyTiffFile"
@@ -2159,7 +2159,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Check behavior when combining.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "YES"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["COMBINE_HIDPI_IMAGES": "YES"]), runDestination: .macOS) { results in
             // There should no no TIFF combining copy task for the double image.
             results.checkNoTask(.matchRuleType("TiffUtil"), .matchRuleItemBasename(".tiff"))
 
@@ -2201,7 +2201,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             for variant in ["thinned", "unthinned"] {
                 results.checkTask(.matchRuleType("CompileAssetCatalogVariant"), .matchRuleItem(variant)) { task in
                     task.checkRuleInfo(["CompileAssetCatalogVariant", variant, "/tmp/Test/aProject/build/Debug/App.app/Contents/Resources", "/tmp/Test/aProject/Sources/A.xcassets", "/tmp/Test/aProject/Sources/B C.xcassets"])
@@ -2245,7 +2245,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             for variant in ["thinned", "unthinned"] {
                 results.checkTask(.matchRuleType("CompileAssetCatalogVariant"), .matchRuleItem(variant)) { task in
                     task.checkRuleInfo(["CompileAssetCatalogVariant", variant, "/tmp/Test/aProject/build/Debug/App.app/Contents/Resources", "/tmp/Test/aProject/Sources/A.xcassets", "/tmp/Test/aProject/Sources/B.xcassets"])
@@ -2291,7 +2291,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Process"), .matchRuleItemBasename("A.dae")) { task in
                 task.checkRuleInfo(["Process", "SceneKit", "document", "\(SRCROOT)/Sources/A.dae"])
                 task.checkCommandLineContains(["scntool", "--compress", "\(SRCROOT)/Sources/A.dae"])
@@ -2339,7 +2339,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTask(.matchRuleItemBasename("foo.d")) { task in
                 task.checkCommandLine(["/usr/sbin/dtrace", "-h", "-Dextra", "-s", "\(SRCROOT)/Sources/foo.d", "-o", "\(SRCROOT)/build/aProject.build/Debug/Framework.build/DerivedSources/foo.h"])
             }
@@ -2387,7 +2387,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTask(.matchRule(["CopyStringsFile", "\(SRCROOT)/build/Debug/App.app/Contents/Resources/en.lproj/Localizable.strings", "\(SRCROOT)/Sources/en.lproj/Localizable.strings"])) { _ in }
             results.checkTask(.matchRule(["CopyStringsFile", "\(SRCROOT)/build/Debug/App.app/Contents/Resources/jp.lproj/Localizable.strings", "\(SRCROOT)/Sources/jp.lproj/Localizable.strings"])) { _ in }
             results.checkNoTask(.matchRuleType("CopyStringsFile"))
@@ -2437,7 +2437,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild() { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTask(.matchRule(["MkDir", "/tmp/Test/aProject/build/Debug/Framework.framework/Versions/A/Modules"])) { _ in }
             results.checkTask(.matchRule(["SymLink", "/tmp/Test/aProject/build/Debug/Framework.framework/Modules", "Versions/Current/Modules"])) { _ in }
             results.checkTask(.matchRule(["Copy", "/tmp/Test/aProject/build/Debug/Framework.framework/Modules/foo.txt", "/tmp/Test/aProject/Sources/foo.txt"])) { _ in }
@@ -2482,7 +2482,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("App") { target in
                 // There should be a task to process the .applescript file to the Resources folder.
                 results.checkTask(.matchTarget(target), .matchRule(["OSACompile", "\(SRCROOT)/Foo.applescript"])) { task in
@@ -2529,7 +2529,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 // There should be no OSACompile tasks.
                 results.checkNoTask(.matchRuleType("OSACompile"))
 
@@ -2567,7 +2567,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                 ])
             let tester = try await TaskConstructionTester(getCore(), testProject)
 
-            await tester.checkBuild { results in
+            await tester.checkBuild(runDestination: .macOS) { results in
                 // There should be no OSACompile tasks.
                 results.checkNoTask(.matchRuleType("OSACompile"))
 
@@ -2858,7 +2858,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkTarget("CoreFoo") { target in
                 // We should have a copy command to copy the Scripts folder into the Resources build phase.  And the checkBuild() logic will implicitly check that there isn't also a mkdir command for that directory.
                 results.checkTask(.matchTarget(target), .matchRuleType("CpResource"), .matchRuleItemBasename("Scripts")) { task in

--- a/Tests/SWBTaskConstructionTests/SignatureCollectionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SignatureCollectionTaskConstructionTests.swift
@@ -112,7 +112,7 @@ fileprivate struct SignatureCollectionTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(goodiesXCFramework, fs: fs, path: goodiesXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["ENABLE_SIGNATURE_AGGREGATION": "YES"]), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_SIGNATURE_AGGREGATION": "YES"]), runDestination: .macOS, fs: fs) { results in
             // NOTE: The signature collection pulls out the framework signature information **NOT** the xcframework signature info.
             try results.checkTask(.matchRuleType("SignatureCollection"), .matchRuleItemPattern(.contains("Goodies.xcframework"))) { task in
                 task.checkInputs(contain: [.pathPattern(.suffix("Goodies.xcframework"))])
@@ -143,7 +143,7 @@ fileprivate struct SignatureCollectionTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        try await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macCatalyst, overrides: ["ENABLE_SIGNATURE_AGGREGATION": "YES"]), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_SIGNATURE_AGGREGATION": "YES"]), runDestination: .macCatalyst, fs: fs) { results in
             // NOTE: The signature collection pulls out the framework signature information **NOT** the xcframework signature info.
             try results.checkTask(.matchRuleType("SignatureCollection"), .matchRuleItemPattern(.contains("Goodies.xcframework"))) { task in
                 task.checkInputs(contain: [.pathPattern(.suffix("Goodies.xcframework"))])

--- a/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
@@ -55,7 +55,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .anyiOSDevice)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .anyiOSDevice) { results in
             results.checkNoDiagnostics()
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch"])
             results.checkTasks(.matchRuleType("SwiftDriver Compilation")) { #expect($0.count > 0) }
@@ -110,7 +110,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .anyiOSDevice)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .anyiOSDevice) { results in
             results.checkNoDiagnostics()
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "Touch"])
             results.checkTasks(.matchRuleType("SwiftDriver Compilation")) { #expect($0.count > 0) }
@@ -175,7 +175,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
         try await fs.writeJSON(.root.join("tmp/mybaseline/ABI/arm64e-ios.json"), .plDict([:]))
 
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.consumeTasksMatchingRuleTypes(["Gate", "SymLink", "CpHeader", "MkDir", "Touch"])
             results.checkTasks(.matchRuleType("SwiftDriver Compilation")) { #expect($0.count > 0) }
@@ -244,7 +244,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS)) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS) { results in
             results.checkNoDiagnostics()
             // Check CheckSwiftABI is always after GenerateSwiftABIBaseline
             results.checkTasks(.matchRuleType("CheckSwiftABI")) { tasks in
@@ -292,7 +292,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
             results.checkWarning(.prefix("cannot find Swift ABI baseline"))
         }
     }
@@ -334,7 +334,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
         // Check the `Debug` build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTasks(.matchRuleType("SwiftDriver Compilation")) { tasks in
                 #expect(tasks.count > 0)

--- a/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftModuleOnlyTaskConstructionTests.swift
@@ -748,11 +748,9 @@ fileprivate struct SwiftModuleOnlyTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
         let sourceRoot = tester.workspace.projects[0].sourceRoot
 
-        let buildParameters = BuildParameters(
-            configuration: tpc.buildConfiguration,
-            activeRunDestination: tpc.activeRunDestination)
+        let buildParameters = BuildParameters(configuration: tpc.buildConfiguration)
 
-        try await tester.checkBuild(buildParameters) { results in
+        try await tester.checkBuild(buildParameters, runDestination: tpc.activeRunDestination) { results in
             do {
                 // Match tasks we know we're not interested in.
                 results.consumeTasksMatchingRuleTypes([
@@ -846,11 +844,9 @@ fileprivate struct SwiftModuleOnlyTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        let buildParameters = BuildParameters(
-            configuration: tpc.buildConfiguration,
-            activeRunDestination: tpc.activeRunDestination)
+        let buildParameters = BuildParameters(configuration: tpc.buildConfiguration)
 
-        try await tester.checkBuild(buildParameters) { results in
+        try await tester.checkBuild(buildParameters, runDestination: tpc.activeRunDestination) { results in
             // Match tasks we know we're not interested in.
             results.consumeTasksMatchingRuleTypes([
                 "CompileSwift",
@@ -924,11 +920,9 @@ fileprivate struct SwiftModuleOnlyTaskConstructionTests: CoreBasedTests {
         let testProject = try await buildTestProject(testProjectConfig: tpc)
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
-        let buildParameters = BuildParameters(
-            configuration: tpc.buildConfiguration,
-            activeRunDestination: tpc.activeRunDestination)
+        let buildParameters = BuildParameters(configuration: tpc.buildConfiguration)
 
-        await tester.checkBuild(buildParameters) { results in
+        await tester.checkBuild(buildParameters, runDestination: tpc.activeRunDestination) { results in
             // Match tasks we know we're not interested in.
             results.consumeTasksMatchingRuleTypes([
                 "CompileSwift",

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -46,6 +46,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug"
@@ -132,6 +133,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2368,6 +2370,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2456,6 +2459,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2574,6 +2578,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2640,6 +2645,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2681,6 +2687,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2722,6 +2729,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -2782,6 +2790,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug"

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -101,6 +101,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "INFOPLIST_FILE": "Sources/Info.plist",
@@ -1948,6 +1949,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "INFOPLIST_FILE": "Sources/Info.plist",
@@ -2983,6 +2985,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "App",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -4086,6 +4089,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         targetName,
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug"),
                         ],
@@ -4689,6 +4693,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: ["INFOPLIST_FILE": "Sources/Info.plist"]),
                         TestBuildConfiguration("Release", buildSettings: ["INFOPLIST_FILE": "Sources/Info.plist"]),
@@ -7660,6 +7665,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "GENERATE_PKGINFO_FILE": "YES",
@@ -8338,6 +8344,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"
@@ -8422,6 +8429,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"
@@ -8500,6 +8508,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "AppTarget",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "GENERATE_INFOPLIST_FILE": "YES"

--- a/Tests/SWBTaskConstructionTests/TaskOrderingTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskOrderingTests.swift
@@ -50,7 +50,7 @@ fileprivate struct TaskOrderingTests: CoreBasedTests {
             ])
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release")) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Ld")) { task in
                 results.checkTaskFollows(task, .matchRuleType("CompileC"))
             }

--- a/Tests/SWBTaskConstructionTests/TrackedDomainTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TrackedDomainTaskConstructionTests.swift
@@ -241,7 +241,7 @@ fileprivate struct TrackedDomainTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         // Check an install release build.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkTarget("AppTarget") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("ProcessInfoPlistFile")) { task in
                     task.checkCommandLineContains([

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -110,7 +110,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         try await fs.writePlist(baselineDir.join("Info.plist"), .plDict([:]))
         try await fs.writePlist(baselineDir.join("Some-Test-Data.plist"), .plDict([:]))
 
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate and build directory tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -422,7 +422,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build.
-        try await tester.checkBuild(fs: fs) { results in
+        try await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate and build directory related tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -741,7 +741,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate and build directory tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -1008,7 +1008,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install build for the device.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .watchOS), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .watchOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -1069,7 +1069,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build for the simulator.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .watchOSSimulator), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .watchOSSimulator, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -1241,9 +1241,9 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         let topLevelTargets = [tester.workspace.projects[0].targets[0], tester.workspace.projects[0].targets[2]]
 
         // Check a debug build for the device.
-        let deviceParameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .watchOS)
+        let deviceParameters = BuildParameters(action: .build, configuration: "Debug")
         let debugBuildRequest = BuildRequest(parameters: deviceParameters, buildTargets: topLevelTargets.map({ BuildRequest.BuildTargetInfo(parameters: deviceParameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-        try await tester.checkBuild(buildRequest: debugBuildRequest, fs: fs) { results in
+        try await tester.checkBuild(runDestination: .watchOS, buildRequest: debugBuildRequest, fs: fs) { results in
             // Ignore task types we don't plan to examine.
             results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "RegisterExecutionPolicyException"])
 
@@ -1344,9 +1344,9 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install build for the device.
-        let installParameters = BuildParameters(action: .install, configuration: "Debug", activeRunDestination: .watchOS)
+        let installParameters = BuildParameters(action: .install, configuration: "Debug")
         let installBuildRequest = BuildRequest(parameters: installParameters, buildTargets: topLevelTargets.map({ BuildRequest.BuildTargetInfo(parameters: deviceParameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-        try await tester.checkBuild(buildRequest: installBuildRequest, fs: fs) { results in
+        try await tester.checkBuild(runDestination: .watchOS, buildRequest: installBuildRequest, fs: fs) { results in
             // Ignore task types we don't plan to examine.
             results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "RegisterExecutionPolicyException"])
 
@@ -1431,9 +1431,9 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build for the simulator.
-        let simParameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .watchOSSimulator)
+        let simParameters = BuildParameters(action: .build, configuration: "Debug")
         let simBuildRequest = BuildRequest(parameters: simParameters, buildTargets: topLevelTargets.map({ BuildRequest.BuildTargetInfo(parameters: simParameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
-        try await tester.checkBuild(buildRequest: simBuildRequest, fs: fs) { results in
+        try await tester.checkBuild(runDestination: .watchOSSimulator, buildRequest: simBuildRequest, fs: fs) { results in
             // Ignore task types we don't plan to examine.
             results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "RegisterExecutionPolicyException"])
 
@@ -1603,7 +1603,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build for macCatalyst
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .macCatalyst), fs: fs) { results in
+        await tester.checkBuild(runDestination: .macCatalyst, fs: fs) { results in
 
             results.checkTarget("UnitTestTarget") { target in
                 let targetName = target.target.name
@@ -1764,7 +1764,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         let topLevelTargets = [tester.workspace.projects[0].targets[0], tester.workspace.projects[0].targets[3], tester.workspace.projects[0].targets[1], tester.workspace.projects[0].targets[2]]
         let deviceParameters = BuildParameters(action: .build, configuration: "Debug")
         let debugBuildRequest = BuildRequest(parameters: deviceParameters, buildTargets: topLevelTargets.map({ BuildRequest.BuildTargetInfo(parameters: deviceParameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: false, useImplicitDependencies: true, useDryRun: false)
-        try await tester.checkBuild(buildRequest: debugBuildRequest, fs: fs) { results in
+        try await tester.checkBuild(runDestination: .macOS, buildRequest: debugBuildRequest, fs: fs) { results in
             // Ignore task types we don't plan to examine.
             results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "RegisterExecutionPolicyException"])
 
@@ -1991,7 +1991,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         let topLevelTargets = [tester.workspace.projects[0].targets[0], tester.workspace.projects[0].targets[1]]
         let deviceParameters = BuildParameters(action: .build, configuration: "Debug")
         let debugBuildRequest = BuildRequest(parameters: deviceParameters, buildTargets: topLevelTargets.map({ BuildRequest.BuildTargetInfo(parameters: deviceParameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: false, useImplicitDependencies: true, useDryRun: false)
-        try await tester.checkBuild(buildRequest: debugBuildRequest, fs: fs) { results in
+        try await tester.checkBuild(runDestination: .macOS, buildRequest: debugBuildRequest, fs: fs) { results in
             // Ignore task types we don't plan to examine.
             results.consumeTasksMatchingRuleTypes(["Gate", "MkDir", "CreateBuildDirectory", "WriteAuxiliaryFile", "RegisterExecutionPolicyException"])
 
@@ -2201,7 +2201,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         try await fs.writeXCTRunnerApp(xctrunnerPath, archs: ["arm64", "arm64e", "x86_64"], platform: .macOS, infoLookup: core)
 
         // Check a debug build.
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -2534,7 +2534,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install build.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -2810,7 +2810,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         try await fs.writeXCTRunnerApp(simXctrunnerPath, archs: ["x86_64"], platform: .iOSSimulator, infoLookup: core)
 
         // Check a debug build for the device.
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -2899,7 +2899,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install build for the device.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -2993,7 +2993,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build for the simulator.
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .iOSSimulator, fs: fs) { results in
             // For debugging convenience, consume all the Gate tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             // Ignore all build directory tasks
@@ -3079,7 +3079,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a build for a pre-Swift-in-the-OS deployment target
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "12.0"]), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "12.0"]), runDestination: .macOS, fs: fs) { results in
             results.checkTarget("UITestTarget") { target in
 
                 // There should be a 'CopySwiftLibs' task that includes a reference to the libXCTestSwiftSupport.dylib executable.

--- a/Tests/SWBTaskConstructionTests/UnsupportedBehaviorTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnsupportedBehaviorTaskConstructionTests.swift
@@ -131,7 +131,7 @@ fileprivate struct UnsupportedBehaviorTaskConstructionTests: CoreBasedTests {
         try await fs.writePlist(Path(SRCROOT).join("Entitlements.plist"), .plDict([:]))
 
         // Check a debug build for the device.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS), fs: fs) { results in
+        await tester.checkBuild(runDestination: .iOS, fs: fs) { results in
             // For debugging convenience, consume all the Gate and build directory related tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -169,7 +169,7 @@ fileprivate struct UnsupportedBehaviorTaskConstructionTests: CoreBasedTests {
         }
 
         // Check a debug build for the simulator.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator, fs: fs) { results in
             // For debugging convenience, consume all the Gate and build directory related tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
@@ -281,7 +281,7 @@ fileprivate struct UnsupportedBehaviorTaskConstructionTests: CoreBasedTests {
                     ]
                 ),
             ])
-        try await TaskConstructionTester(getCore(), testProject).checkBuild() { results in
+        try await TaskConstructionTester(getCore(), testProject).checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTask(.matchRuleType("Ld")) { task in

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -205,7 +205,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let actoolPath = try await self.actoolPath
 
         // Check the debug build, for the device.
-        try await tester.checkBuild(fs: fs) { results in
+        try await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // Ignore certain classes of tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
@@ -513,7 +513,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         }
 
         // Check the debug build, for the simulator.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOSSimulator), fs: fs) { results in
+        await tester.checkBuild(runDestination: .iOSSimulator, fs: fs) { results in
             // Ignore certain classes of tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
@@ -804,7 +804,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
         // Check an install build for the device.
         let installParameters = BuildParameters(action: .install, configuration: "Debug", overrides: ["BITCODE_GENERATION_MODE": "bitcode"])
-        await tester.checkBuild(installParameters, fs: fs) { results in
+        await tester.checkBuild(installParameters, runDestination: .macOS, fs: fs) { results in
             // Ignore certain classes of tasks.
             results.checkTasks(.matchRuleType("Gate")) { _ in }
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
@@ -1132,7 +1132,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let actoolPath = try await self.actoolPath
 
         // Check the debug build, for the device.
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // Ignore certain classes of tasks.
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "MkDir", "ProcessProductPackaging", "ProcessProductPackagingDER", "Copy", "RegisterExecutionPolicyException", "Touch", "Validate", "ValidateEmbeddedBinary", "WriteAuxiliaryFile"])
 
@@ -1215,7 +1215,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         try fs.write(core.loadSDK(.iOS).path.join("../../../Library/Application Support/MessagesApplicationStub/MessagesApplicationStub"), contents: "stub")
 
         // Check the debug build, for the device.
-        await tester.checkBuild(fs: fs) { results in
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
             // Ignore certain classes of tasks.
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "MkDir", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "Touch", "Validate", "ValidateEmbeddedBinary", "WriteAuxiliaryFile"])
 
@@ -1360,7 +1360,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         try fs.write(core.loadSDK(.watchOS).path.join("Library/Application Support/WatchKit/WK"), contents: "WatchKitStub")
 
         let params = BuildParameters(action: .archive, configuration: "Debug", overrides: ["WATCHKIT_2_SUPPORT_FOLDER_PATH": "/tmp/SideCars"])
-        await tester.checkBuild(params, fs: fs) { results in
+        await tester.checkBuild(params, runDestination: .macOS, fs: fs) { results in
             results.checkNoDiagnostics()
             results.checkTask(.matchRule(["CopyAndPreserveArchs", "/tmp/SideCars/WK"])) { task in
                 // This is a target-independent task because multiple apps may exist in the same project but share a single stub
@@ -1412,13 +1412,13 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         // Expect a warning when deploying to iOS 13 or later.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS, overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "13.0"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "13.0"]), runDestination: .iOS) { results in
             results.checkWarning(.equal("WatchKit Settings bundles in iOS apps are deprecated. (in target 'Watchable' from project 'aProject')"))
             results.checkNoDiagnostics()
         }
 
         // Expect no warning for earlier deployment targets.
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .iOS, overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "12.0"])) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "12.0"]), runDestination: .iOS) { results in
             results.checkNoDiagnostics()
         }
     }
@@ -1466,7 +1466,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", activeRunDestination: .anywatchOSDevice)) { results in
+        await tester.checkBuild(runDestination: .anywatchOSDevice) { results in
             results.checkTarget("CoreFoo") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements"), .matchRuleItemPattern("arm64")) { task in
                     task.checkCommandLineContains(["\(SRCROOT)/build/aProject.build/Debug-watchos/CoreFoo.build/Objects-normal/arm64/CoreFoo.swiftmodule"])

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -72,6 +72,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -1272,6 +1273,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
             targets: [
                 TestStandardTarget(
                     "Watchable",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",

--- a/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
@@ -73,7 +73,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
@@ -181,7 +181,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             try results.checkTarget("App") { target in
                 results.checkNoDiagnostics()
 
@@ -313,7 +313,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Release"])
@@ -408,7 +408,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
@@ -549,7 +549,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkTask(.matchRule(["ProcessXCFramework", "\(SRCROOT)/Support.xcframework", "\(SRCROOT)/build/Debug/Support.framework", "macos"])) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
                 task.checkInputs([
@@ -620,7 +620,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
@@ -721,7 +721,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
@@ -832,7 +832,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
             try fs.write(libraryIdentifierPath.join("other.swiftdoc"), contents: "empty docs")
         }
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRule(["ProcessXCFramework", "\(SRCROOT)/Support.xcframework", "\(SRCROOT)/build/Debug/support.framework", "macos"])) { task in
                 task.checkInputs([
@@ -958,7 +958,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path("/Users/whoever/Library/MobileDevice/Provisioning Profiles/8db0e92c-592c-4f06-bfed-9d945841b78d.mobileprovision"), contents: "profile")
         try await fs.writePlist(Path("/tmp/Test/aProject/codesign.entitlements"), .plDict([:]))
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processExtrasXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRule(["ProcessXCFramework", "\(SRCROOT)/Extras.xcframework", "\(SRCROOT)/build/Debug-iphoneos/Extras.framework", "ios"])) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Extras.xcframework", "--platform", "ios", "--target-path", "\(SRCROOT)/build/Debug-iphoneos"])
@@ -1109,7 +1109,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.createDirectory(extrasXCFrameworkPath, recursive: true)
         try await XCFrameworkTestSupport.writeXCFramework(extrasXCFramework, fs: fs, path: extrasXCFrameworkPath, infoLookup: infoLookup)
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRule(["ProcessXCFramework", "\(SRCROOT)/Support.xcframework", "\(SRCROOT)/build/Debug/Support.framework", "macos"])) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--target-path", "\(SRCROOT)/build/Debug"])
@@ -1163,7 +1163,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), targetName: "lib2", fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, targetName: "lib2", fs: fs) { results in
             results.checkTarget("lib2") { target in
                 results.checkError("\(SRCROOT)/Extras.xcframework: While building for tvOS, no library for this platform was found in '\(SRCROOT)/Extras.xcframework'. (in target 'lib2' from project 'aProject')")
                 results.checkError("\(SRCROOT)/Support.xcframework: While building for tvOS, no library for this platform was found in '\(SRCROOT)/Support.xcframework'. (in target 'lib2' from project 'aProject')")
@@ -1172,7 +1172,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
 
-        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), targetName: "App2", fs: fs) { results in
+        try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, targetName: "App2", fs: fs) { results in
             try results.checkTarget("App2") { target in
                 var processSupportXCFrameworkTask: (any PlannedTask)?
                 results.checkTask(.matchRule(["ProcessXCFramework", "\(SRCROOT)/Support.xcframework", "\(SRCROOT)/build/Debug/Support.framework", "macos"])) { task in
@@ -1275,7 +1275,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         let infoLookup = try await getCore()
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
-        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), fs: fs) { results in
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
             results.checkError(.equal("There is no XCFramework found at '\(SRCROOT)/Support.xcframework'. (in target 'App' from project 'aProject')"))
             results.checkError(.equal("There is no XCFramework found at '\(SRCROOT)/Support.xcframework'. (in target 'App' from project 'aProject')"))
             results.checkNoDiagnostics()

--- a/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
@@ -146,7 +146,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild { results in
+        await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -216,7 +216,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -311,7 +311,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -398,7 +398,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
         let framework2 = BuildRequest.BuildTargetInfo(parameters: BuildParameters(configuration: "Debug"), target: tester.workspace.projects[0].targets[1])
         let buildRequest = BuildRequest(parameters: BuildParameters(configuration: "Debug"), buildTargets: [framework1, framework2], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(buildRequest: buildRequest, clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, clientDelegate: xcstringsTool) { results in
             // This situation caused a multiple commands produce error for the virtual output nodes of the UncompiledXCStrings Gates.
             // The nodes should be unique, at least by target/file pair.
             results.checkNoDiagnostics()
@@ -454,7 +454,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -527,7 +527,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -603,7 +603,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -679,7 +679,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             // This is not a supported configuration.
             results.checkError(.and(.contains("Localizable.xcstrings cannot co-exist with other .strings or .stringsdict tables with the same name."), .prefix("/tmp/Test/Project/Sources/Localizable.xcstrings")))
         }
@@ -756,7 +756,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             // This is not a supported configuration.
             results.checkError(.contains("Cannot have multiple Localizable.xcstrings files in same target."))
         }
@@ -852,7 +852,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
         let target2 = BuildRequest.BuildTargetInfo(parameters: BuildParameters(configuration: "Debug"), target: tester.workspace.projects[0].targets[1])
         let buildRequest = BuildRequest(parameters: BuildParameters(configuration: "Debug"), buildTargets: [target1, target2], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
-        await tester.checkBuild(buildRequest: buildRequest, clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, clientDelegate: xcstringsTool) { results in
             // This is a perfectly supported configuration.
             results.checkNoDiagnostics()
 
@@ -922,7 +922,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             // This is not a supported configuration.
             results.checkError(.contains("Localizable.xcstrings should not be inside an lproj directory."))
         }
@@ -989,7 +989,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "de"]), clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "de"]), runDestination: .iOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1081,7 +1081,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "de ja"]), clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "de ja"]), runDestination: .iOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1173,7 +1173,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", activeRunDestination: .iOS, overrides: ["INSTALLLOC_LANGUAGE": "de"]), clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "de"]), runDestination: .iOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1252,7 +1252,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1375,7 +1375,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1489,7 +1489,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "fr"]), clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "fr"]), runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1519,7 +1519,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "fr de"]), clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "fr de"]), runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("MyFramework") { target in
@@ -1611,7 +1611,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             // This is not a supported configuration.
             results.checkError(.and(.contains("View.xcstrings cannot co-exist with other .strings or .stringsdict tables with the same name."), .prefix("/tmp/Test/Project/Sources/mul.lproj/View.xcstrings")))
         }
@@ -1673,7 +1673,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
-        await tester.checkBuild(clientDelegate: xcstringsTool) { results in
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
             // This is not a supported configuration.
             results.checkError(.and(.contains("An IB file cannot provide its localizations via both a String Catalog and other overriding IB files."), .prefix("/tmp/Test/Project/Sources/Base.lproj/View.xib")))
         }

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -747,7 +747,7 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
     func serializable() async throws {
         try await withTemporaryDirectory { tmpDirPath -> Void in
             let core = try await getCore()
-            let testWorkspace = try TestWorkspace("SomeName", sourceRoot: tmpDirPath, projects: [.init("Project1", groupTree: TestGroup.init("Empty"), targets: [TestStandardTarget("Target1")])]).load(core)
+            let testWorkspace = try TestWorkspace("SomeName", sourceRoot: tmpDirPath, projects: [.init("Project1", groupTree: TestGroup.init("Empty"), targets: [TestStandardTarget("Target1", type: .application)])]).load(core)
             let workspaceContext = WorkspaceContext(core: core, workspace: testWorkspace, processExecutionCache: .sharedForTesting)
 
             let diagnostics: [ConfiguredTarget?: [Diagnostic]] = [

--- a/Tests/SWBTestSupportTests/TestSupportTests.swift
+++ b/Tests/SWBTestSupportTests/TestSupportTests.swift
@@ -56,7 +56,7 @@ import SWBUtil
                             ]),
                     ],
                     targets: [
-                        TestStandardTarget("TestTarget", buildPhases: [
+                        TestStandardTarget("TestTarget", type: .application, buildPhases: [
                             TestSourcesBuildPhase([
                                 TestBuildFile("test.c")
                             ])

--- a/Tests/SWBTestSupportTests/TestSupportTests.swift
+++ b/Tests/SWBTestSupportTests/TestSupportTests.swift
@@ -66,10 +66,10 @@ import SWBUtil
 
             let core = try await getCore()
             let buildA = try TaskConstructionTester(core, testWorkspace)
-            try await buildA.checkBuild { outerResults in
+            try await buildA.checkBuild(runDestination: .macOS) { outerResults in
                 let tasks = outerResults.getTasks(.matchRuleItem("CompileC"))
                 let buildB = try TaskConstructionTester(core, testWorkspace)
-                await buildB.checkBuild { results in
+                await buildB.checkBuild(runDestination: .macOS) { results in
                     // This is not a not a known issue but rather an expected failure
                     withKnownIssue("Task does not belong to the current build") {
                         try results.checkTaskFollows(#require(tasks.only), .matchRuleItem("CompileC"))

--- a/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
@@ -34,6 +34,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let macApp = TestStandardTarget(
                     "macApp",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "SDKROOT": "macosx",
@@ -155,6 +156,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let macApp = TestStandardTarget(
                     "macApp",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
                             "SDKROOT": "macosx",
@@ -236,6 +238,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let appTarget1 = TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
@@ -297,7 +300,9 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                 // Simulate adding a file to the existing target and send new PIF data.
 
                 let appTarget2 = TestStandardTarget(
-                    "AppTarget", guid: appTarget1.guid,
+                    "AppTarget",
+                    guid: appTarget1.guid,
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],
@@ -370,6 +375,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
 
                 let appTarget = TestStandardTarget(
                     "AppTarget",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],
@@ -422,6 +428,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                 let appTarget = TestStandardTarget(
                     "AppTarget",
                     guid: "Foo",
+                    type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug")
                     ],

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -118,8 +118,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                     groupTree: TestGroup("Foo", children: [TestFile("Test.c")]),
                     targets: [
                         TestAggregateTarget("All", dependencies: ["aFramework", "bFramework"]),
-                        TestStandardTarget("aFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
-                        TestStandardTarget("bFramework", buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                        TestStandardTarget("aFramework", type: .application, buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
+                        TestStandardTarget("bFramework", type: .application, buildPhases: [TestSourcesBuildPhase([TestBuildFile("Test.c")])]),
                     ])
                 let testWorkspace = TestWorkspace("aWorkspace",
                                                   sourceRoot: srcroot,

--- a/Tests/SwiftBuildTests/MacCatalystTests.swift
+++ b/Tests/SwiftBuildTests/MacCatalystTests.swift
@@ -44,6 +44,7 @@ fileprivate struct MacCatalystTests: CoreBasedTests {
                 targets: [
                     TestStandardTarget(
                         "Foo",
+                        type: .application,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "SUPPORTS_MACCATALYST": "YES",

--- a/Tests/SwiftBuildTests/PIFTests.swift
+++ b/Tests/SwiftBuildTests/PIFTests.swift
@@ -71,7 +71,7 @@ fileprivate struct PIFTests {
                     projects: [
                         TestProject("aProject",
                                     groupTree: TestGroup("foo"),
-                                    targets: [TestStandardTarget("aTarget")])
+                                    targets: [TestStandardTarget("aTarget", type: .application)])
                     ])
 
                 let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
@@ -103,7 +103,7 @@ fileprivate struct PIFTests {
                     projects: [
                         TestProject("aProject",
                                     groupTree: TestGroup("foo"),
-                                    targets: [TestStandardTarget("aTarget")])
+                                    targets: [TestStandardTarget("aTarget", type: .application)])
                     ])
 
                 let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)


### PR DESCRIPTION
This makes it more obvious that a task construction test is targeting the macOS platform, and makes our test infrastructure slightly less Apple-centric by ceasing to encode an implicit assumption of a default platform.