### PR TITLE
CLIConnection tests: close output stream on shutdown

### DIFF
--- a/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CLIConnection.swift
@@ -151,6 +151,10 @@ final class CLIConnection {
             _ = try? await exitStatus
         }
 
+        // Consume the rest of the output before closing the handle to ensure the dispatch IO is closed
+        while let _ = try? await outputStreamIterator.next() {
+        }
+
         try? monitorHandle.close()
     }
 


### PR DESCRIPTION
Noticed this during a bit of investigation into #21, and don't necessarily expect this to fix it, but it seems correct in order to prevent the fd possibly being closed while the stream is still being read.