### PR TITLE
Remove blocking_sync usages from TaskProducerContext

### DIFF
--- a/Sources/SWBCore/OnDemandResources.swift
+++ b/Sources/SWBCore/OnDemandResources.swift
@@ -18,7 +18,7 @@ public import SWBMacro
 
 public typealias ODRTagSet = Set<String>
 
-public struct ODRAssetPackInfo {
+public struct ODRAssetPackInfo: Sendable {
     public var identifier: String
     public var tags: ODRTagSet
     public var path: Path


### PR DESCRIPTION
These just need simple synchronization; use a mutex instead.

This also plugs a couple occurrences of unsynchronized access.