### PR TITLE
Remove the last usage of DispatchSemaphore in favor of native concurrency primitives

### DIFF
--- a/Sources/SWBBuildSystem/BuildSystemCache.swift
+++ b/Sources/SWBBuildSystem/BuildSystemCache.swift
@@ -26,7 +26,7 @@ extension HeavyCache: BuildSystemCache where Key == Path, Value == SystemCacheEn
 
 package final class SystemCacheEntry: CacheableValue {
     /// Lock that must be held by the active operation using this cache entry.
-    let lock = SWBDispatchSemaphore(value: 1)
+    let lock = AsyncLockedValue(())
 
     /// The environment in use.
     var environment: [String: String]? = nil

--- a/Sources/SWBUtil/SWBDispatch.swift
+++ b/Sources/SWBUtil/SWBDispatch.swift
@@ -124,7 +124,7 @@ extension SWBDispatchData: RandomAccessCollection {
 }
 
 /// Thin wrapper for `DispatchSemaphore` to isolate it from the rest of the codebase and help migration away from it.
-public final class SWBDispatchSemaphore: Sendable {
+internal final class SWBDispatchSemaphore: Sendable {
     private let semaphore: DispatchSemaphore
 
     public init(value: Int) {
@@ -139,19 +139,6 @@ public final class SWBDispatchSemaphore: Sendable {
     public func blocking_wait() {
         assertNoConcurrency {
             semaphore.wait()
-        }
-    }
-
-    /// Waits for the semaphore.
-    ///
-    /// - note: This spawns a background thread to wait for the semaphore in order to avoid blocking the caller.
-    public func wait() async {
-        await withCheckedContinuation { continuation in
-            let semaphore = self.semaphore
-            Thread.detachNewThread {
-                semaphore.wait()
-                continuation.resume()
-            }
         }
     }
 }


### PR DESCRIPTION
This avoids spinning up one thread to synchronize access to cached build systems.