### PR TITLE
Move asset catalog code generation rule ordering into SWBApplePlatform

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -155,6 +155,10 @@ struct ActoolInputFileGroupingStrategyExtension: InputFileGroupingStrategyExtens
         }
         return ["actool": Factory()]
     }
+
+    func fileTypesCompilingToSwiftSources() -> [String] {
+        return ["folder.abstractassetcatalog"]
+    }
 }
 
 struct ImageScaleFactorsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExtension {
@@ -165,6 +169,10 @@ struct ImageScaleFactorsInputFileGroupingStrategyExtension: InputFileGroupingStr
             }
         }
         return ["image-scale-factors": Factory()]
+    }
+
+    func fileTypesCompilingToSwiftSources() -> [String] {
+        return []
     }
 }
 
@@ -177,6 +185,10 @@ struct LocalizationInputFileGroupingStrategyExtension: InputFileGroupingStrategy
         }
         return ["region": Factory()]
     }
+
+    func fileTypesCompilingToSwiftSources() -> [String] {
+        return []
+    }
 }
 
 struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExtension {
@@ -187,6 +199,10 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
             }
         }
         return ["xcstrings": Factory()]
+    }
+
+    func fileTypesCompilingToSwiftSources() -> [String] {
+        return []
     }
 }
 

--- a/Sources/SWBCore/Extensions/InputFileGroupingStrategyExtension.swift
+++ b/Sources/SWBCore/Extensions/InputFileGroupingStrategyExtension.swift
@@ -22,4 +22,5 @@ public struct InputFileGroupingStrategyExtensionPoint: ExtensionPoint, Sendable 
 
 public protocol InputFileGroupingStrategyExtension: Sendable {
     func groupingStrategies() -> [String: any InputFileGroupingStrategyFactory]
+    func fileTypesCompilingToSwiftSources() -> [String]
 }


### PR DESCRIPTION
Generalize the sources phase ordering support to the reference to asset catalogs can move into the SWBApplePlatform plugin