### PR TITLE
Update the list of supported Windows archs

### DIFF
--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -146,7 +146,13 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
                 ].merging(defaultProperties, uniquingKeysWith: { _, new in new })),
                 "SupportedTargets": .plDict([
                     "windows": .plDict([
-                        "Archs": .plArray([.plString("x86_64"), .plString("i686"), .plString("aarch64"), .plString("thumbv7")]),
+                        "Archs": .plArray([
+                            .plString("aarch64"),
+                            .plString("arm64ec"),
+                            .plString("armv7"),
+                            .plString("i686"),
+                            .plString("x86_64"),
+                        ]),
                         "LLVMTargetTripleEnvironment": .plString("msvc"),
                         "LLVMTargetTripleSys": .plString("windows"),
                         "LLVMTargetTripleVendor": .plString("unknown"),


### PR DESCRIPTION
Change thumbv7 to armv7 -- even though it gets canonicalized as such internally, armv7 is the spelling given throughout the LLVM codebase. Also add the triple for the ARM64EC ABI (https://learn.microsoft.com/en-us/windows/arm/arm64ec)