### PR TITLE
Adopt new Swift Testing custom traits API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -257,10 +257,7 @@ let package = Package(
         .target(
             name: "SWBTestSupport",
             dependencies: ["SwiftBuild", "SWBBuildSystem", "SWBCore", "SWBTaskConstruction", "SWBTaskExecution", "SWBUtil", "SWBLLBuild", "SWBMacro"],
-            swiftSettings: swiftSettings(languageMode: .v5) + [
-                // Temporary until swift-testing introduces replacement for this SPI
-                .define("DONT_HAVE_CUSTOM_EXECUTION_TRAIT")
-            ]),
+            swiftSettings: swiftSettings(languageMode: .v5)),
 
         // Tests
         .testTarget(

--- a/Sources/SWBTestSupport/KnownIssueTestSupport.swift
+++ b/Sources/SWBTestSupport/KnownIssueTestSupport.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DONT_HAVE_CUSTOM_EXECUTION_TRAIT
+#if compiler(<6.1)
 public import Testing
 
 extension Trait where Self == Testing.ConditionTrait {
@@ -23,9 +23,9 @@ extension Trait where Self == Testing.ConditionTrait {
     }
 }
 #else
-@_spi(Experimental) package import Testing
+package import Testing
 
-package struct KnownIssueTestTrait: CustomExecutionTrait & TestTrait & SuiteTrait {
+package struct KnownIssueTestTrait: TestTrait & SuiteTrait & TestScoping {
     let comment: Comment
     let isIntermittent: Bool
     let sourceLocation: SourceLocation
@@ -34,7 +34,7 @@ package struct KnownIssueTestTrait: CustomExecutionTrait & TestTrait & SuiteTrai
         true
     }
 
-    @Sendable package func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
+    package func provideScope(for test: Testing.Test, testCase: Testing.Test.Case?, performing function: @Sendable () async throws -> Void) async throws {
         if testCase == nil || test.isSuite {
             try await function()
         } else {

--- a/Sources/SWBTestSupport/UserDefaultTestTrait.swift
+++ b/Sources/SWBTestSupport/UserDefaultTestTrait.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if DONT_HAVE_CUSTOM_EXECUTION_TRAIT
+#if compiler(<6.1)
 public import Testing
 
 extension Trait where Self == Testing.ConditionTrait {
@@ -19,11 +19,11 @@ extension Trait where Self == Testing.ConditionTrait {
     }
 }
 #else
-@_spi(Experimental) package import Testing
+package import Testing
 @_spi(Testing) import SWBUtil
 import Foundation
 
-package struct UserDefaultsTestTrait: CustomExecutionTrait & TestTrait & SuiteTrait {
+package struct UserDefaultsTestTrait: TestTrait & SuiteTrait & TestScoping {
     let userDefaults: [String: String]
     let clean: Bool
 
@@ -31,7 +31,7 @@ package struct UserDefaultsTestTrait: CustomExecutionTrait & TestTrait & SuiteTr
         true
     }
 
-    @Sendable package func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
+    package func provideScope(for test: Testing.Test, testCase: Testing.Test.Case?, performing function: @Sendable () async throws -> Void) async throws {
         if testCase == nil || test.isSuite {
             try await function()
         } else {

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -206,7 +206,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
     /// Stress concurrent access to the build system cache during rapid cancel
     /// then build scenarios.
-    @Test(.requireSDKs(.host),
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"),
           // To aid in establishing the subtle concurrent
           // timing required to trigger chaos, we disable early build operation
           // cancellation.


### PR DESCRIPTION
This is the official replacement for the SPI that was previously being used. This will regain the test coverage of any functions which use these traits, which have been skipped for a while.