### PR TITLE
Inclusive language: rename master object file to prelinked object file

### DIFF
--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -155,11 +155,11 @@ add_library(SWBCore
   SpecImplementations/Tools/LaunchServicesRegisterTool.swift
   SpecImplementations/Tools/LinkerTools.swift
   SpecImplementations/Tools/Lipo.swift
-  SpecImplementations/Tools/MasterObjectLink.swift
   SpecImplementations/Tools/MergeInfoPlist.swift
   SpecImplementations/Tools/MkdirTool.swift
   SpecImplementations/Tools/ModulesVerifierTool.swift
   SpecImplementations/Tools/PLUtilTool.swift
+  SpecImplementations/Tools/PrelinkedObjectLink.swift
   SpecImplementations/Tools/ProcessSDKImports.swift
   SpecImplementations/Tools/ProcessXCFrameworkLibrary.swift
   SpecImplementations/Tools/ProductPackaging.swift

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -717,7 +717,7 @@ public final class BuiltinMacros {
     public static let GENERATE_EMBED_IN_CODE_ACCESSORS = BuiltinMacros.declareBooleanMacro("GENERATE_EMBED_IN_CODE_ACCESSORS")
     public static let GENERATE_INFOPLIST_FILE = BuiltinMacros.declareBooleanMacro("GENERATE_INFOPLIST_FILE")
     public static let GENERATE_KERNEL_MODULE_INFO_FILE = BuiltinMacros.declareBooleanMacro("GENERATE_KERNEL_MODULE_INFO_FILE")
-    public static let GENERATE_MASTER_OBJECT_FILE = BuiltinMacros.declareBooleanMacro("GENERATE_MASTER_OBJECT_FILE")
+    public static let GENERATE_PRELINK_OBJECT_FILE = BuiltinMacros.declareBooleanMacro("GENERATE_PRELINK_OBJECT_FILE")
     public static let GENERATE_PKGINFO_FILE = BuiltinMacros.declareBooleanMacro("GENERATE_PKGINFO_FILE")
     public static let GENERATE_RESOURCE_ACCESSORS = BuiltinMacros.declareBooleanMacro("GENERATE_RESOURCE_ACCESSORS")
     public static let GENERATE_TEST_ENTRY_POINT = BuiltinMacros.declareBooleanMacro("GENERATE_TEST_ENTRY_POINT")
@@ -1753,7 +1753,7 @@ public final class BuiltinMacros {
         GENERATE_EMBED_IN_CODE_ACCESSORS,
         GENERATE_INFOPLIST_FILE,
         GENERATE_KERNEL_MODULE_INFO_FILE,
-        GENERATE_MASTER_OBJECT_FILE,
+        GENERATE_PRELINK_OBJECT_FILE,
         GENERATE_PKGINFO_FILE,
         GENERATE_RESOURCE_ACCESSORS,
         GENERATE_TEST_ENTRY_POINT,

--- a/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
+++ b/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
@@ -129,7 +129,7 @@ public struct BuiltinSpecsExtension: SpecificationsExtension {
             ValidateDevelopmentAssets.self,
             ConstructStubExecutorFileListToolSpec.self,
             GateSpec.self,
-            MasterObjectLinkSpec.self,
+            PrelinkedObjectLinkSpec.self,
             SetAttributesSpec.self,
             WriteFileSpec.self,
             SignatureCollectionSpec.self,

--- a/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
@@ -13,15 +13,15 @@
 import SWBUtil
 import SWBMacro
 
-/// Spec to use the linker to run `ld -r` to create a prelinked object file (a.k.a. "master object file").
-final class MasterObjectLinkSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
-    static let identifier = "com.apple.build-tools.master-object-link"
+/// Spec to use the linker to run `ld -r` to create a prelinked object file.
+public final class PrelinkedObjectLinkSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
+    public static let identifier = "com.apple.build-tools.prelinked-object-link"
 
-    class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
-        return MasterObjectLinkSpec(registry, proxy, ruleInfoTemplate: [], commandLineTemplate: [])
+    public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
+        return PrelinkedObjectLinkSpec(registry, proxy, ruleInfoTemplate: [], commandLineTemplate: [])
     }
 
-    override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
+    public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         guard let toolSpecInfo = await cbc.producer.ldLinkerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate) as? DiscoveredLdLinkerToolSpecInfo else {
             delegate.error("Could not find path to ld binary")
             return
@@ -62,7 +62,7 @@ final class MasterObjectLinkSpec: CommandLineToolSpec, SpecImplementationType, @
         commandLine += cbc.scope.evaluate(BuiltinMacros.PRELINK_FLAGS)
         let warningLdFlags = cbc.scope.evaluate(BuiltinMacros.WARNING_LDFLAGS)
         if !warningLdFlags.isEmpty {
-            // WARNING_LDFLAGS for some reason is only used for creating the master object file.
+            // WARNING_LDFLAGS for some reason is only used for creating the prelinked object file.
             delegate.warning("WARNING_LDFLAGS is deprecated; use OTHER_LDFLAGS instead.", location: .buildSetting(BuiltinMacros.WARNING_LDFLAGS))
             commandLine += warningLdFlags
         }
@@ -70,6 +70,6 @@ final class MasterObjectLinkSpec: CommandLineToolSpec, SpecImplementationType, @
         commandLine += cbc.scope.evaluate(BuiltinMacros.PRELINK_LIBS)
         commandLine += ["-o", outputPath.str]
 
-        delegate.createTask(type: self, ruleInfo: ["MasterObjectLink", outputPath.str], commandLine: commandLine, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: cbc.inputs.map({ $0.absolutePath }), outputs: [outputPath], action: nil, execDescription: "Link \(outputPath.basename)", enableSandboxing: enableSandboxing)
+        delegate.createTask(type: self, ruleInfo: ["PrelinkedObjectLink", outputPath.str], commandLine: commandLine, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: cbc.inputs.map({ $0.absolutePath }), outputs: [outputPath], action: nil, execDescription: "Link \(outputPath.basename)", enableSandboxing: enableSandboxing)
     }
 }

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -442,9 +442,9 @@
                 };
             },
             {
-                Name = "GENERATE_MASTER_OBJECT_FILE";
+                Name = "GENERATE_PRELINK_OBJECT_FILE";
                 Type = bool;
-                DefaultValue = NO;
+                DefaultValue = "$(GENERATE_MASTER_OBJECT_FILE:default=NO)"; // ignore-unacceptable-language; kept for compatibility
             },
             {
                 Name = "PRELINK_LIBS";
@@ -1598,10 +1598,10 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleIdenti
                 );
             },
             {
-                Name = "GENERATE_MASTER_OBJECT_FILE";
+                Name = "GENERATE_PRELINK_OBJECT_FILE";
                 Type = Boolean;
                 Category = "Linking - General";
-                DefaultValue = NO;
+                DefaultValue = "$(GENERATE_MASTER_OBJECT_FILE:default=NO)"; // ignore-unacceptable-language; kept for compatibility
                 ConditionFlavors = (
                     arch,
                     sdk,

--- a/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
+++ b/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
@@ -409,8 +409,8 @@ Generally you should not specify an order file in Debug or Development configura
 "[LINKER_DISPLAYS_MANGLED_NAMES]-name" = "Display Mangled Names";
 "[LINKER_DISPLAYS_MANGLED_NAMES]-description" = "Activating this setting causes the linker to display mangled names for C++ symbols. Normally, this is not recommended, but turning it on can help to diagnose and solve C++ link errors.";
 
-"[GENERATE_MASTER_OBJECT_FILE]-name" = "Perform Single-Object Prelink";
-"[GENERATE_MASTER_OBJECT_FILE]-description" = "Activating this setting will cause the object files built by a target to be prelinked using `ld -r` into a single object file, and that object file will then be linked into the final product. This is useful to force the linker to resolve symbols and link the object files into a single module before building a static library. Also, a separate set of link flags can be applied to the prelink allowing additional control over, for instance, exported symbols.";
+"[GENERATE_PRELINK_OBJECT_FILE]-name" = "Perform Single-Object Prelink";
+"[GENERATE_PRELINK_OBJECT_FILE]-description" = "Activating this setting will cause the object files built by a target to be prelinked using `ld -r` into a single object file, and that object file will then be linked into the final product. This is useful to force the linker to resolve symbols and link the object files into a single module before building a static library. Also, a separate set of link flags can be applied to the prelink allowing additional control over, for instance, exported symbols.";
 
 "[PRELINK_LIBS]-name" = "Prelink libraries";
 "[PRELINK_LIBS]-description" = "Additional libraries to pass when performing a single-object prelink.";

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -963,7 +963,7 @@ public enum PIF {
         public var GCC_OPTIMIZATION_LEVEL: String?
         public var GCC_PREPROCESSOR_DEFINITIONS: [String]?
         public var GENERATE_EMBED_IN_CODE_ACCESSORS: String?
-        public var GENERATE_MASTER_OBJECT_FILE: String?
+        public var GENERATE_PRELINK_OBJECT_FILE: String?
         public var GENERATE_RESOURCE_ACCESSORS: String?
         public var HEADER_SEARCH_PATHS: [String]?
         public var INFOPLIST_FILE: String?
@@ -1045,6 +1045,9 @@ public enum PIF {
         public var USE_HEADERMAP: String?
         public var USES_SWIFTPM_UNSAFE_FLAGS: String?
         public var WATCHOS_DEPLOYMENT_TARGET: String?
+
+        @available(*, deprecated, renamed: "GENERATE_PRELINK_OBJECT_FILE")
+        public var GENERATE_MASTER_OBJECT_FILE: String? // ignore-unacceptable-language
     }
 }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -865,14 +865,14 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
                     }
                 }
 
