### PR TITLE
Move Linux business logic into the Generic Unix Plugin

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -156,7 +156,7 @@ struct AndroidSDKRegistryExtension: SDKRegistryExtension {
 struct AndroidToolchainRegistryExtension: ToolchainRegistryExtension {
     let plugin: AndroidPlugin
 
-    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain] {
+    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
         guard let toolchainPath = try? await plugin.cachedAndroidSDKInstallations(host: context.hostOperatingSystem).first?.toolchainPath else {
             return []
         }

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -229,7 +229,7 @@ public final class Core: Sendable {
         self.toolchainPaths = {
             var toolchainPaths = [(Path, strict: Bool)]()
 
-            toolchainPaths.append((Path(developerPath).join("Toolchains"), strict: !hostOperatingSystem.createFallbackSystemToolchain))
+            toolchainPaths.append((Path(developerPath).join("Toolchains"), strict: developerPath.hasSuffix(".app/Contents/Developer")))
 
             // FIXME: We should support building the toolchain locally (for `inferiorProductsPath`).
 
@@ -679,12 +679,5 @@ struct CoreRegistryDelegate : PlatformRegistryDelegate, SDKRegistryDelegate, Spe
 
     var developerPath: Path {
         core.developerPath
-    }
-}
-
-extension OperatingSystem {
-    /// Whether the Core is allowed to create a fallback toolchain, SDK, and platform for this operating system in cases where no others have been provided.
-    @_spi(Testing) public var createFallbackSystemToolchain: Bool {
-        return self == .linux
     }
 }

--- a/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
@@ -22,16 +22,17 @@ public struct ToolchainRegistryExtensionPoint: ExtensionPoint, Sendable {
 }
 
 public protocol ToolchainRegistryExtension: Sendable {
-    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain]
+    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain]
 }
 
 extension ToolchainRegistryExtension {
-    public func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain] {
+    public func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
         []
     }
 }
 
 public protocol ToolchainRegistryExtensionAdditionalToolchainsContext: Sendable {
     var hostOperatingSystem: OperatingSystem { get }
+    var toolchainRegistry: ToolchainRegistry { get }
     var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/PlatformRegistry.swift
+++ b/Sources/SWBCore/PlatformRegistry.swift
@@ -331,16 +331,8 @@ public final class PlatformRegistry {
             await registerPlatformsInDirectory(path, fs)
         }
 
-        do {
-            if hostOperatingSystem.createFallbackSystemToolchain {
-                try await registerFallbackSystemPlatform(operatingSystem: hostOperatingSystem, fs: fs)
-            }
-        } catch {
-            delegate.error(error)
-        }
-
         @preconcurrency @PluginExtensionSystemActor func platformInfoExtensions() async -> [any PlatformInfoExtensionPoint.ExtensionProtocol] {
-            return await delegate.pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
+            return delegate.pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
         }
 
         struct Context: PlatformInfoExtensionAdditionalPlatformsContext {
@@ -359,22 +351,6 @@ public final class PlatformRegistry {
 
             }
         }
-    }
-
-    private func registerFallbackSystemPlatform(operatingSystem: OperatingSystem, fs: any FSProxy) async throws {
-        try await registerPlatform(Path("/"), .plDict(fallbackSystemPlatformSettings(operatingSystem: operatingSystem)), fs)
-    }
-
-    private func fallbackSystemPlatformSettings(operatingSystem: OperatingSystem) throws -> [String: PropertyListItem] {
-        try [
-            "Type": .plString("Platform"),
-            "Name": .plString(operatingSystem.xcodePlatformName),
-            "Identifier": .plString(operatingSystem.xcodePlatformName),
-            "Description": .plString(operatingSystem.xcodePlatformName),
-            "FamilyName": .plString(operatingSystem.xcodePlatformName.capitalized),
-            "FamilyIdentifier": .plString(operatingSystem.xcodePlatformName),
-            "IsDeploymentPlatform": .plString("YES"),
-        ]
     }
 
     private func loadDeploymentTargetMacroNames() {

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -5282,7 +5282,7 @@ extension Settings {
 }
 
 extension OperatingSystem {
-    @_spi(Testing) public var xcodePlatformName: String {
+    public var xcodePlatformName: String {
         get throws {
             switch self {
             case .macOS:

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -443,52 +443,20 @@ public final class ToolchainRegistry: @unchecked Sendable {
             }
         }
 
-        do {
-            if hostOperatingSystem.createFallbackSystemToolchain {
-                try registerFallbackSystemToolchain(operatingSystem: hostOperatingSystem)
-            }
-        } catch {
-            delegate.error(error)
-        }
-
         struct Context: ToolchainRegistryExtensionAdditionalToolchainsContext {
             var hostOperatingSystem: OperatingSystem
+            var toolchainRegistry: ToolchainRegistry
             var fs: any FSProxy
         }
 
         for toolchainExtension in await delegate.pluginManager.extensions(of: ToolchainRegistryExtensionPoint.self) {
-            for toolchain in await toolchainExtension.additionalToolchains(context: Context(hostOperatingSystem: hostOperatingSystem, fs: fs)) {
-                do {
+            do {
+                for toolchain in try await toolchainExtension.additionalToolchains(context: Context(hostOperatingSystem: hostOperatingSystem, toolchainRegistry: self, fs: fs)) {
                     try register(toolchain)
-                } catch {
-                    delegate.error(error)
                 }
+            } catch {
+                delegate.error(error)
             }
-        }
-    }
-
-    private func registerFallbackSystemToolchain(operatingSystem: OperatingSystem) throws {
-        if lookup(Self.defaultToolchainIdentifier) != nil {
-            return
-        }
-
-        if let swift = StackedSearchPath(environment: .current, fs: fs).lookup(Path("swift")), fs.exists(swift) {
-            let hasUsrBin = swift.normalize().str.hasSuffix("/usr/bin/swift")
-            let hasUsrLocalBin = swift.normalize().str.hasSuffix("/usr/local/bin/swift")
-            let path: Path
-            switch (hasUsrBin, hasUsrLocalBin) {
-            case (true, false):
-                path = swift.dirname.dirname.dirname
-            case (false, true):
-                path = swift.dirname.dirname.dirname.dirname
-            case (false, false):
-                return
-            case (true, true):
-                preconditionFailure()
-            }
-            let llvmDirectories = try Array(fs.listdir(Path("/usr/lib")).filter { $0.hasPrefix("llvm-") }.sorted().reversed())
-            let llvmDirectoriesLocal = try Array(fs.listdir(Path("/usr/local")).filter { $0.hasPrefix("llvm") }.sorted().reversed())
-            try register(Toolchain(Self.defaultToolchainIdentifier, "Default", Version(), [], path, [], llvmDirectories.map { "/usr/lib/\($0)/lib" } + llvmDirectoriesLocal.map { "/usr/local/\($0)/lib" } + ["/usr/lib64"], [:], [:], [:], executableSearchPaths: [path.join("usr").join("bin"), path.join("usr").join("local").join("bin"),  path.join("usr").join("libexec")], testingLibraryPlatformNames: [], fs: fs))
         }
     }
 

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -141,7 +141,7 @@ struct QNXSDKRegistryExtension: SDKRegistryExtension {
 struct QNXToolchainRegistryExtension: ToolchainRegistryExtension {
     let plugin: QNXPlugin
 
-    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async -> [Toolchain] {
+    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
         guard let toolchainPath = try? await plugin.cachedQNXSDPInstallations(host: context.hostOperatingSystem).first?.hostPath else {
             return []
         }

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -338,7 +338,6 @@ import Foundation
 
             let results = CoreDelegateResults(delegate.diagnostics)
             results.checkError(.prefix("missing required default toolchain"))
-            results.checkError(.contains("Toolchains: failed to load toolchains in "))
             results.checkNoDiagnostics()
         }
     }
@@ -380,7 +379,17 @@ import Foundation
         let delegate = Delegate()
         let pluginManager = await PluginManager(skipLoadingPluginIdentifiers: [])
         await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
+        await pluginManager.registerExtensionPoint(ToolchainRegistryExtensionPoint())
         await pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
+        struct MockToolchainExtension: ToolchainRegistryExtension {
+            func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
+                guard context.toolchainRegistry.lookup(ToolchainRegistry.defaultToolchainIdentifier) == nil else {
+                    return []
+                }
+                return [Toolchain(ToolchainRegistry.defaultToolchainIdentifier, "Mock", Version(), ["default"], .root, [], [], [:], [:], [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
+            }
+        }
+        await pluginManager.register(MockToolchainExtension(), type: ToolchainRegistryExtensionPoint.self)
         let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, inferiorProductsPath: Path.root.join("invalid"), environment: [:], buildServiceModTime: Date(), connectionMode: .inProcess)
         for diagnostic in delegate.diagnostics {
             if diagnostic.formatLocalizedDescription(.debug).hasPrefix("warning: found previously-unknown deployment target macro ") {
@@ -408,7 +417,17 @@ import Foundation
         let delegate = Delegate()
         let pluginManager = await PluginManager(skipLoadingPluginIdentifiers: [])
         await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
+        await pluginManager.registerExtensionPoint(ToolchainRegistryExtensionPoint())
         await pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
+        struct MockToolchainExtension: ToolchainRegistryExtension {
+            func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
+                guard context.toolchainRegistry.lookup(ToolchainRegistry.defaultToolchainIdentifier) == nil else {
+                    return []
+                }
+                return [Toolchain(ToolchainRegistry.defaultToolchainIdentifier, "Mock", Version(), ["default"], .root, [], [], [:], [:], [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
+            }
+        }
+        await pluginManager.register(MockToolchainExtension(), type: ToolchainRegistryExtensionPoint.self)
         let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, inferiorProductsPath: Path.root.join("invalid"), environment: environmentOverrides, buildServiceModTime: Date(), connectionMode: .inProcess)
         for diagnostic in delegate.diagnostics {
             if diagnostic.formatLocalizedDescription(.debug).hasPrefix("warning: found previously-unknown deployment target macro ") {

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -80,21 +80,13 @@ import SWBMacro
 
     @Test
     func loadingErrors() async throws {
-        let builtinPlatforms: [String]
-        let hostOS = try ProcessInfo.processInfo.hostOperatingSystem()
-        if hostOS.createFallbackSystemToolchain {
-            builtinPlatforms = try [hostOS.xcodePlatformName]
-        } else {
-            builtinPlatforms = []
-        }
-
         try await withRegistryForTestInputs([
             ("unused", nil),
             ("a.platform", nil),
             ("b.platform", []),
             ("c.platform", ["Type": "Platform", "Name": "c", "Identifier": "c", "Version": "1.0", "Description": "c", "FamilyName": "c", "FamilyIdentifier": "c", "DefaultProperties": ["CODE_SIGNING_REQUIRED": true]]),
         ]) { registry, delegate in
-            #expect(Set(registry.platformsByIdentifier.keys) == Set(["c"] + builtinPlatforms))
+            #expect(Set(registry.platformsByIdentifier.keys) == Set(["c"]))
             registry.loadExtendedInfo(MacroNamespace())
 
             XCTAssertMatch(delegate.errors, [
@@ -128,7 +120,7 @@ import SWBMacro
             ("ok2.platform", ["Type": "Platform", "Name": "ok", "Description": "ok", "FamilyName": "okFamily", "FamilyIdentifier": "ok", "Identifier": "ok", "Version": "1.0"]),
             ("ok2.platform", ["Type": "Platform", "Name": "ok", "Description": "ok", "FamilyName": "okFamily", "FamilyIdentifier": "ok", "Identifier": "ok", "Version": "1.0"]),
         ]) { registry, delegate in
-            #expect(Set(registry.platformsByIdentifier.keys) == Set(["ok"] + builtinPlatforms))
+            #expect(Set(registry.platformsByIdentifier.keys) == Set(["ok"]))
 
             let jPlatform = try #require(registry.lookup(identifier: "ok"))
             #expect(registry.lookup(name: "okName") === jPlatform)


### PR DESCRIPTION
This moves the "fallback system toolchain" logic for Linux (and future Unix-likes such as FreeBSD, OpenBSD, etc.) into the Generic Unix Plugin so that this platform-specific business logic isn't in the core of Swift Build.