### PR TITLE
Fix LD_EXPORT_GLOBAL_SYMBOLS when using swiftc as the linker driver

### DIFF
--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -146,6 +146,18 @@
                 Condition = "NO";
             },
             {
+                Name = "SWIFTC_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                DefaultValue = "$(LD_EXPORT_GLOBAL_SYMBOLS)";
+                Condition = "$(LINKER_DRIVER) == swiftc";
+                CommandLineArgs = {
+                    YES = (
+                        "-Xlinker", "--export-dynamic"
+                    );
+                    NO = ();
+                };
+            },
+            {
                 Name = "__INPUT_FILE_LIST_PATH__";
                 Type = Path;
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -501,6 +501,24 @@
                 Name = "LD_EXPORT_GLOBAL_SYMBOLS";
                 Type = Boolean;
                 DefaultValue = NO;
+            },
+            {
+                Name = "SWIFTC_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                DefaultValue = "$(LD_EXPORT_GLOBAL_SYMBOLS)";
+                Condition = "$(LINKER_DRIVER) == swiftc";
+                CommandLineArgs = {
+                    YES = (
+                        "-Xlinker", "-export_dynamic"
+                    );
+                    NO = ();
+                };
+            },
+            {
+                Name = "CLANG_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                DefaultValue = "$(LD_EXPORT_GLOBAL_SYMBOLS)";
+                Condition = "$(LINKER_DRIVER) == clang";
                 CommandLineArgs = {
                     YES = (
                         "-rdynamic",

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -161,6 +161,12 @@
                 Condition = "NO";
             },
             {
+                Name = "SWIFTC_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                Condition = NO;
+                CommandLineArgs = ();
+            },
+            {
                 Name = "__INPUT_FILE_LIST_PATH__";
                 Type = Path;
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";


### PR DESCRIPTION
https://github.com/swiftlang/swift-build/issues/395

Closes: #395