### PR TITLE
Expose LD_WARN_DUPLICATE_LIBRARIES setting to SwiftPM with correct cross-platform behavior

### DIFF
--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -139,6 +139,12 @@
                 Condition = "NO";
             },
             {
+                // Unsupported
+                Name = "LD_WARN_DUPLICATE_LIBRARIES";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -980,6 +980,7 @@ public enum PIF {
         public var IS_ZIPPERED: String?
         public var KEEP_PRIVATE_EXTERNS: String?
         public var LD_RUNPATH_SEARCH_PATHS: [String]?
+        public var LD_WARN_DUPLICATE_LIBRARIES: String?
         public var LIBRARY_SEARCH_PATHS: [String]?
         public var LINKER_DRIVER: String?
         public var CLANG_COVERAGE_MAPPING_LINKER_ARGS: String?

--- a/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
@@ -133,6 +133,12 @@
                 Condition = "NO";
             },
             {
+                // Unsupported
+                Name = "LD_WARN_DUPLICATE_LIBRARIES";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;

--- a/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
@@ -108,6 +108,12 @@
                 Condition = "NO";
             },
             {
+                // Unsupported
+                Name = "LD_WARN_DUPLICATE_LIBRARIES";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // wasm-ld doesn't support dependency info
                 Name = "LD_DEPENDENCY_INFO_FILE";
                 Type = Path;

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -154,6 +154,12 @@
                 Condition = "NO";
             },
             {
+                // Unsupported
+                Name = "LD_WARN_DUPLICATE_LIBRARIES";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -105,6 +105,7 @@ extension ProjectModel {
             case TAPI_DYLIB_INSTALL_NAME
             case TARGETED_DEVICE_FAMILY
             case LINKER_DRIVER
+            case LD_WARN_DUPLICATE_LIBRARIES
         }
 
         public enum MultipleValueSetting: String, CaseIterable, Sendable, Hashable, Codable {


### PR DESCRIPTION
Expose this flag for SwiftPM in the form of a build setting, and restrict it to supported linkers