### PR TITLE
[CAS] For compilation tasks, add an unintrusive cache hit/miss indicator

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
@@ -373,6 +373,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
             }
             outputDelegate.incrementClangCacheMiss()
             outputDelegate.incrementTaskCounter(.cacheMisses)
+            outputDelegate.emitOutput("Cache miss\n")
             return false
         }
 
@@ -385,6 +386,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
                 }
                 outputDelegate.incrementClangCacheMiss()
                 outputDelegate.incrementTaskCounter(.cacheMisses)
+                outputDelegate.emitOutput("Cache miss\n")
                 return false
             }
         }
@@ -397,6 +399,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
         }
         outputDelegate.incrementClangCacheHit()
         outputDelegate.incrementTaskCounter(.cacheHits)
+        outputDelegate.emitOutput("Cache hit\n")
         outputDelegate.emitOutput(ByteString(encodingAsUTF8: diagnosticText))
         return true
     }

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -647,9 +647,11 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
         if result {
             outputDelegate.incrementSwiftCacheHit()
             outputDelegate.incrementTaskCounter(.cacheHits)
+            outputDelegate.emitOutput("Cache hit\n")
         } else {
             outputDelegate.incrementSwiftCacheMiss()
             outputDelegate.incrementTaskCounter(.cacheMisses)
+            outputDelegate.emitOutput("Cache miss\n")
         }
         return result
     }

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -1842,6 +1842,7 @@ extension BuildOperationTester.BuildResults {
             Issue.record("Unable to find cache miss diagnostic for task \(task)", sourceLocation: sourceLocation)
             return
         }
+        check(contains: .taskHadEvent(task, event: .hadOutput(contents: "Cache miss\n")), sourceLocation: sourceLocation)
     }
 
     fileprivate func checkCompileCacheHit(_ task: Task, sourceLocation: SourceLocation = #_sourceLocation) {
@@ -1851,5 +1852,6 @@ extension BuildOperationTester.BuildResults {
             return
         }
         while getDiagnosticMessageForTask(.contains("using CAS output"), kind: .note, task: task) != nil {}
+        check(contains: .taskHadEvent(task, event: .hadOutput(contents: "Cache hit\n")), sourceLocation: sourceLocation)
     }
 }


### PR DESCRIPTION
This goes in the task's output, so in the Xcode build log the user would have to expand the task output to see such detail.

Looks like this for clang:
<img width="1030" alt="cache hit indication 2" src="https://github.com/user-attachments/assets/a135d8b1-2777-496e-9172-017bbe6f93cf" />

and for Swift:
<img width="1001" alt="cache hit indication 3 swift" src="https://github.com/user-attachments/assets/bb3f3b4c-e1e2-4f6d-8acb-aad2bccda8ce" />
