### PR TITLE
Fix unsafeToInterrupt on Amazon Linux 2

### DIFF
--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -1054,7 +1054,7 @@ final class OperationDelegate: BuildOperationDelegate {
         request.send(BuildOperationReportPathMap(copiedPathMap: copiedPathMap, generatedFilesPathMap: generatedFilesPathMap))
     }
 
-    func buildComplete(_ operation: any BuildSystemOperation, status: BuildOperationEnded.Status?, delegate: any BuildOutputDelegate, metrics: BuildOperationMetrics?) {
+    func buildComplete(_ operation: any BuildSystemOperation, status: BuildOperationEnded.Status?, delegate: any BuildOutputDelegate, metrics: BuildOperationMetrics?) -> BuildOperationEnded.Status {
         if !skipCommandLevelInformation {
             // Kick the target callbacks so that our target-level diagnostics get emitted in the right context in the case of an early build failure due to task construction errors.
             for target in diagnosticsHandler.deferredTargets {
@@ -1062,7 +1062,9 @@ final class OperationDelegate: BuildOperationDelegate {
                 targetComplete(operation, configuredTarget: target)
             }
         }
-        activeBuild.completeBuild(status: status ?? taskCompletionBasedStatus, metrics: metrics)
+        let realStatus = status ?? taskCompletionBasedStatus
+        activeBuild.completeBuild(status: realStatus, metrics: metrics)
+        return realStatus
     }
 
     private func getActiveTargetInfo(_ operation: any BuildSystemOperation, _ configuredTarget: ConfiguredTarget) -> TargetInfo {

--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -12,6 +12,7 @@
 
 package import SWBCore
 import SWBTaskExecution
+package import SWBProtocol
 package import SWBUtil
 
 package import class Foundation.FileManager
@@ -61,7 +62,7 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
         return try BuildDescriptionManager.cacheDirectory(buildRequest, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext).join("XCBuildData")
     }
 
-    package func build() async {
+    package func build() async -> BuildOperationEnded.Status {
         let buildOutputDelegate = delegate.buildStarted(self)
 
         if workspaceContext.userPreferences.enableDebugActivityLogs {
@@ -103,7 +104,7 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
 
         cleanBuildFolders(buildFolders: Set(buildFolders), buildOutputDelegate: buildOutputDelegate)
 
-        delegate.buildComplete(self, status: nil, delegate: buildOutputDelegate, metrics: nil)
+        return delegate.buildComplete(self, status: nil, delegate: buildOutputDelegate, metrics: nil)
     }
 
     package func cancel() {
@@ -205,7 +206,7 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
         delegate.targetPreparationStarted(self, configuredTarget: configuredTarget)
         delegate.targetStarted(self, configuredTarget: configuredTarget)
 
-        let (executable, arguments, workingDirectory, environment) = constructCommandLine(for: configuredTarget.target as! ExternalTarget, action: "clean", settings: settings, workspaceContext: workspaceContext, scope: settings.globalScope)
+        let (executable, arguments, workingDirectory, environment) = constructCommandLine(for: configuredTarget.target as! SWBCore.ExternalTarget, action: "clean", settings: settings, workspaceContext: workspaceContext, scope: settings.globalScope)
         let commandLine = [executable] + arguments
 
         let specLookupContext = SpecLookupCtxt(specRegistry: workspaceContext.core.specRegistry, platform: settings.platform)

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1995,11 +1995,12 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
         return TesterBuildOutputDelegate(delegate: self)
     }
 
-    func buildComplete(_ operation: any BuildSystemOperation, status: BuildOperationEnded.Status?, delegate: any BuildOutputDelegate, metrics: BuildOperationMetrics?) {
+    func buildComplete(_ operation: any BuildSystemOperation, status: BuildOperationEnded.Status?, delegate: any BuildOutputDelegate, metrics: BuildOperationMetrics?) -> BuildOperationEnded.Status {
         queue.async {
             // There is no "build failed" event, so only explicit cancellation needs to map to `buildCancelled`
             self.events.append(status == .cancelled ? .buildCancelled : .buildCompleted)
         }
+        return status ?? .succeeded
     }
 
     func targetPreparationStarted(_ operation: any BuildSystemOperation, configuredTarget: ConfiguredTarget) {


### PR DESCRIPTION
This distro is going EoL in July, but fix the test anyways for better future-proofing.

What happens is that the task fails to execute because there is no working directory support on Amazon Linux 2, so the build fails. However, in that case the background task which waits for the sentinel file to be written will run forever. Ensure that we cancel the background task in cases where the build has completed.