### PR TITLE
Force git to check out text files with Unix newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Our xcspecs in particular expect to exist with Unix newlines, and some tests may fail depending on git's autocrlf settings on Windows. Just standardize the newlines to keep everything consistent.