### PR TITLE
Add visionOS to test support code

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2791,21 +2791,16 @@ extension Diagnostic.Location {
 
 extension BuildVersion.Platform {
     public func deploymentTargetSettingName(infoLookup: (any PlatformInfoLookup)?) -> String {
+        // We need to special-case MACOSX_DEPLOYMENT_TARGET/IPHONEOS_DEPLOYMENT_TARGET because of zippering (see ``CommandProducer/lookupPlatformInfo(platform:)``)
         switch self {
         case .macOS:
             return BuiltinMacros.MACOSX_DEPLOYMENT_TARGET.name
-        case .iOS, .iOSSimulator, .macCatalyst:
+        case .macCatalyst:
             return BuiltinMacros.IPHONEOS_DEPLOYMENT_TARGET.name
-        case .tvOS, .tvOSSimulator:
-            return BuiltinMacros.TVOS_DEPLOYMENT_TARGET.name
-        case .watchOS, .watchOSSimulator:
-            return BuiltinMacros.WATCHOS_DEPLOYMENT_TARGET.name
-        case .driverKit:
-            return BuiltinMacros.DRIVERKIT_DEPLOYMENT_TARGET.name
         default:
             guard let infoProvider = infoLookup?.lookupPlatformInfo(platform: self),
                   let dtsn = infoProvider.deploymentTargetSettingName else {
-                fatalError("external Mach-O based platforms must provide a deployment target setting name")
+                fatalError("Mach-O based platforms must provide a deployment target setting name")
             }
             return dtsn
         }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -315,6 +315,8 @@ extension CommandProducer {
     }
 
     /// Lookup the platform info for this producer
+    ///
+    /// - warning: Because this implementation doesn't actually inspect the platform that's passed in, it can provide the "wrong" answer in cases of zippering on macOS.
     public func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
         return sdkVariant
     }

--- a/Sources/SWBTestSupport/LibraryGeneration.swift
+++ b/Sources/SWBTestSupport/LibraryGeneration.swift
@@ -397,12 +397,16 @@ extension BuildVersion.Platform {
             return "appletvos"
         case .watchOS:
             return "watchos"
+        case .xrOS:
+            return "xros"
         case .iOSSimulator:
             return "iphonesimulator"
         case .tvOSSimulator:
             return "appletvsimulator"
         case .watchOSSimulator:
             return "watchsimulator"
+        case .xrOSSimulator:
+            return "xrsimulator"
         case .driverKit:
             return "driverkit"
         default:
@@ -423,6 +427,8 @@ extension BuildVersion.Platform {
             return targetTripleString(arch: arch, deploymentTarget: Version(13), infoLookup: infoLookup)
         case .watchOS, .watchOSSimulator:
             return targetTripleString(arch: arch, deploymentTarget: Version(6), infoLookup: infoLookup)
+        case .xrOS, .xrOSSimulator:
+            return targetTripleString(arch: arch, deploymentTarget: Version(1), infoLookup: infoLookup)
         case .driverKit:
             return targetTripleString(arch: arch, deploymentTarget: Version(19), infoLookup: infoLookup)
         default:

--- a/Sources/SWBTestSupport/MachO.swift
+++ b/Sources/SWBTestSupport/MachO.swift
@@ -33,7 +33,7 @@ extension BuildVersion.Platform {
     /// The vendor of the platform, suitable for use as the OS field of an LLVM target triple.
     package func vendor(infoLookup: any PlatformInfoLookup) -> String {
         switch self {
-        case .macOS, .iOS, .iOSSimulator, .macCatalyst, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .driverKit:
+        case .macOS, .iOS, .iOSSimulator, .macCatalyst, .tvOS, .tvOSSimulator, .watchOS, .watchOSSimulator, .xrOS, .xrOSSimulator, .driverKit:
             return "apple"
         default:
             return infoLookup.lookupPlatformInfo(platform: self)?.llvmTargetTripleVendor ?? "unknown"
@@ -51,6 +51,8 @@ extension BuildVersion.Platform {
             return "tvos"
         case .watchOS, .watchOSSimulator:
             return "watchos"
+        case .xrOS, .xrOSSimulator:
+            return "xros"
         case .driverKit:
             return "driverkit"
         default:
@@ -68,7 +70,7 @@ extension BuildVersion.Platform {
         switch self {
         case .macCatalyst:
             return "macabi"
-        case .iOSSimulator, .tvOSSimulator, .watchOSSimulator:
+        case .iOSSimulator, .tvOSSimulator, .watchOSSimulator, .xrOSSimulator:
             return "simulator"
         default:
             guard let environment = infoLookup.lookupPlatformInfo(platform: self)?.llvmTargetTripleEnvironment, !environment.isEmpty else {


### PR DESCRIPTION
Add some missing visionOS entries to generic test support code. Also, remove other platforms instead of adding visionOS in another place, since it can simply be looked up dynamically.