### PR TITLE
Add state caches for Windows/Android/QNX plugins

### DIFF
--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -15,10 +15,22 @@ import SWBCore
 import Foundation
 
 @PluginExtensionSystemActor public func initializePlugin(_ manager: PluginManager) {
+    let plugin = WindowsPlugin()
     manager.register(WindowsPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
-    manager.register(WindowsEnvironmentExtension(), type: EnvironmentExtensionPoint.self)
+    manager.register(WindowsEnvironmentExtension(plugin: plugin), type: EnvironmentExtensionPoint.self)
     manager.register(WindowsPlatformExtension(), type: PlatformInfoExtensionPoint.self)
     manager.register(WindowsSDKRegistryExtension(), type: SDKRegistryExtensionPoint.self)
+}
+
+final class WindowsPlugin: Sendable {
+    private let vsInstallations = AsyncSingleValueCache<[VSInstallation], any Error>()
+
+    func cachedVSInstallations() async throws -> [VSInstallation] {
+        try await vsInstallations.value {
+            // Always pass localFS because this will be cached, and executes a process on the host system so there's no reason to pass in any proxy.
+            try await VSInstallation.findInstallations(fs: localFS)
+        }
+    }
 }
 
 struct WindowsPlatformSpecsExtension: SpecificationsExtension {
@@ -28,18 +40,22 @@ struct WindowsPlatformSpecsExtension: SpecificationsExtension {
 }
 
 struct WindowsEnvironmentExtension: EnvironmentExtension {
+    let plugin: WindowsPlugin
+
     func additionalEnvironmentVariables(context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String: String] {
         if context.hostOperatingSystem == .windows {
             // Add the environment variable for the MSVC toolset for Swift and Clang to find it
             let vcToolsInstallDir = "VCToolsInstallDir"
-            let installations = try await VSInstallation.findInstallations(fs: context.fs)
+            let installations = try await plugin.cachedVSInstallations()
                 .sorted(by: { $0.installationVersion > $1.installationVersion })
             if let latest = installations.first {
                 let msvcDir = latest.installationPath.join("VC").join("Tools").join("MSVC")
-                let versions = try context.fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
-                if let latestVersion = versions.first {
-                    let dir = msvcDir.join(latestVersion.description).str
-                    return [vcToolsInstallDir: dir]
+                if context.fs.exists(msvcDir) {
+                    let versions = try context.fs.listdir(msvcDir).map { try Version($0) }.sorted { $0 > $1 }
+                    if let latestVersion = versions.first {
+                        let dir = msvcDir.join(latestVersion.description).str
+                        return [vcToolsInstallDir: dir]
+                    }
                 }
             }
         }


### PR DESCRIPTION
Avoid running some external process invocations related to SDK discovery multiple times during the lifetime of a build service.

rdar://141789051