### PR TITLE
Ensure we do not expect additional linker args to be produced in targets with Swift-produced object files

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -896,7 +896,7 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
 
                 // If there is at least one object file that was built using Swift, ensure the Swift tool is present in the used tools to allow linker spec to add swift specific linker arguments.
                 if objectsInFrameworkPhase.contains(where: { !$0.swiftModulePaths.isEmpty }), !usedTools.keys.contains(context.swiftCompilerSpec) {
-                    usedTools[context.swiftCompilerSpec] = [context.lookupFileType(identifier: "sourcecode.swift")!]
+                    usedTools[context.swiftCompilerSpec] = [context.lookupFileType(identifier: "compiled.mach-o.objfile")!]
                 }
 
                 // If this is an API build, or there are no tasks and object files, don't link, so we don't produce a binary if we're not compiling any code.


### PR DESCRIPTION
If Swift produced an object in the linked libraries of a target, we allow it to generate additional linker options, even if it did not run to compile any source files. However, we should not attempt to inject top-level AST paths for debugging since no actual compile took place, and the paths won't exist at execution time. Use the object file type when injecting Swift tool usage in these targets so that we don't take the unintended code path.

rdar://144729550

