### PR TITLE
`compatibleConfiguredTarget` should consider toolchains

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -694,10 +694,11 @@ extension SpecializationParameters {
             let dependencySettings = buildRequestContext.getCachedSettings(ct.parameters, target: ct.target)
             let dependencyPlatform = dependencySettings.platform
             let dependencySdkVariant = dependencySettings.sdkVariant?.name
+            let dependencyToolchains = dependencySettings.toolchains
             guard Ref(dependencyPlatform) == platform && dependencySdkVariant == sdkVariant else { return false }
             // For dependencies with 'auto' SDKROOT, they get their SDK 'imposed', including if it is internal vs public SDK, not just what platform it is.
             // For such dependencies also confirm that the existing configured dependency matches 'internal vs public' for the SDK.
-            if dependencyHasAutoSDKRoot, let dependencySDK = dependencySettings.sdk, let dependentSDK = sdk, dependencySDK !== dependentSDK {
+            if dependencyHasAutoSDKRoot, let dependencySDK = dependencySettings.sdk, let dependentSDK = sdk, dependencySDK !== dependentSDK || settings.toolchains != dependencyToolchains {
                 return false
             }
             return true
@@ -742,8 +743,9 @@ extension SpecializationParameters {
                             continue
                         }
 
+                        let behavior: Diagnostic.Behavior = buildRequest.enableIndexBuildArena ? .warning : .error
                         let data = DiagnosticData("multiple configured targets of '\(target.name)' are being created for \(currentSettings.platform?.displayName ?? "")")
-                        delegate.emit(Diagnostic(behavior: .error, location: .unknown, data: data))
+                        delegate.emit(Diagnostic(behavior: behavior, location: .unknown, data: data))
                         hasMultipleTargets = true
                     }
                 }


### PR DESCRIPTION
If a specialized target is both reachable via clients that do not customize toolchains and ones that do, `compatibleConfiguredTarget` will consider both targets "compatible" leading to undesired behavior where whichever target happens to be reached first in dependency resolution will control what value for `TOOLCHAINS` will be effective.

Since we only build a specialized target once per platform, we should instead correctly diagnose such configurations as errors since there's no single value for `TOOLCHAINS` that would work.