### PR TITLE
Give labels to the Toolchain constructor

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -161,6 +161,21 @@ struct AndroidToolchainRegistryExtension: ToolchainRegistryExtension {
             return []
         }
 
-        return [Toolchain("android", "Android", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("bin")], testingLibraryPlatformNames: [], fs: context.fs)]
+        return [
+            Toolchain(
+                identifier: "android",
+                displayName: "Android",
+                version: Version(0, 0, 0),
+                aliases: [],
+                path: toolchainPath,
+                frameworkPaths: [],
+                libraryPaths: [],
+                defaultSettings: [:],
+                overrideSettings: [:],
+                defaultSettingsWhenPrimary: [:],
+                executableSearchPaths: [toolchainPath.join("bin")],
+                testingLibraryPlatformNames: [],
+                fs: context.fs)
+        ]
     }
 }

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -74,7 +74,7 @@ public final class Toolchain: Hashable, Sendable {
     /// The names of the platforms for which this toolchain contains testing libraries.
     public let testingLibraryPlatformNames: Set<String>
 
-    package init(_ identifier: String, _ displayName: String, _ version: Version, _ aliases: Set<String>, _ path: Path, _ frameworkPaths: [String], _ libraryPaths: [String], _ defaultSettings: [String: PropertyListItem], _ overrideSettings: [String: PropertyListItem], _ defaultSettingsWhenPrimary: [String: PropertyListItem], executableSearchPaths: [Path], testingLibraryPlatformNames: Set<String>, fs: any FSProxy) {
+    package init(identifier: String, displayName: String, version: Version, aliases: Set<String>, path: Path, frameworkPaths: [String], libraryPaths: [String], defaultSettings: [String: PropertyListItem], overrideSettings: [String: PropertyListItem], defaultSettingsWhenPrimary: [String: PropertyListItem], executableSearchPaths: [Path], testingLibraryPlatformNames: Set<String>, fs: any FSProxy) {
         self.identifier = identifier
         self.version = version
 
@@ -104,7 +104,7 @@ public final class Toolchain: Hashable, Sendable {
         self.testingLibraryPlatformNames = testingLibraryPlatformNames
     }
 
-    convenience init(_ path: Path, operatingSystem: OperatingSystem, fs: any FSProxy, pluginManager: PluginManager, platformRegistry: PlatformRegistry?) async throws {
+    convenience init(path: Path, operatingSystem: OperatingSystem, fs: any FSProxy, pluginManager: PluginManager, platformRegistry: PlatformRegistry?) async throws {
         let data: PropertyListItem
 
         do {
@@ -305,7 +305,7 @@ public final class Toolchain: Hashable, Sendable {
         }
 
         // Construct the toolchain
-        self.init(identifier, displayName, version, aliases, path, frameworkSearchPaths, librarySearchPaths, defaultSettings, overrideSettings, defaultSettingsWhenPrimary, executableSearchPaths: executableSearchPaths, testingLibraryPlatformNames: testingLibraryPlatformNames, fs: fs)
+        self.init(identifier: identifier, displayName: displayName, version: version, aliases: aliases, path: path, frameworkPaths: frameworkSearchPaths, libraryPaths: librarySearchPaths, defaultSettings: defaultSettings, overrideSettings: overrideSettings, defaultSettingsWhenPrimary: defaultSettingsWhenPrimary, executableSearchPaths: executableSearchPaths, testingLibraryPlatformNames: testingLibraryPlatformNames, fs: fs)
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -474,7 +474,7 @@ public final class ToolchainRegistry: @unchecked Sendable {
             guard toolchainPath.basenameWithoutSuffix != "swift-latest" else { continue }
 
             do {
-                let toolchain = try await Toolchain(toolchainPath, operatingSystem: operatingSystem, fs: fs, pluginManager: delegate.pluginManager, platformRegistry: delegate.platformRegistry)
+                let toolchain = try await Toolchain(path: toolchainPath, operatingSystem: operatingSystem, fs: fs, pluginManager: delegate.pluginManager, platformRegistry: delegate.platformRegistry)
                 try register(toolchain)
             } catch let err {
                 delegate.issue(strict: strict, toolchainPath, "failed to load toolchain: \(err)")

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -132,16 +132,16 @@ struct GenericUnixToolchainRegistryExtension: ToolchainRegistryExtension {
             let llvmDirectoriesLocal = try Array(fs.listdir(Path("/usr/local")).filter { $0.hasPrefix("llvm") }.sorted().reversed())
             return [
                 Toolchain(
-                    ToolchainRegistry.defaultToolchainIdentifier,
-                    "Default",
-                    Version(),
-                    ["default"],
-                    path,
-                    [],
-                    llvmDirectories.map { "/usr/lib/\($0)/lib" } + llvmDirectoriesLocal.map { "/usr/local/\($0)/lib" } + ["/usr/lib64"],
-                    [:],
-                    [:],
-                    [:],
+                    identifier: ToolchainRegistry.defaultToolchainIdentifier,
+                    displayName: "Default",
+                    version: Version(),
+                    aliases: ["default"],
+                    path: path,
+                    frameworkPaths: [],
+                    libraryPaths: llvmDirectories.map { "/usr/lib/\($0)/lib" } + llvmDirectoriesLocal.map { "/usr/local/\($0)/lib" } + ["/usr/lib64"],
+                    defaultSettings: [:],
+                    overrideSettings: [:],
+                    defaultSettingsWhenPrimary: [:],
                     executableSearchPaths: realSwiftPath.dirname.relativeSubpath(from: path).map { [path.join($0).join("bin")] } ?? [],
                     testingLibraryPlatformNames: [],
                     fs: fs)

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -146,6 +146,21 @@ struct QNXToolchainRegistryExtension: ToolchainRegistryExtension {
             return []
         }
 
-        return [Toolchain("qnx", "QNX", Version(0, 0, 0), [], toolchainPath, [], [], [:], [:], [:], executableSearchPaths: [toolchainPath.join("usr").join("bin")], testingLibraryPlatformNames: [], fs: context.fs)]
+        return [
+            Toolchain(
+                identifier: "qnx",
+                displayName: "QNX",
+                version: Version(0, 0, 0),
+                aliases: [],
+                path: toolchainPath,
+                frameworkPaths: [],
+                libraryPaths: [],
+                defaultSettings: [:],
+                overrideSettings: [:],
+                defaultSettingsWhenPrimary: [:],
+                executableSearchPaths: [toolchainPath.join("usr").join("bin")],
+                testingLibraryPlatformNames: [],
+                fs: context.fs)
+        ]
     }
 }

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -386,7 +386,7 @@ import Foundation
                 guard context.toolchainRegistry.lookup(ToolchainRegistry.defaultToolchainIdentifier) == nil else {
                     return []
                 }
-                return [Toolchain(ToolchainRegistry.defaultToolchainIdentifier, "Mock", Version(), ["default"], .root, [], [], [:], [:], [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
+                return [Toolchain(identifier: ToolchainRegistry.defaultToolchainIdentifier, displayName: "Mock", version: Version(), aliases: ["default"], path: .root, frameworkPaths: [], libraryPaths: [], defaultSettings: [:], overrideSettings: [:], defaultSettingsWhenPrimary: [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
             }
         }
         await pluginManager.register(MockToolchainExtension(), type: ToolchainRegistryExtensionPoint.self)
@@ -424,7 +424,7 @@ import Foundation
                 guard context.toolchainRegistry.lookup(ToolchainRegistry.defaultToolchainIdentifier) == nil else {
                     return []
                 }
-                return [Toolchain(ToolchainRegistry.defaultToolchainIdentifier, "Mock", Version(), ["default"], .root, [], [], [:], [:], [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
+                return [Toolchain(identifier: ToolchainRegistry.defaultToolchainIdentifier, displayName: "Mock", version: Version(), aliases: ["default"], path: .root, frameworkPaths: [], libraryPaths: [], defaultSettings: [:], overrideSettings: [:], defaultSettingsWhenPrimary: [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
             }
         }
         await pluginManager.register(MockToolchainExtension(), type: ToolchainRegistryExtensionPoint.self)

--- a/Tests/SWBCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SWBCoreTests/ToolchainRegistryTests.swift
@@ -78,7 +78,7 @@ import SWBUtil
                     guard context.toolchainRegistry.lookup(ToolchainRegistry.defaultToolchainIdentifier) == nil else {
                         return []
                     }
-                    return [Toolchain(ToolchainRegistry.defaultToolchainIdentifier, "Mock", Version(), ["default"], .root, [], [], [:], [:], [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
+                    return [Toolchain(identifier: ToolchainRegistry.defaultToolchainIdentifier, displayName: "Mock", version: Version(), aliases: ["default"], path: .root, frameworkPaths: [], libraryPaths: [], defaultSettings: [:], overrideSettings: [:], defaultSettingsWhenPrimary: [:], executableSearchPaths: [], testingLibraryPlatformNames: [], fs: context.fs)]
                 }
             }
             await pluginManager.register(MockToolchainExtension(), type: ToolchainRegistryExtensionPoint.self)


### PR DESCRIPTION
This is some of the oldest code in the codebase, written to Swift 3 standards. Modernize it so it's more readable.