### PR TITLE
Start passing in `-sdk-module-cache-path` to `swiftc` command-line invocations for EBM builds

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1800,11 +1800,15 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     args.append("-explicit-module-build")
                     let explicitDependencyOutputPath = Path(cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH))
                     args.append(contentsOf: ["-module-cache-path", explicitDependencyOutputPath.str])
+                    let moduleCacheDir = cbc.scope.evaluate(BuiltinMacros.MODULE_CACHE_DIR)
                     if LibSwiftDriver.supportsDriverFlag(spelled: "-clang-scanner-module-cache-path"),
-                       !cbc.scope.evaluate(BuiltinMacros.MODULE_CACHE_DIR).isEmpty {
+                       !moduleCacheDir.isEmpty {
                         // Specify the Clang scanner cache separately as a shared cache among different projects
-                        let globalModuleCacheForScanningPath = cbc.scope.evaluate(BuiltinMacros.MODULE_CACHE_DIR)
-                        args.append(contentsOf: ["-clang-scanner-module-cache-path", globalModuleCacheForScanningPath.str])
+                        args.append(contentsOf: ["-clang-scanner-module-cache-path", moduleCacheDir.str])
+                    }
+                    if LibSwiftDriver.supportsDriverFlag(spelled: "-sdk-module-cache-path"),
+                       !moduleCacheDir.isEmpty {
+                        args.append(contentsOf: ["-sdk-module-cache-path", moduleCacheDir.str])
                     }
                 }
             } else {


### PR DESCRIPTION


This will be used to share modules built from interfaces in the SDK rdar://148465272

