### PR TITLE
Expand use of Win32Error

### DIFF
--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(SWBUtil
   VFS.swift
   WaitCondition.swift
   WeakRef.swift
+  Win32Error.swift
   XCBuildDataArchive.swift
   Xcode.swift)
 set_target_properties(SWBUtil PROPERTIES

--- a/Sources/SWBUtil/Library.swift
+++ b/Sources/SWBUtil/Library.swift
@@ -34,7 +34,7 @@ public enum Library: Sendable {
     public static func open(_ path: Path) throws -> LibraryHandle {
         #if os(Windows)
         guard let handle = path.withPlatformString(LoadLibraryW) else {
-            throw LibraryOpenError(message: "LoadLibraryW returned \(GetLastError())")
+            throw LibraryOpenError(message: Win32Error(GetLastError()).description)
         }
         return LibraryHandle(rawValue: handle)
         #else

--- a/Sources/SWBUtil/Win32Error.swift
+++ b/Sources/SWBUtil/Win32Error.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+public import WinSDK
+import Foundation
+
+public struct Win32Error: Error, CustomStringConvertible {
+    public let error: DWORD
+
+    public init(_ error: DWORD) {
+        self.error = error
+    }
+
+    public var description: String {
+        let flags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS)
+        var buffer: UnsafeMutablePointer<WCHAR>?
+        let length: DWORD = withUnsafeMutablePointer(to: &buffer) {
+            $0.withMemoryRebound(to: WCHAR.self, capacity: 2) {
+                FormatMessageW(flags, nil, error, 0, $0, 0, nil)
+            }
+        }
+        guard let buffer, length > 0 else {
+            return "Win32 Error Code \(error)"
+        }
+        defer { LocalFree(buffer) }
+        return String(decodingCString: buffer, as: UTF16.self).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+#endif

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -131,12 +131,12 @@ extension Processes {
         let promise = Promise<Void, any Error>()
         #if os(Windows)
         guard let proc: HANDLE = OpenProcess(SYNCHRONIZE, false, DWORD(pid)) else {
-            throw StubError.error("OpenProcess failed with error \(GetLastError())")
+            throw Win32Error(GetLastError())
         }
         defer { CloseHandle(proc) }
         Thread.detachNewThread {
             if WaitForSingleObject(proc, INFINITE) == WAIT_FAILED {
-                promise.fail(throwing: StubError.error("WaitForSingleObject failed with error \(GetLastError())"))
+                promise.fail(throwing: Win32Error(GetLastError()))
                 return
             }
             promise.fulfill(with: ())


### PR DESCRIPTION
Have its string representation print the actual error message for improved debuggability.