### PR TITLE
Remove last use of deprecated driver dep graph API

### DIFF
--- a/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
+++ b/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
@@ -256,8 +256,6 @@ extension LibSwiftDriver {
 
         private var jobsUnfinished: Set<JobKey>
 
-        public let transitiveDependencyModuleNames: [String]?
-
         internal init(workload: SwiftDriver.DriverExecutorWorkload, argsResolver: ArgsResolver, explicitModulesResolver: ArgsResolver, jobExecutionDelegate: (any JobExecutionDelegate)?, globalExplicitDependencyJobGraph: (any SwiftGlobalExplicitDependencyGraph)?, workingDirectory: Path, eagerCompilationEnabled: Bool) throws {
             self.globalExplicitDependencyJobGraph = globalExplicitDependencyJobGraph
             self.argsResolver = argsResolver
@@ -275,15 +273,6 @@ extension LibSwiftDriver {
                 afterCompilationIndices: self.afterCompilationIndices,
                 verificationIndices: self.verificationIndices
             ) = try Self.evaluateWorkload(workload, argsResolver: argsResolver, explicitModulesResolver: explicitModulesResolver, globalExplicitDependencyJobGraph: globalExplicitDependencyJobGraph, workingDirectory: workingDirectory, eagerCompilationEnabled: eagerCompilationEnabled)
-
-            if let graph = workload.interModuleDependencyGraph {
-                // This calculation is a bit awkward because we cannot directly access the ID of the main module, just its info object
-                let directDependencies = graph.mainModule.directDependencies ?? []
-                let transitiveDependencies = Set(directDependencies + SWBUtil.transitiveClosure(directDependencies, successors: { moduleID in graph.modules[moduleID]?.directDependencies ?? [] }).0)
-                self.transitiveDependencyModuleNames = transitiveDependencies.map(\.moduleName)
-            } else {
-                self.transitiveDependencyModuleNames = nil
-            }
 
             self.jobsUnfinished = Set(plannedTargetJobs.map { $0.key })
             self.jobsUnfinished.formUnion(explicitModuleBuildJobKeys)

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
@@ -93,9 +93,8 @@ final public class SwiftDriverTaskAction: TaskAction, BuildValueValidatingTaskAc
                 outputDelegate.emitNote(message)
             }
 
-            if driverPayload.reportRequiredTargetDependencies != .no && driverPayload.explicitModulesEnabled,
-               let target = task.forTarget,
-               let dependencyModuleNames = try dependencyGraph.queryPlannedBuild(for: driverPayload.uniqueID).transitiveDependencyModuleNames {
+            if driverPayload.reportRequiredTargetDependencies != .no && driverPayload.explicitModulesEnabled, let target = task.forTarget {
+                let dependencyModuleNames = try dependencyGraph.queryTransitiveDependencyModuleNames(for: driverPayload.uniqueID)
                 for dependencyModuleName in dependencyModuleNames {
                     if let targetDependencies = dynamicExecutionDelegate.operationContext.definingTargetsByModuleName[dependencyModuleName] {
                         for targetDependency in targetDependencies {


### PR DESCRIPTION
This also fixes diagnosis of missing target dependencies with newer driver versions

rdar://145000416

