### PR TITLE
Fix perfTestSpecLoading crash

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -382,7 +382,7 @@ public final class Core: Sendable {
 
     private var _specRegistry: SpecRegistry?
 
-    private func initializePlatformRegistry() async {
+    @_spi(Testing) public func initializePlatformRegistry() async {
         var searchPaths: [Path]
         let fs = localFS
         if let onlySearchAdditionalPlatformPaths = getEnvironmentVariable("XCODE_ONLY_EXTRA_PLATFORM_FOLDERS"), onlySearchAdditionalPlatformPaths.boolValue {

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -157,6 +157,9 @@ extension Core {
         // Force the spec registry to load.
         await core.initializeSpecRegistry()
 
+        // 'loadAllSpecs' uses the platform registry, and needs to be initalized since core.platformRegistry is a delayed init property.
+        await core.initializePlatformRegistry()
+
         core.loadAllSpecs()
     }
 }


### PR DESCRIPTION
The perfTestSpecLoading function initailzes the Core class and the calls into core.loadAllSpecs which accesses core.platfromRegistry that has not been initailzed yet.

Call 'core.initializePlatformRegistry' inside the function to initailze the platformRegistry property.