### PR TITLE
Start adopting the new Environment type throughout the codebase

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -184,7 +184,7 @@ extension SetSessionWorkspaceContainerPathRequest: PIFProvidingRequest {
             try fs.createDirectory(dir, recursive: true)
             let pifPath = dir.join(Foundation.UUID().description + ".json")
             let argument = isProject ? "-project" : "-workspace"
-            let result = try await Process.getOutput(url: URL(fileURLWithPath: "/usr/bin/xcrun"), arguments: ["xcodebuild", "-dumpPIF", pifPath.str, argument, path.str], currentDirectoryURL: URL(fileURLWithPath: containerPath.dirname.str, isDirectory: true), environment: ProcessInfo.processInfo.cleanEnvironment.merging(["DEVELOPER_DIR": session.core.developerPath.str], uniquingKeysWith: { _, new in new }))
+            let result = try await Process.getOutput(url: URL(fileURLWithPath: "/usr/bin/xcrun"), arguments: ["xcodebuild", "-dumpPIF", pifPath.str, argument, path.str], currentDirectoryURL: URL(fileURLWithPath: containerPath.dirname.str, isDirectory: true), environment: Environment.current.addingContents(of: [.developerDir: session.core.developerPath.str]))
             if !result.exitStatus.isSuccess {
                 throw StubError.error("Could not dump PIF for '\(path.str)': \(String(decoding: result.stderr, as: UTF8.self))")
             }

--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -214,10 +214,10 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
         let taskIdentifier = task.identifier
         let taskOutputDelegate = delegate.taskStarted(self, taskIdentifier: taskIdentifier, task: task, dependencyInfo: nil)
 
-        let resolvedExecutable = StackedSearchPath(environment: environment, fs: workspaceContext.fs).lookup(Path(executable)) ?? Path(executable)
+        let resolvedExecutable = StackedSearchPath(environment: .init(environment), fs: workspaceContext.fs).lookup(Path(executable)) ?? Path(executable)
 
         do {
-            let result = try await Process.getMergedOutput(url: URL(fileURLWithPath: resolvedExecutable.str), arguments: arguments, currentDirectoryURL: URL(fileURLWithPath: workingDirectory.str), environment: environment)
+            let result = try await Process.getMergedOutput(url: URL(fileURLWithPath: resolvedExecutable.str), arguments: arguments, currentDirectoryURL: URL(fileURLWithPath: workingDirectory.str), environment: .init(environment))
 
             if !result.exitStatus.isSuccess {
                 taskOutputDelegate.emitError("Failed to clean target '\(configuredTarget.target.name)': \(String(decoding: result.output, as: UTF8.self))")

--- a/Sources/SWBCore/SWBFeatureFlag.swift
+++ b/Sources/SWBCore/SWBFeatureFlag.swift
@@ -35,7 +35,7 @@ public struct SWBFeatureFlagProperty {
 
     /// Whether the feature flag is actually set at all.
     public var hasValue: Bool {
-        return SWBUtil.UserDefaults.hasValue(forKey: key) || getEnvironmentVariable(key) != nil
+        return SWBUtil.UserDefaults.hasValue(forKey: key) || getEnvironmentVariable(EnvironmentKey(key)) != nil
     }
 
     /// Indicates whether the feature flag is currently active in the calling environment.
@@ -43,7 +43,7 @@ public struct SWBFeatureFlagProperty {
         if !hasValue {
             return defaultValue
         }
-        return SWBUtil.UserDefaults.bool(forKey: key) || getEnvironmentVariable(key)?.boolValue == true
+        return SWBUtil.UserDefaults.bool(forKey: key) || getEnvironmentVariable(EnvironmentKey(key))?.boolValue == true
     }
 
     fileprivate init(_ key: String, defaultValue: Bool = false) {
@@ -59,7 +59,7 @@ public struct SWBOptionalFeatureFlagProperty {
     /// Returns nil if neither environment variable nor User Default are set.  An implementation can then pick a default behavior.
     /// If both the environment variable and User Default are set, the two values are logically AND'd together; this allows the set false value of either to force the feature flag off.
     public var value: Bool? {
-        let envValue = getEnvironmentVariable(key)
+        let envValue = getEnvironmentVariable(EnvironmentKey(key))
         let envHasValue = envValue != nil
         let defHasValue = SWBUtil.UserDefaults.hasValue(forKey: key)
         if !envHasValue && !defHasValue {

--- a/Sources/SWBCore/Settings/StackedSearchPaths.swift
+++ b/Sources/SWBCore/Settings/StackedSearchPaths.swift
@@ -33,8 +33,8 @@ public final class StackedSearchPath: Sendable {
         self.fs = fs
     }
 
-    public init(environment: [String: String], fs: any FSProxy) {
-        self.paths = environment["PATH"]?.split(separator: Path.pathEnvironmentSeparator).map(Path.init) ?? []
+    public init(environment: Environment, fs: any FSProxy) {
+        self.paths = environment[.path]?.split(separator: Path.pathEnvironmentSeparator).map(Path.init) ?? []
         self.fs = fs
     }
 

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1390,7 +1390,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
     public func executeExternalTool<T>(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: String?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> T) async throws -> T {
         let executionResult = try await delegate.executeExternalTool(commandLine: commandLine, workingDirectory: workingDirectory, environment: environment, executionDescription: executionDescription)
         guard executionResult.exitStatus.isSuccess else {
-            throw RunProcessNonZeroExitError(args: commandLine, workingDirectory: workingDirectory, environment: environment, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
+            throw RunProcessNonZeroExitError(args: commandLine, workingDirectory: workingDirectory, environment: .init(environment), status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
         }
         return try parse(ByteString(executionResult.stdout))
     }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -781,7 +781,7 @@ extension CoreClientDelegate {
             }
 
             return try await externalToolExecutionQueue.withOperation {
-                try await Process.getOutput(url: url, arguments: Array(commandLine.dropFirst()), currentDirectoryURL: workingDirectory.map(URL.init(fileURLWithPath:)), environment: ProcessInfo.processInfo.cleanEnvironment.merging(environment, uniquingKeysWith: { _, new in new }))
+                try await Process.getOutput(url: url, arguments: Array(commandLine.dropFirst()), currentDirectoryURL: workingDirectory.map(URL.init(fileURLWithPath:)), environment: Environment.current.addingContents(of: .init(environment)))
             }
         case let .result(status, stdout, stderr):
             return Processes.ExecutionResult(exitStatus: status, stdout: stdout, stderr: stderr)

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -472,7 +472,7 @@ public final class ToolchainRegistry: @unchecked Sendable {
             return
         }
 
-        if let swift = StackedSearchPath(environment: ProcessInfo.processInfo.cleanEnvironment, fs: fs).lookup(Path("swift")), fs.exists(swift) {
+        if let swift = StackedSearchPath(environment: .current, fs: fs).lookup(Path("swift")), fs.exists(swift) {
             let hasUsrBin = swift.normalize().str.hasSuffix("/usr/bin/swift")
             let hasUsrLocalBin = swift.normalize().str.hasSuffix("/usr/local/bin/swift")
             let path: Path

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -46,7 +46,7 @@ struct QNXEnvironmentExtension: EnvironmentExtension {
 
     func additionalEnvironmentVariables(context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String : String] {
         if let latest = try await plugin.cachedQNXSDPInstallations(host: context.hostOperatingSystem).first {
-            return latest.environment
+            return .init(latest.environment)
         }
         return [:]
     }

--- a/Sources/SWBQNXPlatform/QNXSDP.swift
+++ b/Sources/SWBQNXPlatform/QNXSDP.swift
@@ -28,11 +28,13 @@ struct QNXSDP: Sendable {
         self.sysroot = sysroot
         self.configurationPath = configurationPath
 
-        let environment = [
+        var environment: Environment = [
             "QNX_TARGET": sysroot.str,
-            "QNX_HOST": hostPath?.str,
             "QNX_CONFIGURATION_EXCLUSIVE": configurationPath.str,
-        ].compactMapValues { $0 }
+        ]
+        if let hostPath {
+            environment["QNX_HOST"] = hostPath.str
+        }
         self.environment = environment
 
         self.version = try await {
@@ -60,7 +62,7 @@ struct QNXSDP: Sendable {
     /// Equivalent to `QNX_HOST`.
     public let hostPath: Path?
 
-    public let environment: [String: String]
+    public let environment: Environment
 
     private static func hostPath(host: OperatingSystem, path: Path) -> Path? {
         switch host {

--- a/Sources/SWBTaskExecution/TaskActions/EmbedSwiftStdLibTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/EmbedSwiftStdLibTaskAction.swift
@@ -525,7 +525,7 @@ public final class EmbedSwiftStdLibTaskAction: TaskAction {
             }
 
             guard !failed else {
-                throw RunProcessNonZeroExitError(args: args, workingDirectory: task.workingDirectory.str, environment: effectiveEnvironment, status: {
+                throw RunProcessNonZeroExitError(args: args, workingDirectory: task.workingDirectory.str, environment: .init(effectiveEnvironment), status: {
                     if case let .exit(exitStatus, _) = processDelegate.outputDelegate.result {
                         return exitStatus
                     }

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1918,7 +1918,7 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
                     if !self.hadErrors {
                         switch result {
                         case let .exit(exitStatus, _) where !exitStatus.isSuccess && !exitStatus.wasCanceled:
-                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory.str, environment: task.environment.bindingsDictionary, status: exitStatus, mergedOutput: output).description)"))))
+                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory.str, environment: .init(task.environment.bindingsDictionary), status: exitStatus, mergedOutput: output).description)"))))
                         case .failedSetup:
                             self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed setup."))))
                         case .exit, .skipped:

--- a/Sources/SWBTestSupport/EnvironmentKey.swift
+++ b/Sources/SWBTestSupport/EnvironmentKey.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+
+extension EnvironmentKey {
+    public static let externalToolchainsDir = Self("EXTERNAL_TOOLCHAINS_DIR")
+}

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -215,13 +215,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    package static func skipIfEnvironment(key: String, value: String) -> Self {
+    package static func skipIfEnvironment(key: EnvironmentKey, value: String) -> Self {
         disabled("environment sets '\(key)' to '\(value)'") {
             getEnvironmentVariable(key) == value
         }
     }
 
-    package static func skipIfEnvironmentVariableSet(key: String) -> Self {
+    package static func skipIfEnvironmentVariableSet(key: EnvironmentKey) -> Self {
         disabled("environment sets '\(key)'") {
             getEnvironmentVariable(key) != nil
         }

--- a/Sources/SWBUtil/EnvironmentHelpers.swift
+++ b/Sources/SWBUtil/EnvironmentHelpers.swift
@@ -12,25 +12,25 @@
 
 import Foundation
 
-@TaskLocal fileprivate var processEnvironment = ProcessInfo.processInfo.environment
+@TaskLocal fileprivate var processEnvironment = Environment.current
 
 /// Binds the internal defaults to the specified `environment` for the duration of the synchronous `operation`.
 /// - parameter clean: `true` to start with a clean environment, `false` to merge the input environment over the existing process environment.
 /// - note: This is implemented via task-local values.
-@_spi(Testing) public func withEnvironment<R>(_ environment: [String: String], clean: Bool = false, operation: () throws -> R) rethrows -> R {
+@_spi(Testing) public func withEnvironment<R>(_ environment: Environment, clean: Bool = false, operation: () throws -> R) rethrows -> R {
     try $processEnvironment.withValue(clean ? environment : processEnvironment.addingContents(of: environment), operation: operation)
 }
 
 /// Binds the internal defaults to the specified `environment` for the duration of the asynchronous `operation`.
 /// - parameter clean: `true` to start with a clean environment, `false` to merge the input environment over the existing process environment.
 /// - note: This is implemented via task-local values.
-@_spi(Testing) public func withEnvironment<R>(_ environment: [String: String], clean: Bool = false, operation: () async throws -> R) async rethrows -> R {
+@_spi(Testing) public func withEnvironment<R>(_ environment: Environment, clean: Bool = false, operation: () async throws -> R) async rethrows -> R {
     try await $processEnvironment.withValue(clean ? environment : processEnvironment.addingContents(of: environment), operation: operation)
 }
 
 /// Gets the value of the named variable from the process' environment.
 /// - parameter name: The name of the environment variable.
 /// - returns: The value of the variable as a `String`, or `nil` if it is not defined in the environment.
-public func getEnvironmentVariable(_ name: String) -> String? {
+public func getEnvironmentVariable(_ name: EnvironmentKey) -> String? {
     processEnvironment[name]
 }

--- a/Sources/SWBUtil/EnvironmentKey.swift
+++ b/Sources/SWBUtil/EnvironmentKey.swift
@@ -25,6 +25,10 @@ extension EnvironmentKey {
     package static let path: Self = "PATH"
 }
 
+extension EnvironmentKey {
+    package static let developerDir: Self = "DEVELOPER_DIR"
+}
+
 extension EnvironmentKey: CodingKeyRepresentable {}
 
 extension EnvironmentKey: Comparable {

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -80,7 +80,7 @@ fileprivate func xSecCodePathIsSigned(_ path: Path) throws -> Bool {
 
 // FIXME: Move this fully to Swift Concurrency and execute the process via llbuild after PbxCp is fully converted to Swift
 /// Spawns a process and waits for it to finish, closing stdin and redirecting stdout and stderr to fdout. Failure to launch, non-zero exit code, or exit with a signal will throw an error.
-fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ environment: [String: String]?, _ workingDirPath: String?, _ dryRun: Bool, _ stream: OutputByteStream) async throws {
+fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ environment: Environment?, _ workingDirPath: String?, _ dryRun: Bool, _ stream: OutputByteStream) async throws {
     stream <<< launchPath.str
     for arg in arguments ?? [] {
         stream <<< " \(arg)"
@@ -97,7 +97,7 @@ fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ 
     stream <<< "\(String(decoding: output, as: UTF8.self))"
 
     if !exitStatus.isSuccess {
-        throw RunProcessNonZeroExitError(args: [launchPath.str] + (arguments ?? []), workingDirectory: workingDirPath, environment: environment ?? [:], status: exitStatus, mergedOutput: ByteString(output))
+        throw RunProcessNonZeroExitError(args: [launchPath.str] + (arguments ?? []), workingDirectory: workingDirPath, environment: environment ?? .init(), status: exitStatus, mergedOutput: ByteString(output))
     }
 }
 

--- a/Sources/SWBUtil/UserDefaults.swift
+++ b/Sources/SWBUtil/UserDefaults.swift
@@ -361,7 +361,7 @@ public let xcodeUserDefaultsToExportToSwiftBuild = [
 
 /// Global function which exports the supplied user default key, if present in the standard UserDefaults, to the process environment if it has not already been set.
 public func exportUserDefaultToEnvironment(_ key: String) {
-    if let _ = getEnvironmentVariable(key) {
+    if let _ = getEnvironmentVariable(EnvironmentKey(key)) {
         // do not override existing environment variable
         return
     }

--- a/Sources/SWBUtil/Xcode.swift
+++ b/Sources/SWBUtil/Xcode.swift
@@ -24,7 +24,7 @@ public enum Xcode: Sendable {
             throw StubError.error("\(xcodeSelectPath.str) does not exist")
         }
 
-        let environment = getEnvironmentVariable("DEVELOPER_DIR").map { ["DEVELOPER_DIR": $0] } ?? [:]
+        let environment = Environment.current.filter { $0.key == .developerDir }
         let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: xcodeSelectPath.str), arguments: ["-p"], environment: environment)
         if !executionResult.exitStatus.isSuccess {
             throw RunProcessNonZeroExitError(args: [xcodeSelectPath.str, "-p"], workingDirectory: nil, environment: environment, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -144,11 +144,11 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                 results.checkNoErrors()
 
                 let toolchain = try #require(core.toolchainRegistry.defaultToolchain)
-                let environment: [String: String]
+                let environment: Environment
                 if destination.imageFormat(core) == .elf {
                     environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
                 } else {
-                    environment = [:]
+                    environment = .init()
                 }
 
                 let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix)").join(core.hostOperatingSystem.imageFormat.executableName(basename: "tool")).str), arguments: [], environment: environment)
@@ -377,11 +377,11 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                 }
 
                 let toolchain = try #require(try await getCore().toolchainRegistry.defaultToolchain)
-                let environment: [String: String]
+                let environment: Environment
                 if destination.platform == "linux" {
                     environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/linux").str]
                 } else {
-                    environment = [:]
+                    environment = .init()
                 }
 
                 let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix)").join(core.hostOperatingSystem.imageFormat.executableName(basename: "tool")).str), arguments: [], environment: environment)

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -303,7 +303,7 @@ import Foundation
         }
     }
 
-    @Test(.skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
+    @Test(.skipIfEnvironmentVariableSet(key: .externalToolchainsDir))
     func externalToolchainsDir() async throws {
         try await withTemporaryDirectory { tmpDir in
             let originalToolchain = try await toolchainPathsCount()
@@ -352,13 +352,13 @@ import Foundation
     }
 
     func testExternalToolchainPath(withSetEnv externalToolchainPathsString: String?, expecting expectedPathStrings: [String], _ originalToolchainCount: Int) async throws {
-        var env = ProcessInfo.processInfo.environment.filter { $0.key != "EXTERNAL_TOOLCHAINS_DIR" }
+        var env = Environment.current.filter { $0.key != .externalToolchainsDir }
         if let externalToolchainPathsString {
-            env["EXTERNAL_TOOLCHAINS_DIR"] = externalToolchainPathsString
+            env[.externalToolchainsDir] = externalToolchainPathsString
         }
 
         try await withEnvironment(env, clean: true) {
-            #expect(getEnvironmentVariable("EXTERNAL_TOOLCHAINS_DIR") == externalToolchainPathsString)
+            #expect(getEnvironmentVariable(.externalToolchainsDir) == externalToolchainPathsString)
 
             try await testExternalToolchainPath(environmentOverrides: [:], expecting: expectedPathStrings, originalToolchainCount)
         }

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -2042,7 +2042,7 @@ import SWBMacro
     func toolchainBuildSettings() async throws {
         let fs = localFS
         try await withTemporaryDirectory(fs: fs) { toolchainsDir in
-            try await withEnvironment(["EXTERNAL_TOOLCHAINS_DIR": toolchainsDir.str]) {
+            try await withEnvironment([.externalToolchainsDir: toolchainsDir.str]) {
                 // Add in our custom toolchain.
                 try fs.createDirectory(toolchainsDir.join("org.swift.testoss.xctoolchain"), recursive: true)
                 try await fs.writePlist(toolchainsDir.join("org.swift.testoss.xctoolchain").join("Info.plist"), .plDict([

--- a/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
+++ b/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
@@ -157,7 +157,7 @@ import SWBTestSupport
     }
 
     /// Test that default and overriding build settings defined in a toolchain are exported.
-    @Test(.requireHostOS(.macOS), .skipIfEnvironmentVariableSet(key: "EXTERNAL_TOOLCHAINS_DIR"))
+    @Test(.requireHostOS(.macOS), .skipIfEnvironmentVariableSet(key: .externalToolchainsDir))
     func exportingToolchainSettings() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             // Toolchains are only loaded from the localFS, so we can't use a PseudoFS here.
@@ -178,8 +178,8 @@ import SWBTestSupport
             ])
 
             // Configure the test data.
-            let environment = ["EXTERNAL_TOOLCHAINS_DIR": toolchainDirPath.str]
-            let core = try await Self.makeCore(environment: environment)
+            let environment: Environment = [.externalToolchainsDir: toolchainDirPath.str]
+            let core = try await Self.makeCore(environment: .init(environment))
             let testWorkspace = try TestWorkspace(
                 "Workspace",
                 projects: [TestProject(
@@ -201,7 +201,7 @@ import SWBTestSupport
                         )
                     ])
                 ]).load(core)
-            let context = try await contextForTestData(testWorkspace, core: core, environment: environment)
+            let context = try await contextForTestData(testWorkspace, core: core, environment: .init(environment))
             let buildRequestContext = BuildRequestContext(workspaceContext: context)
             let testProject = context.workspace.projects[0]
             let testTarget = testProject.targets[0]

--- a/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
@@ -171,7 +171,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
 
     @Test(.requireSDKs(.driverKit), arguments: [true, false])
     func driverKitFrameworkInstallHeaders(trace: Bool) async throws {
-        var env = ProcessInfo.processInfo.environment.filter { $0.key != "IIG_TRACE_HEADERS" }
+        var env = Environment.current.filter { $0.key != EnvironmentKey("IIG_TRACE_HEADERS") }
         if trace {
             env["IIG_TRACE_HEADERS"] = "1"
         }

--- a/Tests/SWBTaskExecutionTests/TaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/TaskTestSupport.swift
@@ -63,7 +63,7 @@ class MockDynamicTaskExecutionDelegate: DynamicTaskExecutionDelegate {
             throw StubError.error("Invalid number of arguments")
         }
 
-        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: commandLine[0]), arguments: Array(commandLine.dropFirst()), currentDirectoryURL: URL(fileURLWithPath: workingDirectory), environment: environment)
+        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: commandLine[0]), arguments: Array(commandLine.dropFirst()), currentDirectoryURL: URL(fileURLWithPath: workingDirectory), environment: .init(environment))
 
         // FIXME: Pass the real PID
         let pid = llbuild_pid_t.invalid

--- a/Tests/SWBUtilTests/ProcessTests.swift
+++ b/Tests/SWBUtilTests/ProcessTests.swift
@@ -105,7 +105,7 @@ fileprivate struct ProcessTests {
         #expect(result.exitStatus == .exit(42))
     }
 
-    @Test(.enabled(if: StackedSearchPath(environment: ProcessInfo.processInfo.environment, fs: localFS).lookup(Path("clang")) != nil, "requires clang in PATH"))
+    @Test(.enabled(if: StackedSearchPath(environment: .current, fs: localFS).lookup(Path("clang")) != nil, "requires clang in PATH"))
     func uncaughtSignal() async throws {
         try await withTemporaryDirectory { tmpDir in
             let mainCPath = tmpDir.join("main.c").str

--- a/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
@@ -80,21 +80,21 @@ final class CLIConnection {
         }
     }
 
-    static var environment: [String: String] {
-        var env = ProcessInfo.processInfo.environment.filter(keys: [
+    static var environment: Environment {
+        var env = Environment.current.filter(keys: [
             "PATH", // important to allow swift to be looked up in PATH on Windows/Linux
             "DEVELOPER_DIR",
             "DYLD_FRAMEWORK_PATH",
             "DYLD_LIBRARY_PATH",
             "LLVM_PROFILE_FILE",
             "MallocNanoZone"
-        ]).addingContents(of: [
+        ]).addingContents(of: Environment([
             // Prevent locally-enabled MSL from failing several tests because MSL prints messages to standard output streams.
             "EnableMallocStackLoggingLiteOnStart": "0"
-        ])
+        ]))
         // For Windows when running in an IDE like VS Code
-        if env["PATH"] == nil, let swiftRuntimePath = try? swiftRuntimePath() {
-            env["PATH"] = swiftRuntimePath.str
+        if env[.path] == nil, let swiftRuntimePath = try? swiftRuntimePath() {
+            env[.path] = swiftRuntimePath.str
         }
         // Required to be set for Process.run to function
         if env["SystemRoot"] == nil, let systemRoot = try? systemRoot() {
@@ -128,7 +128,7 @@ final class CLIConnection {
         task.standardInput = sessionHandle
         task.standardOutput = sessionHandle
         task.standardError = sessionHandle
-        task.environment = Self.environment
+        task.environment = .init(Self.environment)
         do {
             exitPromise = try task.launch()
         } catch {

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -26,7 +26,7 @@ fileprivate struct ServiceConsoleTests {
         // Test against a non-pty.
         let task = SWBUtil.Process()
         task.executableURL = try CLIConnection.swiftbuildToolURL
-        task.environment = CLIConnection.environment
+        task.environment = .init(CLIConnection.environment)
 
         task.standardInput = FileHandle.nullDevice
         try await withExtendedLifetime(Pipe()) { outputPipe in

--- a/Tests/SwiftBuildTests/ValidationTests.swift
+++ b/Tests/SwiftBuildTests/ValidationTests.swift
@@ -24,7 +24,7 @@ fileprivate struct ValidationTests: CoreBasedTests {
         let url = URL(fileURLWithPath: testPath.str)
 
         // Propagate a standard environment.
-        var environment: [String: String] = ProcessInfo.processInfo.environment.filter(keys: ["HOME", "PATH", "SDKROOT", "TOOLCHAINS", "DEVELOPER_DIR", "LLVM_PROFILE_FILE", "DYLD_FRAMEWORK_PATH", "DYLD_LIBRARY_PATH", "CI"])
+        var environment: Environment = .current.filter(keys: ["HOME", "PATH", "SDKROOT", "TOOLCHAINS", "DEVELOPER_DIR", "LLVM_PROFILE_FILE", "DYLD_FRAMEWORK_PATH", "DYLD_LIBRARY_PATH", "CI"])
 
         // If llbuild hasn't been build there are two scenarios:
         //     - in Debug it will link against the one in build products dir


### PR DESCRIPTION
Mostly starting at the "edges", in tests and in some central APIs. Does nothing for Unix-like platforms, but will fix some case sensitivity issues on Windows when accessing specific environment variables.

Closes #296