### PR TITLE
Add more test coverage for visionOS

### DIFF
--- a/Sources/SWBUtil/ProcessInfo.swift
+++ b/Sources/SWBUtil/ProcessInfo.swift
@@ -108,6 +108,8 @@ extension ProcessInfo {
                 return .tvOS(simulator: simulatorRoot != nil)
             case "Watch OS":
                 return .watchOS(simulator: simulatorRoot != nil)
+            case "xrOS":
+                return .visionOS(simulator: simulatorRoot != nil)
             default:
                 break
             }

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -178,6 +178,46 @@ import Foundation
         }
     }
 
+    @Test(.requireSDKs(.xrOS))
+    func platformLoading_visionOS() async throws {
+        let core = try await getCore()
+
+        do {
+            let identifier = "com.apple.platform.xros"
+            if let platform = core.platformRegistry.lookup(identifier: identifier) {
+                #expect(platform.signingContext is DeviceSigningContext)
+
+                let sdkCanonicalName = try #require(platform.sdkCanonicalName)
+                let publicSDK = try #require(core.sdkRegistry.lookup(sdkCanonicalName))
+                let defaultVariant = try #require(publicSDK.defaultVariant)
+                #expect(defaultVariant.deviceFamilies.list == [
+                    DeviceFamily(identifier: 7, name: "vision", displayName: "Apple Vision")
+                ])
+            }
+            else {
+                Issue.record("did not load platform '\(identifier)'")
+            }
+        }
+
+        do {
+            let identifier = "com.apple.platform.xrsimulator"
+            if let platform = core.platformRegistry.lookup(identifier: identifier) {
+                #expect(platform.signingContext is SimulatorSigningContext)
+
+                let sdkCanonicalName = try #require(platform.sdkCanonicalName)
+                let publicSDK = try #require(core.sdkRegistry.lookup(sdkCanonicalName))
+                let defaultVariant = try #require(publicSDK.defaultVariant)
+                #expect(defaultVariant.deviceFamilies.list == [
+                    DeviceFamily(identifier: 7, name: "vision", displayName: "Apple Vision")
+                ])
+            }
+            else {
+                Issue.record("did not load platform '\(identifier)'")
+            }
+        }
+    }
+
+
     @Test(.requireHostOS(.macOS))
     func toolchainLoading() async throws {
         // Validate that we loaded the default toolchain.

--- a/Tests/SWBCoreTests/SDKRegistryTests.swift
+++ b/Tests/SWBCoreTests/SDKRegistryTests.swift
@@ -881,6 +881,16 @@ import SWBMacro
         #expect(realRegistry.lookup("watchsimulator")?.targetBuildVersionPlatform() == .watchOSSimulator)
     }
 
+    /// Tests that the visionOS SDK knows which Mach-O platforms it's targeting.
+    @Test(.requireSDKs(.xrOS))
+    func SDKBuildVersionPlatform_visionOS() async throws {
+        let realRegistry = try await getCore().sdkRegistry
+
+        #expect(realRegistry.lookup("xros")?.targetBuildVersionPlatform() == .xrOS)
+        #expect(realRegistry.lookup("xrsimulator")?.targetBuildVersionPlatform() == .xrOSSimulator)
+    }
+
+
     /// Tests that the DriverKit SDK knows which Mach-O platform it's targeting.
     @Test(.requireSDKs(.driverKit))
     func SDKBuildVersionPlatform_DriverKit() async throws {

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -1096,7 +1096,7 @@ import SWBMacro
         let arch32 = try #require(Architecture.host.as32bit.stringValue)
         let arch64 = try #require(Architecture.host.as64bit.stringValue)
 
-        let destinations: [RunDestinationInfo] = [.macOS, .macCatalyst, .iOS, .iOSSimulator, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .linux].filter { core.sdkRegistry.lookup($0.sdk) != nil }
+        let destinations: [RunDestinationInfo] = [.macOS, .macCatalyst, .iOS, .iOSSimulator, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .xrOS, .xrOSSimulator, .linux].filter { core.sdkRegistry.lookup($0.sdk) != nil }
 
         for destination in destinations {
             let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: destination, overrides: ["SDKROOT": destination.sdk, "SDK_VARIANT": destination.sdkVariant ?? ""])
@@ -1146,7 +1146,7 @@ import SWBMacro
         let project = context.workspace.projects[0]
         let target = project.targets[0]
 
-        let destinations: [RunDestinationInfo] = [.macOS, .macCatalyst, .iOS, .iOSSimulator, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .driverKit, .linux].filter { core.sdkRegistry.lookup($0.sdk) != nil }
+        let destinations: [RunDestinationInfo] = [.macOS, .macCatalyst, .iOS, .iOSSimulator, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .xrOS, .xrOSSimulator, .driverKit, .linux].filter { core.sdkRegistry.lookup($0.sdk) != nil }
 
         for destination in destinations {
             let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: destination, overrides: ["SDKROOT": destination.sdk, "SDK_VARIANT": destination.sdkVariant ?? ""])
@@ -1170,6 +1170,8 @@ import SWBMacro
                 #expect(try scope.evaluate(scope.namespace.declareStringMacro("RECOMMENDED_TVOS_DEPLOYMENT_TARGET")) == "15.0")
             case .watchOS, .watchOSSimulator:
                 #expect(try scope.evaluate(scope.namespace.declareStringMacro("RECOMMENDED_WATCHOS_DEPLOYMENT_TARGET")) == "8.0")
+            case .xrOS, .xrOSSimulator:
+                #expect(try scope.evaluate(scope.namespace.declareStringMacro("RECOMMENDED_XROS_DEPLOYMENT_TARGET")) == "1.0")
             case .driverKit:
                 #expect(try scope.evaluate(scope.namespace.declareStringMacro("RECOMMENDED_DRIVERKIT_DEPLOYMENT_TARGET")) == "20.0")
             case .linux:

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -189,6 +189,11 @@ import SWBMacro
         try await testProductTypeSpecLoadingClassAssociations(domain: "watchos")
     }
 
