### PR TITLE
Skip large file copy test in GitHub actions

### DIFF
--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -172,6 +172,10 @@ extension Trait where Self == Testing.ConditionTrait {
         #endif
     }
 
+    package static func skipInGitHubActions(_ comment: Comment? = nil) -> Self {
+        return .skipIfEnvironmentVariableSet(key: "GITHUB_ACTIONS")
+    }
+
     package static func requireClangFeatures(_ requiredFeatures: DiscoveredClangToolSpecInfo.FeatureFlag...) -> Self {
         enabled("Clang compiler does not support features: \(requiredFeatures)") {
             let features = try await ConditionTraitContext.shared.clangFeatures
@@ -235,8 +239,8 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    package static func skipIfEnvironmentVariableSet(key: EnvironmentKey) -> Self {
-        disabled("environment sets '\(key)'") {
+    package static func skipIfEnvironmentVariableSet(key: EnvironmentKey, _ comment: Comment? = nil) -> Self {
+        disabled(comment ?? "environment sets '\(key)'") {
             getEnvironmentVariable(key) != nil
         }
     }

--- a/Tests/SWBTaskExecutionTests/PBXCpTests.swift
+++ b/Tests/SWBTaskExecutionTests/PBXCpTests.swift
@@ -442,7 +442,8 @@ fileprivate struct PBXCpTests: CoreBasedTests {
     fileprivate let buffer0 = [UInt8](repeating: 0xAA, count: 1024 * 513)
     fileprivate let buffer1 = [UInt8](repeating: 0x55, count: 1024 * 513)
 
-    @Test(.skipHostOS(.windows, "LocalFS needs to use stat64 on windows...."))
+    @Test(.skipHostOS(.windows, "LocalFS needs to use stat64 on windows...."),
+          .skipInGitHubActions("GitHub action runners do not have enough storage space for this test"))
     func largerFile() async throws {
         try await withTemporaryDirectory { tmp in
             // Test copying a large file.


### PR DESCRIPTION
I think we're hitting failures in GitHub Actions because this test requires 8gb of disk and GitHub Actions runners only have 14gb in total