### PR TITLE
Add some missing test annotations and fix run destinations

### DIFF
--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -24,8 +24,7 @@ import class Foundation.ProcessInfo
 
 @Suite
 fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
-
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
     func outputParsing() async throws {
         try await withTemporaryDirectory { tmpDir in
             let destination: RunDestinationInfo = .host

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -179,7 +179,7 @@ fileprivate struct LinkerTests: CoreBasedTests {
     /// * The clang output on Windows has paths that have double slashes, not
     ///   quite valid command quoted. i.e. "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC"
     ///   This needs to be taken into account.
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
     func alternateLinkerSelection() async throws {
         let runDestination: RunDestinationInfo = .host
         let swiftVersion = try await self.swiftVersion

--- a/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
@@ -20,7 +20,7 @@ import SWBTaskExecution
 
 @Suite
 fileprivate struct SwiftBuildTraceTests: CoreBasedTests {
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
     func swiftBuildTraceEmission() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             try await withEnvironment(["SWIFTBUILD_TRACE_FILE": tmpDirPath.join(".SWIFTBUILD_TRACE").str]) {


### PR DESCRIPTION
Fix some .macOS run destinations that should have been moved to .host when the tests themselves were, and add .requireThreadSafeWorkingDirectory annotations to relevant tests.