### PR TITLE
Added needed dependency to iOSAppSandboxAndHardnedRuntimeBuildSetting…

### DIFF
--- a/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
@@ -239,7 +239,7 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
     }
 
     /// Test that the `ProcessProductEntitlementsTaskAction` does not embed build settings that only apply to macOS.
-    @Test(.requireSDKs(.iOS))
+    @Test(.requireSDKs(.macOS, .iOS))
     func iOSAppSandboxAndHardnedRuntimeBuildSettingEnabled() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = entitlementsTestWorkspace(

--- a/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/EntitlementsBuildOperationTests.swift
@@ -240,7 +240,7 @@ fileprivate struct EntitlementsBuildOperationTests: CoreBasedTests {
 
     /// Test that the `ProcessProductEntitlementsTaskAction` does not embed build settings that only apply to macOS.
     @Test(.requireSDKs(.macOS, .iOS))
-    func iOSAppSandboxAndHardnedRuntimeBuildSettingEnabled() async throws {
+    func iOSAppSandboxAndHardenedRuntimeBuildSettingEnabled() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = entitlementsTestWorkspace(
                 sourceRoot: tmpDirPath,


### PR DESCRIPTION
Adds needed test dependency as iOSAppSandboxAndHardnedRuntimeBuildSettingEnabled still requires macOS.