### PR TITLE
Expand Linux checks to include Android or remove Linux checks

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -684,7 +684,7 @@ struct CoreRegistryDelegate : PlatformRegistryDelegate, SDKRegistryDelegate, Spe
 
 extension OperatingSystem {
     /// Whether the Core is allowed to create a fallback toolchain, SDK, and platform for this operating system in cases where no others have been provided.
-    internal var createFallbackSystemToolchain: Bool {
+    @_spi(Testing) public var createFallbackSystemToolchain: Bool {
         return self == .linux
     }
 }

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -5282,7 +5282,7 @@ extension Settings {
 }
 
 extension OperatingSystem {
-    var xcodePlatformName: String {
+    @_spi(Testing) public var xcodePlatformName: String {
         get throws {
             switch self {
             case .macOS:

--- a/Sources/SWBCore/WorkspaceContext.swift
+++ b/Sources/SWBCore/WorkspaceContext.swift
@@ -384,7 +384,7 @@ public final class WorkspaceContext: Sendable {
 
 extension FSProxy {
     private static var CreatedByBuildSystemAttribute: String {
-        #if os(Linux)
+        #if os(Linux) || os(Android)
         // On Linux, "the name [of an extended attribute] must be a null-terminated string prefixed by a namespace identifier and a dot character" and only the "user" namespace is available for unrestricted access.
         "user.org.swift.swift-build.CreatedByBuildSystem"
         #else

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -81,11 +81,12 @@ import SWBMacro
     @Test
     func loadingErrors() async throws {
         let builtinPlatforms: [String]
-#if os(Linux)
-        builtinPlatforms = ["linux"]
-#else
-        builtinPlatforms = []
-#endif
+        let hostOS = try ProcessInfo.processInfo.hostOperatingSystem()
+        if hostOS.createFallbackSystemToolchain {
+            builtinPlatforms = try [hostOS.xcodePlatformName]
+        } else {
+            builtinPlatforms = []
+        }
 
         try await withRegistryForTestInputs([
             ("unused", nil),

--- a/Tests/SWBLLBuildTests/LLBuildTests.swift
+++ b/Tests/SWBLLBuildTests/LLBuildTests.swift
@@ -589,10 +589,6 @@ fileprivate class LoggingDelegate: BuildSystemDelegate {
     }
 
     @Test(.requireLLBuild(apiVersion: 15)) func commandSkipping() throws {
-        #if os(Linux) && !DEBUG
-        return // fails on Linux in release mode
-        #endif
-
         let fs = PseudoFS()
 
         // Write the test manifest.
@@ -616,7 +612,8 @@ fileprivate class LoggingDelegate: BuildSystemDelegate {
         // Configure the delegate
         class Delegate: LoggingDelegate {
             override func shouldCommandStart(_ command: Command) -> Bool {
-                assert(super.shouldCommandStart(command))
+                let shouldStart = super.shouldCommandStart(command)
+                #expect(shouldStart)
                 return false
             }
         }

--- a/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
@@ -247,7 +247,7 @@ public struct AsyncCLIConnectionResponseSequence<Base: AsyncSequence>: AsyncSequ
                     } catch let error as SWBUtil.POSIXError {
                         // The result of a read operation when pty session is closed is platform-dependent.
                         // BSDs send EOF, Linux raises EIO...
-                        #if os(Linux)
+                        #if os(Linux) || os(Android)
                         if error.code == EIO {
                             break
                         }
@@ -276,7 +276,7 @@ public struct AsyncCLIConnectionResponseSequence<Base: AsyncSequence>: AsyncSequ
                 } catch let error as SWBUtil.POSIXError {
                     // The result of a read operation when pty session is closed is platform-dependent.
                     // BSDs send EOF, Linux raises EIO...
-                    #if os(Linux)
+                    #if os(Linux) || os(Android)
                     if error.code == EIO {
                         break
                     }


### PR DESCRIPTION
Anywhere we were checking for a Linux host, include Android as well if appropriate. Also adjust a couple other places to be non-Linux-specific where appropriate