### PR TITLE
Remove variant name from explicit precompile rule info to allow deduping

### DIFF
--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
@@ -66,15 +66,13 @@ public struct SwiftDriverJobTaskKey: Serializable, CustomDebugStringConvertible 
 }
 
 public struct SwiftDriverExplicitDependencyJobTaskKey: Serializable, CustomDebugStringConvertible {
-    let variant: String
     let arch: String
     let driverJobKey: LibSwiftDriver.JobKey
     let driverJobSignature: ByteString
     let compilerLocation: LibSwiftDriver.CompilerLocation
     let casOptions: CASOptions?
 
-    init(variant: String, arch: String, driverJobKey: LibSwiftDriver.JobKey, driverJobSignature: ByteString, compilerLocation: LibSwiftDriver.CompilerLocation, casOptions: CASOptions?) {
-        self.variant = variant
+    init(arch: String, driverJobKey: LibSwiftDriver.JobKey, driverJobSignature: ByteString, compilerLocation: LibSwiftDriver.CompilerLocation, casOptions: CASOptions?) {
         self.arch = arch
         self.driverJobKey = driverJobKey
         self.driverJobSignature = driverJobSignature
@@ -83,8 +81,7 @@ public struct SwiftDriverExplicitDependencyJobTaskKey: Serializable, CustomDebug
     }
 
     public func serialize<T>(to serializer: T) where T : Serializer {
-        serializer.serializeAggregate(6) {
-            serializer.serialize(variant)
+        serializer.serializeAggregate(5) {
             serializer.serialize(arch)
             serializer.serialize(driverJobKey)
             serializer.serialize(driverJobSignature)
@@ -94,8 +91,7 @@ public struct SwiftDriverExplicitDependencyJobTaskKey: Serializable, CustomDebug
     }
 
     public init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(6)
-        variant = try deserializer.deserialize()
+        try deserializer.beginAggregate(5)
         arch = try deserializer.deserialize()
         driverJobKey = try deserializer.deserialize()
         driverJobSignature = try deserializer.deserialize()
@@ -104,7 +100,7 @@ public struct SwiftDriverExplicitDependencyJobTaskKey: Serializable, CustomDebug
     }
 
     public var debugDescription: String {
-        "<SwiftDriverExplicitDependencyJob arch=\(arch) variant=\(variant) jobKey=\(driverJobKey) jobSignature=\(driverJobSignature) compilerLocation=\(compilerLocation) casOptions=\(String(describing: casOptions))>"
+        "<SwiftDriverExplicitDependencyJob arch=\(arch) jobKey=\(driverJobKey) jobSignature=\(driverJobSignature) compilerLocation=\(compilerLocation) casOptions=\(String(describing: casOptions))>"
     }
 }
 
@@ -173,7 +169,7 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
                 commandLine = commandLinePrefix + job.commandLine
                 expectedOutputs = job.outputs
                 assert(expectedOutputs.count > 0, "Explicit modules job was expected to have at least one primary output")
-                ruleInfo = ["SwiftExplicitDependency\(job.ruleInfoType)", key.variant, key.arch, expectedOutputs.first?.str ?? "<unknown>"]
+                ruleInfo = ["SwiftExplicitDependency\(job.ruleInfoType)", key.arch, expectedOutputs.first?.str ?? "<unknown>"]
                 forTarget = nil
                 descriptionForLifecycle = job.descriptionForLifecycle
                 // WMO doesn't apply to explicit module builds
@@ -266,7 +262,7 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
                 guard let job = context.swiftModuleDependencyGraph.plannedExplicitDependencyBuildJob(for: key.driverJobKey) else {
                     throw StubError.error("Failed to lookup explicit module Swift driver job \(key.driverJobKey)")
                 }
-                return SwiftDriverJobTaskAction(job, variant: key.variant, arch: key.arch, identifier: .explicitDependency, isUsingWholeModuleOptimization: false)
+            return SwiftDriverJobTaskAction(job, variant: nil, arch: key.arch, identifier: .explicitDependency, isUsingWholeModuleOptimization: false)
             default:
                 fatalError("Unexpected dynamic task key: \(dynamicTaskKey)")
         }

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobSchedulingTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobSchedulingTaskAction.swift
@@ -270,7 +270,6 @@ open class SwiftDriverJobSchedulingTaskAction: TaskAction {
         let key: DynamicTaskKey
         if plannedJob.driverJob.categorizer.isExplicitDependencyBuild {
             key = .swiftDriverExplicitDependencyJob(SwiftDriverExplicitDependencyJobTaskKey(
-                variant: driverPayload.variant,
                 arch: driverPayload.architecture,
                 driverJobKey: plannedJob.key,
                 driverJobSignature: plannedJob.driverJob.signature,

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -112,12 +112,12 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
     }
 
     let identifier: SwiftDriverJobIdentifier
-    let variant: String
+    let variant: String?
     let arch: String
     let driverJob: LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob
     let isUsingWholeModuleOptimization: Bool
 
-    init(_ driverJob: LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob, variant: String, arch: String, identifier: SwiftDriverJobIdentifier, isUsingWholeModuleOptimization: Bool) {
+    init(_ driverJob: LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob, variant: String?, arch: String, identifier: SwiftDriverJobIdentifier, isUsingWholeModuleOptimization: Bool) {
         self.driverJob = driverJob
         self.variant = variant
         self.arch = arch
@@ -211,7 +211,7 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
         }
     }
 
-    internal func constructDriverJobTaskKey(variant: String,
+    internal func constructDriverJobTaskKey(variant: String?,
                                             arch: String,
                                             plannedJob: LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob,
                                             identifier: String?,
@@ -220,13 +220,15 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
         let key: DynamicTaskKey
         if plannedJob.driverJob.categorizer.isExplicitDependencyBuild {
             key = .swiftDriverExplicitDependencyJob(SwiftDriverExplicitDependencyJobTaskKey(
-                variant: variant,
                 arch: arch,
                 driverJobKey: plannedJob.key,
                 driverJobSignature: plannedJob.driverJob.signature,
                 compilerLocation: compilerLocation,
                 casOptions: casOptions))
         } else {
+            guard let variant else {
+                fatalError("Expected variant for non-explicit-module job: \(plannedJob.driverJob.descriptionForLifecycle)")
+            }
             guard let jobID = identifier else {
                 fatalError("Expected job identifier for target compile: \(plannedJob.driverJob.descriptionForLifecycle)")
             }


### PR DESCRIPTION
Not all variants depend on incompatible modules. Remove the variant name from the rule info so that identical tasks are deduplicated properly and cannot race.

