### PR TITLE
Pass -ftyped-cxx-new-delete as a linker arg.

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
@@ -2927,6 +2927,11 @@
                   YES = ("-ftyped-cxx-new-delete");
                   NO  = ("-fno-typed-cxx-new-delete");
                 };
+                AdditionalLinkerArgs = {
+                    compiler-default = ();
+                    YES = ("-ftyped-cxx-new-delete");
+                    NO = ();
+                };
             },
             // Index-while-building options, not visible in build settings.
             {


### PR DESCRIPTION
The motivation here is to make back deployment easier by conditionally linking in a shim layer in the clang driver.

rdar://149709799
