### PR TITLE
Fix typo in PR template's Swift CI test command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@ _[Put a one line description of your change into the PR title, please be specifi
 
 _[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_
 
-_[Tests can be run by commenting `@swift-ci` test on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
+_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_


### PR DESCRIPTION
The GitHub PR template file in this repo lists a comment you can add to a PR to cause Swift CI to run tests, but it has a formatting typo: the backtick is in the wrong place, so this PR fixes that.