### PR TITLE
Slightly refactor requireThreadSafeWorkingDirectory in anticipation of future changes

### DIFF
--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -139,8 +139,13 @@ extension Trait where Self == Testing.ConditionTrait {
     /// Constructs a condition trait that causes a test to be disabled if the Foundation process spawning implementation is not using `posix_spawn_file_actions_addchdir`.
     package static var requireThreadSafeWorkingDirectory: Self {
         disabled("Thread-safe process working directory support is unavailable.", {
-            // Amazon Linux 2 has glibc 2.26, and glibc 2.29 is needed for posix_spawn_file_actions_addchdir_np support
-            FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false
+            switch try ProcessInfo.processInfo.hostOperatingSystem() {
+            case .linux:
+                // Amazon Linux 2 has glibc 2.26, and glibc 2.29 is needed for posix_spawn_file_actions_addchdir_np support
+                FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false
+            default:
+                false
+            }
         })
     }
 


### PR DESCRIPTION
Only check for Amazon Linux 2 when running on Linux in the first place.