### PR TITLE
Annotate "$targetA is missing a dependency on $targetB" diagnostics with target location (rdar://149397709)

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -879,8 +879,15 @@ package final class BuildOperation: BuildSystemOperation {
     }
 
     package func taskDiscoveredRequiredTargetDependency(target: ConfiguredTarget, antecedent: ConfiguredTarget, reason: RequiredTargetDependencyReason, warningLevel: BooleanWarningLevel) {
-        if !transitiveDependencyExists(target: target, antecedent: antecedent) {
+        let diagnosticBehavior: SWBUtil.Diagnostic.Behavior
+        switch warningLevel {
+        case .yesError: diagnosticBehavior = .error
+        case .yes: diagnosticBehavior = .warning
+        case .no: return
+        }
+        let targetDiagnosticsEngine = buildOutputDelegate.diagnosticsEngine(for: target)
 
+        if !transitiveDependencyExists(target: target, antecedent: antecedent) {
             // Ensure we only diagnose missing dependencies when platform and SDK variant match. We perform this check as late as possible since computing settings can be expensive.
             let targetSettings = requestContext.getCachedSettings(target.parameters, target: target.target)
             let antecedentSettings = requestContext.getCachedSettings(antecedent.parameters, target: antecedent.target)
@@ -898,14 +905,8 @@ package final class BuildOperation: BuildSystemOperation {
             } else {
                 message = DiagnosticData("'\(target.target.name)' is missing a dependency on '\(antecedent.target.name)' because \(reason)")
             }
-            switch warningLevel {
-            case .yes:
-                buildOutputDelegate.emit(Diagnostic(behavior: .warning, location: .unknown, data: message))
-            case .yesError:
-                buildOutputDelegate.emit(Diagnostic(behavior: .error, location: .unknown, data: message))
-            default:
-                break
-            }
+
+            targetDiagnosticsEngine.emit(Diagnostic(behavior: diagnosticBehavior, location: .unknown, data: message))
         }
     }
 }

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -2970,9 +2970,9 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 try await tester.checkBuild(runDestination: destination, buildRequest: buildRequest, persistent: true) { results in
                     switch warningLevel {
                     case .yes:
-                        results.checkWarning("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1'")
+                        results.checkWarning("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1' (in target 'Framework2' from project 'aProject')")
                     case .yesError:
-                        results.checkError("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1'")
+                        results.checkError("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1' (in target 'Framework2' from project 'aProject')")
                     default:
                         break
                     }

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -4613,11 +4613,11 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                 try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
                     switch warningLevel {
                     case .yes:
-                        results.checkWarning("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1'")
-                        results.checkWarning("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2'")
+                        results.checkWarning("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1' (in target 'Framework3' from project 'aProject')")
+                        results.checkWarning("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2' (in target 'Framework3' from project 'aProject')")
                     case .yesError:
-                        results.checkError("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1'")
-                        results.checkError("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2'")
+                        results.checkError("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1' (in target 'Framework3' from project 'aProject')")
+                        results.checkError("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2' (in target 'Framework3' from project 'aProject')")
                     default:
                         break
                     }


### PR DESCRIPTION
Having target annotations here provides metadata for e.g. xcresult bundles and then makes it possible for automation to group issues by project and target.