### PR TITLE
Introduce LINKER_DRIVER build setting into the PIF generation model

### DIFF
--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -981,6 +981,7 @@ public enum PIF {
         public var KEEP_PRIVATE_EXTERNS: String?
         public var LD_RUNPATH_SEARCH_PATHS: [String]?
         public var LIBRARY_SEARCH_PATHS: [String]?
+        public var LINKER_DRIVER: String?
         public var CLANG_COVERAGE_MAPPING_LINKER_ARGS: String?
         public var CURRENT_PROJECT_VERSION: String?
         public var MACH_O_TYPE: String?

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -104,6 +104,7 @@ extension ProjectModel {
             case SWIFT_USER_MODULE_VERSION
             case TAPI_DYLIB_INSTALL_NAME
             case TARGETED_DEVICE_FAMILY
+            case LINKER_DRIVER
         }
 
         public enum MultipleValueSetting: String, CaseIterable, Sendable, Hashable, Codable {


### PR DESCRIPTION
This build setting is needed from SwiftPM for PIF generation.
