### PR TITLE
[SwiftCaching] Improve swift caching batch build performance

### DIFF
--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingDynamicTaskSpec.swift
@@ -23,12 +23,12 @@ final class SwiftCachingKeyQueryDynamicTaskSpec: DynamicTaskSpec {
             type: self,
             payload: nil,
             forTarget: dynamicTask.target,
-            ruleInfo: ["SwiftCachingKeyQuery", swiftCachingKeyQueryTaskKey.cacheKey],
-            commandLine: ["builtin-swiftCachingKeyQuery", .literal(ByteString(encodingAsUTF8: swiftCachingKeyQueryTaskKey.cacheKey))],
+            ruleInfo: ["SwiftCachingKeyQuery", swiftCachingKeyQueryTaskKey.cacheKeys.description],
+            commandLine: ["builtin-swiftCachingKeyQuery", .literal(ByteString(encodingAsUTF8: swiftCachingKeyQueryTaskKey.cacheKeys.description))],
             environment: dynamicTask.environment,
             workingDirectory: dynamicTask.workingDirectory,
             showEnvironment: dynamicTask.showEnvironment,
-            execDescription: "Swift caching query key \(swiftCachingKeyQueryTaskKey.cacheKey)",
+            execDescription: "Swift caching query key \(swiftCachingKeyQueryTaskKey.cacheKeys)",
             priority: .network,
             isDynamic: true
         )
@@ -57,12 +57,12 @@ final class SwiftCachingMaterializeKeyDynamicTaskSpec: DynamicTaskSpec {
             type: self,
             payload: nil,
             forTarget: dynamicTask.target,
-            ruleInfo: ["SwiftCachingKeyMaterializer", swiftCachingTaskKey.cacheKey],
-            commandLine: ["builtin-swiftCachingKeyMaterializer", .literal(ByteString(encodingAsUTF8: swiftCachingTaskKey.cacheKey))],
+            ruleInfo: ["SwiftCachingKeyMaterializer", swiftCachingTaskKey.cacheKeys.description],
+            commandLine: ["builtin-swiftCachingKeyMaterializer", .literal(ByteString(encodingAsUTF8: swiftCachingTaskKey.cacheKeys.description))],
             environment: dynamicTask.environment,
             workingDirectory: dynamicTask.workingDirectory,
             showEnvironment: dynamicTask.showEnvironment,
-            execDescription: "Swift caching materialize key \(swiftCachingTaskKey.cacheKey)",
+            execDescription: "Swift caching materialize key \(swiftCachingTaskKey.cacheKeys)",
             priority: .network,
             isDynamic: true
         )

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingTaskKeys.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingTaskKeys.swift
@@ -15,19 +15,19 @@ public import SWBUtil
 
 public struct SwiftCachingKeyQueryTaskKey: Serializable, CustomDebugStringConvertible {
     let casOptions: CASOptions
-    let cacheKey: String
+    let cacheKeys: [String]
     let compilerLocation: LibSwiftDriver.CompilerLocation
 
-    init(casOptions: CASOptions, cacheKey: String, compilerLocation: LibSwiftDriver.CompilerLocation) {
+    init(casOptions: CASOptions, cacheKeys: [String], compilerLocation: LibSwiftDriver.CompilerLocation) {
         self.casOptions = casOptions
-        self.cacheKey = cacheKey
+        self.cacheKeys = cacheKeys
         self.compilerLocation = compilerLocation
     }
 
     public func serialize<T>(to serializer: T) where T : Serializer {
         serializer.serializeAggregate(3) {
             serializer.serialize(casOptions)
-            serializer.serialize(cacheKey)
+            serializer.serialize(cacheKeys)
             serializer.serialize(compilerLocation)
         }
     }
@@ -35,12 +35,12 @@ public struct SwiftCachingKeyQueryTaskKey: Serializable, CustomDebugStringConver
     public init(from deserializer: any Deserializer) throws {
         try deserializer.beginAggregate(3)
         casOptions = try deserializer.deserialize()
-        cacheKey = try deserializer.deserialize()
+        cacheKeys = try deserializer.deserialize()
         compilerLocation = try deserializer.deserialize()
     }
 
     public var debugDescription: String {
-        "<SwiftCachingKeyQuery casOptions=\(casOptions) cacheKey=\(cacheKey) compilerLocation=\(compilerLocation)>"
+        "<SwiftCachingKeyQuery casOptions=\(casOptions) cacheKey=\(cacheKeys) compilerLocation=\(compilerLocation)>"
     }
 }
 

--- a/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
@@ -45,9 +45,15 @@ public final class SwiftCachingKeyQueryTaskAction: TaskAction {
 
             do {
                 // Request global query to get maximum search space that the database supports
-                let cacheHit = try await cas.queryCacheKey(key.cacheKey, globally: true) != nil
-                if key.casOptions.enableDiagnosticRemarks {
-                    outputDelegate.remark("cache key query \(cacheHit ? "hit" : "miss")")
+                for cacheKey in key.cacheKeys {
+                    let cacheHit = try await cas.queryCacheKey(cacheKey, globally: true) != nil
+                    if key.casOptions.enableDiagnosticRemarks {
+                        outputDelegate.remark("cache key query \(cacheHit ? "hit" : "miss")")
+                    }
+                    guard cacheHit else {
+                        // return on first failure.
+                        return .succeeded
+                    }
                 }
             } catch {
                 guard !key.casOptions.enableStrictCASErrors else { throw error }


### PR DESCRIPTION
Improve swift caching build performance, especially batch build performance by:
* Use more accurate dependency tracking by requesting cache key querying jobs in parallel when requesting all the explicit module dependencies. This allows build system to plan cache key querying jobs in the gaps of explicit module build, thus the compilation job can start sooner.
* Instead of issuing multiple key queries per batched job, issue one key querying job for multiple keys instead. This can dramatically reduce the number of jobs planned thus improves the efficiency. Also in the cache miss cases, if the first key hits the cache miss, there is no need to continue querying other keys since the job needs to be run anyway.

rdar://146429825
