### PR TITLE
Validate embedded frameworks

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -246,6 +246,7 @@ public final class BuiltinMacros {
     public static let SEPARATE_SYMBOL_EDIT = BuiltinMacros.declareBooleanMacro("SEPARATE_SYMBOL_EDIT")
     public static let SKIP_INSTALL = BuiltinMacros.declareBooleanMacro("SKIP_INSTALL")
     public static let SKIP_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("SKIP_CLANG_STATIC_ANALYZER")
+    public static let SKIP_EMBEDDED_FRAMEWORKS_VALIDATION = BuiltinMacros.declareBooleanMacro("SKIP_EMBEDDED_FRAMEWORKS_VALIDATION")
     public static let STRINGSDATA_DIR = BuiltinMacros.declarePathMacro("STRINGSDATA_DIR")
     public static let STRIP_BITCODE_FROM_COPIED_FILES = BuiltinMacros.declareBooleanMacro("STRIP_BITCODE_FROM_COPIED_FILES")
     public static let STRIP_INSTALLED_PRODUCT = BuiltinMacros.declareBooleanMacro("STRIP_INSTALLED_PRODUCT")
@@ -2113,6 +2114,7 @@ public final class BuiltinMacros {
         SHARED_SUPPORT_FOLDER_PATH,
         SKIP_INSTALL,
         SKIP_CLANG_STATIC_ANALYZER,
+        SKIP_EMBEDDED_FRAMEWORKS_VALIDATION,
         SOURCE_ROOT,
         SPECIALIZATION_SDK_OPTIONS,
         SRCROOT,

--- a/Sources/SWBUniversalPlatform/Specs/ProductTypeValidationTool.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/ProductTypeValidationTool.xcspec
@@ -29,6 +29,18 @@
                 CommandLineFlag = "-validate-for-store";
             },
             {
+                Name = ShallowBundle;
+                Type = boolean;
+                DefaultValue = "$(SHALLOW_BUNDLE)";
+                CommandLineFlag = "-shallow-bundle";
+            },
+            {
+                Name = SkipEmbeddedFrameworksValidation;
+                Type = boolean;
+                DefaultValue = "$(SKIP_EMBEDDED_FRAMEWORKS_VALIDATION)";
+                CommandLineFlag = "-no-validate-embedded-frameworks";
+            },
+            {
                 Name = __no_validate_extension__;
                 Type = boolean;
                 DefaultValue = YES;

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -2958,6 +2958,9 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             try await tester.fs.writeFramework(sourceDynamicFrameworkPath, archs: runDestination.platform == "macosx" ? ["arm64", "x86_64"] : ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: false) { _, _, headersDir, resourcesDir in
                 try await tester.fs.writeFileContents(headersDir.join("ADynamicFwk.h")) { $0 <<< "" }
                 try await tester.fs.writePlist(resourcesDir.join("ADynamicResource.plist"), .plDict([:]))
+                try await tester.fs.writePlist(resourcesDir.join("Info.plist"), .plDict([
+                    "CFBundleIdentifier": "com.apple.ADynamicFwk",
+                ]))
             }
 
             let sourceDynamicFrameworkFiles = try tester.fs.traverse(sourceDynamicFrameworkPath, { $0.relativeSubpath(from: sourceDynamicFrameworkPath) }).sorted()
@@ -3006,6 +3009,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "LSMinimumSystemVersion": "11.0",
                     "MinimumOSVersion": "11.0",
                     "CFBundleSupportedPlatforms": bundleSupportedPlatforms,
+                    "CFBundleIdentifier": "com.apple.AStaticFwk",
                 ]))
             }
 

