### PR TITLE
Update README.md instructions for SwiftPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 
 ### With SwiftPM
 
-When building SwiftPM from sources which include Swift Build integration, passing `--build-system swiftbuild` will enable the new build-system. This functionality is not currently available in nightly toolchains.
+When building SwiftPM from sources which include Swift Build integration, passing `--build-system next` will enable the new build-system. This functionality is not currently available in nightly toolchains.
 
 ### With Xcode
 


### PR DESCRIPTION
I noticed SwiftPM only supports `--build-system native/xcode/next` so the instructions in the README don't seem accurate. I'm updating them to `--build-system next` assuming that "next" refers to swift-build. Let me know otherwise.

### Environment

```
swift-driver version: 1.120.5 Apple Swift version 6.1 (swiftlang-6.1.0.110.21 clang-1700.0.13.3)
Target: arm64-apple-macosx15.0
```

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
