### PR TITLE
Avoid nondeterministically clearing the build description manager's build description cache in tests

### DIFF
--- a/Sources/SWBUtil/HeavyCache.swift
+++ b/Sources/SWBUtil/HeavyCache.swift
@@ -33,8 +33,22 @@ public func clearAllHeavyCaches() {
     }
 }
 
-@_spi(Testing) public func withHeavyCacheGlobalState<T>(_ body: () async throws -> T) async rethrows -> T {
-    try await $allHeavyCaches.withValue(.init([])) {
+public func withHeavyCacheGlobalState<T>(isolated: Bool = true, _ body: () throws -> T) rethrows -> T {
+    if isolated {
+        try $allHeavyCaches.withValue(.init([])) {
+            try body()
+        }
+    } else {
+        try body()
+    }
+}
+
+@_spi(Testing) public func withHeavyCacheGlobalState<T>(isolated: Bool = true, _ body: () async throws -> T) async rethrows -> T {
+    if isolated {
+        try await $allHeavyCaches.withValue(.init([])) {
+            try await body()
+        }
+    } else {
         try await body()
     }
 }

--- a/Tests/SWBUtilTests/HeavyCacheTests.swift
+++ b/Tests/SWBUtilTests/HeavyCacheTests.swift
@@ -188,16 +188,7 @@ fileprivate struct HeavyCacheTests {
 
 /// Provides a HeavyCache suitable for use in tests (eviction policy disabled to prevent memory pressure interference).
 fileprivate func withHeavyCache<Key, Value>(isolatedGlobalState: Bool = true, maximumSize: Int? = nil, timeToLive: Duration? = nil, _ block: (HeavyCache<Key, Value>) async throws -> Void) async rethrows {
-    func withIsolatedGlobalState(block: () async throws -> Void) async rethrows {
-        if isolatedGlobalState {
-            try await withHeavyCacheGlobalState {
-                try await block()
-            }
-        } else {
-            try await block()
-        }
-    }
-    try await withIsolatedGlobalState {
+    try await withHeavyCacheGlobalState(isolated: isolatedGlobalState) {
         try await block(HeavyCache<Key, Value>(maximumSize: maximumSize, timeToLive: timeToLive, evictionPolicy: .never))
     }
 }


### PR DESCRIPTION
If we've told the build description manager to never evict build descriptions from its cache, ensure that the cache isn't attached to the heavy cache global state, so that it isn't cleared by other tests running concurrently.