-                // Handle linking master objects.  Presently we always do this if GENERATE_MASTER_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a master object file to be generated.
-                // FIXME: The implicitly means that if GENERATE_MASTER_OBJECT_FILE is enabled then we will always try to link.  That's arguably not correct.
-                if !isForAPI && scope.evaluate(BuiltinMacros.GENERATE_MASTER_OBJECT_FILE) {
-                    let executableName = scope.evaluate(BuiltinMacros.EXECUTABLE_NAME) + "-" + arch + "-master.o"
+                // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.
+                // FIXME: The implicitly means that if GENERATE_PRELINK_OBJECT_FILE is enabled then we will always try to link.  That's arguably not correct.
+                if !isForAPI && scope.evaluate(BuiltinMacros.GENERATE_PRELINK_OBJECT_FILE) {
+                    let executableName = scope.evaluate(BuiltinMacros.EXECUTABLE_NAME) + "-" + arch + "-prelink.o"
                     // FIXME: It would be more consistent to put this in the per-arch directory.
                     let output = Path(scope.evaluate(BuiltinMacros.PER_VARIANT_OBJECT_FILE_DIR)).join(executableName)
                     await appendGeneratedTasks(&perArchTasks, options: [.linking, .linkingRequirement, .unsignedProductRequirement]) { delegate in
-                        await context.masterObjectLinkSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: linkerInputNodes.map { FileToBuild(context: context, absolutePath: $0.path) }, output: output), delegate)
+                        await context.prelinkedObjectLinkSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: linkerInputNodes.map { FileToBuild(context: context, absolutePath: $0.path) }, output: output), delegate)
                     }
                     linkerInputNodes = [context.createNode(output)]
                 }
