### PR TITLE
Support TBDs in BuildDependencyInfo (rdar://142294767)

### DIFF
--- a/Sources/SWBBuildService/BuildDependencyInfo.swift
+++ b/Sources/SWBBuildService/BuildDependencyInfo.swift
@@ -403,10 +403,16 @@ extension BuildDependencyInfo {
 
                 let filename = resolvedBuildFile.absolutePath.basename
 
+                // TODO: all of the below are using linkType: .searchPath, we aren't reporting .absolutePath
+
                 if resolvedBuildFile.fileType.conformsTo(identifier: "wrapper.framework") {
+                    // TODO: static frameworks?
                     await inputs.addInput(TargetDependencyInfo.Input(inputType: .framework, name: .name(filename), linkType: .searchPath, libraryType: .dynamic))
                 }
                 else if resolvedBuildFile.fileType.conformsTo(identifier: "compiled.mach-o.dylib") {
+                    await inputs.addInput(TargetDependencyInfo.Input(inputType: .library, name: .name(filename), linkType: .searchPath, libraryType: .dynamic))
+                }
+                else if resolvedBuildFile.fileType.conformsTo(identifier: "sourcecode.text-based-dylib-definition") {
                     await inputs.addInput(TargetDependencyInfo.Input(inputType: .library, name: .name(filename), linkType: .searchPath, libraryType: .dynamic))
                 }
                 else if resolvedBuildFile.fileType.conformsTo(identifier: "archive.ar") {

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -273,6 +273,8 @@ package final class TestFile: TestInternalStructureItem, CustomStringConvertible
             return "text.json.xcstrings"
         case ".swift":
             return "sourcecode.swift"
+        case ".tbd":
+            return "sourcecode.text-based-dylib-definition"
         case ".tif", ".tiff":
             return "image.tiff"
         case ".txt":

--- a/Tests/SWBBuildServiceTests/BuildDependencyInfoTests.swift
+++ b/Tests/SWBBuildServiceTests/BuildDependencyInfoTests.swift
@@ -41,6 +41,7 @@ import Foundation
                     TestFile("libFoo.dylib"),
                     TestFile("libBar.a"),
                     TestFile("libBaz.a"),
+                    TestFile("libQux.tbd"),
                 ]),
             buildConfigurations: [
                 TestBuildConfiguration(
@@ -124,6 +125,7 @@ import Foundation
                         TestFrameworksBuildPhase([
                             "Foundation.framework",
                             "libBar.a",
+                            "libQux.tbd",
                         ])
                     ]
                 ),
@@ -218,6 +220,10 @@ import Foundation
                     #expect(input.linkType == .searchPath)
                 }
                 results.checkTargetInputName(target, .name("libBar.a")) { input in
+                    #expect(input.inputType == .library)
+                    #expect(input.linkType == .searchPath)
+                }
+                results.checkTargetInputName(target, .name("libQux.tbd")) { input in
                     #expect(input.inputType == .library)
                     #expect(input.linkType == .searchPath)
                 }
@@ -325,6 +331,8 @@ import Foundation
 
                                     "-Xlinker -reexport-lXlinkerLib",
                                     "-Wl,-reexport-lQuoteLib",
+
+                                    // TODO: we should support positional arguments as well but that requires a complete understanding of all possible linker args, will come back to this
                                 ].joined(separator: " ")
                             ]),
                     ],


### PR DESCRIPTION
This handles TBDs in the libraries build phase but not in OTHER_LDFLAGS yet, because we don't handle positional arguments at all. We'll need a complete understanding of the ld/driver CLI (and ability to keep it up to date) to support that. Will track that elsewhere.