### PR TITLE
[TEST-ONLY] Partial revert #302

### DIFF
--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -19,7 +19,8 @@ import SWBTestSupport
 import SWBUtil
 
 @Suite(.skipHostOS(.windows, "Windows platform has no CAS support yet"),
-       .requireCompilationCaching, .requireDependencyScannerPlusCaching)
+       .requireCompilationCaching, .requireDependencyScannerPlusCaching,
+       .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
 fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
     let canUseCASPlugin: Bool
     let canUseCASPruning: Bool

--- a/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
@@ -191,7 +191,8 @@ fileprivate struct ClangModuleVerifierTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching, .requireCompilationCaching)
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching, .requireCompilationCaching,
+          .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
     func cachedBuild() async throws {
         try await withTemporaryDirectory { (tmpDirPath: Path) in
             let archs = ["arm64", "x86_64"]

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -18,7 +18,8 @@ import SWBUtil
 
 import SWBTaskExecution
 
-@Suite(.requireSwiftFeatures(.compilationCaching), .requireCompilationCaching)
+@Suite(.requireSwiftFeatures(.compilationCaching), .requireCompilationCaching,
+       .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
 fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))
     func swiftCachingSimple() async throws {


### PR DESCRIPTION
Unfortunately, caching tests are still flaky in some CI infrastructure. Partially revert by keeping the `.flaky` tags but leaving the test fixes.
