### PR TITLE
[CAS] Adjust the caching report text to not mention 'miss'

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -681,7 +681,8 @@ package final class BuildOperation: BuildSystemOperation {
                 adaptor.withActivity(ruleInfo: "CompilationCacheMetrics", executionDescription: "Report compilation cache metrics", signature: signature, target: nil, parentActivity: nil) { activity in
                     func getSummary(hits: Int, misses: Int) -> String {
                         let hitPercent = Int((Double(hits) / Double(hits + misses) * 100).rounded())
-                        return "\(hits) hit\(hits == 1 ? "" : "s") (\(hitPercent)%), \(misses) miss\(misses == 1 ? "" : "es")"
+                        let total = hits + misses
+                        return "\(hits) hit\(hits == 1 ? "" : "s") / \(total) cacheable task\(total == 1 ? "" : "s") (\(hitPercent)%)"
                     }
                     delegate.emit(diagnostic: Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData(getSummary(hits: cacheHits, misses: cacheMisses))), for: activity, signature: signature)
                     return .succeeded

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -234,7 +234,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                 // Make sure scanning happens before compilation...
                 results.check(event: .taskHadEvent(scanTask, event: .completed), precedes: .taskHadEvent(compileTask, event: .started))
 
-                results.checkNote("0 hits (0%), 1 miss")
+                results.checkNote("0 hits / 1 cacheable task (0%)")
                 results.checkCompileCacheMiss(compileTask)
                 results.checkNoDiagnostics()
             }
@@ -262,7 +262,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                     // Make sure scanning happens before compilation.
                     results.check(event: .taskHadEvent(scanTask, event: .completed), precedes: .taskHadEvent(compileTask, event: .started))
 
-                    results.checkNote("1 hit (100%), 0 misses")
+                    results.checkNote("1 hit / 1 cacheable task (100%)")
                     results.checkCompileCacheHit(compileTask)
                 }
                 results.checkNoDiagnostics()

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -110,7 +110,7 @@ fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
                     numCompile += tasks.count
                 }
 
-                results.checkNote("0 hits (0%), 4 misses")
+                results.checkNote("0 hits / 4 cacheable tasks (0%)")
 
                 results.checkNoTask()
             }
@@ -126,7 +126,7 @@ fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
                     results.checkKeyQueryCacheHit(task)
                 }
 
-                results.checkNote("4 hits (100%), 0 misses")
+                results.checkNote("4 hits / 4 cacheable tasks (100%)")
             }
             #expect(try readMetrics("two").contains("\"swiftCacheHits\":\(numCompile),\"swiftCacheMisses\":0"))
         }


### PR DESCRIPTION
The text now reads "2 hits / 4 cacheable tasks (50%)". The intention of the change is to avoid "miss" which can have negative associations.