### PR TITLE
Exclude llvm-cas://URLs from the module report

### DIFF
--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -256,12 +256,19 @@ public final class SwiftModuleDependencyGraph: SwiftGlobalExplicitDependencyGrap
             summaryCSV.writeRow([moduleID, "\(jobs.count)"])
             summaryMessage += "\(moduleID): \(jobs.count == 1 ? "1 variant" : "\(jobs.count) variants")\n"
 
-            let mergeResult = nWayMerge(jobs.map { $0.commandLine.map { $0.asString } }).filter {
+            let mergeResult = nWayMerge(jobs.map { $0.commandLine.filter {
+                if ["pcm", "dia", "d"].contains(Path($0).fileExtension) {
+                    // Filter differences in module paths, they are a function of the other args
+                    return false
+                } else if $0.hasPrefix("llvmcas://") {
+                    // Filter differences in CAS URLs, they are a function of the other args
+                    return false
+                } else {
+                    return true
+                }
+            }.map { $0.asString } }).filter {
                 if $0.elementOf.count == jobs.count {
                     // Don't report args common to all variants
-                    return false
-                } else if ["pcm", "dia", "d"].contains(Path($0.element).fileExtension) {
-                    // Don't report differences in module paths, they are a function of the other args
                     return false
                 } else {
                     return true


### PR DESCRIPTION
Differences in these IDs are captured elsewhere, they're not useful to show to the user in the report, and diffing them is expensive

rdar://146320247

