### PR TITLE
rdar://64344067 (Architecture specialization)

### DIFF
--- a/Sources/SWBCore/LinkageDependencyResolver.swift
+++ b/Sources/SWBCore/LinkageDependencyResolver.swift
@@ -110,7 +110,7 @@ actor LinkageDependencyResolver {
             await resolver.concurrentPerform(iterations: topLevelTargetsToDiscover.count, maximumParallelism: 100) { [self] i in
                 if Task.isCancelled { return }
                 let configuredTarget = topLevelTargetsToDiscover[i]
-                let imposedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                let imposedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: nil)
                 let dependenciesOnPath = LinkageDependencies()
                 await linkageDependencies(for: configuredTarget, imposedParameters: imposedParameters, dependenciesOnPath: dependenciesOnPath)
             }
@@ -179,10 +179,10 @@ actor LinkageDependencyResolver {
                 if let imposedParameters = imposedParameters, dependency.target.target.type == .aggregate {
                     imposedParametersForDependency = imposedParameters
                 } else {
-                    imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                    imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
                 }
             } else {
-                imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
             }
             await self.linkageDependencies(for: dependency.target, imposedParameters: imposedParametersForDependency, dependenciesOnPath: dependenciesOnPath)
         }

--- a/Sources/SWBCore/TargetDependencyResolver.swift
+++ b/Sources/SWBCore/TargetDependencyResolver.swift
@@ -334,7 +334,7 @@ fileprivate extension TargetDependencyResolver {
             await resolver.concurrentPerform(iterations: topLevelTargetsToDiscover.count, maximumParallelism: 100) { [self] i in
                 if Task.isCancelled { return }
                 let configuredTarget = topLevelTargetsToDiscover[i]
-                let imposedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                let imposedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: nil)
                 await discoverInfo(for: configuredTarget, imposedParameters: imposedParameters)
             }
         }
@@ -451,7 +451,7 @@ fileprivate extension TargetDependencyResolver {
                 let targetsUsingSuffixedSDK = configuredTargets.filter { settingsForConfiguredTarget[$0]?.sdk?.canonicalNameSuffix?.nilIfEmpty != nil }
                 if let suffixedTarget = targetsUsingSuffixedSDK.first, targetsUsingSuffixedSDK.count == 1 {
                     // Compute specialization parameters without opinion about the suffixed SDK.
-                    let fullParameters = resolver.specializationParameters(suffixedTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                    let fullParameters = resolver.specializationParameters(suffixedTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: nil)
                     let parameters = SpecializationParameters(source: .target(name: suffixedTarget.target.name), platform: fullParameters.platform, sdkVariant: fullParameters.sdkVariant, supportedPlatforms: fullParameters.supportedPlatforms, toolchain: nil, canonicalNameSuffix: nil)
 
                     // Check if any of the unsuffixed targets are incompatible with parameters other than whether the suffixed SDK is being used.
@@ -681,10 +681,10 @@ fileprivate extension TargetDependencyResolver {
                 if let imposedParameters = imposedParameters, dependency.target.target.type == .aggregate {
                     imposedParametersForDependency = imposedParameters
                 } else {
-                    imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                    imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
                 }
             } else {
-                imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                imposedParametersForDependency = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
             }
             await self.discoverInfo(for: dependency.target, imposedParameters: imposedParametersForDependency)
         }
@@ -754,7 +754,7 @@ fileprivate extension TargetDependencyResolver {
             if resolver.makeAggregateTargetsTransparentForSpecialization && dependency.target.target.type == .aggregate {
                 dependencyImposedParameters = imposedParameters
             } else {
-                dependencyImposedParameters = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                dependencyImposedParameters = resolver.specializationParameters(dependency.target, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
             }
             await addDependencies(forConfiguredTarget: dependency.target, toDependencyClosure: &dependencyClosure, dependencyPath: &dependencyPath, imposedParameters: dependencyImposedParameters)
         }
@@ -767,7 +767,7 @@ fileprivate extension TargetDependencyResolver {
             if resolver.makeAggregateTargetsTransparentForSpecialization {
                 // Aggregate targets should be transparent for specialization, so unless we already have imposed parameters, we will compute them based on the parent of the aggregate unless that is an aggregate itself.
                 if imposedParameters == nil && configuredDependency.target.target.type == .aggregate && configuredTarget.target.type != .aggregate {
-                    imposedParametersForDependency = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                    imposedParametersForDependency = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: imposedParameters?.superimposedProperties?.forPropagation)
                 } else {
                     imposedParametersForDependency = imposedParameters
                 }
@@ -788,7 +788,7 @@ fileprivate extension TargetDependencyResolver {
             // FIXME: We eventually will also need to reconcile conflicting requirements, one example: <rdar://problem/31587072> In Swift Build, creating ConfiguredTargets from Targets should take into account minimum deployment target
             var specializedParameters = imposedParameters?.effectiveParameters(target: configuredTarget, dependency: ConfiguredTarget(parameters: buildParameters, target: dependency), dependencyResolver: resolver)
             if specializedParameters == nil {
-                specializedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext)
+                specializedParameters = resolver.specializationParameters(configuredTarget, workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, superimposedProperties: nil)
             }
 
             // Get the configured dependency.  Package product dependencies are always 'explicit'.


### PR DESCRIPTION
This implements a "lite" version of architecture specialization, piggy-backing on superimposed parameters. The lite part is that we do not actually build an accurate set of architectures per client but instead will build the superset of all architectures required by any client, plus the default set of architectures inherent to the target. This means we might be overbuilding in certain cases, but we should no longer have issues with arches that are required by client targets missing from specialized targets.

This should be functional in basic terms, but has no tests yet and will break any tests involving specialization which closely monitor overrides due to the extra `ARCHES` override added here. I haven't yet decided whether I want to try to prune overrides that are superficial or update the affected tests.
