### PR TITLE
Explicitly annotate sendability of public 'Purpose' enum

### DIFF
--- a/Sources/SWBCore/Settings/CASOptions.swift
+++ b/Sources/SWBCore/Settings/CASOptions.swift
@@ -170,7 +170,7 @@ public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
         self.limitingStrategy = try deserializer.deserialize()
     }
 
-    public enum Purpose {
+    public enum Purpose: Sendable {
         case generic
         case compiler(GCCCompatibleLanguageDialect)
     }


### PR DESCRIPTION
Fix a warning in contexts where we require explicit annotation of public types

rdar://144845295