### PR TITLE
Simplify cross-platform hashing implementations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -195,7 +195,6 @@ let package = Package(
                 "SWBCSupport",
                 "SWBLibc",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux, .openbsd, .android])),
                 .product(name: "SystemPackage", package: "swift-system", condition: .when(platforms: [.linux, .android, .windows])),
             ],
             exclude: ["CMakeLists.txt"],
@@ -427,7 +426,6 @@ for target in package.targets {
 // `SWIFTCI_USE_LOCAL_DEPS` configures if dependencies are locally available to build
 if useLocalDependencies {
     package.dependencies += [
-        .package(path: "../swift-crypto"),
         .package(path: "../swift-driver"),
         .package(path: "../swift-system"),
         .package(path: "../swift-argument-parser"),
@@ -437,7 +435,6 @@ if useLocalDependencies {
     }
 } else {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0"..<"4.0.0"),
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.4.1")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),

--- a/Plugins/cmake-smoke-test/cmake-smoke-test.swift
+++ b/Plugins/cmake-smoke-test/cmake-smoke-test.swift
@@ -41,12 +41,6 @@ struct CMakeSmokeTest: CommandPlugin {
         let swiftSystemURL = try findSiblingRepository("swift-system", swiftBuildURL: swiftBuildURL)
         let swiftSystemBuildURL = context.pluginWorkDirectoryURL.appending(component: "swift-system")
 
-        let swiftAsn1URL = try findSiblingRepository("swift-asn1", swiftBuildURL: swiftBuildURL)
-        let swiftAsn1BuildURL = context.pluginWorkDirectoryURL.appending(component: "swift-asn1")
-
-        let swiftCryptoURL = try findSiblingRepository("swift-crypto", swiftBuildURL: swiftBuildURL)
-        let swiftCryptoBuildURL = context.pluginWorkDirectoryURL.appending(component: "swift-crypto")
-
         let llbuildURL = try findSiblingRepository("llbuild", swiftBuildURL: swiftBuildURL)
         let llbuildBuildURL = context.pluginWorkDirectoryURL.appending(component: "llbuild")
 
@@ -56,7 +50,7 @@ struct CMakeSmokeTest: CommandPlugin {
         let swiftDriverURL = try findSiblingRepository("swift-driver", swiftBuildURL: swiftBuildURL)
         let swiftDriverBuildURL = context.pluginWorkDirectoryURL.appending(component: "swift-driver")
 
-        for url in [swiftToolsSupportCoreBuildURL, swiftAsn1BuildURL, swiftCryptoBuildURL, swiftSystemBuildURL, llbuildBuildURL, swiftArgumentParserBuildURL, swiftDriverBuildURL, swiftBuildBuildURL] {
+        for url in [swiftToolsSupportCoreBuildURL, swiftSystemBuildURL, llbuildBuildURL, swiftArgumentParserBuildURL, swiftDriverBuildURL, swiftBuildBuildURL] {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         }
 
@@ -69,8 +63,6 @@ struct CMakeSmokeTest: CommandPlugin {
             "-DArgumentParser_DIR=\(swiftArgumentParserBuildURL.appending(components: "cmake", "modules").path())",
             "-DLLBuild_DIR=\(llbuildBuildURL.appending(components: "cmake", "modules").path())",
             "-DTSC_DIR=\(swiftToolsSupportCoreBuildURL.appending(components: "cmake", "modules").path())",
-            "-DSwiftASN1_DIR=\(swiftAsn1BuildURL.appending(components: "cmake", "modules").path())",
-            "-DSwiftCrypto_DIR=\(swiftCryptoBuildURL.appending(components: "cmake", "modules").path())",
             "-DSwiftDriver_DIR=\(swiftDriverBuildURL.appending(components: "cmake", "modules").path())",
             "-DSwiftSystem_DIR=\(swiftSystemBuildURL.appending(components: "cmake", "modules").path())"
         ]
@@ -86,18 +78,6 @@ struct CMakeSmokeTest: CommandPlugin {
         try await Process.checkNonZeroExit(url: cmakeURL, arguments: sharedCMakeArgs + [swiftToolsSupportCoreURL.path()], workingDirectory: swiftToolsSupportCoreBuildURL)
         try await Process.checkNonZeroExit(url: ninjaURL, arguments: [], workingDirectory: swiftToolsSupportCoreBuildURL)
         print("Built swift-tools-support-core")
-
-        if hostOS != .macOS && hostOS != .windows {
-            print("Building swift-asn1")
-            try await Process.checkNonZeroExit(url: cmakeURL, arguments: sharedCMakeArgs + [swiftAsn1URL.path()], workingDirectory: swiftAsn1BuildURL)
-            try await Process.checkNonZeroExit(url: ninjaURL, arguments: [], workingDirectory: swiftAsn1BuildURL)
-            print("Built swift-asn1")
-
-            print("Building swift-crypto")
-            try await Process.checkNonZeroExit(url: cmakeURL, arguments: sharedCMakeArgs + [swiftCryptoURL.path()], workingDirectory: swiftCryptoBuildURL)
-            try await Process.checkNonZeroExit(url: ninjaURL, arguments: [], workingDirectory: swiftCryptoBuildURL)
-            print("Built swift-crypto")
-        }
 
         if hostOS != .macOS {
             print("Building swift-system")

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1530,7 +1530,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
             return
         }
 
-        let signatureCtx = MD5Context()
+        let signatureCtx = InsecureHashContext()
         signatureCtx.add(string: "CleanupCompileCache")
         signatureCtx.add(string: cachePath.str)
         let signature = signatureCtx.signature

--- a/Sources/SWBCore/EnvironmentBindings.swift
+++ b/Sources/SWBCore/EnvironmentBindings.swift
@@ -41,7 +41,7 @@ public struct EnvironmentBindings: Sendable {
     }
 
     /// Add a signature of the bindings into the given context.
-    public func computeSignature(into ctx: MD5Context) {
+    public func computeSignature(into ctx: InsecureHashContext) {
         for (variable, val) in bindings {
             // The signature computation should record the variable name and value data, and the positions which divide them.
             ctx.add(string: variable)

--- a/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
+++ b/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
@@ -103,7 +103,7 @@ public struct SwiftDriverJob: Serializable, CustomDebugStringConvertible {
         self.cacheKeys = job.outputCacheKeys.reduce(into: [String]()) { result, key in
             result.append(key.value)
         }.sorted()
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         for arg in commandLine {
             md5.add(bytes: arg)
         }

--- a/Sources/SWBCore/PlannedTask.swift
+++ b/Sources/SWBCore/PlannedTask.swift
@@ -28,7 +28,7 @@ public struct TaskIdentifier: Comparable, Hashable, Serializable, CustomStringCo
     }
 
     public var sandboxProfileSentinel: String {
-        let taskIdentifierChecksumContext = MD5Context()
+        let taskIdentifierChecksumContext = InsecureHashContext()
         taskIdentifierChecksumContext.add(string: self.rawValue)
         return taskIdentifierChecksumContext.signature.asString
     }
@@ -45,7 +45,7 @@ extension TaskIdentifier {
     }
 
     public init(forTarget: ConfiguredTarget?, dynamicTaskPayload: ByteString, priority: TaskPriority) {
-        let ctx = MD5Context()
+        let ctx = InsecureHashContext()
         ctx.add(bytes: dynamicTaskPayload)
         self.rawValue = "P\(priority.rawValue):\(forTarget?.guid.stringValue ?? ""):\(forTarget?.parameters.configuration ?? ""):\(ctx.signature.asString)"
     }

--- a/Sources/SWBCore/ProjectModel/BuildPhase.swift
+++ b/Sources/SWBCore/ProjectModel/BuildPhase.swift
@@ -124,7 +124,7 @@ public class BuildPhaseWithBuildFiles: BuildPhase, @unchecked Sendable
 
     /// Returns a string that can be used as a suffix for the base name of a derived file in order to make its filename unique. This is based on the file's path but contains only characters that have no special meaning in filenames.  For example, the string will never contain a path separator character.
     public static func filenameUniquefierSuffixFor(path: Path) -> String {
-        let digester = MD5Context.init()
+        let digester = InsecureHashContext.init()
         digester.add(string: path.normalize().str)
         return digester.signature.asString
     }

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -690,7 +690,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
                 previousArg = argAsByteString
             }
 
-            let ctx = MD5Context()
+            let ctx = InsecureHashContext()
             ctx.add(string: inputFileType.identifier)
             ctx.add(string: self.identifier)
 
@@ -1412,7 +1412,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             return nil
         }
 
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         md5.add(string: prefixHeader.str)
         let sharingIdentHashValue = md5.signature
         let baseCachePath = scope.evaluate(BuiltinMacros.SHARED_PRECOMPS_DIR)

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -951,7 +951,7 @@ public final class SwiftCommandOutputParser: TaskOutputParser {
                 ruleInfo = "\(ruleInfo) \(path.str.quotedDescription)"
             }
             let signature: ByteString = {
-                let md5 = MD5Context()
+                let md5 = InsecureHashContext()
                 md5.add(string: ruleInfo)
                 return md5.signature
             }()
@@ -3584,7 +3584,7 @@ extension SwiftCompilerSpec {
     static public func computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(variant: String, arch: String, path: Path) -> ([String], ByteString) {
         let ruleInfo = ["SwiftCompile", variant, arch, path.str.quotedDescription]
         let signature: ByteString = {
-            let md5 = MD5Context()
+            let md5 = InsecureHashContext()
             md5.add(string: ruleInfo.joined(separator: " "))
             return md5.signature
         }()

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
@@ -37,7 +37,7 @@ final class CustomTaskProducer: PhasedTaskProducer, TaskProducer {
                 
                 if outputs.isEmpty {
                     // If there are no outputs, create a virtual output that can be wired up to gates
-                    let md5Context = MD5Context()
+                    let md5Context = InsecureHashContext()
                     for arg in commandLine {
                         md5Context.add(string: arg)
                     }

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -928,7 +928,7 @@ package final class BuildDescriptionBuilder {
     }
 
     package static func computeShellToolSignature(args: [ByteString], environment: EnvironmentBindings?, dependencyData: DependencyDataStyle?, isUnsafeToInterrupt: Bool, additionalSignatureData: String) -> ByteString {
-        let ctx = MD5Context()
+        let ctx = InsecureHashContext()
         for arg in args {
             ctx.add(bytes: arg)
         }

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -728,7 +728,7 @@ private final class BuildSystemTaskPlanningDelegate: TaskPlanningDelegate {
     }
 
     package func recordAttachment(contents: SWBUtil.ByteString) -> SWBUtil.Path {
-        let digester = MD5Context()
+        let digester = InsecureHashContext()
         digester.add(bytes: contents)
         let path = descriptionPath.join("attachments").join(digester.signature.asString)
         do {

--- a/Sources/SWBTaskExecution/BuildDescriptionSignature.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionSignature.swift
@@ -114,7 +114,7 @@ extension BuildDescriptionSignatureComponents {
     }
 
     func signatureStringValue(humanReadableString: ByteString) -> BuildDescriptionSignature {
-        let hashContext = MD5Context()
+        let hashContext = InsecureHashContext()
         hashContext.add(bytes: humanReadableString)
         return hashContext.signature
     }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
@@ -90,7 +90,7 @@ package final class CompilationCachingDataPruner: Sendable {
         startedAction()
         let serializer = MsgPackSerializer()
         key.serialize(to: serializer)
-        let signatureCtx = MD5Context()
+        let signatureCtx = InsecureHashContext()
         signatureCtx.add(string: "ClangCachingPruneData")
         signatureCtx.add(bytes: serializer.byteString)
         let signature = signatureCtx.signature
@@ -159,7 +159,7 @@ package final class CompilationCachingDataPruner: Sendable {
         startedAction()
         let serializer = MsgPackSerializer()
         key.serialize(to: serializer)
-        let signatureCtx = MD5Context()
+        let signatureCtx = InsecureHashContext()
         signatureCtx.add(string: "ClangCachingPruneData")
         signatureCtx.add(bytes: serializer.byteString)
         let signature = signatureCtx.signature

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
@@ -62,7 +62,7 @@ package final class CompilationCachingUploader {
         }
 
         startedUpload()
-        let signatureCtx = MD5Context()
+        let signatureCtx = InsecureHashContext()
         signatureCtx.add(string: "ClangCachingUpload")
         signatureCtx.add(string: cacheKey)
         let signature = signatureCtx.signature
@@ -122,7 +122,7 @@ package final class CompilationCachingUploader {
         }
 
         startedUpload()
-        let signatureCtx = MD5Context()
+        let signatureCtx = InsecureHashContext()
         signatureCtx.add(string: "SwiftCachingUpload")
         signatureCtx.add(string: cacheKey)
         let signature = signatureCtx.signature

--- a/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
@@ -117,7 +117,7 @@ public final class AuxiliaryFileTaskAction: TaskAction {
             serializer.serialize(context.logContents)
             super.serialize(to: serializer)
         }
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         md5.add(bytes: serializer.byteString)
         return md5.signature
     }

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobSchedulingTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobSchedulingTaskAction.swift
@@ -137,7 +137,7 @@ open class SwiftDriverJobSchedulingTaskAction: TaskAction {
                         return
                     }
 
-                    let signatureCtx = MD5Context()
+                    let signatureCtx = InsecureHashContext()
                     signatureCtx.add(string: task.identifier.rawValue)
                     signatureCtx.add(string: "swiftdriverjobdiscoveryactivity")
                     signatureCtx.add(number: dependencyID)

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -164,7 +164,7 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
     private var state = State()
 
     public override func getSignature(_ task: any ExecutableTask, executionDelegate: any TaskExecutionDelegate) -> ByteString {
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         // We intentionally do not integrate the superclass signature here, because the driver job's signature captures the same information without requiring expensive serialization.
         md5.add(bytes: driverJob.driverJob.signature)
         task.environment.computeSignature(into: md5)

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -52,7 +52,7 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
         // FIXME: This is quite inefficient as practically used by the build system, because we end up serializing every task action twice, effectively. We could do a lot better if we were willing to lift this signature out somewhere else, but this is simply and ensures that by default we tend to capture every interesting piece of information in the signature.
         let sz = MsgPackSerializer()
         serialize(to: sz)
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         md5.add(bytes: sz.byteString)
         return md5.signature
     }
@@ -67,7 +67,7 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
     /// This is checked to determine if the command needs to rebuild versus the last time it was run.
     open func getSignature(_ task: any ExecutableTask, executionDelegate: any TaskExecutionDelegate) -> ByteString
     {
-        let md5 = MD5Context()
+        let md5 = InsecureHashContext()
         md5.add(bytes: serializedRepresentationSignature!)
         for arg in task.commandLine {
             md5.add(bytes: arg.asByteString)

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -122,8 +122,8 @@ extension Trait where Self == Testing.ConditionTrait {
 
     /// Constructs a condition trait that causes a test to be disabled if not running on the specified host OS.
     /// - parameter when: An additional constraint to apply such that the host OS requirement is only applied if this parameter is _also_ true. Defaults to true.
-    package static func requireHostOS(_ os: OperatingSystem, when condition: Bool = true) -> Self {
-        enabled("This test requires a \(os) host OS.", { try ProcessInfo.processInfo.hostOperatingSystem() == os && condition })
+    package static func requireHostOS(_ os: OperatingSystem..., when condition: Bool = true) -> Self {
+        enabled("This test requires a \(os) host OS.", { os.contains(try ProcessInfo.processInfo.hostOperatingSystem()) && condition })
     }
 
     /// Constructs a condition trait that causes a test to be disabled if running on the specified host OS.

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -316,7 +316,7 @@ package class TestTaskPlanningDelegate: TaskPlanningDelegate, @unchecked Sendabl
     }
 
     package func recordAttachment(contents: SWBUtil.ByteString) -> SWBUtil.Path {
-        let digester = MD5Context()
+        let digester = InsecureHashContext()
         digester.add(bytes: contents)
         if let path = tmpDir?.path.join(digester.signature.asString) {
             do {

--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -108,5 +108,4 @@ target_link_libraries(SWBUtil PUBLIC
   SWBCSupport
   SWBLibc
   ArgumentParser
-  $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<NOT:$<PLATFORM_ID:Darwin>>>:Crypto::Crypto>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:SwiftSystem::SystemPackage>)

--- a/Sources/SWBUtil/FilesSignature.swift
+++ b/Sources/SWBUtil/FilesSignature.swift
@@ -71,7 +71,7 @@ fileprivate extension FSProxy {
 
     /// Returns the signature of a list of files.
     func filesSignature(_ statInfos: [(Path, stat?)]) -> ByteString {
-        let md5Context = MD5Context()
+        let md5Context = InsecureHashContext()
         for (path, statInfo) in statInfos {
             md5Context.add(string: path.str)
             if let statInfo {

--- a/Sources/SWBUtil/HashContext.swift
+++ b/Sources/SWBUtil/HashContext.swift
@@ -14,8 +14,6 @@
 import WinSDK
 #elseif canImport(CryptoKit)
 private import CryptoKit
-#else
-private import Crypto
 #endif
 
 public import Foundation
@@ -104,7 +102,7 @@ fileprivate final class BCryptHashContext: HashContext {
 
 @available(*, unavailable)
 extension BCryptHashContext: Sendable { }
-#else
+#elseif canImport(CryptoKit)
 fileprivate final class SwiftCryptoHashContext<HF: HashFunction>: HashContext {
     @usableFromInline
     internal var hash = HF()
@@ -147,6 +145,199 @@ fileprivate final class SwiftCryptoHashContext<HF: HashFunction>: HashContext {
 extension SwiftCryptoHashContext: Sendable { }
 #endif
 
+fileprivate final class VendoredSHA256HashContext: HashContext {
+    /// The length of the output digest (in bits).
+    private static let digestLength = 256
+
+    /// The size of each blocks (in bits).
+    private static let blockBitSize = 512
+
+    /// The initial hash value.
+    private static let initalHashValue: [UInt32] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+    ]
+
+    /// The constants in the algorithm (K).
+    private static let konstants: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    ]
+
+    private var bytes: OutputByteStream
+
+    init() {
+        self.bytes = .init()
+    }
+
+    func add<D>(bytes: D) where D : DataProtocol {
+        self.bytes.write(bytes)
+    }
+
+    var signature: ByteString {
+        let digest =  self.hash(self.bytes.bytes)
+        var result = [UInt8](repeating: 0, count: Int(digest.count) * 2)
+
+        digest.bytes.withUnsafeBufferPointer { ptr in
+            for i in 0..<ptr.count {
+                let value = ptr[i]
+                result[i*2 + 0] = hexchar(value >> 4)
+                result[i*2 + 1] = hexchar(value & 0x0F)
+            }
+        }
+
+        return ByteString(result)
+    }
+
+    private func hash(_ bytes: ByteString) -> ByteString {
+        var input = bytes.bytes
+
+        // Pad the input.
+        pad(&input)
+
+        // Break the input into N 512-bit blocks.
+        let messageBlocks = input.blocks(size: Self.blockBitSize / 8)
+
+        /// The hash that is being computed.
+        var hash = Self.initalHashValue
+
+        // Process each block.
+        for block in messageBlocks {
+            process(block, hash: &hash)
+        }
+
+        // Finally, compute the result.
+        var result = [UInt8](repeating: 0, count: Self.digestLength / 8)
+        for (idx, element) in hash.enumerated() {
+            let pos = idx * 4
+            result[pos + 0] = UInt8((element >> 24) & 0xff)
+            result[pos + 1] = UInt8((element >> 16) & 0xff)
+            result[pos + 2] = UInt8((element >> 8) & 0xff)
+            result[pos + 3] = UInt8(element & 0xff)
+        }
+
+        return ByteString(result)
+    }
+
+    /// Process and compute hash from a block.
+    private func process(_ block: ArraySlice<UInt8>, hash: inout [UInt32]) {
+
+        // Compute message schedule.
+        var W = [UInt32](repeating: 0, count: Self.konstants.count)
+        for t in 0..<W.count {
+            switch t {
+            case 0...15:
+                let index = block.startIndex.advanced(by: t * 4)
+                // Put 4 bytes in each message.
+                W[t]  = UInt32(block[index + 0]) << 24
+                W[t] |= UInt32(block[index + 1]) << 16
+                W[t] |= UInt32(block[index + 2]) << 8
+                W[t] |= UInt32(block[index + 3])
+            default:
+                let σ1 = W[t-2].rotateRight(by: 17) ^ W[t-2].rotateRight(by: 19) ^ (W[t-2] >> 10)
+                let σ0 = W[t-15].rotateRight(by: 7) ^ W[t-15].rotateRight(by: 18) ^ (W[t-15] >> 3)
+                W[t] = σ1 &+ W[t-7] &+ σ0 &+ W[t-16]
+            }
+        }
+
+        var a = hash[0]
+        var b = hash[1]
+        var c = hash[2]
+        var d = hash[3]
+        var e = hash[4]
+        var f = hash[5]
+        var g = hash[6]
+        var h = hash[7]
+
+        // Run the main algorithm.
+        for t in 0..<Self.konstants.count {
+            let Σ1 = e.rotateRight(by: 6) ^ e.rotateRight(by: 11) ^ e.rotateRight(by: 25)
+            let ch = (e & f) ^ (~e & g)
+            let t1 = h &+ Σ1 &+ ch &+ Self.konstants[t] &+ W[t]
+
+            let Σ0 = a.rotateRight(by: 2) ^ a.rotateRight(by: 13) ^ a.rotateRight(by: 22)
+            let maj = (a & b) ^ (a & c) ^ (b & c)
+            let t2 = Σ0 &+ maj
+
+            h = g
+            g = f
+            f = e
+            e = d &+ t1
+            d = c
+            c = b
+            b = a
+            a = t1 &+ t2
+        }
+
+        hash[0] = a &+ hash[0]
+        hash[1] = b &+ hash[1]
+        hash[2] = c &+ hash[2]
+        hash[3] = d &+ hash[3]
+        hash[4] = e &+ hash[4]
+        hash[5] = f &+ hash[5]
+        hash[6] = g &+ hash[6]
+        hash[7] = h &+ hash[7]
+    }
+
+    /// Pad the given byte array to be a multiple of 512 bits.
+    private func pad(_ input: inout [UInt8]) {
+        // Find the bit count of input.
+        let inputBitLength = input.count * 8
+
+        // Append the bit 1 at end of input.
+        input.append(0x80)
+
+        // Find the number of bits we need to append.
+        //
+        // inputBitLength + 1 + bitsToAppend ≡ 448 mod 512
+        let mod = inputBitLength % 512
+        let bitsToAppend = mod < 448 ? 448 - 1 - mod : 512 + 448 - mod - 1
+
+        // We already appended first 7 bits with 0x80 above.
+        input += [UInt8](repeating: 0, count: (bitsToAppend - 7) / 8)
+
+        // We need to append 64 bits of input length.
+        for byte in UInt64(inputBitLength).toByteArray().lazy.reversed() {
+            input.append(byte)
+        }
+        assert((input.count * 8) % 512 == 0, "Expected padded length to be 512.")
+    }
+}
+
+private extension UInt64 {
+    /// Converts the 64 bit integer into an array of single byte integers.
+    func toByteArray() -> [UInt8] {
+        var value = self.littleEndian
+        return withUnsafeBytes(of: &value, Array.init)
+    }
+}
+
+private extension UInt32 {
+    /// Rotates self by given amount.
+    func rotateRight(by amount: UInt32) -> UInt32 {
+        return (self >> amount) | (self << (32 - amount))
+    }
+}
+
+private extension Array {
+    /// Breaks the array into the given size.
+    func blocks(size: Int) -> AnyIterator<ArraySlice<Element>> {
+        var currentIndex = startIndex
+        return AnyIterator {
+            if let nextIndex = self.index(currentIndex, offsetBy: size, limitedBy: self.endIndex) {
+                defer { currentIndex = nextIndex }
+                return self[currentIndex..<nextIndex]
+            }
+            return nil
+        }
+    }
+}
+
 /// Convert a hexadecimal digit to a lowercase ASCII character value.
 private func hexchar(_ value: UInt8) -> UInt8 {
     assert(value >= 0 && value < 16)
@@ -173,25 +364,29 @@ public class DelegatedHashContext: HashContext {
     }
 }
 
-public final class MD5Context: DelegatedHashContext {
+public final class InsecureHashContext: DelegatedHashContext {
     public init() {
         #if os(Windows)
         super.init(impl: BCryptHashContext(algorithm: "MD5", digestLength: 16))
-        #else
+        #elseif canImport(CryptoKit)
         super.init(impl: SwiftCryptoHashContext<Insecure.MD5>())
+        #else
+        super.init(impl: VendoredSHA256HashContext())
         #endif
     }
 }
 
 @available(*, unavailable)
-extension MD5Context: Sendable { }
+extension InsecureHashContext: Sendable { }
 
 public final class SHA256Context: DelegatedHashContext {
     public init() {
         #if os(Windows)
         super.init(impl: BCryptHashContext(algorithm: "SHA256", digestLength: 32))
-        #else
+        #elseif canImport(CryptoKit)
         super.init(impl: SwiftCryptoHashContext<SHA256>())
+        #else
+        super.init(impl: VendoredSHA256HashContext())
         #endif
     }
 }

--- a/Sources/SWBUtil/String.swift
+++ b/Sources/SWBUtil/String.swift
@@ -694,7 +694,7 @@ public func ==<T: Collection>(lhs: T, rhs: String) -> Bool where T.Iterator.Elem
 extension String {
     /// Returns MD5 hex string representation.
     public func md5() -> String {
-        let context = MD5Context()
+        let context = InsecureHashContext()
         context.add(string: self)
         return context.signature.asString
     }

--- a/Tests/SWBCoreTests/SwiftCompilerTests.swift
+++ b/Tests/SWBCoreTests/SwiftCompilerTests.swift
@@ -412,7 +412,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             #expect(delegate.events[safe: 1]?.0 == "skippedSubtask")
 
             let expectedSignature: ByteString = {
-                let md5 = MD5Context()
+                let md5 = InsecureHashContext()
                 md5.add(string: "CompileSwift VARIANT ARCH bar.swift")
                 return md5.signature
             }()

--- a/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
@@ -58,7 +58,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
             try await tester.checkBuild(runDestination: .host) { results in
-                try results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
+                try results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("-common-args.resp"))) { task, contents in
                     let responseFilePath = try #require(task.outputs.only)
 
                     // The command arguments in the response file vary vastly between different platforms, so just check for some basics present in the content.
@@ -165,7 +165,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
             await tester.checkBuild(runDestination: .host) { results in
-                results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
+                results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("-common-args.resp"))) { task, contents in
                     let stringContents = contents.asString
                     #expect(stringContents.contains("-target"))
                     let blocksFlag = switch runDestination {
@@ -348,7 +348,7 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
             let core = try await getCore()
             let tester = try TaskConstructionTester(core, testProject)
             await tester.checkBuild(runDestination: .host) { results in
-                results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("7187679823f38a2a940e0043cdf9d637-common-args.resp"))) { task, contents in
+                results.checkWriteAuxiliaryFileTask(.matchRuleItemPattern(.suffix("-common-args.resp"))) { task, contents in
                     let stringContents = contents.asString
                     #expect(stringContents.contains("-Xclang -Wno-shorten-64-to-32"))
                     results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("a.c"))) { compileTask in

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -30,13 +30,7 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
     func fullManifest(fileSystem: String) -> String {
         let tmp = Path.root.join("tmp").strWithPosixSlashes
         let deps = Path.root.join("tmp").join("foo.d")
-        let signature: String
-        #if os(Windows)
-        // non-constant on Windows because Path.root may evaluate to any drive letter
-        signature = BuildDescriptionBuilder.computeShellToolSignature(args: ["true"], environment: EnvironmentBindings(), dependencyData: .makefile(deps), isUnsafeToInterrupt: false, additionalSignatureData: "").unsafeStringValue
-        #else
-        signature = "aca37e3650838b65a98c26816eed1031"
-        #endif
+        let signature = BuildDescriptionBuilder.computeShellToolSignature(args: ["true"], environment: EnvironmentBindings(), dependencyData: .makefile(deps), isUnsafeToInterrupt: false, additionalSignatureData: "").unsafeStringValue
         return """
             {"client":{"name":"basic","version":0,"file-system":"\(fileSystem)","perform-ownership-analysis":"\(SWBFeatureFlag.performOwnershipAnalysis.value ? "yes" : "no")"},"targets":{"":["<all>"]},"nodes":{"\(tmp)/filtered/":{"content-exclusion-patterns":["_CodeSignature","*.gitignore"]}},"commands":{"<all>":{"tool":"phony","inputs":[],"outputs":["<all>"]},"P0:::Foo":{"tool":"shell","description":"Foo","inputs":["\(tmp)/all/","\(tmp)/filtered/"],"outputs":[],"args":["true"],"env":{},"working-directory":"\(Path.pathSeparatorString.escapedForJSON)","deps":["\(deps.str.escapedForJSON)"],"deps-style":"makefile","signature":"\(signature)"}}}
             """

--- a/Tests/SWBUtilTests/HashContextTests.swift
+++ b/Tests/SWBUtilTests/HashContextTests.swift
@@ -17,19 +17,19 @@ import SWBUtil
 @Suite fileprivate struct HashContextTests {
     @Test
     func basics() {
-        let first = MD5Context()
+        let first = InsecureHashContext()
         first.add(string: "first")
         let firstSignature = first.signature
         #expect(!firstSignature.isEmpty)
 
-        let second = MD5Context()
+        let second = InsecureHashContext()
         second.add(string: "first")
         second.add(string: "second")
         let secondSignature = second.signature
         #expect(!secondSignature.isEmpty)
         #expect(firstSignature != secondSignature)
 
-        let third = MD5Context()
+        let third = InsecureHashContext()
         third.add(bytes: ByteString("first"))
         third.add(bytes: ByteString("second"))
         let thirdSignature = third.signature
@@ -39,39 +39,39 @@ import SWBUtil
     }
 
     /// Check against a known hash value.
-    @Test
+    @Test(.requireHostOS(.macOS, .windows))
     func value() {
-        #expect(MD5Context().signature == "d41d8cd98f00b204e9800998ecf8427e")
+        #expect(InsecureHashContext().signature == "d41d8cd98f00b204e9800998ecf8427e")
     }
 
     @Test
     func variations() {
-        let first = MD5Context()
+        let first = InsecureHashContext()
         first.add(string: "first")
-        let second = MD5Context()
+        let second = InsecureHashContext()
         second.add(bytes: ByteString(encodingAsUTF8: "first"))
         #expect(first.signature == second.signature)
     }
 
-    @Test
+    @Test(.requireHostOS(.macOS, .windows))
     func numbers() {
         do {
-            let ctx = MD5Context()
+            let ctx = InsecureHashContext()
             ctx.add(number: 0x01 as UInt8)
             #expect(ctx.signature == "55a54008ad1ba589aa210d2629c1df41")
         }
         do {
-            let ctx = MD5Context()
+            let ctx = InsecureHashContext()
             ctx.add(number: 0x0102 as UInt16)
             #expect(ctx.signature == "050d144172d916d0846f839e0412e929")
         }
         do {
-            let ctx = MD5Context()
+            let ctx = InsecureHashContext()
             ctx.add(number: 0x01020304 as UInt32)
             #expect(ctx.signature == "c73cabeb6558aba030bba9ca49dcdd75")
         }
         do {
-            let ctx = MD5Context()
+            let ctx = InsecureHashContext()
             ctx.add(number: 0x0102030405060708 as UInt64)
             #expect(ctx.signature == "8a7334bacf760ff26b99fad472ded851")
         }


### PR DESCRIPTION
Eliminate the package dependency on swift-crypto to simplify the bootstrapped build. Instead, vendor the SHA256 implementation from swift-tools-support-core and use it as a fallback if neither WinSDK nor CryptoKit is available.