+    @Test(.requireSDKs(.xrOS))
+    func productTypeSpecLoadingClassAssociations_visionOS() async throws {
+        try await testProductTypeSpecLoadingClassAssociations(domain: "xros")
+    }
+
     @Test
     func packageTypeSpecLoading() async throws {
         let (spec, _, errors) = try await parseTestSpec(PackageTypeSpec.self, [

--- a/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BitcodeTaskConstructionTests.swift
@@ -467,6 +467,11 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
         try await _testBitcodeFlags(sdkroot: "watchsimulator", expectBitcode: false)
     }
 
+    @Test(.requireSDKs(.xrOS))
+    func bitcodeUnsupportedPlatformsIgnored_visionOSSimulator() async throws {
+        try await _testBitcodeFlags(sdkroot: "xrsimulator", expectBitcode: false)
+    }
+
     @Test(.requireSDKs(.iOS))
     func bitcodeSupportedPlatforms_iOS() async throws {
         try await _testBitcodeFlags(sdkroot: "iphoneos", expectBitcode: true)
@@ -480,5 +485,10 @@ fileprivate struct BitcodeTaskConstructionTests: CoreBasedTests {
     @Test(.requireSDKs(.watchOS))
     func bitcodeSupportedPlatforms_watchOS() async throws {
         try await _testBitcodeFlags(sdkroot: "watchos", expectBitcode: true)
+    }
+
+    @Test(.requireSDKs(.xrOS))
+    func bitcodeSupportedPlatforms_visionOS() async throws {
+        try await _testBitcodeFlags(sdkroot: "xros", expectBitcode: false) // bitcode was never supported on visionOS
     }
 }

--- a/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
@@ -40,6 +40,12 @@ fileprivate struct ShellScriptTaskConstructionTests: CoreBasedTests {
         try await testShellScriptDeploymentTargetPruning(sdkroot: "watchsimulator", expectedDeploymentTargetPrefix: "WATCHOS")
     }
 
+    @Test(.requireSDKs(.xrOS))
+    func shellScriptDeploymentTargetPruning_visionOS() async throws {
+        try await testShellScriptDeploymentTargetPruning(sdkroot: "xros", expectedDeploymentTargetPrefix: "XROS")
+        try await testShellScriptDeploymentTargetPruning(sdkroot: "xrsimulator", expectedDeploymentTargetPrefix: "XROS")
+    }
+
     @Test(.requireSDKs(.driverKit))
     func shellScriptDeploymentTargetPruning_DriverKit() async throws {
         try await testShellScriptDeploymentTargetPruning(sdkroot: "driverkit", expectedDeploymentTargetPrefix: "DRIVERKIT")

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -7583,6 +7583,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                 "IPHONEOS_DEPLOYMENT_TARGET": core.loadSDK(.iOS).defaultDeploymentTarget,
                                 "TVOS_DEPLOYMENT_TARGET": core.loadSDK(.tvOS).defaultDeploymentTarget,
                                 "WATCHOS_DEPLOYMENT_TARGET": core.loadSDK(.watchOS).defaultDeploymentTarget,
+                                "XROS_DEPLOYMENT_TARGET": core.loadSDK(.xrOS).defaultDeploymentTarget,
                                 "DRIVERKIT_DEPLOYMENT_TARGET": core.loadSDK(.driverKit).defaultDeploymentTarget,
                             ]
                         )
@@ -7634,6 +7635,15 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
         try await _defaultDeploymentTargetInRangeTester(runDestination: .watchOS).checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .watchOS) { results in
             results.checkTask(.matchRuleType("Ld"), .matchRuleItem("/tmp/Test/aProject/build/Debug-watchos/Foo.framework/Foo")) { _ in }
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.xrOS))
+    func defaultDeploymentTargetInRange_visionOS() async throws {
+
+        try await _defaultDeploymentTargetInRangeTester(runDestination: .xrOS).checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .xrOS) { results in
+            results.checkTask(.matchRuleType("Ld"), .matchRuleItem("/tmp/Test/aProject/build/Debug-xros/Foo.framework/Foo")) { _ in }
             results.checkNoDiagnostics()
         }
     }

--- a/Tests/SWBUtilTests/MachOTests.swift
+++ b/Tests/SWBUtilTests/MachOTests.swift
@@ -783,6 +783,8 @@ fileprivate struct MachOTests {
             BuildVersion.Platform.tvOSSimulator: (platform: "tvos", environment: "simulator"),
             BuildVersion.Platform.watchOS: (platform: "watchos", environment: nil),
             BuildVersion.Platform.watchOSSimulator: (platform: "watchos", environment: "simulator"),
+            BuildVersion.Platform.xrOS: (platform: "xros", environment: nil),
+            BuildVersion.Platform.xrOSSimulator: (platform: "xros", environment: "simulator"),
         ]
 
         for (input, data) in versions {


### PR DESCRIPTION
Go through the tests that were testing all other Apple platforms, and add visionOS for completeness.