### PR TITLE
Use -Xlinker when constructing response files for Swift AST paths

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
@@ -114,7 +114,7 @@ final public class SwiftDriverTaskAction: TaskAction, BuildValueValidatingTaskAc
                     for job in plannedBuild.explicitModulesPlannedDriverJobs() {
                         for output in job.driverJob.outputs {
                             if output.fileExtension == "swiftmodule" {
-                                responseFileCommandLine.append(contentsOf: ["-Wl,-add_ast_path", "-Wl,\(output.str)"])
+                                responseFileCommandLine.append(contentsOf: ["-Xlinker", "-add_ast_path", "-Xlinker", "\(output.str)"])
                             }
                         }
                     }


### PR DESCRIPTION
This way we don't need to vary the args based on which compiler is the linker driver

rdar://148630017