### PR TITLE
Update the language for 'Enabling the Swift language feature ...' warnings

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1490,7 +1490,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
             switch feature.level {
             case .warn:
-                delegate.warning("Enabling the Swift language feature '\(identifier)' is recommended; \(supplementaryMessage)")
+                delegate.warning("Enabling the Swift language feature '\(identifier)' will become a requirement in the future; \(supplementaryMessage)")
             case .error:
                 delegate.error("Enabling the Swift language feature '\(identifier)' is required; \(supplementaryMessage)")
             case .ignore:

--- a/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
+++ b/Sources/SWBTestSupport/DiagnosticsCheckingResult.swift
@@ -202,7 +202,7 @@ package func _filterDiagnostic(message: String) -> String? {
         return nil
     }
 
-    if message.hasPrefix("Enabling the Swift language feature 'MemberImportVisibility' is recommended") {
+    if message.hasPrefix("Enabling the Swift language feature 'MemberImportVisibility' will become a requirement in the future") {
         return nil
     }
 

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -4895,7 +4895,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                 do {
                     let params = BuildParameters(configuration: "Debug")
                     try await tester.checkBuild(runDestination: .macOS, buildRequest: parameterizedBuildRequest(params)) { results in
-                        results.checkWarnings([.contains("Enabling the Swift language feature 'DeprecateApplicationMain' is recommended; set 'SWIFT_UPCOMING_FEATURE_DEPRECATE_APPLICATION_MAIN = YES'")], failIfNotFound: true)
+                        results.checkWarnings([.contains("Enabling the Swift language feature 'DeprecateApplicationMain' will become a requirement in the future; set 'SWIFT_UPCOMING_FEATURE_DEPRECATE_APPLICATION_MAIN = YES'")], failIfNotFound: true)
                         results.checkNotes([.contains("Learn more about 'DeprecateApplicationMain' by visiting https://www.swift.org/swift-evolution/")])
                         results.checkNoErrors()
                     }


### PR DESCRIPTION
These warnings are nudging developers to adopt features before they become required. They're not just recommendations.

Resolves rdar://149086651.
