### PR TITLE
Fix typo in `isCompatible`

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -190,7 +190,7 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         let toolchain = effectiveToolchainOverride(originalParameters: configuredTarget.parameters, workspaceContext: workspaceContext)
         return (platform == nil || platform === settings.platform) &&
             (sdkVariant == nil || sdkVariant?.name == settings.sdkVariant?.name) &&
-            (toolchain == nil || toolchain == settings.globalScope.evaluate(BuiltinMacros.EFFECTIVE_TOOLCHAINS_DIRS)) &&
+            (toolchain == nil || toolchain == settings.globalScope.evaluate(BuiltinMacros.TOOLCHAINS)) &&
         (canonicalNameSuffix == nil || canonicalNameSuffix?.nilIfEmpty == settings.sdk?.canonicalNameSuffix)
     }
 


### PR DESCRIPTION
This just looks like a straight typo since `SpecializationParameters.toolchain` corresponds to the `TOOLCHAINS` build setting. I'm a bit surprised we have not seen this materialize in any bugs, but then again, customizing `TOOLCHAINS` is somewhat rare and hitting this would require two targets with different customizations of `TOOLCHAINS` to be depending on the same specialized target for the same platform.
