### PR TITLE
Allow task spec to filter command line for signature

### DIFF
--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -889,6 +889,7 @@ public protocol TaskTypeDescription: AnyObject, ConditionallyStartable, Sendable
 
     /// The command line that should be used for the change-tracking signature, i.e.
     /// the command line with the output-agnostic arguments removed.
+    /// A nil return indicates that the command line should be used as is.
     func commandLineForSignature(for task: any ExecutableTask) -> [ByteString]?
 
     /// Whether instances of this task are unsafe to interrupt.

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -69,8 +69,8 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
     {
         let md5 = InsecureHashContext()
         md5.add(bytes: serializedRepresentationSignature!)
-        for arg in task.commandLine {
-            md5.add(bytes: arg.asByteString)
+        for arg in task.type.commandLineForSignature(for: task) ?? [] {
+            md5.add(bytes: arg)
             md5.add(number: 0)
         }
         task.environment.computeSignature(into: md5)

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -69,7 +69,8 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
     {
         let md5 = InsecureHashContext()
         md5.add(bytes: serializedRepresentationSignature!)
-        for arg in task.type.commandLineForSignature(for: task) ?? [] {
+        let commandLine = task.type.commandLineForSignature(for: task) ?? task.commandLine.map { $0.asByteString }
+        for arg in commandLine {
             md5.add(bytes: arg)
             md5.add(number: 0)
         }


### PR DESCRIPTION
This wires TaskTypeDescription#commandLineForSignature() into the default implementation of TaskAction#getSignature(), allowing task action implementations to get correct signature normalization by default.