### PR TITLE
Move App Intents Task Producer to SWBApplePlatform

### DIFF
--- a/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
@@ -12,6 +12,7 @@
 
 import SWBUtil
 import SWBMacro
+public import SWBCore
 
 /// The minimal data we need to serialize to reconstruct `generateLocalizationInfo`
 private struct AppIntentsLocalizationPayload: TaskPayload {

--- a/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
@@ -51,15 +51,14 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
         guard !context.settings.globalScope.evaluate(BuiltinMacros.LM_SKIP_METADATA_EXTRACTION) else {
             return []
         }
+        guard let configuredTarget = self.targetContext.configuredTarget, let buildPhaseTarget = configuredTarget.target as? BuildPhaseTarget else {
+            return []
+        }
 
         context.addDeferredProducer {
             let scope = self.context.settings.globalScope
             var deferredTasks: [any PlannedTask] = []
             let buildFilesProcessingContext = BuildFilesProcessingContext(self.context.settings.globalScope)
-
-            guard let configuredTarget = self.targetContext.configuredTarget, let buildPhaseTarget = configuredTarget.target as? BuildPhaseTarget else {
-                fatalError("Target is not a BuildPhaseTarget")
-            }
             let swiftSources: [FileToBuild] = self.filterBuildFiles(buildPhaseTarget.sourcesBuildPhase?.buildFiles, identifiers: ["sourcecode.swift"], buildFilesProcessingContext: buildFilesProcessingContext)
             let perArchConstMetadataFiles = self.context.generatedSwiftConstMetadataFiles()
 

--- a/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
@@ -12,14 +12,11 @@
 
 import SWBCore
 import SWBUtil
+import SWBTaskConstruction
 
 final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
-    var sourcesBuildPhase: SourcesBuildPhase?
-    var resourcesBuildPhase: ResourcesBuildPhase?
 
-    init(_ context: TargetTaskProducerContext, sourcesBuildPhase: SourcesBuildPhase?, resourcesBuildPhase: ResourcesBuildPhase?, phaseStartNodes: [any PlannedNode], phaseEndNode: any PlannedNode) {
-        self.sourcesBuildPhase = sourcesBuildPhase
-        self.resourcesBuildPhase = resourcesBuildPhase
+    init(_ context: TargetTaskProducerContext, phaseStartNodes: [any PlannedNode], phaseEndNode: any PlannedNode) {
         super.init(context, phaseStartNodes: phaseStartNodes, phaseEndNode: phaseEndNode)
     }
 
@@ -58,8 +55,12 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
         context.addDeferredProducer {
             let scope = self.context.settings.globalScope
             var deferredTasks: [any PlannedTask] = []
-            let buildFilesProcessingContext = BuildFilesProcessingContext(scope)
-            let swiftSources: [FileToBuild] = self.filterBuildFiles(self.sourcesBuildPhase?.buildFiles, identifiers: ["sourcecode.swift"], buildFilesProcessingContext: buildFilesProcessingContext)
+            let buildFilesProcessingContext = BuildFilesProcessingContext(self.context.settings.globalScope)
+
+            guard let configuredTarget = self.targetContext.configuredTarget, let buildPhaseTarget = configuredTarget.target as? BuildPhaseTarget else {
+                fatalError("Target is not a BuildPhaseTarget")
+            }
+            let swiftSources: [FileToBuild] = self.filterBuildFiles(buildPhaseTarget.sourcesBuildPhase?.buildFiles, identifiers: ["sourcecode.swift"], buildFilesProcessingContext: buildFilesProcessingContext)
             let perArchConstMetadataFiles = self.context.generatedSwiftConstMetadataFiles()
 
             var metadataDependencyList: Set<Path> = []
@@ -136,12 +137,12 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
                 }
 
             }
-            let appShortcutStringsSources: [FileToBuild] = self.filterBuildFiles(self.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { ["AppShortcuts.strings", "AppShortcuts.xcstrings"].contains($0.absolutePath.basename) }
+            let appShortcutStringsSources: [FileToBuild] = self.filterBuildFiles(buildPhaseTarget.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { ["AppShortcuts.strings", "AppShortcuts.xcstrings"].contains($0.absolutePath.basename) }
 
             let cbc = CommandBuildContext(producer: self.context, scope: scope, inputs: swiftSources + constMetadataFilesToBuild + appShortcutStringsSources, resourcesDir: buildFilesProcessingContext.resourcesDir)
 
 
-            let assistantIntentsStringsSources: [FileToBuild] = self.filterBuildFiles(self.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { ["AssistantIntents.strings", "AssistantIntents.xcstrings"].contains($0.absolutePath.basename) }
+            let assistantIntentsStringsSources: [FileToBuild] = self.filterBuildFiles(buildPhaseTarget.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { ["AssistantIntents.strings", "AssistantIntents.xcstrings"].contains($0.absolutePath.basename) }
             await self.appendGeneratedTasks(&deferredTasks) { delegate in
                 let shouldConstructAppIntentsMetadataTask = self.context.appIntentsMetadataCompilerSpec.shouldConstructAppIntentsMetadataTask(cbc)
                 let isInstallLoc = scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc")
@@ -161,13 +162,13 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
                     ((!scope.effectiveInputInfoPlistPath().isEmpty && shouldConstructAppIntentsMetadataTask) || isInstallLoc) {
                     var infoPlistSources: [FileToBuild]
                     if isInstallLoc {
-                        infoPlistSources = self.filterBuildFiles(self.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { $0.absolutePath.basename.hasSuffix("InfoPlist.strings") || $0.absolutePath.basename.hasSuffix("InfoPlist.xcstrings") }
+                        infoPlistSources = self.filterBuildFiles(buildPhaseTarget.resourcesBuildPhase?.buildFiles, identifiers: ["text.plist.strings", "text.json.xcstrings"], buildFilesProcessingContext: buildFilesProcessingContext).filter { $0.absolutePath.basename.hasSuffix("InfoPlist.strings") || $0.absolutePath.basename.hasSuffix("InfoPlist.xcstrings") }
                         // The installLoc builds should include an AppShortcuts strings/xcstrings file to run SSU tasks
                         guard appShortcutStringsSources.count == 1 else {
                             return
                         }
                     } else {
-                        infoPlistSources = [FileToBuild(context: self.context, absolutePath: scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH)))]
+                        infoPlistSources = [FileToBuild(absolutePath: scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH)), inferringTypeUsing: self.context)]
                     }
                     let yamlGenerationInputs: [FileToBuild] = infoPlistSources + appShortcutStringsSources
                     let appIntentsSsuTrainingCbc = CommandBuildContext(producer: self.context, scope: scope, inputs: yamlGenerationInputs, resourcesDir: buildFilesProcessingContext.resourcesDir)
@@ -178,5 +179,15 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
         }
 
         return tasks
+    }
+}
+
+extension TaskProducerContext {
+    var appIntentsMetadataCompilerSpec: AppIntentsMetadataCompilerSpec {
+        return workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appintentsmetadata", domain: domain) as! AppIntentsMetadataCompilerSpec
+    }
+
+    var appIntentsSsuTrainingCompilerSpec: AppIntentsSSUTrainingCompilerSpec {
+        return workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appintents-ssu-training", domain: domain) as! AppIntentsSSUTrainingCompilerSpec
     }
 }

--- a/Sources/SWBApplePlatform/AppIntentsSSUTrainingCompiler.swift
+++ b/Sources/SWBApplePlatform/AppIntentsSSUTrainingCompiler.swift
@@ -13,6 +13,7 @@
 import SWBUtil
 import Foundation
 import SWBMacro
+public import SWBCore
 
 final public class AppIntentsSSUTrainingCompilerSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.compilers.appintents-ssu-training"

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -40,8 +40,10 @@ struct TaskProducersExtension: TaskProducerExtension {
     }
 
     var unorderedPostSetupTaskProducers: [any TaskProducerFactory] {
-        [StubBinaryTaskProducerFactory(),
-         AppIntentsMetadataTaskProducerFactory()]
+        [
+            StubBinaryTaskProducerFactory(),
+            AppIntentsMetadataTaskProducerFactory()
+        ]
     }
 
     var globalTaskProducers: [any GlobalTaskProducerFactory] {

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -40,7 +40,8 @@ struct TaskProducersExtension: TaskProducerExtension {
     }
 
     var unorderedPostSetupTaskProducers: [any TaskProducerFactory] {
-        [StubBinaryTaskProducerFactory()]
+        [StubBinaryTaskProducerFactory(),
+         AppIntentsMetadataTaskProducerFactory()]
     }
 
     var globalTaskProducers: [any GlobalTaskProducerFactory] {
@@ -62,6 +63,16 @@ struct StubBinaryTaskProducerFactory: TaskProducerFactory, GlobalTaskProducerFac
     }
 }
 
+struct AppIntentsMetadataTaskProducerFactory : TaskProducerFactory {
+    var name: String {
+        "AppIntentsMetadataTaskProducer"
+    }
+
+    func createTaskProducer(_ context: TargetTaskProducerContext, startPhaseNodes: [PlannedVirtualNode], endPhaseNode: PlannedVirtualNode) -> any TaskProducer {
+        AppIntentsMetadataTaskProducer(context, phaseStartNodes: startPhaseNodes, phaseEndNode: endPhaseNode)
+    }
+}
+
 struct RealityAssetsTaskProducerFactory: TaskProducerFactory {
     var name: String {
         "RealityAssetsTaskProducer"
@@ -76,6 +87,8 @@ struct ApplePlatformSpecsExtension: SpecificationsExtension {
     func specificationClasses() -> [any SpecIdentifierType.Type] {
         [
             ActoolCompilerSpec.self,
+            AppIntentsMetadataCompilerSpec.self,
+            AppIntentsSSUTrainingCompilerSpec.self,
             CoreDataModelCompilerSpec.self,
             CoreMLCompilerSpec.self,
             CopyTiffFileSpec.self,

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -41,7 +41,12 @@ struct TaskProducersExtension: TaskProducerExtension {
 
     var unorderedPostSetupTaskProducers: [any TaskProducerFactory] {
         [
-            StubBinaryTaskProducerFactory(),
+            StubBinaryTaskProducerFactory()
+        ]
+    }
+
+    var unorderedPostBuildPhasesTaskProducers: [any TaskProducerFactory] {
+        [
             AppIntentsMetadataTaskProducerFactory()
         ]
     }

--- a/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
+++ b/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
@@ -44,9 +44,7 @@ public struct BuiltinSpecsExtension: SpecificationsExtension {
 
     public func specificationClasses() -> [any SpecIdentifierType.Type] {
         [
-            AppIntentsMetadataCompilerSpec.self,
             AppShortcutStringsMetadataCompilerSpec.self,
-            AppIntentsSSUTrainingCompilerSpec.self,
             CodesignToolSpec.self,
             CopyToolSpec.self,
             ClangStatCacheSpec.self,

--- a/Sources/SWBCore/SpecImplementations/Specs.swift
+++ b/Sources/SWBCore/SpecImplementations/Specs.swift
@@ -284,7 +284,7 @@ public class FileTypeSpec : Spec, SpecType, @unchecked Sendable {
     public let isFramework: Bool
 
     /// The extensions matched by this file type.
-    let extensions: Set<String>
+    public let extensions: Set<String>
 
     /// The language dialect, suitable for passing to clang via its `-x` option.  This will be `nil` if the file type does not define the language dialect.
     public let languageDialect: GCCCompatibleLanguageDialect?

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -1138,8 +1138,14 @@ public struct LocalizationBuildPortion: Hashable, Sendable {
     /// The name of the architecture we were building for.
     public let architecture: String
 
+    public init(effectivePlatformName: String, variant: String, architecture: String) {
+        self.effectivePlatformName = effectivePlatformName
+        self.variant = variant
+        self.architecture = architecture
+    }
+
     /// Returns a platform name to use for localization info purposes.
-    static func effectivePlatformName(scope: MacroEvaluationScope, sdkVariant: SDKVariant?) -> String {
+    public static func effectivePlatformName(scope: MacroEvaluationScope, sdkVariant: SDKVariant?) -> String {
         if let sdkVariant, sdkVariant.isMacCatalyst {
             // Treat Catalyst as a separate platform.
             return MacCatalystInfo.localizationEffectivePlatformName

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
@@ -472,10 +472,6 @@ extension StandardTarget
             }
         }
 
-        createNewPhaseNode("AppIntentsMetadataTaskProducer")
-        taskProducers.append(AppIntentsMetadataTaskProducer(taskProducerContext, sourcesBuildPhase: self.sourcesBuildPhase, resourcesBuildPhase: self.resourcesBuildPhase, phaseStartNodes: [setupEndPhaseNode, buildPhasesEndNode], phaseEndNode: endPhaseNode))
-        postprocessingTaskProducerInputNodes.append(endPhaseNode)
-
         // Add postprocessing task producers.  These are ordered after all of the other task producers.
         createNewPhaseNode("ProductPostprocessingTaskProducer")
         taskProducers.append(ProductPostprocessingTaskProducer(taskProducerContext, phaseStartNodes: postprocessingTaskProducerInputNodes, phaseEndNode: endPhaseNode))

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
@@ -467,7 +467,7 @@ extension StandardTarget
         for taskProducerExtension in taskProducerExtensions {
             for factory in taskProducerExtension.unorderedPostSetupTaskProducers {
                 createNewPhaseNode(factory.name)
-                taskProducers.append(factory.createTaskProducer(taskProducerContext, startPhaseNodes: [setupEndPhaseNode], endPhaseNode: endPhaseNode))
+                taskProducers.append(factory.createTaskProducer(taskProducerContext, startPhaseNodes: [setupEndPhaseNode, buildPhasesEndNode], endPhaseNode: endPhaseNode))
                 postprocessingTaskProducerInputNodes.append(endPhaseNode)
             }
         }

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
@@ -467,6 +467,12 @@ extension StandardTarget
         for taskProducerExtension in taskProducerExtensions {
             for factory in taskProducerExtension.unorderedPostSetupTaskProducers {
                 createNewPhaseNode(factory.name)
+                taskProducers.append(factory.createTaskProducer(taskProducerContext, startPhaseNodes: [setupEndPhaseNode], endPhaseNode: endPhaseNode))
+                postprocessingTaskProducerInputNodes.append(endPhaseNode)
+            }
+
+            for factory in taskProducerExtension.unorderedPostBuildPhasesTaskProducers {
+                createNewPhaseNode(factory.name)
                 taskProducers.append(factory.createTaskProducer(taskProducerContext, startPhaseNodes: [setupEndPhaseNode, buildPhasesEndNode], endPhaseNode: endPhaseNode))
                 postprocessingTaskProducerInputNodes.append(endPhaseNode)
             }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -72,7 +72,7 @@ package final class BuildFilesProcessingContext: BuildFileFilteringContext {
     fileprivate let resolveBuildRules: Bool
 
     /// The resources directory for the product, if relevant.
-    let resourcesDir: Path
+    public let resourcesDir: Path
     /// The resources intermediates directory, if appropriate.
     let tmpResourcesDir: Path
 

--- a/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
@@ -102,7 +102,7 @@ open class PhasedTaskProducer: StandardTaskProducer {
     /// The subclass *must* manually report these, if `addTaskBarrier` is used.
     var additionalGateTasks: [any PlannedTask] = []
 
-    var targetContext: TargetTaskProducerContext
+    public var targetContext: TargetTaskProducerContext
 
     /// Create a phased task producer.
     ///

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -201,9 +201,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         }
     }
 
-    let appIntentsMetadataCompilerSpec: AppIntentsMetadataCompilerSpec
-    let appShortcutStringsMetadataCompilerSpec: AppShortcutStringsMetadataCompilerSpec
-    let appIntentsSsuTrainingCompilerSpec: AppIntentsSSUTrainingCompilerSpec
+    public let appShortcutStringsMetadataCompilerSpec: AppShortcutStringsMetadataCompilerSpec
     let appleScriptCompilerSpec: CommandLineToolSpec
     public let clangSpec: ClangCompilerSpec
     public let clangAssemblerSpec: ClangCompilerSpec
@@ -331,9 +329,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         //
         // FIXME: These should really be bound even earlier, like in the spec cache. Or at least, we should throw here and just produce a dep graph error if any are missing.
         let domain = settings.platform?.name ?? ""
-        self.appIntentsMetadataCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appintentsmetadata", domain: domain) as! AppIntentsMetadataCompilerSpec
         self.appShortcutStringsMetadataCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appshortcutstringsmetadata", domain: domain) as! AppShortcutStringsMetadataCompilerSpec
-        self.appIntentsSsuTrainingCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appintents-ssu-training", domain: domain) as! AppIntentsSSUTrainingCompilerSpec
         self.appleScriptCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.osacompile", domain: domain) as! CommandLineToolSpec
         self.clangSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangCompilerSpec
         self.clangAssemblerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangAssemblerSpec
@@ -556,7 +552,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     }
 
     /// Get the product generated Swift Objective-C interface header files.
-    func generatedSwiftConstMetadataFiles() -> [String: [Path]] {
+    public func generatedSwiftConstMetadataFiles() -> [String: [Path]] {
         return queue.blocking_sync {
             assert(_inDeferredMode)
             return _generatedGeneratedSwiftConstMetadataFiles
@@ -607,7 +603,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     }
 
     /// Add a deferred task production block.
-    func addDeferredProducer(_ body: @escaping () async -> [any PlannedTask]) {
+    public func addDeferredProducer(_ body: @escaping () async -> [any PlannedTask]) {
         queue.blocking_sync {
             assert(!_inDeferredMode)
             _deferredProducers.append(body)

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducerExtensionPoint.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducerExtensionPoint.swift
@@ -26,6 +26,7 @@ package protocol TaskProducerExtension: Sendable {
 
     var setupTaskProducers: [any TaskProducerFactory] { get }
     var unorderedPostSetupTaskProducers: [any TaskProducerFactory] { get }
+    var unorderedPostBuildPhasesTaskProducers: [any TaskProducerFactory] { get }
     var globalTaskProducers: [any GlobalTaskProducerFactory] { get }
 }
 


### PR DESCRIPTION
This PR relocates the App Intents task producer and associated spec subclasses to the SWBApplePlatform directory, following the discussion in issue #17. 

**Important**: I have not yet updated the tests to account for this move. The build is successful. My focus is on getting feedback on the code changes before addressing test updates. I'm open to any input or suggestions on the refactor itself