### PR TITLE
Impose `PATH` onto linker driver

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -304,6 +304,12 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         return runpathSearchPaths
     }
 
+    override public func environmentFromSpec(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [(String, String)] {
+        var env: [(String, String)] = super.environmentFromSpec(cbc, delegate, lookup: lookup)
+        env.append(("PATH", cbc.producer.executableSearchPaths.environmentRepresentation))
+        return env
+    }
+
     override public func constructLinkerTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, libraries: [LibrarySpecifier], usedTools: [CommandLineToolSpec: Set<FileTypeSpec>]) async {
         // Validate that OTHER_LDFLAGS doesn't contain flags for constructs which we have dedicated settings for. This should be expanded over time.
         let dyldEnvDiagnosticBehavior: Diagnostic.Behavior = SWBFeatureFlag.useStrictLdEnvironmentBuildSetting.value ? .error : .warning


### PR DESCRIPTION
Currently, we use Swift Build's search paths for determining which linker will be used and for version discovery etc, but we are not making any effort to actually enforce that the linker tools found using search paths are the ones used in practice. In the majority of cases, the used toolchain comes with linker tools and linker drivers will use those by default, so the discrepancy doesn't matter, but for toolchains where this isn't the case, what Swift Build thinks the linker will be and what it actually is will diverge.

This changes the environment in of linker tools to fix that discrepancy.
