### PR TITLE
Remove confusing special case in deployment target setting name lookup

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2793,18 +2793,10 @@ extension Diagnostic.Location {
 
 extension BuildVersion.Platform {
     public func deploymentTargetSettingName(infoLookup: (any PlatformInfoLookup)?) -> String {
-        // We need to special-case MACOSX_DEPLOYMENT_TARGET/IPHONEOS_DEPLOYMENT_TARGET because of zippering (see ``CommandProducer/lookupPlatformInfo(platform:)``)
-        switch self {
-        case .macOS:
-            return BuiltinMacros.MACOSX_DEPLOYMENT_TARGET.name
-        case .macCatalyst:
-            return BuiltinMacros.IPHONEOS_DEPLOYMENT_TARGET.name
-        default:
-            guard let infoProvider = infoLookup?.lookupPlatformInfo(platform: self),
-                  let dtsn = infoProvider.deploymentTargetSettingName else {
-                fatalError("Mach-O based platforms must provide a deployment target setting name")
-            }
-            return dtsn
+        guard let infoProvider = infoLookup?.lookupPlatformInfo(platform: self),
+              let dtsn = infoProvider.deploymentTargetSettingName else {
+            fatalError("Mach-O based platforms must provide a deployment target setting name")
         }
+        return dtsn
     }
 }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -313,13 +313,6 @@ extension CommandProducer {
     func expandedSearchPaths(for macro: PathListMacroDeclaration, scope: MacroEvaluationScope) -> [String] {
         return expandedSearchPaths(for: scope.evaluate(macro), scope: scope)
     }
-
-    /// Lookup the platform info for this producer
-    ///
-    /// - warning: Because this implementation doesn't actually inspect the platform that's passed in, it can provide the "wrong" answer in cases of zippering on macOS.
-    public func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
-        return sdkVariant
-    }
 }
 
 /// Describes the context in which an individual invocation of a command line spec is being built.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1161,6 +1161,10 @@ extension TaskProducerContext: Hashable {
 }
 
 extension TaskProducerContext: CommandProducer {
+    public func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+        workspaceContext.core.lookupPlatformInfo(platform: platform)
+    }
+    
     public var preferredArch: String? {
         return settings.preferredArch
     }

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -229,4 +229,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package func lookupLibclang(path: SWBUtil.Path) -> (libclang: SWBCore.Libclang?, version: Version?) {
         (nil, nil)
     }
+    package func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+        core.lookupPlatformInfo(platform: platform)
+    }
 }

--- a/Tests/SWBCoreTests/SDKRegistryTests.swift
+++ b/Tests/SWBCoreTests/SDKRegistryTests.swift
@@ -485,7 +485,7 @@ import SWBMacro
                     }
 
                     func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
-                        toastosVariant
+                        platform.rawValue == 99 ? toastosVariant : nil
                     }
                 }
 


### PR DESCRIPTION
Previously, the CommandProducer protocol provided a default implementation of `lookupPlatformInfo(platform:)` which simply returned the current SDK variant without considering the platform that was actually passed in.

This led to some cases around zippering (where an alternate platform's deployment target is requested) to give the wrong answer because the command producer was still operating in the context of the primary platform, leading to further workarounds in other places which special cased macOS and Mac Catalyst to return the right answer again.

To solve this, remove CommandProducer's default implementation and instead provide implementations in the concrete TaskProducerContext and MockCommandProducer (for testing) types which have access to a Core, and can therefore simply call through to the real canonical implementation.