### PR TITLE
Remove default run destination argument from build description tests

### DIFF
--- a/Tests/SWBTaskExecutionTests/StaleFileRemovalTests.swift
+++ b/Tests/SWBTaskExecutionTests/StaleFileRemovalTests.swift
@@ -174,7 +174,7 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
                             for sanitizer in sanitizers {
                                 overrides[sanitizer.settingName] = "YES"
                             }
-                            let planRequest = try await self.planRequest(for: workspace, configuration: configuration, overrides: overrides, fs: fs, includingTargets: { _ in true })
+                            let planRequest = try await self.planRequest(for: workspace, configuration: configuration, activeRunDestination: .macOS, overrides: overrides, fs: fs, includingTargets: { _ in true })
                             let delegate = MockTestBuildDescriptionConstructionDelegate()
                             let _ = try await manager.getNewOrCachedBuildDescription(planRequest, clientDelegate: MockTestTaskPlanningClientDelegate(), constructionDelegate: delegate)!
 


### PR DESCRIPTION
This makes it more obvious that a test is targeting the macOS platform, and makes our test infrastructure slightly less Apple-centric by ceasing to encode an implicit assumption of a default platform.