### PR TITLE
Filter out linker warnings about an empty SubFrameworks directory in Catalyst tests.

### DIFF
--- a/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
+++ b/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
@@ -210,5 +210,10 @@ package func _filterDiagnostic(message: String) -> String? {
         return nil
     }
 
+    // Workaround: rdar://146492614
+    if message.contains(#/Search path '.+\/System\/iOSSupport\/System\/Library\/SubFrameworks' not found/#) {
+        return nil
+    }
+
     return message
 }


### PR DESCRIPTION
Warnings about this are an artifact of how Catalyst support is implemented rather than providing actionable information.

rdar://146492614