### PR TITLE
App Sandbox build setting ends up in iOS signed app

### DIFF
--- a/Sources/SWBCore/SigningSupport.swift
+++ b/Sources/SWBCore/SigningSupport.swift
@@ -30,6 +30,8 @@ public protocol PlatformSigningContext
     func shouldPassEntitlementsFileContentToCodeSign() -> Bool
 
     func requiresEntitlements(_ scope: MacroEvaluationScope, hasProfile: Bool, productFileType: FileTypeSpec) -> Bool
+
+    func supportsAppSandboxAndHardenedRuntime() -> Bool
 }
 
 extension PlatformSigningContext
@@ -58,12 +60,19 @@ extension PlatformSigningContext
     {
         return hasProfile || scope.evaluate(BuiltinMacros.ENTITLEMENTS_REQUIRED)
     }
+
+    @_spi(Testing) public func supportsAppSandboxAndHardenedRuntime() -> Bool {
+        return false
+    }
 }
 
 
 /// Provides behavior for code signing for the macOS platform.
 @_spi(Testing) public struct MacSigningContext: PlatformSigningContext
 {
+    @_spi(Testing) public func supportsAppSandboxAndHardenedRuntime() -> Bool {
+        return true
+    }
 }
 
 

--- a/Sources/SWBCore/SpecImplementations/Tools/ProductPackaging.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ProductPackaging.swift
@@ -114,15 +114,12 @@ public final class ProductPackagingToolSpec : GenericCommandLineToolSpec, SpecId
                     entitlementsDictionary["com.apple.security.get-task-allow"] = nil
                 }
 
-                let isAppSandboxEnabled = cbc.scope.evaluate(BuiltinMacros.ENABLE_APP_SANDBOX)
-                let isHardenedRuntimeEnabled = cbc.scope.evaluate(BuiltinMacros.ENABLE_HARDENED_RUNTIME)
-
                 // rdar://142845111 (Turn on `AppSandboxConflictingValuesEmitsWarning` by default)
                 if SWBFeatureFlag.enableAppSandboxConflictingValuesEmitsWarning.value {
                     EntitlementConflictDiagnosticEmitter.checkForConflicts(cbc, delegate, entitlementsDictionary: entitlementsDictionary, entitlementsPath: codeSignEntitlementsInput?.absolutePath)
                 }
 
-                if isAppSandboxEnabled || isHardenedRuntimeEnabled {
+                if cbc.producer.platform?.signingContext.supportsAppSandboxAndHardenedRuntime() == true {
                     // Inject entitlements that are settable via build settings.
                     // This is only supported when App Sandbox or Hardened Runtime is enabled.
                     for (buildSetting, entitlementPrefix) in Self.sandboxFileAccessSettingsAndEntitlements {

--- a/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
@@ -238,24 +238,24 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
         }
     }
 
-    /// Test that the `ProcessProductEntitlementsTaskAction` does not embed build settings based entitlements that are dependent on App Sandbox being enabled, when App Sandbox is disabled.
-    @Test(.requireSDKs(.macOS))
-    func macOSAppSandboxEnabledEntitlementsWithSandboxDisabled() async throws {
+    /// Test that the `ProcessProductEntitlementsTaskAction` does not embed build settings that only apply to macOS.
+    @Test(.requireSDKs(.iOS))
+    func iOSAppSandboxAndHardnedRuntimeBuildSettingEnabled() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = entitlementsTestWorkspace(
                 sourceRoot: tmpDirPath,
                 buildSettings: [
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "INFOPLIST_FILE": "Info.plist",
-                    "CODE_SIGN_IDENTITY": "-",
-                    "RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES": "NO",
-                    "RUNTIME_EXCEPTION_ALLOW_JIT": "NO",
-                    "RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY": "NO",
-                    "AUTOMATION_APPLE_EVENTS": "NO",
-                    "RUNTIME_EXCEPTION_DEBUGGING_TOOL": "NO",
-                    "RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION": "NO",
-                    "RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION": "NO",
-                    "ENABLE_APP_SANDBOX": "NO",
+                    "AD_HOC_CODE_SIGNING_ALLOWED": "YES",
+                    "RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES": "YES",
+                    "RUNTIME_EXCEPTION_ALLOW_JIT": "YES",
+                    "RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY": "YES",
+                    "AUTOMATION_APPLE_EVENTS": "YES",
+                    "RUNTIME_EXCEPTION_DEBUGGING_TOOL": "YES",
+                    "RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION": "YES",
+                    "RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION": "YES",
+                    "ENABLE_APP_SANDBOX": "YES",
                     "ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER": "readwrite",
                     "ENABLE_FILE_ACCESS_PICTURE_FOLDER": "readonly",
                     "ENABLE_FILE_ACCESS_MUSIC_FOLDER": "readwrite",
@@ -271,7 +271,7 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
                     "ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY": "YES",
                     "ENABLE_RESOURCE_ACCESS_USB": "YES",
                     "ENABLE_RESOURCE_ACCESS_PRINTING": "YES",
-                    "SDKROOT": "macosx"
+                    "SDKROOT": "iphoneos"
                 ]
             )
 
@@ -478,47 +478,6 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
                     "com.apple.security.network.server": .plBool(true),
                 ]
             )
