### PR TITLE
Revert "Annotate "$targetA is missing a dependency on $targetB" diagn…

### DIFF
--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -2969,9 +2969,9 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 try await tester.checkBuild(runDestination: destination, buildRequest: buildRequest, persistent: true) { results in
                     switch warningLevel {
                     case .yes:
-                        results.checkWarning("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1' (in target 'Framework2' from project 'aProject')")
+                        results.checkWarning("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1'")
                     case .yesError:
-                        results.checkError("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1' (in target 'Framework2' from project 'aProject')")
+                        results.checkError("'Framework2' is missing a dependency on 'Framework1' because dependency scan of 'file_2.c' discovered a dependency on 'Framework1'")
                     default:
                         break
                     }

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -4597,11 +4597,11 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                 try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
                     switch warningLevel {
                     case .yes:
-                        results.checkWarning("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1' (in target 'Framework3' from project 'aProject')")
-                        results.checkWarning("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2' (in target 'Framework3' from project 'aProject')")
+                        results.checkWarning("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1'")
+                        results.checkWarning("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2'")
                     case .yesError:
-                        results.checkError("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1' (in target 'Framework3' from project 'aProject')")
-                        results.checkError("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2' (in target 'Framework3' from project 'aProject')")
+                        results.checkError("'Framework3' is missing a dependency on 'Framework1' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework1'")
+                        results.checkError("'Framework3' is missing a dependency on 'Framework2' because dependency scan of Swift module 'Framework3' discovered a dependency on 'Framework2'")
                     default:
                         break
                     }


### PR DESCRIPTION
…ostics with target location (rdar://149397709)"

This reverts commit f97263c5681eea0c5a6591ff8ed06de7c44abb22.

This seems to trigger conflicting target info in client events. Reverting while I investigate.