### PR TITLE
Make SpecRegistry Sendable and use Swift Concurrency

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -721,7 +721,7 @@ extension Core {
 /// The delegate used to convey information to registry subsystems about the core, including a channel for those registries to report diagnostics.  This struct is created by the core itself and refers to the core.  It exists as a struct separate from core to avoid creating an ownership cycle between the core and the registry objects.
 ///
 /// Although primarily used by registries during the loading of the core, this delegate is persisted since registries may need to report additional information after loading.  For example, new toolchains may be downloaded.
-struct CoreRegistryDelegate : PlatformRegistryDelegate, SDKRegistryDelegate, SpecRegistryDelegate, ToolchainRegistryDelegate, SpecRegistryProvider {
+struct CoreRegistryDelegate : PlatformRegistryDelegate, SDKRegistryDelegate, SpecRegistryDelegate, ToolchainRegistryDelegate, SpecRegistryProvider, Sendable {
     unowned let core: Core
 
     var diagnosticsEngine: DiagnosticProducingDelegateProtocolPrivate<DiagnosticsEngine> {

--- a/Sources/SWBCore/DiagnosticSupport.swift
+++ b/Sources/SWBCore/DiagnosticSupport.swift
@@ -18,7 +18,7 @@ extension Diagnostic {
     public static let libRemarksAvailable = isLibRemarksAvailable()
 }
 
-public struct DiagnosticProducingDelegateProtocolPrivate<T> {
+public struct DiagnosticProducingDelegateProtocolPrivate<T: Sendable>: Sendable {
     fileprivate let instance: T
 
     public init(_ instance: T) {

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -19,7 +19,7 @@ import SWBMacro
 
 @Suite fileprivate struct PlatformRegistryTests {
     final class TestDataDelegate: PlatformRegistryDelegate {
-        final class MockSpecRegistryDelegate : SpecRegistryDelegate {
+        final class MockSpecRegistryDelegate: SpecRegistryDelegate, Sendable {
             let diagnosticsEngine: DiagnosticProducingDelegateProtocolPrivate<DiagnosticsEngine>
 
             init(_ diagnosticsEngine: DiagnosticsEngine) {

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -21,7 +21,7 @@ import SWBMacro
     var specDataCaches = Registry<Spec, any SpecDataCache>()
 
     class TestDataDelegate : SpecParserDelegate {
-        class MockSpecRegistryDelegate : SpecRegistryDelegate {
+        final class MockSpecRegistryDelegate: SpecRegistryDelegate, Sendable {
             private let _diagnosticsEngine: DiagnosticsEngine
 
             init(_ diagnosticsEngine: DiagnosticsEngine) {

--- a/Tests/SWBCoreTests/SpecParserTests.swift
+++ b/Tests/SWBCoreTests/SpecParserTests.swift
@@ -29,7 +29,7 @@ fileprivate final class MockSpecType: SpecType {
 
 @Suite fileprivate struct SpecParserTests {
     final class TestDataDelegate : SpecParserDelegate {
-        class MockSpecRegistryDelegate : SpecRegistryDelegate {
+        final class MockSpecRegistryDelegate: SpecRegistryDelegate, Sendable {
             private let _diagnosticsEngine: DiagnosticsEngine
 
             init(_ diagnosticsEngine: DiagnosticsEngine) {

--- a/Tests/SWBCoreTests/SpecRegistryTests.swift
+++ b/Tests/SWBCoreTests/SpecRegistryTests.swift
@@ -18,7 +18,7 @@ import SWBUtil
 @_spi(Testing) import SWBCore
 
 @Suite fileprivate struct SpecRegistryTests: CoreBasedTests {
-    final class TestDataDelegate: SpecRegistryDelegate {
+    final class TestDataDelegate: SpecRegistryDelegate, Sendable {
         private let _diagnosticsEngine = DiagnosticsEngine()
 
         var diagnosticsEngine: DiagnosticProducingDelegateProtocolPrivate<DiagnosticsEngine> {


### PR DESCRIPTION
TSan found some races in the spec proxy registration code, switch that to Swift async to get better compile time assurance it's free of data races.