### PR TITLE
Factor out the registration of the Windows platform/SDK into the plugin

### DIFF
--- a/Sources/SWBAndroidPlatform/AndroidSDK.swift
+++ b/Sources/SWBAndroidPlatform/AndroidSDK.swift
@@ -125,8 +125,7 @@ struct AndroidSDK: Sendable {
         }
     }
 
-    public static func findInstallations(fs: any FSProxy) async throws -> [AndroidSDK] {
-        let host = try ProcessInfo.processInfo.hostOperatingSystem()
+    public static func findInstallations(host: OperatingSystem, fs: any FSProxy) async throws -> [AndroidSDK] {
         let defaultLocation: Path? = switch host {
         case .windows:
             // %LOCALAPPDATA%\Android\Sdk

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -263,8 +263,13 @@ private struct SetSessionUserInfoMsg: MessageHandler {
             throw MsgParserError.missingWorkspaceContext
         }
 
+        struct Context: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
+            var hostOperatingSystem: OperatingSystem
+            var fs: any FSProxy
+        }
+
         // Update the workspace context.
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: workspaceContext.core.pluginManager, fs: workspaceContext.fs)
+        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: workspaceContext.core.pluginManager, context: Context(hostOperatingSystem: workspaceContext.core.hostOperatingSystem, fs: workspaceContext.fs))
         workspaceContext.updateUserInfo(try await UserInfo(user: message.user, group: message.group, uid: message.uid, gid: message.gid, home: Path(message.home), processEnvironment: message.processEnvironment, buildSystemEnvironment: message.buildSystemEnvironment).addingPlatformDefaults(from: env))
 
         return VoidResponse()

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -486,8 +486,13 @@ package final class BuildOperation: BuildSystemOperation {
             self.buildOutputDelegate.error("unable to retrieve additional environment variables via the BuildOperationExtensionPoint.")
         }
 
+        struct Context: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
+            var hostOperatingSystem: OperatingSystem
+            var fs: any FSProxy
+        }
+
         do {
-            try await buildEnvironment.addContents(of: EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, fs: fs))
+            try await buildEnvironment.addContents(of: EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: Context(hostOperatingSystem: core.hostOperatingSystem, fs: fs)))
         } catch {
             self.buildOutputDelegate.error("unable to retrieve additional environment variables via the EnvironmentExtensionPoint.")
         }

