### PR TITLE
Add missing SWBUtil files to CMakeLists

### DIFF
--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(SWBUtil
   ElapsedTimer.swift
   EmptyState.swift
   Environment.swift
+  EnvironmentKey.swift
+  EnvironmentHelpers.swift
   Error.swift
   FileHandle+Async.swift
   FilesSignature.swift


### PR DESCRIPTION
Reverts swiftlang/swift-build#298 as it broke the Windows bots