### PR TITLE
Add missing deprecated GENERATE_MASTER_OBJECT_FILE API

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -106,6 +106,9 @@ extension ProjectModel {
             case TARGETED_DEVICE_FAMILY
             case LINKER_DRIVER
             case LD_WARN_DUPLICATE_LIBRARIES
+
+            // @available(*, deprecated, renamed: "GENERATE_PRELINK_OBJECT_FILE") // can't add @available because it breaks CaseIterable
+            case GENERATE_MASTER_OBJECT_FILE // ignore-unacceptable-language
         }
 
         public enum MultipleValueSetting: String, CaseIterable, Sendable, Hashable, Codable {


### PR DESCRIPTION
Missed this in #452, just going it add it for now while we're merging branches around to reduce the chance of things going wrong.