### PR TITLE
[Explicit Module Builds] Add support for Swift incremental dependency scanning

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1002,6 +1002,7 @@ public final class BuiltinMacros {
     public static let SWIFT_EMIT_MODULE_INTERFACE = BuiltinMacros.declareBooleanMacro("SWIFT_EMIT_MODULE_INTERFACE")
     public static let SWIFT_ENABLE_BATCH_MODE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BATCH_MODE")
     public static let SWIFT_ENABLE_INCREMENTAL_COMPILATION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_COMPILATION")
+    public static let SWIFT_ENABLE_INCREMENTAL_SCAN = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_SCAN")
     public static let SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES")
     public static let SWIFT_ENABLE_LIBRARY_EVOLUTION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LIBRARY_EVOLUTION")
     public static let SWIFT_ENABLE_BARE_SLASH_REGEX = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BARE_SLASH_REGEX")
@@ -2164,6 +2165,7 @@ public final class BuiltinMacros {
         SWIFT_EMIT_MODULE_INTERFACE,
         SWIFT_ENABLE_BATCH_MODE,
         SWIFT_ENABLE_INCREMENTAL_COMPILATION,
+        SWIFT_ENABLE_INCREMENTAL_SCAN,
         SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES,
         SWIFT_ENABLE_LIBRARY_EVOLUTION,
         SWIFT_USE_INTEGRATED_DRIVER,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -119,6 +119,7 @@ public struct SwiftSourceFileIndexingInfo: SourceFileIndexingInfo {
         "-emit-dependencies",
         "-serialize-diagnostics",
         "-incremental",
+        "-incremental-dependency-scan",
         "-parseable-output",
         "-use-frontend-parseable-output",
         "-whole-module-optimization",
@@ -153,6 +154,7 @@ public struct SwiftSourceFileIndexingInfo: SourceFileIndexingInfo {
     // can be removed after we use the new driver instead (rdar://75851402).
     private static let newDriverFlags: Set<ByteString> = [
         "-driver-print-graphviz",
+        "-incremental-dependency-scan",
         "-explicit-module-build",
         "-experimental-explicit-module-build",
         "-nonlib-dependency-scanner",
@@ -1743,6 +1745,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
                 if cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_INCREMENTAL_COMPILATION) {
                     args.append("-incremental")
+                    if LibSwiftDriver.supportsDriverFlag(spelled: "-incremental-dependency-scan"),
+                       cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_INCREMENTAL_SCAN) {
+                        args.append("-incremental-dependency-scan")
+                    }
                 }
             }
 
@@ -3284,6 +3290,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         for arg in [
             // Should strip this because it saves some work and avoids writing a useless incremental build record
             "-incremental",
+            // Same as above
+            "-incremental-dependency-scan",
 
             // Stripped because we want to end up in single file mode
             "-enable-batch-mode",


### PR DESCRIPTION
Re-landing https://github.com/swiftlang/swift-build/pull/434 but with an opt-in setting for now, instead of opt-out.
---------------------------------
With an opt-in build setting `SWIFT_ENABLE_INCREMENTAL_SCAN` to allow early adopters to try it out
