### PR TITLE
Move Apple deployment targets into Apple plugin

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -164,6 +164,17 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
 }
 
 struct ApplePlatformInfoExtension: PlatformInfoExtension {
+    func knownDeploymentTargetMacroNames() -> Set<String> {
+        [
+            "MACOSX_DEPLOYMENT_TARGET",
+            "IPHONEOS_DEPLOYMENT_TARGET",
+            "TVOS_DEPLOYMENT_TARGET",
+            "WATCHOS_DEPLOYMENT_TARGET",
+            "DRIVERKIT_DEPLOYMENT_TARGET",
+            "XROS_DEPLOYMENT_TARGET",
+        ]
+    }
+
     func preferredArchValue(for platformName: String) -> String? {
         // FIXME: rdar://65011964 (Remove PLATFORM_PREFERRED_ARCH)
         // Don't add values for any new platforms

--- a/Sources/SWBCore/PlatformRegistry.swift
+++ b/Sources/SWBCore/PlatformRegistry.swift
@@ -393,19 +393,8 @@ public final class PlatformRegistry {
                 platformsByDeploymentTarget[macroName, default: Set<String>()].insert(platform.correspondingDevicePlatform?.name ?? platform.name)
             }
         }
-        // Now add in all deployment targets we know about.  This is because clang also knows about these deployment targets intrinsically when they are passed as environment variables, so we sometimes need to work with them even if the platform which defines them is not installed.
-        for macroName in [
-            "MACOSX_DEPLOYMENT_TARGET",
-            "IPHONEOS_DEPLOYMENT_TARGET",
-            "TVOS_DEPLOYMENT_TARGET",
-            "WATCHOS_DEPLOYMENT_TARGET",
-            "DRIVERKIT_DEPLOYMENT_TARGET",
-            "XROS_DEPLOYMENT_TARGET",
-        ] {
-            allDeploymentTargetMacroNames.insert(macroName)
-            platformsByDeploymentTarget[macroName] = nil
-        }
 
+        // Now add in all deployment targets we know about.  This is because clang also knows about these deployment targets intrinsically when they are passed as environment variables, so we sometimes need to work with them even if the platform which defines them is not installed.
         @preconcurrency @PluginExtensionSystemActor func platformInfoExtensions() -> [any PlatformInfoExtensionPoint.ExtensionProtocol] {
             delegate.pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
         }


### PR DESCRIPTION
Removes more Apple-isms from SWBCore.