### PR TITLE
When an object file is in the Frameworks build phase of a static library target, don't add it to both the command line and the link-file-list of the libtool task.

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -1521,9 +1521,8 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
                 }
 
             case .object:
-                // A static library can bring in the contents of a .o file.
-                inputPaths.append(specifier.path)
-                return [specifier.path.str]
+                // Object files are added to linker inputs in the sources task producer and so end up in the link-file-list.
+                return []
 
             case .framework:
                 // A static library can build against a framework, since the library in the framework could be a static library, which is valid, and we can't tell here whether it is or not.  So we leave it to libtool to do the right thing here.

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1261,11 +1261,10 @@ import SWBMacro
         }
         var libraries = [LinkerSpec.LibrarySpecifier]()
         for kind in LinkerSpec.LibrarySpecifier.Kind.allCases {
-            guard kind != .object else {
-                continue
-            }
             libraries.append(contentsOf: generateLibrarySpecifiers(kind: kind))
         }
+        // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
+        libraries.append(LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]))
 
         await linkerSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 
@@ -1501,6 +1500,9 @@ import SWBMacro
             LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo2.framework"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
             LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo3.framework"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
             LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo4.framework"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+
+            // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
+            LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
         ]
         await librarianSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 


### PR DESCRIPTION
This matches the behavior for ld of only putting it in the link-file-list.

Also modify some tests to check this behavior.

rdar://136958525