### PR TITLE
Ensure we use ConfiguredTarget GUID comparison to avoid diagnosing a Swift -> Clang module dependency as missing

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -861,7 +861,12 @@ package final class BuildOperation: BuildSystemOperation {
                 return
             }
 
-            let message = DiagnosticData("'\(target.target.name)' is missing a dependency on '\(antecedent.target.name)' because \(reason)")
+            let message: DiagnosticData
+            if self.userPreferences.enableDebugActivityLogs {
+                message = DiagnosticData("'\(target.target.name):\(target.guid.stringValue)' is missing a dependency on '\(antecedent.target.name):\(antecedent.guid.stringValue)' because \(reason)")
+            } else {
+                message = DiagnosticData("'\(target.target.name)' is missing a dependency on '\(antecedent.target.name)' because \(reason)")
+            }
             switch warningLevel {
             case .yes:
                 buildOutputDelegate.emit(Diagnostic(behavior: .warning, location: .unknown, data: message))

--- a/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
@@ -198,7 +198,7 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
 
         if let target = task.forTarget {
             for requiredDependency in result.requiredTargetDependencies {
-                guard requiredDependency.target != task.forTarget else {
+                guard requiredDependency.target.guid != task.forTarget?.guid else {
                     continue
                 }
                 executionDelegate.taskDiscoveredRequiredTargetDependency(target: target, antecedent: requiredDependency.target, reason: .clangModuleDependency(translationUnit: explicitModulesPayload.sourcePath, dependencyModuleName: requiredDependency.moduleName), warningLevel: explicitModulesPayload.reportRequiredTargetDependencies)

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
@@ -99,7 +99,7 @@ final public class SwiftDriverTaskAction: TaskAction, BuildValueValidatingTaskAc
                 for dependencyModuleName in dependencyModuleNames {
                     if let targetDependencies = dynamicExecutionDelegate.operationContext.definingTargetsByModuleName[dependencyModuleName] {
                         for targetDependency in targetDependencies {
-                            guard targetDependency != target else {
+                            guard targetDependency.guid != target.guid else {
                                 continue
                             }
                             executionDelegate.taskDiscoveredRequiredTargetDependency(target: target, antecedent: targetDependency, reason: .swiftModuleDependency(dependentModuleName: driverPayload.moduleName, dependencyModuleName: dependencyModuleName), warningLevel: driverPayload.reportRequiredTargetDependencies)


### PR DESCRIPTION


ConfiguredTarget identity may change when loading a cached build description, so ensure we use GUID comparison where needed

rdar://144708654

