### PR TITLE
Disable explicit module builds for the index arena

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3815,6 +3815,11 @@ private class SettingsBuilder {
             table.push(BuiltinMacros.EFFECTIVE_PLATFORM_NAME, literal: MacCatalystInfo.publicSDKBuiltProductsDirSuffix)
         }
 
+        table.push(BuiltinMacros.SWIFT_ENABLE_EXPLICIT_MODULES, literal: .disabled)
+        table.push(BuiltinMacros._EXPERIMENTAL_SWIFT_EXPLICIT_MODULES, literal: .disabled)
+        table.push(BuiltinMacros.CLANG_ENABLE_EXPLICIT_MODULES, literal: false)
+        table.push(BuiltinMacros._EXPERIMENTAL_CLANG_EXPLICIT_MODULES, literal: false)
+
         push(table, .exported)
     }
 

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -546,6 +546,10 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             try results.checkTask(.matchTargetName("AppTarget"), .matchRuleItem("SwiftDriver Compilation Requirements")) { task in
                 task.checkRuleInfo(["SwiftDriver Compilation Requirements", "AppTarget", "normal", "x86_64", "com.apple.xcode.tools.swift.compiler"])
 
+                // Explicit modules are disabled for semantic functionality currently, make sure it is also disabled
+                // for preparation in general.
+                task.checkCommandLineDoesNotContain("-explicit-module-build")
+
                 let skipFlag = swiftFeatures.has(.experimentalSkipAllFunctionBodies) ? "-experimental-skip-all-function-bodies" : "-experimental-skip-non-inlinable-function-bodies"
                 task.checkCommandLineContains(["-module-name", "AppTarget", "-Onone", "-Xfrontend", skipFlag, "-emit-dependencies", "-emit-module", "-emit-module-path", "-emit-objc-header", "-emit-objc-header-path"])
                 if swiftFeatures.has(.experimentalAllowModuleWithCompilerErrors) {
@@ -793,8 +797,11 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
 
             results.checkNoTask(.matchCommandLineArgument("clang-stat-cache"))
 
-            try results.checkTask(.matchTargetName("AppTarget"), .matchRuleItem("CompileC")) { task in
+            // Explicit modules are disabled for semantic functionality currently, make sure it is also disabled
+            // for preparation in general.
+            results.checkNoTask(.matchRuleItem("ScanDependencies"))
 
+            try results.checkTask(.matchTargetName("AppTarget"), .matchRuleItem("CompileC")) { task in
                 if clangFeatures.has(.allowPcmWithCompilerErrors) {
                     task.checkCommandLineContains(["-Xclang", "-fallow-pcm-with-compiler-errors"])
                 } else {


### PR DESCRIPTION
Explicit module arguments are removed for the arguments returned for indexing. Also disable them for preparation in general so we're not mixing between the two.

Resolves rdar://147354913.