### PR TITLE
[CAS] Change the detailed caching diagnostic remarks to be notes instead

### DIFF
--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
@@ -114,10 +114,10 @@ package final class CompilationCachingDataPruner: Sendable {
                 do {
                     let dbSize = try casDBs.getOndiskSize()
                     let sizeLimit = try computeCASSizeLimit(casOptions: casOpts, dbSize: dbSize, fileSystem: fs)
-                    if casOpts.enableDiagnosticRemarks, let dbSize, let sizeLimit, sizeLimit < dbSize {
+                    if let dbSize, let sizeLimit, sizeLimit < dbSize {
                         activityReporter.emit(
                             diagnostic: Diagnostic(
-                                behavior: .remark,
+                                behavior: .note,
                                 location: .unknown,
                                 data: DiagnosticData("cache size (\(dbSize)) larger than size limit (\(sizeLimit))")
                             ),
@@ -183,10 +183,10 @@ package final class CompilationCachingDataPruner: Sendable {
                 do {
                     let dbSize = try casDBs.getStorageSize()
                     let sizeLimit = try computeCASSizeLimit(casOptions: casOpts, dbSize: dbSize.map{Int($0)}, fileSystem: fs)
-                    if casOpts.enableDiagnosticRemarks, let dbSize, let sizeLimit, sizeLimit < dbSize {
+                    if let dbSize, let sizeLimit, sizeLimit < dbSize {
                         activityReporter.emit(
                             diagnostic: Diagnostic(
-                                behavior: .remark,
+                                behavior: .note,
                                 location: .unknown,
                                 data: DiagnosticData("cache size (\(dbSize)) larger than size limit (\(sizeLimit))")
                             ),
@@ -252,10 +252,10 @@ package final class CompilationCachingDataPruner: Sendable {
                 do {
                     let dbSize = (try? toolchainCAS.getOnDiskSize()).map { Int($0) }
                     let sizeLimit = try computeCASSizeLimit(casOptions: casOpts, dbSize: dbSize, fileSystem: fs).map { Int64($0) }
-                    if casOpts.enableDiagnosticRemarks, let dbSize, let sizeLimit, sizeLimit < dbSize {
+                    if let dbSize, let sizeLimit, sizeLimit < dbSize {
                         activityReporter.emit(
                             diagnostic: Diagnostic(
-                                behavior: .remark,
+                                behavior: .note,
                                 location: .unknown,
                                 data: DiagnosticData("cache size (\(dbSize)) larger than size limit (\(sizeLimit))")
                             ),

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
@@ -82,7 +82,7 @@ package final class CompilationCachingUploader {
         if enableDiagnosticRemarks {
             for output in clangCompilation.getOutputs() {
                 activityReporter.emit(
-                    diagnostic: Diagnostic(behavior: .remark, location: .unknown, data: DiagnosticData("uploaded CAS output \(output.name): \(output.casID)")),
+                    diagnostic: Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("uploaded CAS output \(output.name): \(output.casID)")),
                     for: activityID,
                     signature: signature
                 )
@@ -144,7 +144,7 @@ package final class CompilationCachingUploader {
             if enableDiagnosticRemarks {
                 for output in try swiftCompilation.getOutputs() {
                     activityReporter.emit(
-                        diagnostic: Diagnostic(behavior: .remark,
+                        diagnostic: Diagnostic(behavior: .note,
                                                location: .unknown,
                                                data: DiagnosticData("uploaded CAS output \(output.kindName): \(output.casID)")),
                         for: activityID,

--- a/Sources/SWBTaskExecution/TaskActions/ClangCachingKeyQueryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCachingKeyQueryTaskAction.swift
@@ -64,7 +64,7 @@ public final class ClangCachingKeyQueryTaskAction: TaskAction {
                 cachedComp = nil
             }
             if key.casOptions.enableDiagnosticRemarks {
-                outputDelegate.remark("cache \(cachedComp != nil ? "hit" : "miss")")
+                outputDelegate.note("cache \(cachedComp != nil ? "hit" : "miss")")
             }
             return .succeeded
         } catch {

--- a/Sources/SWBTaskExecution/TaskActions/ClangCachingOutputMaterializerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCachingOutputMaterializerTaskAction.swift
@@ -59,7 +59,7 @@ public final class ClangCachingOutputMaterializerTaskAction: TaskAction {
             }
             if obj == nil {
                 if key.casOptions.enableDiagnosticRemarks {
-                    outputDelegate.remark("missing CAS object: \(key.casID)")
+                    outputDelegate.note("missing CAS object: \(key.casID)")
                 }
             }
             return .succeeded

--- a/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
@@ -369,7 +369,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
         }
         guard let cachedComp = try casDBs.getLocalCachedCompilation(cacheKey: cacheKey) else {
             if enableDiagnosticRemarks {
-                outputDelegate.remark("cache miss: \(cacheKey)")
+                outputDelegate.note("cache miss: \(cacheKey)")
             }
             outputDelegate.incrementClangCacheMiss()
             outputDelegate.incrementTaskCounter(.cacheMisses)
@@ -380,8 +380,8 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
         for output in outputs {
             guard cachedComp.isOutputMaterialized(output) else {
                 if enableDiagnosticRemarks {
-                    outputDelegate.remark("missing CAS output \(output.name): \(output.casID)")
-                    outputDelegate.remark("cache miss: \(cacheKey)")
+                    outputDelegate.note("missing CAS output \(output.name): \(output.casID)")
+                    outputDelegate.note("cache miss: \(cacheKey)")
                 }
                 outputDelegate.incrementClangCacheMiss()
                 outputDelegate.incrementTaskCounter(.cacheMisses)
@@ -390,9 +390,9 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
         }
         let diagnosticText = try cachedComp.replay(commandLine: command.arguments, workingDirectory: workingDirectory.str)
         if enableDiagnosticRemarks {
-            outputDelegate.remark("replayed cache hit: \(cacheKey)")
+            outputDelegate.note("replayed cache hit: \(cacheKey)")
             for output in outputs {
-                outputDelegate.remark("using CAS output \(output.name): \(output.casID)")
+                outputDelegate.note("using CAS output \(output.name): \(output.casID)")
             }
         }
         outputDelegate.incrementClangCacheHit()
@@ -415,7 +415,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
         guard let cachedComp = try casDBs.getLocalCachedCompilation(cacheKey: cacheKey) else {
             // This can happen if caching an invocation is skipped due to using date/time macros which makes the output non-deterministic.
             if enableDiagnosticRemarks {
-                outputDelegate.remark("compilation was not cached for key: \(cacheKey)")
+                outputDelegate.note("compilation was not cached for key: \(cacheKey)")
             }
             return
         }

--- a/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftCachingKeyQueryTaskAction.swift
@@ -49,7 +49,7 @@ public final class SwiftCachingKeyQueryTaskAction: TaskAction {
                 for cacheKey in key.cacheKeys {
                     let cacheHit = try await cas.queryCacheKey(cacheKey, globally: true) != nil
                     if key.casOptions.enableDiagnosticRemarks {
-                        outputDelegate.remark("cache key query \(cacheHit ? "hit" : "miss")")
+                        outputDelegate.note("cache key query \(cacheHit ? "hit" : "miss")")
                     }
                     guard cacheHit else {
                         // return on first failure.
@@ -60,7 +60,7 @@ public final class SwiftCachingKeyQueryTaskAction: TaskAction {
                 guard !key.casOptions.enableStrictCASErrors else { throw error }
                 outputDelegate.warning(error.localizedDescription)
                 if key.casOptions.enableDiagnosticRemarks {
-                    outputDelegate.remark("cache key query failed")
+                    outputDelegate.note("cache key query failed")
                 }
             }
             return .succeeded

--- a/Sources/SWBTaskExecution/TaskActions/SwiftCachingOutputMaterializerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftCachingOutputMaterializerTaskAction.swift
@@ -49,13 +49,13 @@ public final class SwiftCachingOutputMaterializerTaskAction: TaskAction {
             do {
                 let loaded = try await cas.download(with: key.casID)
                 if !loaded && key.casOptions.enableDiagnosticRemarks {
-                    outputDelegate.remark("cached output \(key.casID) not found")
+                    outputDelegate.note("cached output \(key.casID) not found")
                 }
             } catch {
                 guard !key.casOptions.enableStrictCASErrors else { throw error }
                 outputDelegate.warning(error.localizedDescription)
                 if key.casOptions.enableDiagnosticRemarks {
-                    outputDelegate.remark("cached output \(key.casID) downloading failed")
+                    outputDelegate.note("cached output \(key.casID) downloading failed")
                 }
             }
             return .succeeded

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -599,24 +599,24 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
                 // If any of the key misses, return cache miss.
                 guard let comp = try cas.queryLocalCacheKey(cacheKey) else {
                     if enableDiagnosticRemarks {
-                        outputDelegate.remark("local cache miss for key: \(cacheKey)")
+                        outputDelegate.note("local cache miss for key: \(cacheKey)")
                     }
                     return false
                 }
                 if enableDiagnosticRemarks {
-                    outputDelegate.remark("local cache found for key: \(cacheKey)")
+                    outputDelegate.note("local cache found for key: \(cacheKey)")
                 }
                 // Check all outputs are materialized.
                 // Doing the check immediately after the key allows associating the output remarks with the right key.
                 for output in try comp.getOutputs() {
                     if !output.isMaterialized {
                         if enableDiagnosticRemarks {
-                            outputDelegate.remark("cached output \(output.kindName) not available locally: \(output.casID)")
+                            outputDelegate.note("cached output \(output.kindName) not available locally: \(output.casID)")
                         }
                         return false
                     }
                     if enableDiagnosticRemarks {
-                        outputDelegate.remark("using CAS output \(output.kindName): \(output.casID)")
+                        outputDelegate.note("using CAS output \(output.kindName): \(output.casID)")
                     }
                 }
                 comps.append(comp)
@@ -642,7 +642,7 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
 
         let result = try await replayCachedCommandImpl()
         if enableDiagnosticRemarks {
-            outputDelegate.remark("replay cache \(result ? "hit" : "miss")")
+            outputDelegate.note("replay cache \(result ? "hit" : "miss")")
         }
         if result {
             outputDelegate.incrementSwiftCacheHit()

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -201,7 +201,7 @@ fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
 
 extension BuildOperationTester.BuildResults {
     fileprivate func checkKeyQueryCacheMiss(_ task: Task, sourceLocation: SourceLocation = #_sourceLocation) {
-        let found = (getDiagnosticMessageForTask(.contains("cache miss"), kind: .remark, task: task) != nil)
+        let found = (getDiagnosticMessageForTask(.contains("cache miss"), kind: .note, task: task) != nil)
         guard found else {
             Issue.record("Unable to find cache miss diagnostic for task \(task)", sourceLocation: sourceLocation)
             return
@@ -209,7 +209,7 @@ extension BuildOperationTester.BuildResults {
     }
 
     fileprivate func checkKeyQueryCacheHit(_ task: Task, sourceLocation: SourceLocation = #_sourceLocation) {
-        let found = (getDiagnosticMessageForTask(.contains("cache found for key"), kind: .remark, task: task) != nil)
+        let found = (getDiagnosticMessageForTask(.contains("cache found for key"), kind: .note, task: task) != nil)
         guard found else {
             Issue.record("Unable to find cache hit diagnostic for task \(task)", sourceLocation: sourceLocation)
             return


### PR DESCRIPTION
Remarks pollute the issue navigator in Xcode, the notes are more appropriate as offering additional details for a particular task.