### PR TITLE
OpenBSD support.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -195,7 +195,7 @@ let package = Package(
                 "SWBCSupport",
                 "SWBLibc",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .android])),
+                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .openbsd, .android])),
                 .product(name: "SystemPackage", package: "swift-system", condition: .when(platforms: [.linux, .android, .windows])),
             ],
             exclude: ["CMakeLists.txt"],

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -665,7 +665,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
             let UTIME_OMIT = 1073741822
             #endif
             let atime = timespec(tv_sec: 0, tv_nsec: Int(UTIME_OMIT))
-            let mtime = timespec(tv_sec: timestamp, tv_nsec: 0)
+            let mtime = timespec(tv_sec: time_t(timestamp), tv_nsec: 0)
             guard utimensat(AT_FDCWD, path.str, [atime, mtime], 0) == 0 else {
                 throw POSIXError(errno, context: "utimensat", "AT_FDCWD", path.str, String(timestamp))
             }
@@ -1390,7 +1390,7 @@ public class PseudoFS: FSProxy, @unchecked Sendable {
                 #if os(Windows)
                 info.st_mtimespec = timespec(tv_sec: Int64(node.timestamp), tv_nsec: 0)
                 #else
-                info.st_mtimespec = timespec(tv_sec: node.timestamp, tv_nsec: 0)
+                info.st_mtimespec = timespec(tv_sec: time_t(node.timestamp), tv_nsec: 0)
                 #endif
                 info.st_size = off_t(contents.bytes.count)
                 info.st_dev = node.device
@@ -1403,7 +1403,7 @@ public class PseudoFS: FSProxy, @unchecked Sendable {
                 info.st_mtimespec = timespec(tv_sec: Int64(node.timestamp), tv_nsec: 0)
                 #else
                 info.st_mode = S_IFDIR
-                info.st_mtimespec = timespec(tv_sec: node.timestamp, tv_nsec: 0)
+                info.st_mtimespec = timespec(tv_sec: time_t(node.timestamp), tv_nsec: 0)
                 #endif
                 info.st_size = off_t(dir.contents.count)
                 info.st_dev = node.device
@@ -1416,7 +1416,7 @@ public class PseudoFS: FSProxy, @unchecked Sendable {
                 info.st_mtimespec = timespec(tv_sec: Int64(node.timestamp), tv_nsec: 0)
                 #else
                 info.st_mode = S_IFLNK
-                info.st_mtimespec = timespec(tv_sec: node.timestamp, tv_nsec: 0)
+                info.st_mtimespec = timespec(tv_sec: time_t(node.timestamp), tv_nsec: 0)
                 #endif
                 info.st_size = off_t(0)
                 info.st_dev = node.device

--- a/Sources/SWBUtil/Lock.swift
+++ b/Sources/SWBUtil/Lock.swift
@@ -26,6 +26,9 @@ public final class Lock: @unchecked Sendable {
     #if os(Windows)
     @usableFromInline
     let mutex: UnsafeMutablePointer<SRWLOCK> = UnsafeMutablePointer.allocate(capacity: 1)
+    #elseif os(OpenBSD)
+    @usableFromInline
+    let mutex: UnsafeMutablePointer<pthread_mutex_t?> = UnsafeMutablePointer.allocate(capacity: 1)
     #else
     @usableFromInline
     let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)


### PR DESCRIPTION
* Ensure the swift-crypto dependency is conditioned for the platform.

  The relevant swift-crypto changes are not landed upstream yet, but when they are, this picks up the dependency.

* Cast timestamps to time_t.

  This is done unconditionally here, because the standard specifies that `tv_sec` in `timespec` has type `time_t`, and doing so avoids a type mismatch error on the platform.

* Since pthread types are pointers here, make the usual changes to capture the fact they are optional types on the Swift side.

So far, this has been the only set of changes that have seemed necessary.

Fixes swiftlang/swift-build#114.