@@ -912,7 +912,7 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
                     continue
                 }
 
-                // Create the linker task.  If we have no input files but decide to create the task anyway, then this task will rely on gate tasks to be properly ordered (which is what happens for the master object file task above if there are no input files).
+                // Create the linker task.  If we have no input files but decide to create the task anyway, then this task will rely on gate tasks to be properly ordered (which is what happens for the prelinked object file task above if there are no input files).
                 if !linkerInputNodes.isEmpty || (components.contains("build") && scope.evaluate(BuiltinMacros.MERGE_LINKED_LIBRARIES)) {
                     // Compute the output path.
                     let output: Path

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -228,7 +228,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     public let ldLinkerSpec: LdLinkerSpec
     public let libtoolLinkerSpec: LibtoolLinkerSpec
     public let lipoSpec: LipoToolSpec
-    let masterObjectLinkSpec: CommandLineToolSpec
+    let prelinkedObjectLinkSpec: CommandLineToolSpec
     public let mkdirSpec: MkdirToolSpec
     let modulesVerifierSpec: ModulesVerifierToolSpec
     let clangModuleVerifierInputGeneratorSpec: ClangModuleVerifierInputGeneratorSpec
@@ -354,7 +354,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.ldLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as LdLinkerSpec
         self.libtoolLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as LibtoolLinkerSpec
         self.lipoSpec = workspaceContext.core.specRegistry.getSpec("com.apple.xcode.linkers.lipo", domain: domain) as! LipoToolSpec
-        self.masterObjectLinkSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.master-object-link", domain: domain) as! CommandLineToolSpec
+        self.prelinkedObjectLinkSpec = workspaceContext.core.specRegistry.getSpec(PrelinkedObjectLinkSpec.identifier, domain: domain) as! CommandLineToolSpec
         self.mkdirSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.mkdir", domain: domain) as! MkdirToolSpec
         self.modulesVerifierSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.modules-verifier", domain: domain) as! ModulesVerifierToolSpec
         self.clangModuleVerifierInputGeneratorSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.module-verifier-input-generator", domain: domain) as! ClangModuleVerifierInputGeneratorSpec
@@ -724,9 +724,9 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
             return false
         }
 
