### PR TITLE
Add missing requireThreadSafeWorkingDirectory annotation to unitTestWithGeneratedEntryPoint

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -397,7 +397,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.skipHostOS(.macOS), .skipHostOS(.windows, "cannot find testing library"))
+    @Test(.skipHostOS(.macOS), .skipHostOS(.windows, "cannot find testing library"), .requireThreadSafeWorkingDirectory)
     func unitTestWithGeneratedEntryPoint() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = try await TestProject(


### PR DESCRIPTION
Prevent the test from failing on Amazon Linux 2