### PR TITLE
Always add linkage dependencies to host tool targets for the index arena

### DIFF
--- a/Sources/SWBCore/TargetDependencyResolver.swift
+++ b/Sources/SWBCore/TargetDependencyResolver.swift
@@ -811,18 +811,8 @@ fileprivate extension TargetDependencyResolver {
             if let asPackageProduct = dependency as? PackageProductTarget {
                 packageProductDependencies.append(asPackageProduct)
             } else {
-                if buildRequest.enableIndexBuildArena && !resolver.isTargetSuitableForPlatform(dependency, parameters: configuredTarget.parameters, imposedParameters: imposedParameters) {
-                    // The index build is all about source code, being able to produce source dependencies products for compilation purposes, it doesn't produce binaries.
-                    // If a dependency is not supported for the platform of the dependent, presumably the dependent will not be able to use its products for compilation purposes, since the source products will be put in a different platform directory and/or they will not be usable by the dependent (e.g. the module will not be importable from a different platform).
-                    // If the dependency was intended to be usable from that platform for compilation purposes, it would be a supported platform.
-                    // There is one exception - host tools which are required by compilation, and therefore must be registered as dependencies.
-                    func isHostBuildTool(_ target: Target) -> Bool {
-                        guard let standardTarget = target as? StandardTarget else { return false }
-                        return ProductTypeIdentifier(standardTarget.productTypeIdentifier).isHostBuildTool
-                    }
-                    guard isHostBuildTool(dependency) || dependencyPath?.contains(where: { isHostBuildTool($0.target) }) == true else {
-                        continue
-                    }
+                if !resolver.isTargetSuitableForPlatformForIndex(dependency, parameters: configuredTarget.parameters, imposedParameters: imposedParameters, dependencies: dependencyPath) {
+                    continue
                 }
 
                 // If we have an existing, compatible configured target, use its build parameters.


### PR DESCRIPTION
Settings are propagated to dependent targets through the linkage graph rather than the target graph (unless
`UseTargetDependenciesForImpartedBuildSettings` is set). While the target graph was updated to allow host tool dependencies even when configuring for a different platform in the index arena, the linkage graph was not. This meant that we'd miss imparting settings in this case (eg. include paths up from dependencies) and thus fail to build the host tool in cases this is required. As the host tool is built without the preparation settings (since it needs to actually build the executable), this would then continually run for every preparation request.

The fix here is to add linkage dependencies for host tools as well and to unify the two "is compatible for index arena" checks to avoid this in the future. That exposes another issue, however, which is that doing so would then result in having multiple configured targets all with the same (host) platform. Avoid that by forcing the parameters to that of the host platform for the index arena.

Resolves rdar://140882270.