### PR TITLE
Fix a bunch of tests accidentally reliant on in-memory caches

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
@@ -98,7 +98,7 @@ fileprivate struct BuildBacktraceTests: CoreBasedTests {
                 }
             }
 
-            try await tester.checkNullBuild(runDestination: .macOS, buildRequest: buildRequest)
+            try await tester.checkNullBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true)
 
             try await tester.fs.writeFileContents(SRCROOT.join("Sources/foo.c")) { file in
                 file <<<
@@ -441,7 +441,7 @@ fileprivate struct BuildBacktraceTests: CoreBasedTests {
                 results.checkNoDiagnostics()
             }
 
-            try await tester.checkNullBuild(runDestination: .macOS, buildRequest: buildRequest, signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs)
+            try await tester.checkNullBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true, signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs)
 
             try await tester.fs.writeFileContents(SRCROOT.join("Sources/foo.c")) { file in
                 file <<<

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -3066,7 +3066,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                 let buildTargets = tester.workspace.projects[0].targets.map { BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }
                 let buildRequest = BuildRequest(parameters: parameters, buildTargets: buildTargets, dependencyScope: .workspace, continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false, buildCommand: .build(style: .buildOnly, skipDependencies: false), schemeCommand: .launch)
 
-                try await tester.checkBuild(parameters: parameters, runDestination: runDestination, buildRequest: buildRequest, signableTargets: signableTargets) { results in
+                try await tester.checkBuild(parameters: parameters, runDestination: runDestination, buildRequest: buildRequest, persistent: true, signableTargets: signableTargets) { results in
                     results.checkNoDiagnostics()
                     results.consumeTasksMatchingRuleTypes()
 
@@ -3436,7 +3436,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
 
             // Perform the first (clean) build and expect to see a compile task.
             try await confirmation("First archive should succeed.") { firstBuildSucceed in
-                try await tester.checkBuild(parameters: parameters, runDestination: .macOS) { results in
+                try await tester.checkBuild(parameters: parameters, runDestination: .macOS, persistent: true) { results in
                     results.checkTask(.matchRuleItem("CompileC"), body: { _ in })
                     results.checkTasks { tasks in
                         #expect(tasks.count > 0)
@@ -3448,7 +3448,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
 
             // Perform the second (incremental) build, and expect to see no tasks run because we didn't change anything.
             try await confirmation("Second archive should succeed.") { secondBuildSucceed in
-                try await tester.checkBuild(parameters: parameters, runDestination: .macOS) { results in
+                try await tester.checkBuild(parameters: parameters, runDestination: .macOS, persistent: true) { results in
                     results.checkTasks(.matchRuleType("ClangStatCache")) { _ in }
                     if tester.userPreferences.enableBuildSystemCaching {
                         results.checkNoTask()

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -1836,7 +1836,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 """
             }
 
-            try await tester.checkBuild(runDestination: .macOS) { results in
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
                 // There be 2 scanning actions.
                 results.checkTasks(.matchRuleType("ScanDependencies")) { scanTasks in
                     #expect(scanTasks.count == 2)
@@ -1856,7 +1856,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 """
             }
 
-            try await tester.checkBuild(runDestination: .macOS) { results in
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
                 // There should 2 scanning actions.
                 // Both files will recompile.
                 results.checkTasks(.matchRuleType("ScanDependencies")) { compileTasks in
@@ -1892,7 +1892,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 """
             }
 
-            try await tester.checkBuild(runDestination: .macOS) { results in
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
                 // There should 2 scanning actions.
                 // Both files will recompile.
                 results.checkTasks(.matchRuleType("ScanDependencies")) { compileTasks in

--- a/Tests/SWBBuildSystemTests/InstallAPIBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/InstallAPIBuildOperationTests.swift
@@ -76,7 +76,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS, persistent: true)
 
                 // Update a public header.
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/Public.h"), body: { $0 <<< "void f(void); // prototype" })
@@ -86,7 +86,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS, persistent: true)
 
                 // Update a private header.
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/Private.h"), body: { $0 <<< "void g(void); // prototype" })
@@ -96,7 +96,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS, persistent: true)
                 try await tester.checkBuild(parameters: parameters, runDestination: .macOS, buildCommand: .cleanBuildFolder(style: .regular)) { _ in }
             }
         }
@@ -161,7 +161,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS, persistent: true)
 
                 // Update a private header.
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/Private.h"), body: { $0 <<< "void g(void); // prototype" })
@@ -171,7 +171,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOS, persistent: true)
                 try await tester.checkBuild(parameters: parameters, runDestination: .macOS, buildCommand: .cleanBuildFolder(style: .regular)) { _ in }
             }
         }
@@ -253,7 +253,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: false), runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: false), runDestination: .macOS, persistent: true)
 
                 try await tester.checkBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: true), runDestination: .macOS, persistent: true) { results in
                     try results.checkTask(.matchRuleType("GenerateTAPI")) { tapiTask in
@@ -265,7 +265,7 @@ fileprivate struct InstallAPIBuildOperationTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                 }
 
-                try await tester.checkNullBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: true), runDestination: .macOS)
+                try await tester.checkNullBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: true), runDestination: .macOS, persistent: true)
                 try await tester.checkBuild(parameters: parameters(excludePublicHeader: true, excludePrivateHeader: true), runDestination: .macOS, buildCommand: .cleanBuildFolder(style: .regular)) { _ in }
             }
         }


### PR DESCRIPTION
These tests could occasionally fail if an in-memory build description was evicted at the right time. Ensure they can fallback to the individual temp directories' on disk caches

