### PR TITLE
[Explicit Module Builds] Enable incremental dependency scanning

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1003,6 +1003,7 @@ public final class BuiltinMacros {
     public static let SWIFT_EMIT_MODULE_INTERFACE = BuiltinMacros.declareBooleanMacro("SWIFT_EMIT_MODULE_INTERFACE")
     public static let SWIFT_ENABLE_BATCH_MODE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BATCH_MODE")
     public static let SWIFT_ENABLE_INCREMENTAL_COMPILATION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_COMPILATION")
+    public static let SWIFT_DISABLE_INCREMENTAL_SCAN = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_INCREMENTAL_SCAN")
     public static let SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES")
     public static let SWIFT_ENABLE_LIBRARY_EVOLUTION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LIBRARY_EVOLUTION")
     public static let SWIFT_ENABLE_BARE_SLASH_REGEX = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BARE_SLASH_REGEX")
@@ -2164,6 +2165,7 @@ public final class BuiltinMacros {
         SWIFT_EMIT_MODULE_INTERFACE,
         SWIFT_ENABLE_BATCH_MODE,
         SWIFT_ENABLE_INCREMENTAL_COMPILATION,
+        SWIFT_DISABLE_INCREMENTAL_SCAN,
         SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES,
         SWIFT_ENABLE_LIBRARY_EVOLUTION,
         SWIFT_USE_INTEGRATED_DRIVER,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -119,6 +119,7 @@ public struct SwiftSourceFileIndexingInfo: SourceFileIndexingInfo {
         "-emit-dependencies",
         "-serialize-diagnostics",
         "-incremental",
+        "-incremental-dependency-scan",
         "-parseable-output",
         "-use-frontend-parseable-output",
         "-whole-module-optimization",
@@ -153,6 +154,7 @@ public struct SwiftSourceFileIndexingInfo: SourceFileIndexingInfo {
     // can be removed after we use the new driver instead (rdar://75851402).
     private static let newDriverFlags: Set<ByteString> = [
         "-driver-print-graphviz",
+        "-incremental-dependency-scan",
         "-explicit-module-build",
         "-experimental-explicit-module-build",
         "-nonlib-dependency-scanner",
@@ -1743,6 +1745,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
                 if cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_INCREMENTAL_COMPILATION) {
                     args.append("-incremental")
+                    if LibSwiftDriver.supportsDriverFlag(spelled: "-incremental-dependency-scan"),
+                       !cbc.scope.evaluate(BuiltinMacros.SWIFT_DISABLE_INCREMENTAL_SCAN) {
+                        args.append("-incremental-dependency-scan")
+                    }
                 }
             }
 
@@ -3279,6 +3285,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         for arg in [
             // Should strip this because it saves some work and avoids writing a useless incremental build record
             "-incremental",
+            // Same as above
+            "-incremental-dependency-scan",
 
             // Stripped because we want to end up in single file mode
             "-enable-batch-mode",

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -831,6 +831,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                             "ENABLE_PREVIEWS": "YES",
                             "CLANG_ENABLE_MODULES": "YES",
                             "SDK_STAT_CACHE_ENABLE": "NO",
+                            "SWIFT_DISABLE_INCREMENTAL_SCAN": "YES",
 
                             "SWIFT_ENABLE_EXPLICIT_MODULES": explicitModules ? "YES" : "NO",
 

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -3616,6 +3616,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                                             "ENABLE_PREVIEWS": "YES",
                                             "SWIFT_USE_INTEGRATED_DRIVER": useIntegratedDriver ? "YES" : "NO",
                                             "SWIFT_ENABLE_EXPLICIT_MODULES": useIntegratedDriver ? "YES" : "NO",
+                                            "SWIFT_DISABLE_INCREMENTAL_SCAN": "YES",
                                             "_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES": useIntegratedDriver ? "YES" : "NO",
                                             // Eager linking is not supported when using the driver binary.
                                             "EAGER_LINKING": "NO",

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -645,6 +645,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                                 "SWIFT_PACKAGE_NAME": "FooPkg",
                                                 "SWIFT_EMIT_MODULE_INTERFACE": "YES",
                                                 "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                                                "SWIFT_DISABLE_INCREMENTAL_SCAN": "YES",
                                                ]),
                     ],
                     buildPhases: [
@@ -830,6 +831,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                                 "DEFINES_MODULE": "YES",
                                                 "SWIFT_VERSION": swiftVersion,
                                                 "SWIFT_EMIT_MODULE_INTERFACE": "YES",
+                                                "SWIFT_DISABLE_INCREMENTAL_SCAN": "YES",
                                                ]),
                     ],
                     buildPhases: [
@@ -1524,6 +1526,64 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             results.checkTarget("Exec") { target in
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements")) { task in
                     task.checkCommandLineDoesNotContain("-explicit-module-build")
+                }
+            }
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.macOS), .enabled(if: LibSwiftDriver.supportsDriverFlag(spelled: "-incremental-dependency-scan")))
+    func optOutIncrementalScanning() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("main.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Exec", type: .commandLineTool,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug",
+                                               buildSettings: [
+                                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                                "SWIFT_VERSION": swiftVersion,
+                                               ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "main.swift",
+                        ]),
+                    ])
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS) { results in
+            results.checkTarget("Exec") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements")) { task in
+                    task.checkCommandLineContains(["-explicit-module-build"])
+                    task.checkCommandLineContains(["-incremental"])
+                    task.checkCommandLineContains(["-incremental-dependency-scan"])
+                }
+            }
+            results.checkNoDiagnostics()
+        }
+
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["SWIFT_DISABLE_INCREMENTAL_SCAN": "YES"]), runDestination: .macOS) { results in
+            results.checkTarget("Exec") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements")) { task in
+                    task.checkCommandLineContains(["-explicit-module-build"])
+                    task.checkCommandLineContains(["-incremental"])
+                    task.checkCommandLineDoesNotContain("-incremental-dependency-scan")
                 }
             }
             results.checkNoDiagnostics()


### PR DESCRIPTION
With an opt-out build setting `SWIFT_DISABLE_INCREMENTAL_SCAN` in case early adoption shows any troubles.

Adopts functionality landed in:
https://github.com/swiftlang/swift-driver/pull/1786
https://github.com/swiftlang/swift/pull/78962