### PR TITLE
Remove workaround for executable files on Windows

### DIFF
--- a/Sources/SWBTestSupport/Misc.swift
+++ b/Sources/SWBTestSupport/Misc.swift
@@ -196,36 +196,6 @@ extension ProcessInfo {
         return false
     }
 
-    /// Whether the process is running translated, e.g. using Rosetta on macOS, or Prism on Windows.
-    package var isTranslated: Bool {
-        #if os(Windows)
-        var pProcessMachine = USHORT(IMAGE_FILE_MACHINE_UNKNOWN)
-        var pNativeMachine = USHORT(IMAGE_FILE_MACHINE_UNKNOWN)
-        guard IsWow64Process2(GetCurrentProcess(), &pProcessMachine, &pNativeMachine) else {
-            return false
-        }
-        // Checking of specific architectures is a bit fragile, but we only support AMD64 and ARM64 on Windows for now.
-        guard pNativeMachine == IMAGE_FILE_MACHINE_ARM64 else {
-            return false
-        }
-        var systemInfo = SYSTEM_INFO()
-        GetNativeSystemInfo(&systemInfo)
-        return systemInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64
-        #elseif canImport(Darwin)
-        let sysctl_proc_translated = "sysctl.proc_translated"
-        var len: Int = 0
-        if sysctlbyname(sysctl_proc_translated, nil, &len, nil, 0) == 0 {
-            var p = [CChar](repeating: 0, count: len)
-            if len > 0 && sysctlbyname(sysctl_proc_translated, &p, &len, nil, 0) == 0 {
-                return p[0] == 1
-            }
-        }
-        return false
-        #else
-        return false
-        #endif
-    }
-
     // Get memory usage of current process in bytes
     package var memoryUsage: UInt64 {
         #if canImport(Darwin)

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -71,6 +71,8 @@ public struct FileInfo: Equatable, Sendable {
 
     public var isExecutable: Bool {
         #if os(Windows)
+        // Per https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions, "user execute bits are set according to the filename extension".
+        // Don't use FileManager.isExecutableFile due to https://github.com/swiftlang/swift-foundation/issues/860
         return (statBuf.st_mode & UInt16(_S_IEXEC)) != 0
         #else
         return (statBuf.st_mode & S_IXUSR) != 0
@@ -148,6 +150,7 @@ public protocol FSProxy: AnyObject, Sendable {
     // FIXME: Need to document behavior w.r.t. error handling.
     func isDirectory(_ path: Path) -> Bool
 
+    /// Checks whether the given path has the execute bit (which on Windows is determined by the file extension).
     func isExecutable(_ path: Path) throws -> Bool
 
     /// Checks whether the given path is a symlink, also returning whether the linked file exists.

--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -129,7 +129,7 @@ extension Process {
             throw StubError.error("\(url) is not an absolute file URL")
         }
         let executableFilePath = try url.standardizedFileURL.filePath
-        if !FileManager.default.isExecutableFile(atPath: executableFilePath.str) {
+        if try !localFS.isExecutable(executableFilePath) {
             throw StubError.error("\(executableFilePath.str) is not an executable file")
         }
         let process = Process()

--- a/Tests/SWBUtilTests/ProcessTests.swift
+++ b/Tests/SWBUtilTests/ProcessTests.swift
@@ -226,13 +226,7 @@ extension SWBUtil.Process {
         let hostOS = try ProcessInfo.processInfo.hostOperatingSystem()
         let scriptString = try await script(hostOS)
         if hostOS == .windows {
-            // https://github.com/apple/swift-foundation/issues/860
-            if ProcessInfo.processInfo.isTranslated {
-                let systemRoot = try #require(getEnvironmentVariable("SystemRoot"), "Can't determine path to cmd.exe because the SystemRoot environment variable is not set")
-                commandShellPath = "\(systemRoot)\\SysWOW64\\cmd.exe"
-            } else {
-                commandShellPath = try #require(getEnvironmentVariable("ComSpec"), "Can't determine path to cmd.exe because the ComSpec environment variable is not set")
-            }
+            commandShellPath = try #require(getEnvironmentVariable("ComSpec"), "Can't determine path to cmd.exe because the ComSpec environment variable is not set")
             arguments = ["/c", scriptString]
         } else {
             commandShellPath = "/bin/sh"


### PR DESCRIPTION
Use our FSProxy abstraction instead of Foundation, which doesn't suffer from https://github.com/swiftlang/swift-foundation/issues/860