### PR TITLE
[BuildOperation] Change the summary about the cache hit/miss metrics to combine all hits/misses

### DIFF
--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -234,7 +234,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                 // Make sure scanning happens before compilation...
                 results.check(event: .taskHadEvent(scanTask, event: .completed), precedes: .taskHadEvent(compileTask, event: .started))
 
-                results.check(contains: .activityEmittedData(ruleInfo: "CompilationCacheMetrics", ByteString(encodingAsUTF8: "Clang compiler: 0 hits (0%), 1 miss").bytes))
+                results.checkNote("0 hits (0%), 1 miss")
                 results.checkCompileCacheMiss(compileTask)
                 results.checkNoDiagnostics()
             }
@@ -262,7 +262,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                     // Make sure scanning happens before compilation.
                     results.check(event: .taskHadEvent(scanTask, event: .completed), precedes: .taskHadEvent(compileTask, event: .started))
 
-                    results.check(contains: .activityEmittedData(ruleInfo: "CompilationCacheMetrics", ByteString(encodingAsUTF8: "Clang compiler: 1 hit (100%), 0 misses").bytes))
+                    results.checkNote("1 hit (100%), 0 misses")
                     results.checkCompileCacheHit(compileTask)
                 }
                 results.checkNoDiagnostics()

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -109,7 +109,7 @@ fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
                     numCompile += tasks.count
                 }
 
-                results.check(contains: .activityEmittedData(ruleInfo: "CompilationCacheMetrics", ByteString(encodingAsUTF8: "Swift compiler: 0 hits (0%), 4 misses").bytes))
+                results.checkNote("0 hits (0%), 4 misses")
 
                 results.checkNoTask()
             }
@@ -121,7 +121,7 @@ fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
 
             tester.userInfo = rawUserInfo.withAdditionalEnvironment(environment: metricsEnv("two"))
             try await tester.checkBuild(runDestination: .anyiOSDevice, persistent: true) { results in
-                results.check(contains: .activityEmittedData(ruleInfo: "CompilationCacheMetrics", ByteString(encodingAsUTF8: "Swift compiler: 4 hits (100%), 0 misses").bytes))
+                results.checkNote("4 hits (100%), 0 misses")
             }
             #expect(try readMetrics("two").contains("\"swiftCacheHits\":\(numCompile),\"swiftCacheMisses\":0"))
         }


### PR DESCRIPTION
Separating by compiler is not that useful, this is intended for a high-level overview. A couple of changes
* Report the combined cache hits/misses
* Report the summary as a diagnostic note to make it more visible