-        // If this target is generating a master object file, then we assume it will produce a binary.
-        // FIXME: This is nasty.  See SourcesTaskProducer.generateTasks() for handling of GENERATE_MASTER_OBJECT_FILE.
-        guard !scope.evaluate(BuiltinMacros.GENERATE_MASTER_OBJECT_FILE) else {
+        // If this target is generating a prelinked object file, then we assume it will produce a binary.
+        // FIXME: This is nasty.  See SourcesTaskProducer.generateTasks() for handling of GENERATE_PRELINK_OBJECT_FILE.
+        guard !scope.evaluate(BuiltinMacros.GENERATE_PRELINK_OBJECT_FILE) else {
             return true
         }
 

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -40,7 +40,7 @@ extension ProjectModel {
             case GENERATE_INFOPLIST_FILE
             case GCC_C_LANGUAGE_STANDARD
             case GCC_OPTIMIZATION_LEVEL
-            case GENERATE_MASTER_OBJECT_FILE
+            case GENERATE_PRELINK_OBJECT_FILE
             case INFOPLIST_FILE
             case IPHONEOS_DEPLOYMENT_TARGET
             case KEEP_PRIVATE_EXTERNS

--- a/Tests/SWBTaskConstructionTests/PrelinkedObjectFileTests.swift
+++ b/Tests/SWBTaskConstructionTests/PrelinkedObjectFileTests.swift
@@ -18,10 +18,10 @@ import SWBUtil
 import SWBProtocol
 
 @Suite
-fileprivate struct MasterObjectFileTests: CoreBasedTests {
-    // Test interesting permutations of generating a master object file.
+fileprivate struct PrelinkedObjectFileTests: CoreBasedTests {
+    // Test interesting permutations of generating a prelinked object file.
     @Test(.requireSDKs(.macOS))
-    func masterObjectFileGeneration() async throws {
+    func prelinkedObjectFileGeneration() async throws {
         let core = try await getCore()
         let testProject = TestProject(
             "aProject",
@@ -46,7 +46,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
                         TestBuildConfiguration(
                             "Debug",
                             buildSettings: [
-                                "GENERATE_MASTER_OBJECT_FILE": "YES",
+                                "GENERATE_PRELINK_OBJECT_FILE": "YES",
                                 "WARNING_LDFLAGS": "-lWarningLibrary",
                                 "PRELINK_LIBS": "-lSomeLibrary -lAnotherLibrary",
                                 "PRELINK_FLAGS": "-exported_symbols_list Exports.exp",
@@ -71,9 +71,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-exported_symbols_list", "Exports.exp", "-lWarningLibrary", "-lSomeLibrary", "-lAnotherLibrary", "-o", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-master.o")])
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-exported_symbols_list", "Exports.exp", "-lWarningLibrary", "-lSomeLibrary", "-lAnotherLibrary", "-o", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", "x86_64", "-D", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("-L\(SRCROOT)/build/Debug"), "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/x86_64/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/x86_64/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug/libAllLibraries.a")])
@@ -100,9 +100,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-exported_symbols_list", "Exports.exp", "-lWarningLibrary", "-lSomeLibrary", "-lAnotherLibrary", "-o", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-master.o")])
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-exported_symbols_list", "Exports.exp", "-lWarningLibrary", "-lSomeLibrary", "-lAnotherLibrary", "-o", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", "x86_64", "-D", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("-L\(SRCROOT)/build/Debug/BuiltProducts"), "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/x86_64/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug/AllLibraries.build/Objects-normal/x86_64/AllLibraries_libtool_dependency_info.dat", "-o", "/tmp/aProject.dst/usr/local/lib/libAllLibraries.a"])
@@ -137,8 +137,8 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkNoTask(.matchTarget(target), .matchRuleType("MasterObjectLink"))
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink"))
             }
 
             // There should be no other tasks.
