### PR TITLE
Don't assert equality of modification timestamps after file copies

### DIFF
--- a/Tests/SWBTaskExecutionTests/PBXCpTests.swift
+++ b/Tests/SWBTaskExecutionTests/PBXCpTests.swift
@@ -555,14 +555,12 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(result.success == true)
             #expect(result.output == "copying src...\n 9 bytes\n")
             #expect(try fs.read(dst) == "contents1")
-            let modificationDate = try fs.getFileInfo(dst).modificationDate
 
             try await Task.sleep(for: .milliseconds(500))
             let result2 = await pbxcp(["builtin-copy", "-skip-copy-if-contents-equal", "-rename", "-v", src.str, dst.str], cwd: Path("/"))
             #expect(result2.success == true)
             #expect(result2.output == "note: skipping copy of '\(src.str)' because it has the same contents as '\(dst.str)'\n")
             #expect(try fs.read(dst) == "contents1")
-            #expect(try fs.getFileInfo(dst).modificationDate == modificationDate)
 
             try await Task.sleep(for: .milliseconds(500))
             try fs.write(src, contents: "contents2")
@@ -570,7 +568,6 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(result3.success == true)
             #expect(result3.output == "copying src...\n 9 bytes\n")
             #expect(try fs.read(dst) == "contents2")
-            #expect(try fs.getFileInfo(dst).modificationDate != modificationDate)
         }
 
         try await withTemporaryDirectory { tmp in
@@ -587,14 +584,12 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(result.success == true)
             #expect(result.output == "copying file...\n 9 bytes\n")
             #expect(try fs.read(dstFile) == "contents1")
-            let modificationDate = try fs.getFileInfo(dstFile).modificationDate
 
             try await Task.sleep(for: .milliseconds(500))
             let result2 = await pbxcp(["builtin-copy", "-skip-copy-if-contents-equal", "-rename", "-v", src.str, dst.str], cwd: Path("/"))
             #expect(result2.success == true)
             #expect(result2.output == "note: skipping copy of '\(src.str)' because it has the same contents as '\(dst.str)'\n")
             #expect(try fs.read(dstFile) == "contents1")
-            #expect(try fs.getFileInfo(dstFile).modificationDate == modificationDate)
 
             try await Task.sleep(for: .milliseconds(500))
             try fs.write(srcFile, contents: "contents2")
@@ -602,7 +597,6 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             #expect(result3.success == true)
             #expect(result3.output == "copying src/...\n")
             #expect(try fs.read(dstFile) == "contents2")
-            #expect(try fs.getFileInfo(dstFile).modificationDate != modificationDate)
         }
     }
 

--- a/Tests/SWBUtilTests/FSProxyTests.swift
+++ b/Tests/SWBUtilTests/FSProxyTests.swift
@@ -260,14 +260,14 @@ import SWBTestSupport
         }
     }
 
-    @Test(.skipHostOS(.linux)) // flaky on Linux because timestamps have been observed to vary by 0.001s after copying
+    @Test
     func localCopyFile() throws {
         try withTemporaryDirectory { tmpDir in
             try _testCopyFile(localFS, basePath: tmpDir)
         }
     }
 
-    @Test(.skipHostOS(.linux)) // flaky on Linux because timestamps have been observed to vary by 0.001s after copying
+    @Test
     func localCopyTree() throws {
         try withTemporaryDirectory { tmpDir in
             try _testCopyTree(localFS, basePath: tmpDir)
@@ -1111,7 +1111,10 @@ import SWBTestSupport
         if try ProcessInfo.processInfo.hostOperatingSystem() != .windows {
             #expect(try fs.getFilePermissions(testDataPathDst) == permissions)
         }
-        #expect(try fs.getFileInfo(testDataPath).modificationDate == fs.getFileInfo(testDataPathDst).modificationDate)
+        if fs is PseudoFS {
+            // There is no guarantee that the implementation of copy() will preserve the modification timestamp on either files and/or directories, on any real filesystem, so only make this assertion for the pseudo filesystem which we wholly control.
+            #expect(try fs.getFileInfo(testDataPath).modificationDate == fs.getFileInfo(testDataPathDst).modificationDate)
+        }
         #expect(try ByteString(testData) == fs.read(testDataPathDst))
     }
 
@@ -1121,7 +1124,10 @@ import SWBTestSupport
             #expect(lhs.isDirectory == rhs.isDirectory, sourceLocation: sourceLocation)
             #expect(lhs.isExecutable == rhs.isExecutable, sourceLocation: sourceLocation)
             #expect(lhs.isSymlink == rhs.isSymlink, sourceLocation: sourceLocation)
-            #expect(lhs.modificationDate == rhs.modificationDate, sourceLocation: sourceLocation)
+            if fs is PseudoFS {
+                // There is no guarantee that the implementation of copy() will preserve the modification timestamp on either files and/or directories, on any real filesystem, so only make this assertion for the pseudo filesystem which we wholly control.
+                #expect(lhs.modificationDate == rhs.modificationDate, sourceLocation: sourceLocation)
+            }
             #expect(lhs.owner == rhs.owner, sourceLocation: sourceLocation)
             #expect(lhs.permissions == rhs.permissions, sourceLocation: sourceLocation)
         }


### PR DESCRIPTION
FSProxy's copy() function (which uses FileManager in the LocalFS implementation) does not appear to be able to guarantee that timestamps will be preserved for copied files or directories, on any filesystem or platform. Small variances are often observed here when the copy (for whatever reason) takes longer than the minimum timestamp resolution of the underlying filesystem with respect to the creation time of the original file. This leads to flaky tests on Windows and Linux. This is generally not observed on macOS presumably due to the use of copyfile() in Foundation's implementation which uses APFS cloning and therefore doesn't go down the fallback path which creates new directory and filesystem nodes at the destination.

So, drop the assertions as we can't actually make this guarantee, and it's not clear we really want to make this guarantee with the desire to shift the build system away from reliance on timestamps as much as possible in the fullness of time.

rdar://146697830