### PR TITLE
Make some `SWBBuildService` APIs public

### DIFF
--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -13,7 +13,7 @@
 import struct Foundation.Date
 
 package import SWBBuildSystem
-package import SWBCore
+public import SWBCore
 import SWBLibc
 import SWBProtocol
 import SWBServiceCore
@@ -25,7 +25,7 @@ import SWBMacro
 // FIXME: Workaround: <rdar://problem/26249252> Unable to prefer my own type over NS renamed types
 import class SWBTaskExecution.Task
 
-package protocol ActiveBuildOperation {
+public protocol ActiveBuildOperation {
     /// A unique identifier for this build.
     var id: Int { get }
 

--- a/Sources/SWBBuildService/BuildService.swift
+++ b/Sources/SWBBuildService/BuildService.swift
@@ -14,8 +14,8 @@ import Foundation
 import SWBBuildSystem
 import SWBCore
 import SWBLibc
-package import SWBProtocol
-package import SWBServiceCore
+public import SWBProtocol
+public import SWBServiceCore
 import SWBUtil
 
 typealias Cache = SWBUtil.Cache
@@ -46,7 +46,7 @@ private struct CoreCacheKey: Equatable, Hashable {
 /// This is the central class which manages a service instance communicating with a unique client.
 ///
 /// This class is designed to be thread safe: clients can send messages from any thread and they will be sent in FIFO order. Note that individual messages are currently always processed in FIFO order non-concurrently. Messages which require non-trivial amounts of time to service should always be split to use an asynchronous reply.
-package class BuildService: Service, @unchecked Sendable {
+open class BuildService: Service, @unchecked Sendable {
     /// The map of registered sessions.
     var sessionMap = Dictionary<String, Session>()
 
@@ -67,7 +67,7 @@ package class BuildService: Service, @unchecked Sendable {
     /// Async lock to guard access to `sharedCoreCache`, since its `getOrInsert` method can't be given an async closure.
     private var sharedCoreCacheLock = ActorLock()
 
-    package func nextBuildOperationID() -> Int {
+    public func nextBuildOperationID() -> Int {
         return lastBuildOperationID.withLock { value in
             let lastID = value
             value += 1

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -13,7 +13,7 @@
 import SWBBuildSystem
 package import SWBCore
 import SWBProtocol
-package import SWBServiceCore
+public import SWBServiceCore
 import SWBTaskConstruction
 import SWBTaskExecution
 package import SWBUtil
@@ -1557,10 +1557,10 @@ private struct ClearAllCaches: MessageHandler {
 
 // MARK: ServiceExtension Support
 
-package struct ServiceSessionMessageHandlers: ServiceExtension {
-    package init() {}
+public struct ServiceSessionMessageHandlers: ServiceExtension {
+    public init() {}
 
-    package func register(_ service: Service) {
+    public func register(_ service: Service) {
         service.registerMessageHandler(CreateSessionHandler.self)
         service.registerMessageHandler(ListSessionsHandler.self)
         service.registerMessageHandler(WaitForQuiescenceHandler.self)
@@ -1573,10 +1573,10 @@ package struct ServiceSessionMessageHandlers: ServiceExtension {
     }
 }
 
-package struct ServicePIFMessageHandlers: ServiceExtension {
-    package init() {}
+public struct ServicePIFMessageHandlers: ServiceExtension {
+    public init() {}
 
-    package func register(_ service: Service) {
+    public func register(_ service: Service) {
         service.registerMessageHandler(SetSessionPIFMsg.self)
         service.registerMessageHandler(TransferSessionPIFMsg.self)
         service.registerMessageHandler(TransferSessionPIFObjectsMsg.self)
@@ -1595,10 +1595,10 @@ package struct WorkspaceModelMessageHandlers: ServiceExtension {
     }
 }
 
-package struct ActiveBuildBasicMessageHandlers: ServiceExtension {
-    package init() {}
+public struct ActiveBuildBasicMessageHandlers: ServiceExtension {
+    public init() {}
 
-    package func register(_ service: Service) {
+    public func register(_ service: Service) {
         service.registerMessageHandler(CreateBuildRequestMsg.self)
         service.registerMessageHandler(BuildStartRequestMsg.self)
         service.registerMessageHandler(BuildCancelRequestMsg.self)

--- a/Sources/SWBBuildService/Session.swift
+++ b/Sources/SWBBuildService/Session.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SWBBuildSystem
-package import SWBCore
-package import SWBProtocol
-package import SWBServiceCore
+public import SWBCore
+public import SWBProtocol
+public import SWBServiceCore
 package import SWBTaskExecution
 import SWBUtil
 import struct Foundation.UUID
@@ -26,7 +26,7 @@ enum SessionError: Error {
 /// This class manages a unique session corresponding to a unique remote client session.
 ///
 /// A session object manages a single workspace, but the client might elect to create multiple sessions for the same workspace.
-package final class Session {
+public final class Session {
     /// A PIF transfer operation.
     final class PIFTransferOperation {
         enum Status {
@@ -149,7 +149,7 @@ package final class Session {
     let UID: String
 
     /// The active workspace session
-    package internal(set) var workspaceContext: WorkspaceContext?
+    public internal(set) var workspaceContext: WorkspaceContext?
 
     /// The incremental PIF loader.
     private let incrementalPIFLoader: IncrementalPIFLoader
@@ -343,7 +343,7 @@ package final class Session {
     }
 
     /// Registers a build operation with the session
-    package func registerActiveBuild(_ build: any ActiveBuildOperation) throws {
+    public func registerActiveBuild(_ build: any ActiveBuildOperation) throws {
         // We currently don't support running multiple build operations in one session, this is just a defensive precondition.
         // But we do allow build description creation operations to run concurrently with normal builds. These are important for index queries to function properly even during a build.
         // We also allow 'prepare-for-index' build operations to run concurrently with a normal build but only one at a time. These are important for functionality in the Xcode editor to work properly, that the user directly interacts with.
@@ -370,7 +370,7 @@ package final class Session {
     }
 
     /// Unregister a build operation from the session
-    package func unregisterActiveBuild(_ build: any ActiveBuildOperation) {
+    public func unregisterActiveBuild(_ build: any ActiveBuildOperation) {
         guard activeBuilds.removeValue(forKey: build.id) != nil else {
             fatalError("tried to unregister nonexistent build: '\(build)'")
         }
@@ -389,7 +389,7 @@ protocol ClientExchange {
 
 extension Request {
     /// Retrieve the session for the message, or throw if invalid.
-    package func session<T: SessionMessage>(for message: T) throws -> Session {
+    public func session<T: SessionMessage>(for message: T) throws -> Session {
         guard let session = buildService.sessionMap[message.sessionHandle] else {
             throw MsgParserError.unknownSession(handle: message.sessionHandle)
         }


### PR DESCRIPTION
This will allow experimentation with making build service executables which use Swift Build as a dependency.