### PR TITLE
Add new libcxx flag for disabling container overflow checks for Asan.

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang LLVM 1.0.xcspec
@@ -2736,6 +2736,7 @@
                     YES = ();
                     NO = (
                         "-D_LIBCPP_HAS_NO_ASAN",
+                        "-D_LIBCPP_HAS_ASAN=0",
                     );
                 };
                 Condition = "$(CLANG_ADDRESS_SANITIZER)";

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -4135,7 +4135,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     // There should be one CompileC task, which includes the ASan option, and which puts its output in a -asan directory.
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
                         task.checkRuleInfo([.equal("CompileC"), .equal("\(SRCROOT)/build/aProject.build/Debug/\(targetName).build/Objects-normal-asan/x86_64/SourceFile.o"), .suffix("SourceFile.m"), .any, .any, .any, .any])
-                        task.checkCommandLineContains(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang", "-fsanitize=address", "-D_LIBCPP_HAS_NO_ASAN", "\(SRCROOT)/build/aProject.build/Debug/\(targetName).build/Objects-normal-asan/x86_64/SourceFile.o"])
+                        task.checkCommandLineContains(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang", "-fsanitize=address", "-D_LIBCPP_HAS_NO_ASAN", "-D_LIBCPP_HAS_ASAN=0", "\(SRCROOT)/build/aProject.build/Debug/\(targetName).build/Objects-normal-asan/x86_64/SourceFile.o"])
                     }
 
                     // There should be one CompileSwiftSources task, which includes the ASan option, and which puts its output in a -asan directory.


### PR DESCRIPTION
libcxx 20 has changed the naming scheme of internal macros that indicate feature availability. This affects the name of the macro used to include sanitizer container annotations -- it was renamed from `_LIBCPP_HAS_NO_ASAN` -> `_LIBCPP_HAS_ASAN`.

libcxx change: https://github.com/llvm/llvm-project/pull/89178

This change adds the new flag name to maintain current behavior, which is to disable these checks by default.
Sanitizer container overflow checks are prone to false positives when vector objects are modified outside of instrumented code -- so we have historically defaulted to disabling this on Xcode projects via the libcxx macro.

rdar://149350723