### PR TITLE
Adopt libclang working directory optimization API

### DIFF
--- a/Sources/SWBCSupport/CLibclang.h
+++ b/Sources/SWBCSupport/CLibclang.h
@@ -49,6 +49,7 @@ typedef struct {
     const char *module_map_path;
     const char **file_deps;
     const char *include_tree_id;
+    bool is_cwd_ignored;
     const char **module_deps;
     const char *cache_key;
     const char **build_arguments;
@@ -121,6 +122,9 @@ bool libclang_has_cas_pruning_feature(libclang_t lib);
 
 /// Whether the libclang has CAS up-to-date checking support.
 bool libclang_has_cas_up_to_date_checks_feature(libclang_t lib);
+
+/// Whether the libclang has current working directory optimization support.
+bool libclang_has_current_working_directory_optimization(libclang_t lib);
 
 /// Create the CAS options object.
 libclang_casoptions_t libclang_casoptions_create(libclang_t lib);

--- a/Sources/SWBCore/LibclangVendored/Libclang.swift
+++ b/Sources/SWBCore/LibclangVendored/Libclang.swift
@@ -98,6 +98,10 @@ public final class Libclang {
     public var supportsCASUpToDateChecks: Bool {
         libclang_has_cas_up_to_date_checks_feature(lib)
     }
+
+    public var supportsCurrentWorkingDirectoryOptimization: Bool {
+        libclang_has_current_working_directory_optimization(lib)
+    }
 }
 
 enum DependencyScanningError: Error {
@@ -130,6 +134,7 @@ public final class DependencyScanner {
         public var module_deps: some Sequence<String> { clang_module_dependency.module_deps.toLazyStringSequence() }
         public var cache_key: String? { clang_module_dependency.cache_key.map { String(cString: $0) } }
         public var build_arguments: some Sequence<String> { clang_module_dependency.build_arguments.toLazyStringSequence() }
+        public var is_cwd_ignored: Bool { clang_module_dependency.is_cwd_ignored }
     }
 
     public struct Command {

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
@@ -429,8 +429,8 @@ package final class ClangModuleDependencyGraph {
                                     fileDependencies: fileDependencies,
                                     includeTreeID: module.include_tree_id,
                                     moduleDependencies: OrderedSet(moduleDeps),
-                                    // Cached builds do not rely on the process working directory, and different scanner working directories should not inhibit task deduplication
-                                    workingDirectory: module.cache_key != nil ? Path.root : workingDirectory,
+                                    // Cached builds do not rely on the process working directory, and different scanner working directories should not inhibit task deduplication. The same is true if the scanner reports the working directory can be ignored.
+                                    workingDirectory: module.cache_key != nil || module.is_cwd_ignored ? Path.root : workingDirectory,
                                     command: DependencyInfo.CompileCommand(cacheKey: module.cache_key, arguments: commandLine),
                                     transitiveIncludeTreeIDs: transitiveIncludeTreeIDs,
                                     transitiveCompileCommandCacheKeys: transitiveCommandCacheKeys,

--- a/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
@@ -144,7 +144,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
                 taskKey: .precompileClangModule(precompileModuleTaskKey),
                 taskID: state.dynamicTaskBaseID,
                 singleUse: true,
-                workingDirectory: dependencyInfo.workingDirectory,
+                workingDirectory: Path.root,
                 environment: task.environment,
                 forTarget: nil,
                 priority: .preferred,

--- a/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
@@ -101,7 +101,7 @@ final public class PrecompileClangModuleTaskAction: TaskAction, BuildValueValida
                 taskKey: .precompileClangModule(taskKey),
                 taskID: taskID,
                 singleUse: false,
-                workingDirectory: dependencyInfo.workingDirectory,
+                workingDirectory: Path.root,
                 environment: task.environment,
                 forTarget: task.forTarget,
                 priority: .preferred,
@@ -188,7 +188,7 @@ final public class PrecompileClangModuleTaskAction: TaskAction, BuildValueValida
                 if try ClangCompileTaskAction.replayCachedCommand(
                     command,
                     casDBs: casDBs,
-                    workingDirectory: task.workingDirectory,
+                    workingDirectory: dependencyInfo.workingDirectory,
                     outputDelegate: outputDelegate,
                     enableDiagnosticRemarks: key.casOptions!.enableDiagnosticRemarks
                 ) {
@@ -198,7 +198,7 @@ final public class PrecompileClangModuleTaskAction: TaskAction, BuildValueValida
 
             let delegate = TaskProcessDelegate(outputDelegate: outputDelegate)
             // The frontend invocations should be unaffected by the environment, pass an empty one.
-            try await spawn(commandLine: commandLine, environment: [:], workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
+            try await spawn(commandLine: commandLine, environment: [:], workingDirectory: dependencyInfo.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
 
             let result = delegate.commandResult ?? .failed
             if result == .succeeded {

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -346,6 +346,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    package static var requireDependencyScannerWorkingDirectoryOptimization: Self {
+        enabled {
+            let libclang = try #require(try await ConditionTraitContext.shared.libclang)
+            return libclang.supportsCurrentWorkingDirectoryOptimization
+        }
+    }
+
     package static var requireCompilationCaching: Self {
         enabled("compilation caching is not supported") {
             try await ConditionTraitContext.shared.supportsCompilationCaching


### PR DESCRIPTION
Adopt new libclang API which the scanner uses to notify the build system when it is ok to compile a module using an arbitrary current working directory to facilitate increased module sharing. The relevant API was introduced in https://github.com/swiftlang/llvm-project/pull/10146.

rdar://145991369