--- a/Sources/SWBCore/Extensions/EnvironmentExtension.swift
+++ b/Sources/SWBCore/Extensions/EnvironmentExtension.swift
@@ -22,15 +22,20 @@ public struct EnvironmentExtensionPoint: ExtensionPoint {
 
     // MARK: - actual extension point
 
-    public static func additionalEnvironmentVariables(pluginManager: PluginManager, fs: any FSProxy) async throws -> [String: String] {
+    public static func additionalEnvironmentVariables(pluginManager: PluginManager, context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String: String] {
         var env: [String: String] = [:]
         for ext in pluginManager.extensions(of: Self.self) {
-            try await env.merge(ext.additionalEnvironmentVariables(fs: fs), uniquingKeysWith: { _, new in new })
+            try await env.merge(ext.additionalEnvironmentVariables(context: context), uniquingKeysWith: { _, new in new })
         }
         return env
     }
 }
 
 public protocol EnvironmentExtension: Sendable {
-    func additionalEnvironmentVariables(fs: any FSProxy) async throws -> [String: String]
+    func additionalEnvironmentVariables(context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String: String]
+}
+
+public protocol EnvironmentExtensionAdditionalEnvironmentVariablesContext: Sendable {
+    var hostOperatingSystem: OperatingSystem { get }
+    var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
+++ b/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
@@ -34,7 +34,9 @@ public protocol PlatformInfoExtension: Sendable {
 
     func additionalToolchainExecutableSearchPaths(toolchainIdentifier: String, toolchainPath: Path) -> [Path]
 
-    func additionalPlatforms() -> [(path: Path, data: [String: PropertyListItem])]
+    func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])]
+
+    func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path])
 }
 
 extension PlatformInfoExtension {
@@ -62,7 +64,16 @@ extension PlatformInfoExtension {
         []
     }
 
-    public func additionalPlatforms() -> [(path: Path, data: [String: PropertyListItem])] {
+    public func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
         []
     }
+
+    public func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path]) {
+    }
+}
+
+public protocol PlatformInfoExtensionAdditionalPlatformsContext: Sendable {
+    var hostOperatingSystem: OperatingSystem { get }
+    var developerPath: Path { get }
+    var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/Extensions/SDKRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/SDKRegistryExtension.swift
@@ -23,7 +23,7 @@ public struct SDKRegistryExtensionPoint: ExtensionPoint {
 public protocol SDKRegistryExtension: Sendable {
     var supportedSDKCanonicalNameSuffixes: Set<String> { get }
 
-    func additionalSDKs(platformRegistry: PlatformRegistry) async -> [(path: Path, platform: Platform?, data: [String: PropertyListItem])]
+    func additionalSDKs(context: any SDKRegistryExtensionAdditionalSDKsContext) async throws -> [(path: Path, platform: Platform?, data: [String: PropertyListItem])]
 }
 
 extension SDKRegistryExtension {
@@ -31,7 +31,13 @@ extension SDKRegistryExtension {
         []
     }
 
-    public func additionalSDKs(platformRegistry: PlatformRegistry) async -> [(path: Path, platform: Platform?, data: [String: PropertyListItem])] {
+    public func additionalSDKs(context: any SDKRegistryExtensionAdditionalSDKsContext) async throws -> [(path: Path, platform: Platform?, data: [String: PropertyListItem])] {
         []
     }
+}
+
+public protocol SDKRegistryExtensionAdditionalSDKsContext: Sendable {
+    var hostOperatingSystem: OperatingSystem { get }
+    var platformRegistry: PlatformRegistry { get }
+    var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
@@ -22,11 +22,16 @@ public struct ToolchainRegistryExtensionPoint: ExtensionPoint, Sendable {
 }
 
 public protocol ToolchainRegistryExtension: Sendable {
-    func additionalToolchains(fs: any FSProxy) async -> [Toolchain]
+    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain]
 }
 
 extension ToolchainRegistryExtension {
-    public func additionalToolchains(fs: any FSProxy) async -> [Toolchain] {
+    public func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain] {
         []
     }
+}
+
+public protocol ToolchainRegistryExtensionAdditionalToolchainsContext: Sendable {
+    var hostOperatingSystem: OperatingSystem { get }
+    var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -144,6 +144,7 @@ public struct InfoPlistProcessorTaskActionContext: PlatformBuildContext, Seriali
             sdk = loadedSDK
         } else {
             sdk = nil
+            _ = deserializer.deserializeNil() // skip past SDK variant name
             sdkVariant = nil
         }
 

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -451,8 +451,13 @@ public final class ToolchainRegistry: @unchecked Sendable {
             delegate.error(error)
         }
 
+        struct Context: ToolchainRegistryExtensionAdditionalToolchainsContext {
+            var hostOperatingSystem: OperatingSystem
+            var fs: any FSProxy
+        }
+
         for toolchainExtension in await delegate.pluginManager.extensions(of: ToolchainRegistryExtensionPoint.self) {
-            for toolchain in await toolchainExtension.additionalToolchains(fs: fs) {
+            for toolchain in await toolchainExtension.additionalToolchains(context: Context(hostOperatingSystem: hostOperatingSystem, fs: fs)) {
                 do {
                     try register(toolchain)
                 } catch {

--- a/Sources/SWBQNXPlatform/QNXSDP.swift
+++ b/Sources/SWBQNXPlatform/QNXSDP.swift
@@ -75,8 +75,7 @@ struct QNXSDP: Sendable {
         }
     }
 
-    public static func findInstallations(fs: any FSProxy) async throws -> [QNXSDP] {
-        let host = try ProcessInfo.processInfo.hostOperatingSystem()
+    public static func findInstallations(host: OperatingSystem, fs: any FSProxy) async throws -> [QNXSDP] {
         var searchPaths = [Path.homeDirectory]
         if host == .windows {
             if let systemDrive = getEnvironmentVariable("SystemDrive") {

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1209,6 +1209,11 @@ package final class BuildOperationTester {
     /// The user preferences to supply when testing.
     package var userPreferences = UserPreferences.defaultForTesting
 
+    private struct EnvironmentVariablesExtensionContext: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
+        var hostOperatingSystem: OperatingSystem
+        var fs: any FSProxy
+    }
+
     /// Create a build tester.
     ///
     /// - simulated: Whether or not the build is being done in simulation.
@@ -1223,7 +1228,7 @@ package final class BuildOperationTester {
         self.clientDelegate = clientDelegate ?? MockTestClientDelegate()
         self.continueBuildingAfterErrors = continueBuildingAfterErrors
         self.systemInfo = systemInfo
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, fs: fs)
+        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: EnvironmentVariablesExtensionContext(hostOperatingSystem: core.hostOperatingSystem, fs: fs))
         self.userInfo = try await Self.defaultUserInfo.addingPlatformDefaults(from: env)
     }
 
@@ -1241,7 +1246,7 @@ package final class BuildOperationTester {
         self.clientDelegate = clientDelegate ?? MockTestClientDelegate()
         self.continueBuildingAfterErrors = continueBuildingAfterErrors
         self.systemInfo = systemInfo
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, fs: fs)
+        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: EnvironmentVariablesExtensionContext(hostOperatingSystem: core.hostOperatingSystem, fs: fs))
         self.userInfo = try await Self.defaultUserInfo.addingPlatformDefaults(from: env)
     }
 

--- a/Sources/SWBWebAssemblyPlatform/Plugin.swift
+++ b/Sources/SWBWebAssemblyPlatform/Plugin.swift
@@ -28,7 +28,7 @@ struct WebAssemblyPlatformSpecsExtension: SpecificationsExtension {
 }
 
 struct WebAssemblyPlatformExtension: PlatformInfoExtension {
-    func additionalPlatforms() -> [(path: Path, data: [String: PropertyListItem])] {
+    func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
         [
             (.root, [
                 "Type": .plString("Platform"),
@@ -49,12 +49,9 @@ struct WebAssemblyPlatformExtension: PlatformInfoExtension {
 // us from doing this today but we should revisit this later and consider
 // renaming this plugin to something like `SWBSwiftSDKPlatform`.
 struct WebAssemblySDKRegistryExtension: SDKRegistryExtension {
-    func additionalSDKs(platformRegistry: PlatformRegistry) async -> [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] {
-        guard let host = try? ProcessInfo.processInfo.hostOperatingSystem() else {
-            return []
-        }
-
-        guard let wasmPlatform = platformRegistry.lookup(name: "webassembly") else {
+    func additionalSDKs(context: any SDKRegistryExtensionAdditionalSDKsContext) async throws -> [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] {
+        let host = context.hostOperatingSystem
+        guard let wasmPlatform = context.platformRegistry.lookup(name: "webassembly") else {
             return []
         }
 
@@ -79,7 +76,7 @@ struct WebAssemblySDKRegistryExtension: SDKRegistryExtension {
 
         let wasmSwiftSDKs = (try? SwiftSDK.findSDKs(
             targetTriples: Array(supportedTriples.keys),
-            fs: localFS
+            fs: context.fs
         )) ?? []
 
         var wasmSDKs: [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] = []

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -17,6 +17,8 @@ import Foundation
 @PluginExtensionSystemActor public func initializePlugin(_ manager: PluginManager) {
     manager.register(WindowsPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(WindowsEnvironmentExtension(), type: EnvironmentExtensionPoint.self)
+    manager.register(WindowsPlatformExtension(), type: PlatformInfoExtensionPoint.self)
+    manager.register(WindowsSDKRegistryExtension(), type: SDKRegistryExtensionPoint.self)
 }
 
 struct WindowsPlatformSpecsExtension: SpecificationsExtension {
@@ -26,15 +28,15 @@ struct WindowsPlatformSpecsExtension: SpecificationsExtension {
 }
 
 struct WindowsEnvironmentExtension: EnvironmentExtension {
-    func additionalEnvironmentVariables(fs: any FSProxy) async throws -> [String: String] {
-        if try ProcessInfo.processInfo.hostOperatingSystem() == .windows {
+    func additionalEnvironmentVariables(context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String: String] {
+        if context.hostOperatingSystem == .windows {
             // Add the environment variable for the MSVC toolset for Swift and Clang to find it
             let vcToolsInstallDir = "VCToolsInstallDir"
-            let installations = try await VSInstallation.findInstallations(fs: fs)
+            let installations = try await VSInstallation.findInstallations(fs: context.fs)
                 .sorted(by: { $0.installationVersion > $1.installationVersion })
             if let latest = installations.first {
                 let msvcDir = latest.installationPath.join("VC").join("Tools").join("MSVC")
-                let versions = try fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
+                let versions = try context.fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
                 if let latestVersion = versions.first {
                     let dir = msvcDir.join(latestVersion.description).str
                     return [vcToolsInstallDir: dir]
@@ -42,5 +44,99 @@ struct WindowsEnvironmentExtension: EnvironmentExtension {
             }
         }
         return [:]
+    }
+}
+
+struct WindowsPlatformExtension: PlatformInfoExtension {
+    func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
+        let operatingSystem = context.hostOperatingSystem
+        guard operatingSystem == .windows else {
+            return []
+        }
+
+        let platformsPath = context.developerPath.join("Platforms")
+        return try context.fs.listdir(platformsPath).compactMap { version in
+            let versionedPlatformsPath = platformsPath.join(version)
+            guard context.fs.isDirectory(versionedPlatformsPath) else {
+                return nil
+            }
+
+            let windowsInfoPlistPath = versionedPlatformsPath.join("Windows.platform").join("Info.plist")
+            guard context.fs.exists(windowsInfoPlistPath) else {
+                return nil
+            }
+
+            let windowsInfoPlist = try PropertyList.fromPath(windowsInfoPlistPath, fs: context.fs)
+            guard case let .plDict(dict) = windowsInfoPlist else {
+                throw StubError.error("Unexpected top-level property list type in \(windowsInfoPlistPath.str) (expected dictionary)")
+            }
+
+            return (windowsInfoPlistPath.dirname, dict.merging([
+                "Type": .plString("Platform"),
+                "Name": .plString("windows"),
+                "Identifier": .plString("windows"),
+                "Description": .plString("Windows"),
+                "FamilyName": .plString("Windows"),
+                "FamilyIdentifier": .plString("windows"),
+                "IsDeploymentPlatform": .plString("YES"),
+                "Version": .plString(version),
+            ]) { old, new in new })
+        }
+    }
+
+    public func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path]) {
+        // Block the default registration mechanism from picking up the incomplete SDKSettings.plist on disk.
+        // The WindowsSDKRegistryExtension will handle discovery and registration of the SDK.
+        if platformName == "windows" {
+            sdkSearchPaths = []
+        }
+    }
+}
+
+struct WindowsSDKRegistryExtension: SDKRegistryExtension {
+    func additionalSDKs(context: any SDKRegistryExtensionAdditionalSDKsContext) async throws -> [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] {
+        guard let windowsPlatform = context.platformRegistry.lookup(name: "windows") else {
+            return []
+        }
+
+        let windowsSDKSettingsPlistPath = windowsPlatform.path.join("Developer").join("SDKs").join("Windows.sdk").join("SDKSettings.plist")
+        let windowsSDKSettingsPlist = try PropertyList.fromPath(windowsSDKSettingsPlistPath, fs: context.fs)
+        guard case let .plDict(dict) = windowsSDKSettingsPlist else {
+            throw StubError.error("Unexpected top-level property list type in \(windowsSDKSettingsPlistPath.str) (expected dictionary)")
+        }
+
+        let defaultProperties: [String: PropertyListItem] = [
+            "GCC_GENERATE_DEBUGGING_SYMBOLS": .plString("NO"),
+            "LD_DEPENDENCY_INFO_FILE": .plString(""),
+
+            "GENERATE_TEXT_BASED_STUBS": "NO",
+            "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
+
+            "LIBRARY_SEARCH_PATHS": "$(inherited) $(SDKROOT)/usr/lib/swift/windows/$(CURRENT_ARCH)",
+
+            "OTHER_SWIFT_FLAGS": "$(inherited) -libc $(DEFAULT_USE_RUNTIME)",
+
+            "DEFAULT_USE_RUNTIME": "MD",
+        ]
+
+        return try [
+            (windowsSDKSettingsPlistPath.dirname, windowsPlatform, dict.merging([
+                "Type": .plString("SDK"),
+                "Version": .plString(Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description),
+                "CanonicalName": .plString("windows"),
+                "IsBaseSDK": .plBool(true),
+                "DefaultProperties": .plDict([
+                    "PLATFORM_NAME": .plString("windows"),
+                ].merging(defaultProperties, uniquingKeysWith: { _, new in new })),
+                "SupportedTargets": .plDict([
+                    "windows": .plDict([
+                        "Archs": .plArray([.plString("x86_64"), .plString("i686"), .plString("aarch64"), .plString("thumbv7")]),
+                        "LLVMTargetTripleEnvironment": .plString("msvc"),
+                        "LLVMTargetTripleSys": .plString("windows"),
+                        "LLVMTargetTripleVendor": .plString("unknown"),
+                    ])
+                ]),
+            ]) { old, new in new })
+        ]
     }
 }

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -47,6 +47,10 @@ import SWBMacro
         var errors: [String] {
             return _diagnosticsEngine.diagnostics.filter { $0.behavior == .error }.map { $0.formatLocalizedDescription(.debugWithoutBehavior) }
         }
+
+        var developerPath: Path {
+            Path.temporaryDirectory
+        }
     }
 
     /// Helper function for scanning test inputs.

--- a/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
@@ -1580,9 +1580,10 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
 
         let platformName = "macosx"
         let platform = try #require(core.platformRegistry.lookup(name: platformName), "invalid platform name '\(platformName)'")
+        let sdk = try #require(core.sdkRegistry.lookup(platformName), "invalid SDK name '\(platformName)'")
         let executionDelegate = MockExecutionDelegate(core: try await getCore())
 
-        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: core.sdkRegistry.lookup(platformName), sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
+        let action = InfoPlistProcessorTaskAction(try prepareContext(InfoPlistProcessorTaskActionContext(scope: scope, productType: nil, platform: platform, sdk: sdk, sdkVariant: nil, cleanupRequiredArchitectures: []), fs: executionDelegate.fs))
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-infoPlistUtility", "-platform", platformName, "/tmp/input.plist", "-o", "/tmp/output.plist", "-genpkginfo", "/tmp/PkgInfo"], workingDirectory: Path.root.join("tmp"), outputs: [], action: action, execDescription: "Copy Info.plist")
 
         // Write the test files.


### PR DESCRIPTION
This removes clunky hardcoded knowledge of the Windows setup from the core libraries.