### PR TITLE
Add assertion failure on out of bounds access to explicit dependency tracker

### DIFF
--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -100,6 +100,10 @@ private struct GlobalExplicitDependencyTracker {
                 assertionFailure("Unexpectedly found a regular job in 'plannedExplicitDependencyJobs'")
                 continue
             }
+            guard plannedExplicitDependencyJobs.indices.contains(index) else {
+                assertionFailure("Unexpectedly found an out of bounds job index into 'plannedExplicitDependencyJobs'")
+                continue
+            }
             let job = plannedExplicitDependencyJobs[index]
             assert(job.key == key)
             jobs.append(job)


### PR DESCRIPTION
A recent change turned a missing key here into an out of bounds access into an array. Downgrade it to an assertionFailure which is ignored in release builds in order to be more resilient to this failure and provide more information when investigating in debug builds.

rdar://147361460