### PR TITLE
[Specs] Introduce `COMPILATION_CACHE_ENABLE_CACHING` for controlling all the compiler-specific caching settings

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -507,7 +507,7 @@ public final class BuiltinMacros {
     public static let CLANG_EXPLICIT_MODULES_IGNORE_LIBCLANG_VERSION_MISMATCH = BuiltinMacros.declareBooleanMacro("CLANG_EXPLICIT_MODULES_IGNORE_LIBCLANG_VERSION_MISMATCH")
     public static let CLANG_EXPLICIT_MODULES_OUTPUT_PATH = BuiltinMacros.declareStringMacro("CLANG_EXPLICIT_MODULES_OUTPUT_PATH")
     public static let SWIFT_EXPLICIT_MODULES_OUTPUT_PATH = BuiltinMacros.declareStringMacro("SWIFT_EXPLICIT_MODULES_OUTPUT_PATH")
-    public static let CLANG_ENABLE_COMPILE_CACHE = BuiltinMacros.declareEnumMacro("CLANG_ENABLE_COMPILE_CACHE") as EnumMacroDeclaration<CompilationCachingSetting>
+    public static let CLANG_ENABLE_COMPILE_CACHE = BuiltinMacros.declareBooleanMacro("CLANG_ENABLE_COMPILE_CACHE")
     public static let CLANG_CACHE_FINE_GRAINED_OUTPUTS = BuiltinMacros.declareEnumMacro("CLANG_CACHE_FINE_GRAINED_OUTPUTS") as EnumMacroDeclaration<FineGrainedCachingSetting>
     public static let CLANG_CACHE_FINE_GRAINED_OUTPUTS_VERIFICATION = BuiltinMacros.declareEnumMacro("CLANG_CACHE_FINE_GRAINED_OUTPUTS_VERIFICATION") as EnumMacroDeclaration<FineGrainedCachingVerificationSetting>
     public static let CLANG_DISABLE_DEPENDENCY_INFO_FILE = BuiltinMacros.declareBooleanMacro("CLANG_DISABLE_DEPENDENCY_INFO_FILE")
@@ -1066,7 +1066,7 @@ public final class BuiltinMacros {
     public static let SWIFT_VERSION = BuiltinMacros.declareStringMacro("SWIFT_VERSION")
     public static let EFFECTIVE_SWIFT_VERSION = BuiltinMacros.declareStringMacro("EFFECTIVE_SWIFT_VERSION")
     public static let SWIFT_WHOLE_MODULE_OPTIMIZATION = BuiltinMacros.declareBooleanMacro("SWIFT_WHOLE_MODULE_OPTIMIZATION")
-    public static let SWIFT_ENABLE_COMPILE_CACHE = BuiltinMacros.declareEnumMacro("SWIFT_ENABLE_COMPILE_CACHE") as EnumMacroDeclaration<CompilationCachingSetting>
+    public static let SWIFT_ENABLE_COMPILE_CACHE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_COMPILE_CACHE")
     public static let SWIFT_ENABLE_PREFIX_MAPPING = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_PREFIX_MAPPING")
     public static let SWIFT_OTHER_PREFIX_MAPPINGS = BuiltinMacros.declareStringListMacro("SWIFT_OTHER_PREFIX_MAPPINGS")
     public static let SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR = BuiltinMacros.declareStringMacro("SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR")
@@ -2629,15 +2629,6 @@ public enum SwiftDependencyRegistrationMode: String, Equatable, Hashable, Enumer
     case makeStyleDependenciesSupplementedByScanner = "make-style"
     case swiftDependencyScannerOnly = "dependency-scanner"
     case verifySwiftDependencyScanner = "verify-swift-dependency-scanner"
-}
-
-/// Enumeration macro type for tri-state boolean value of whether the user has enabled compilation caching builds, disabled, or not set.
-public enum CompilationCachingSetting: String, Equatable, Hashable, EnumerationMacroType {
-    public static let defaultValue = CompilationCachingSetting.notset
-
-    case notset = "NOT_SET"
-    case enabled = "YES"
-    case disabled = "NO"
 }
 
 public enum FineGrainedCachingSetting: String, Equatable, Hashable, EnumerationMacroType {

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -581,11 +581,11 @@ final class WorkspaceSettings: Sendable {
         }
 
         if SWBFeatureFlag.enableClangCachingByDefault.value {
-            table.push(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE, literal: .enabled)
+            table.push(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE, literal: true)
         }
 
         if SWBFeatureFlag.enableSwiftCachingByDefault.value {
-            table.push(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE, literal: .enabled)
+            table.push(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE, literal: true)
         }
 
         return table

--- a/Sources/SWBCore/ShellScript.swift
+++ b/Sources/SWBCore/ShellScript.swift
@@ -216,7 +216,7 @@ public func computeScriptEnvironment(_ type: ScriptType, scope: MacroEvaluationS
     // Ensure that BUILD_DESCRIPTION_CACHE_DIR is never exported as it is *not* something we want customers to use.
     result.removeValue(forKey: BuiltinMacros.BUILD_DESCRIPTION_CACHE_DIR.name)
 
-    if scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE) == .enabled {
+    if scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE) {
         // Make sure the cache directory is not going to be deleted via an `xcodebuild` invocation from the script.
         result["COMPILATION_CACHE_KEEP_CAS_DIRECTORY"] = "YES"
     }

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -847,7 +847,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             return false
         }
 
-        let buildSettingEnabled = cbc.scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE) == .enabled
+        let buildSettingEnabled = cbc.scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE)
 
         // If a blocklist is provided in the toolchain, use it to determine the default for the current project
         guard let blocklist = clangInfo?.clangCachingBlocklist else {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1412,7 +1412,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
     private func swiftCachingEnabled(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, _ moduleName: String, _ useIntegratedDriver: Bool, _ explicitModuleBuildEnabled: Bool, _ disabledPCHCompile: Bool) async -> Bool {
         guard cbc.producer.supportsCompilationCaching else { return false }
 
-        guard cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE) == .enabled else {
+        guard cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE) else {
             return false
         }
         if cbc.scope.evaluate(BuiltinMacros.INDEX_ENABLE_BUILD_ARENA) {

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -1748,6 +1748,22 @@ For more information on mergeable libraries, see [Configuring your project to us
                 DefaultValue = NO;
             },
 
+            {
+                Name = "COMPILATION_CACHE_ENABLE_CACHING";
+                Type = Boolean;
+                Category = "Compilation Caching";
+                DefaultValue = "$(COMPILATION_CACHE_ENABLE_CACHING_DEFAULT)";
+                DisplayName = "Enable Compilation Caching";
+                Description = "Caches the results of compilations for a particular set of inputs.";
+            },
+            {
+                Name = "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS";
+                Type = Boolean;
+                Category = "Compilation Caching";
+                DisplayName = "Compilation Caching Diagnostic Info";
+                Description = "Emits diagnostic information for cached compilation tasks.";
+            },
+
             // FIXME: The TAPI settings should not need to be here in order to have them appear in the project editor UI.
             {
                 Name = "SUPPORTS_TEXT_BASED_API";

--- a/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
@@ -2948,6 +2948,12 @@
                 };
             },
 
+            {
+                Name = "CLANG_ENABLE_COMPILE_CACHE";
+                Type = Boolean;
+                DefaultValue = "$(COMPILATION_CACHE_ENABLE_CACHING)";
+            },
+
             // Thread Sanitizer options.
             {
                 Name = "CLANG_THREAD_SANITIZER";

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -931,6 +931,11 @@
                 Description = "Coordinates the build of the main module's modular dependencies via explicit tasks scheduled by the build system.";
             },
             {
+                Name = "SWIFT_ENABLE_COMPILE_CACHE";
+                Type = Boolean;
+                DefaultValue = "$(COMPILATION_CACHE_ENABLE_CACHING)";
+            },
+            {
                 Name = "SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS";
                 Type = Boolean;
                 DefaultValue = "$(_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES:default=$(SWIFT_ENABLE_EXPLICIT_MODULES))";

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1848,14 +1848,14 @@ import SWBMacro
         let core = try await getCore()
         let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
         let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp") as FileTypeSpec
-        let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_COMPILE_CACHE") as? EnumMacroDeclaration<CompilationCachingSetting>)
+        let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
 
         func test(caching: Bool, prefixMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
-            table.push(enableCompileCache, literal: caching ? .enabled : .disabled)
+            table.push(enableCompileCache, literal: caching)
             table.push(enablePrefixMap, literal: prefixMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")
@@ -1902,7 +1902,7 @@ import SWBMacro
         let swiftSpec = try core.specRegistry.getSpec("com.apple.xcode.tools.swift.compiler") as CompilerSpec
 
         let mockFileType = try core.specRegistry.getSpec("sourcecode.swift") as FileTypeSpec
-        let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_COMPILE_CACHE") as? EnumMacroDeclaration<CompilationCachingSetting>)
+        let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
@@ -1922,7 +1922,7 @@ import SWBMacro
 
             // remove in rdar://53000820
             table.push(BuiltinMacros.USE_SWIFT_RESPONSE_FILE, literal: true)
-            table.push(enableCompileCache, literal: caching ? .enabled : .disabled)
+            table.push(enableCompileCache, literal: caching)
             table.push(enablePrefixMap, literal: prefixMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")


### PR DESCRIPTION
Also make the new setting, along with `COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS` show up in settings UI.