### PR TITLE
[Swift] Add missing upcoming feature flags

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -819,6 +819,19 @@
                 Description = "Infer conformances of global-actor isolated types as isolated to the same actor unless isolation is explicitly specified as `nonisolated`.";
             },
 
+            {
+                Name = "SWIFT_UPCOMING_FEATURE_NONISOLATED_NONSENDING_BY_DEFAULT";
+                Type = Boolean;
+                DefaultValue = NO;
+                CommandLineArgs = {
+                    YES = ( "-enable-upcoming-feature", "NonisolatedNonsendingByDefault" );
+                    NO  = ();
+                };
+                DisplayName = "Nonisolated Nonsending By Default";
+                Category = "Upcoming Features";
+                Description = "Runs nonisolated async functions on the caller's actor by default unless the function is explicitly marked `@concurrent`.";
+            },
+
             // Experimental features
             {
                 Name = "SWIFT_EXPERIMENTAL_FEATURE_DEBUG_DESCRIPTION_MACRO";

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -806,6 +806,19 @@
                 Description = "Changes existential types to require explicit annotation with the `any` keyword.";
             },
 
+            {
+                Name = "SWIFT_UPCOMING_FEATURE_INFER_ISOLATED_CONFORMANCES";
+                Type = Boolean;
+                DefaultValue = NO;
+                CommandLineArgs = {
+                    YES = ( "-enable-upcoming-feature", "InferIsolatedConformances" );
+                    NO  = ();
+                };
+                DisplayName = "Infer Isolated Conformances";
+                Category = "Upcoming Features";
+                Description = "Infer conformances of global-actor isolated types as isolated to the same actor unless isolation is explicitly specified as `nonisolated`.";
+            },
+
             // Experimental features
             {
                 Name = "SWIFT_EXPERIMENTAL_FEATURE_DEBUG_DESCRIPTION_MACRO";


### PR DESCRIPTION
Two newly added feature flags were missing:

  - `InferIsolatedConformances`
  - `NonisolatedNonsendingByDefault`

Resolves: rdar://problem/150397637