-        }
-    }
-
-    /// Test that the `ProcessProductEntitlementsTaskAction` does not embed build settings based entitlements that are dependent on Hardened Runtime being enabled, when Hardened Runtime is disabled.
-    @Test(.requireSDKs(.macOS))
-    func macOSHardenedRuntimeEnabledEntitlementsWithHardenedRuntimeDisabled() async throws {
-        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
-            let testWorkspace = entitlementsTestWorkspace(
-                sourceRoot: tmpDirPath,
-                buildSettings: [
-                    "PRODUCT_NAME": "$(TARGET_NAME)",
-                    "INFOPLIST_FILE": "Info.plist",
-                    "CODE_SIGN_IDENTITY": "-",
-                    "ENABLE_HARDENED_RUNTIME": "NO",
-                    "RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES": "YES",
-                    "RUNTIME_EXCEPTION_ALLOW_JIT": "YES",
-                    "RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY": "YES",
-                    "AUTOMATION_APPLE_EVENTS": "YES",
-                    "RUNTIME_EXCEPTION_DEBUGGING_TOOL": "YES",
-                    "RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION": "YES",
-                    "RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION": "YES",
-                    "ENABLE_FILE_ACCESS_DOWNLOADS_FOLDER": "readwrite",
-                    "ENABLE_FILE_ACCESS_PICTURE_FOLDER": "readonly",
-                    "ENABLE_FILE_ACCESS_MUSIC_FOLDER": "readwrite",
-                    "ENABLE_FILE_ACCESS_MOVIES_FOLDER": "readonly",
-                    "ENABLE_INCOMING_NETWORK_CONNECTIONS": "YES",
-                    "ENABLE_OUTGOING_NETWORK_CONNECTIONS": "YES",
-                    "ENABLE_RESOURCE_ACCESS_AUDIO_INPUT": "YES",
-                    "ENABLE_RESOURCE_ACCESS_BLUETOOTH": "YES",
-                    "ENABLE_RESOURCE_ACCESS_CALENDARS": "YES",
-                    "ENABLE_RESOURCE_ACCESS_CAMERA": "YES",
-                    "ENABLE_RESOURCE_ACCESS_CONTACTS": "YES",
-                    "ENABLE_RESOURCE_ACCESS_LOCATION": "YES",
-                    "ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY": "YES",
-                    "SDKROOT": "macosx"
-                ]
-            )
-
-            try await buildTestBinaryAndValidateEntitlements(testWorkspace: testWorkspace, expectedEntitlements: [
-                "com.apple.application-identifier": "$(AppIdentifierPrefix)$(CFBundleIdentifier)",
-            ])
         }
     }
 


### PR DESCRIPTION
If the app sandbox entitlement ends up in an iOS app, the app is not installable on device as the corresponding provisioning profile cannot include this entitlement. The app sandbox and hardened runtime entitlements are only applicable on macOS.