### PR TITLE
Add FreeBSD platform to ProjectModel API

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -162,6 +162,7 @@ extension ProjectModel {
             case windows
             case wasi
             case openbsd
+            case freebsd
 
             public var asConditionStrings: [String] {
                 let filters = self.toPlatformFilter().map { (filter: ProjectModel.PlatformFilter) -> String in
@@ -262,6 +263,9 @@ public extension ProjectModel.BuildSettings.Platform {
 
         case .openbsd:
             result.append(.init(platform: "openbsd"))
+
+        case .freebsd:
+            result.append(.init(platform: "freebsd"))
         }
         return result
     }


### PR DESCRIPTION
Add the `freebsd` platform to the new PIF encoding API (i.e., `ProjectModel`).

We need this when sending over the PIF JSON from SwiftPM (with the new `--build-system swiftbuild` option) given SwiftPM `PackageModel.Platform` already supports FreeBSD.