### PR TITLE
Restore support for the llvm-bc (bitcode) field in the Swift file map.

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3067,6 +3067,12 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     fileMapEntry.indexUnitOutputPath = indexObjectPath.str
                 }
             }
+            let objectFilePrefix = objectFilePath.basenameWithoutSuffix
+            // The path to the bitcode file.  This is used, for example, by LTO.
+            if compilationMode.compileSources {
+                let bitcodeFilePath = objectFileDir.join(objectFilePrefix + ".bc")
+                fileMapEntry.llvmBitcode = bitcodeFilePath.str
+            }
             return (objectFilePath, fileMapEntry)
         }
 
@@ -3782,6 +3788,7 @@ struct SwiftOutputFileMap: Codable {
     struct Entry: Codable {
         var object: String?
         var indexUnitOutputPath: String?
+        var llvmBitcode: String?
         var remap: String?
         var diagnostics: String?
         var emitModuleDiagnostics: String?
@@ -3795,6 +3802,7 @@ struct SwiftOutputFileMap: Codable {
         enum CodingKeys: String, CodingKey {
             case object
             case indexUnitOutputPath = "index-unit-output-path"
+            case llvmBitcode = "llvm-bc"
             case remap
             case diagnostics
             case emitModuleDiagnostics = "emit-module-diagnostics"

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -326,10 +326,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             #expect(fileDict["dependencies"]?.stringValue == "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename).d")
                             #expect(fileDict["swift-dependencies"]?.stringValue == "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename).swiftdeps")
                             #expect(fileDict["swiftmodule"]?.stringValue == "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename)~partial.swiftmodule")
+                            #expect(fileDict["llvm-bc"]?.stringValue == "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename).bc")
                             #expect(fileDict["const-values"]?.stringValue == "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename).swiftconstvalues")
                             if swiftFeatures.has(.indexUnitOutputPathWithoutWarning) {
                                 #expect(fileDict["index-unit-output-path"]?.stringValue == "/aProject.build/Debug/AppTarget.build/Objects-normal/x86_64/\(filename).o")
-                                #expect(fileDict.count == 7)
+                                #expect(fileDict.count == 8)
                             } else {
                                 #expect(fileDict.count == 6)
                             }
@@ -1265,9 +1266,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                         } else {
                             compileTask.checkCommandLineContains(["-lto=llvm-thin"])
                         }
+                        compileTask.checkOutputs(contain: [.namePattern(.suffix("Bar.bc"))])
                     }
                     results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { archiverTask in
                         results.checkTaskFollows(archiverTask, .matchTarget(target), .matchRuleType("SwiftDriver Compilation"))
+                        archiverTask.checkInputs(contain: [.namePattern(.suffix("Bar.bc"))])
                     }
                 }
                 results.checkTarget("CoreFoo") { target in
@@ -1277,9 +1280,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                         } else {
                             compileTask.checkCommandLineContains(["-lto=llvm-thin"])
                         }
+                        compileTask.checkOutputs(contain: [.namePattern(.suffix("Foo.bc"))])
                     }
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { linkerTask in
                         results.checkTaskFollows(linkerTask, .matchTarget(target), .matchRuleType("SwiftDriver Compilation"))
+                        linkerTask.checkInputs(contain: [.namePattern(.suffix("Foo.bc"))])
                         if ltoSetting == "YES_THIN" {
                             linkerTask.checkCommandLineMatches([.anySequence, "-Xlinker", "-cache_path_lto", "-Xlinker", .suffix("/LTOCache"), .anySequence])
                         }


### PR DESCRIPTION
This is still used by, e.g., Swift LTO.

rdar://150188689