### PR TITLE
Ensure all overloads of SWBBuildService.createSession pass along the …

### DIFF
--- a/Sources/SwiftBuild/SWBBuildService.swift
+++ b/Sources/SwiftBuild/SWBBuildService.swift
@@ -196,7 +196,7 @@ public final class SWBBuildService: Sendable {
 
     // ABI compatibility
     public func createSession(name: String, developerPath: String? = nil, cachePath: String?, inferiorProductsPath: String?, environment: [String:String]?) async -> (Result<SWBBuildServiceSession, any Error>, [SwiftBuildMessage.DiagnosticInfo]) {
-        await createSession(name: name, resourceSearchPaths: [], cachePath: cachePath, inferiorProductsPath: inferiorProductsPath, environment: environment)
+        await createSession(name: name, developerPath: developerPath, resourceSearchPaths: [], cachePath: cachePath, inferiorProductsPath: inferiorProductsPath, environment: environment)
     }
 
     /// Create a new service session.


### PR DESCRIPTION
…developerPath parameter.

Without this, clients which use a deprecated createSession overload fail to find the Developer directory during initialization.

This fixes #292.