--- a/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
@@ -83,6 +83,7 @@ fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
                                     TestBuildConfiguration("Debug",
                                                            buildSettings: [
                                                             "INSTALL_PATH": "/Applications",
+                                                            "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
                                                            ]),
                                 ],
                                 buildPhases: [
@@ -553,8 +554,8 @@ fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
                                 "INSTALL_GROUP": "",
                                 "INSTALL_MODE_FLAG": "",
                                 "SDK_STAT_CACHE_ENABLE": "NO",
-
-                                "ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT": useAppStoreCodelessFrameworksWorkaround ? "NO" : "YES"
+                                "ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT": useAppStoreCodelessFrameworksWorkaround ? "NO" : "YES",
+                                "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
                             ])
                         ],
                         targets: [
@@ -1029,6 +1030,7 @@ fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
                                                            buildSettings: [
                                                             "INSTALL_PATH": "/Applications",
                                                             "MERGE_LINKED_LIBRARIES": "$(APP_MERGE_LINKED_LIBRARIES)",      // Builds below can override APP_MERGE_LINKED_LIBRARIES to NO to disable merging.
+                                                            "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
                                                            ]),
                                 ],
                                 buildPhases: [
@@ -1396,6 +1398,7 @@ fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
                                     TestBuildConfiguration(CONFIGURATION,
                                                            buildSettings: [
                                                             "INSTALL_PATH": "/Applications",
+                                                            "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
                                                            ]),
                                 ],
                                 buildPhases: [

--- a/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
@@ -772,6 +772,7 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
                                 "SKIP_INSTALL": "NO",
                                 "GENERATE_INFOPLIST_FILE": "YES",
                                 "SWIFT_VERSION": swiftVersion,
+                                "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
                             ]
                         )],
                         targets: [

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -219,7 +219,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("AppTarget.app")) { task in
                     task.checkRuleInfo(["Validate", "\(SRCROOT)/build/Debug-iphoneos/AppTarget.app"])
-                    task.checkCommandLine(["builtin-validationUtility", "\(SRCROOT)/build/Debug-iphoneos/AppTarget.app", "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", "\(SRCROOT)/build/Debug-iphoneos/AppTarget.app", "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
 
                     task.checkInputs([
                         .path("\(SRCROOT)/build/Debug-iphoneos/AppTarget.app"),
@@ -351,7 +351,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("AppTarget.app")) { task in
                     task.checkRuleInfo(["Validate", "\(SRCROOT)/build/Debug-iphonesimulator/AppTarget.app"])
-                    task.checkCommandLine(["builtin-validationUtility", "\(SRCROOT)/build/Debug-iphonesimulator/AppTarget.app", "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", "\(SRCROOT)/build/Debug-iphonesimulator/AppTarget.app", "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
 
                     task.checkInputs([
                         .path("\(SRCROOT)/build/Debug-iphonesimulator/AppTarget.app"),
@@ -439,7 +439,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("AppTarget.app")) { task in
                     task.checkRuleInfo(["Validate", "\(srcRoot.str)/build/Debug-iphoneos/AppTarget.app"])
-                    task.checkCommandLine(["builtin-validationUtility", "\(srcRoot.str)/build/Debug-iphoneos/AppTarget.app", "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", "\(srcRoot.str)/build/Debug-iphoneos/AppTarget.app", "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
 
                     task.checkOutputs([
                         .path("\(srcRoot.str)/build/Debug-iphoneos/AppTarget.app"),

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -392,7 +392,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("Watchable WatchKit App.app")) { task in
-                    task.checkCommandLine(["builtin-validationUtility", builtWatchAppPath, "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", builtWatchAppPath, "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
                 }
 
                 // There should be no other tasks for this target.
@@ -498,7 +498,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("Watchable.app")) { task in
-                    task.checkCommandLine(["builtin-validationUtility", builtHostIOSAppPath, "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", builtHostIOSAppPath, "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
                 }
 
                 // There should be no other tasks for this target.
@@ -681,7 +681,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("Watchable WatchKit App.app")) { task in
-                    task.checkCommandLine(["builtin-validationUtility", builtWatchAppPath, "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", builtWatchAppPath, "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
                 }
 
                 // There should be no other tasks for this target.
@@ -788,7 +788,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
                 // There should be one product validation task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Validate"), .matchRuleItemBasename("Watchable.app")) { task in
-                    task.checkCommandLine(["builtin-validationUtility", builtHostIOSAppPath, "-infoplist-subpath", "Info.plist"])
+                    task.checkCommandLine(["builtin-validationUtility", builtHostIOSAppPath, "-shallow-bundle", "-infoplist-subpath", "Info.plist"])
                 }
 
                 // There should be no other tasks for this target.


### PR DESCRIPTION
Validate embedded frameworks as part of the `ValidateProductTaskAction` to surface issues which would later prevent installation or App Store submission.

rdar://124355004