@@ -153,9 +153,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS, .iOS))
-    func masterObjectFileGenerationVariant_macCatalyst() async throws {
+    func prelinkedObjectFileGenerationVariant_macCatalyst() async throws {
         let core = try await getCore()
-        // Test that a master object file gets generated even if the target contains no sources or libraries in its build phases.
+        // Test that a prelinked object file gets generated even if the target contains no sources or libraries in its build phases.
         let testProject = TestProject(
             "aProject",
             groupTree: TestGroup(
@@ -179,7 +179,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
                         TestBuildConfiguration(
                             "Debug",
                             buildSettings: [
-                                "GENERATE_MASTER_OBJECT_FILE": "YES",
+                                "GENERATE_PRELINK_OBJECT_FILE": "YES",
                             ]),
                     ],
                     buildPhases: [
@@ -201,9 +201,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-master.o")])
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", "x86_64", "-D", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("-L\(SRCROOT)/build/Debug-maccatalyst"), "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/x86_64/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/x86_64/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug-maccatalyst/libAllLibraries.a")])
@@ -222,9 +222,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.iOS))
-    func masterObjectFileGenerationVariant_ios() async throws {
+    func prelinkedObjectFileGenerationVariant_ios() async throws {
         let core = try await getCore()
-        // Test that a master object file gets generated even if the target contains no sources or libraries in its build phases.
+        // Test that a prelinked object file gets generated even if the target contains no sources or libraries in its build phases.
         let testProject = TestProject(
             "aProject",
             groupTree: TestGroup(
@@ -248,7 +248,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
                         TestBuildConfiguration(
                             "Debug",
                             buildSettings: [
-                                "GENERATE_MASTER_OBJECT_FILE": "YES",
+                                "GENERATE_PRELINK_OBJECT_FILE": "YES",
                             ]),
                     ],
                     buildPhases: [
@@ -270,9 +270,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "arm64", "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphoneos/AllLibraries.build/Objects-normal/libAllLibraries.a-arm64-master.o")])
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "arm64", "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphoneos/AllLibraries.build/Objects-normal/libAllLibraries.a-arm64-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", "arm64", "-D", "-syslibroot", .equal(results.runDestinationSDK.path.str), .equal("-L\(SRCROOT)/build/Debug-iphoneos"), "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug-iphoneos/AllLibraries.build/Objects-normal/arm64/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug-iphoneos/AllLibraries.build/Objects-normal/arm64/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug-iphoneos/libAllLibraries.a")])
@@ -291,7 +291,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.iOS))
-    func masterObjectFileGenerationVariant_ios_simulator() async throws {
+    func prelinkedObjectFileGenerationVariant_ios_simulator() async throws {
         let core = try await getCore()
         let testProject = TestProject(
             "aProject",
@@ -316,7 +316,7 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
                         TestBuildConfiguration(
                             "Debug",
                             buildSettings: [
-                                "GENERATE_MASTER_OBJECT_FILE": "YES",
+                                "GENERATE_PRELINK_OBJECT_FILE": "YES",
                             ]),
                     ],
                     buildPhases: [
@@ -338,9 +338,9 @@ fileprivate struct MasterObjectFileTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
 
             results.checkTarget("AllLibraries") { target in
-                // There should be tasks to create the master object file and then the static library.
-                results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-master.o")])
+                // There should be tasks to create the prelinked object file and then the static library.
+                results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", "x86_64", "-D", "-syslibroot", .equal(results.runDestinationSDK.path.str), .equal("-L\(SRCROOT)/build/Debug-iphonesimulator"), "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/x86_64/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/x86_64/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug-iphonesimulator/libAllLibraries.a")])

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -97,7 +97,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         "ALTERNATE_OWNER": "fooOwner",
                         "ALTERNATE_GROUP": "",
                         "ALTERNATE_MODE": "",
-                        "GENERATE_MASTER_OBJECT_FILE": "YES",
+                        "GENERATE_PRELINK_OBJECT_FILE": "YES",
                     ]),
                 ],
                 targets: [
@@ -885,9 +885,9 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     }
                     results.checkNoTask(.matchTarget(target), .matchRuleType("Copy"))
 
-                    // There should be one master object link task.
-                    results.checkTask(.matchTarget(target), .matchRuleType("MasterObjectLink")) { task in
-                        task.checkRuleInfo(["MasterObjectLink", "\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-master.o"])
+                    // There should be one prelinked object link task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
+                        task.checkRuleInfo(["PrelinkedObjectLink", "\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-prelink.o"])
                         let nonUniqueObjs = task.commandLineAsStrings.filter { $0.contains("NonUnique") }
                         if nonUniqueObjs.count != 2 {
                             #expect(nonUniqueObjs.count == 2)
@@ -895,7 +895,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         }
 
                         #expect(nonUniqueObjs[0] != nonUniqueObjs[1])
-                        task.checkCommandLineMatches([StringPattern.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile-Matched-Excluded.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile-Matched-Included.o"), .equal(nonUniqueObjs[0]), .equal(nonUniqueObjs[1]), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile_MRR.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Lex.yy.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/y.tab.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Script-Output-Custom-SourceFile.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Script-Output-Standard-SourceFile.o"), "-o", .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-master.o")])
+                        task.checkCommandLineMatches([StringPattern.suffix("ld"), "-r", "-arch", "x86_64", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile-Matched-Excluded.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile-Matched-Included.o"), .equal(nonUniqueObjs[0]), .equal(nonUniqueObjs[1]), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile_MRR.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Lex.yy.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/y.tab.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Script-Output-Custom-SourceFile.o"), .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/Script-Output-Standard-SourceFile.o"), "-o", .equal("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-prelink.o")])
 
                         task.checkInputs([
                             .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/x86_64/SourceFile.o"),
@@ -915,7 +915,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             .namePattern(.prefix("target-"))])
 
                         task.checkOutputs([
-                            .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-master.o"),])
+                            .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-x86_64-prelink.o"),])
 
                     }
 


### PR DESCRIPTION
This renames occurrences of "master" in relation to this feature to "prelink" or "prelinked". There are 3 remaining exceptions, which is to default the GENERATE_PRELINK_OBJECT_FILE build setting to GENERATE_MASTER_OBJECT_FILE for backwards compatibility.