### PR TITLE
Use `URL.homeDirectory` instead of `FileManager.homeDirectoryForCurrentUser`.

### DIFF
--- a/Sources/SWBCore/SwiftSDK.swift
+++ b/Sources/SWBCore/SwiftSDK.swift
@@ -79,7 +79,7 @@ public struct SwiftSDK: Sendable {
                 create: false
             ).appendingPathComponent("org.swift.swiftpm")
         } else {
-            spmURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".swiftpm")
+            spmURL = URL.homeDirectory.appendingPathComponent(".swiftpm")
         }
         return try spmURL.appendingPathComponent("swift-sdks").filePath
     }


### PR DESCRIPTION
`FileManager.homeDirectoryForCurrentUser` is only available for macOS on Apple platforms, which breaks building SwiftBuild for iOS.