### PR TITLE
Initial support for tracking locations for assigned values in XCConfigs

### DIFF
--- a/Sources/SWBCore/MacroConfigFileLoader.swift
+++ b/Sources/SWBCore/MacroConfigFileLoader.swift
@@ -242,7 +242,7 @@ final class MacroConfigFileLoader: Sendable {
                 return MacroConfigFileParser(byteString: data, path: path, delegate: delegate)
             }
 
-            mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, parser: MacroConfigFileParser) {
+            mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, line: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
                 // Look up the macro name, creating it as a user-defined macro if it isn’t already known.
                 let macro = table.namespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, macroName)
 
@@ -253,7 +253,8 @@ final class MacroConfigFileLoader: Sendable {
                 }
 
                 // Parse the value in a manner consistent with the macro definition.
-                table.push(macro, table.namespace.parseForMacro(macro, value: value), conditions: conditionSet)
+                let location = MacroValueAssignmentLocation(path: path, line: line, startColumn: startColumn, endColumn: endColumn)
+                table.push(macro, table.namespace.parseForMacro(macro, value: value), conditions: conditionSet, location: location)
             }
 
             func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser) {
@@ -301,8 +302,8 @@ fileprivate final class MacroValueAssignmentTableRef {
         table.namespace
     }
 
-    func push(_ macro: MacroDeclaration, _ value: MacroExpression, conditions: MacroConditionSet? = nil) {
-        table.push(macro, value, conditions: conditions)
+    func push(_ macro: MacroDeclaration, _ value: MacroExpression, conditions: MacroConditionSet? = nil, location: MacroValueAssignmentLocation? = nil) {
+        table.push(macro, value, conditions: conditions, location: location)
     }
 }
 

--- a/Sources/SWBMacro/MacroConfigFileParser.swift
+++ b/Sources/SWBMacro/MacroConfigFileParser.swift
@@ -276,6 +276,7 @@ public final class MacroConfigFileParser {
     // MARK: Parsing of value assignment starts here.
     /// Parses a macro value assignment line of the form MACRONAME [ optional conditions ] ... = VALUE  ';'?
     private func parseMacroValueAssignment() {
+        let startOfLine = currIdx - 1
         // First skip over any whitespace and comments.
         skipWhitespaceAndComments()
 
@@ -361,6 +362,7 @@ public final class MacroConfigFileParser {
         // Skip over the equals sign.
         assert(currChar == /* '=' */ 61)
         advance()
+        let startColumn = currIdx - startOfLine
 
         var chunks : [String] = []
         while let chunk = parseNonListAssignmentRHS() {
@@ -383,7 +385,7 @@ public final class MacroConfigFileParser {
         }
         // Finally, now that we have the name, conditions, and value, we tell the delegate about it.
         let value = chunks.joined(separator: " ")
-        delegate?.foundMacroValueAssignment(name, conditions: conditions, value: value, parser: self)
+        delegate?.foundMacroValueAssignment(name, conditions: conditions, value: value, path: path, line: currLine, startColumn: startColumn, endColumn: currIdx - startOfLine, parser: self)
     }
 
     public func parseNonListAssignmentRHS() -> String? {
@@ -518,7 +520,7 @@ public final class MacroConfigFileParser {
             }
             func endPreprocessorInclusion() {
             }
-            func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, parser: MacroConfigFileParser) {
+            func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, line: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
                 self.macroName = macroName
                 self.conditions = conditions.isEmpty ? nil : conditions
             }
@@ -565,7 +567,7 @@ public protocol MacroConfigFileParserDelegate {
     func endPreprocessorInclusion()
 
     /// Invoked once for each macro value assignment.  The `macroName` is guaranteed to be non-empty, but `value` may be empty.  Any macro conditions are passed as tuples in the `conditions`; parameters are guaranteed to be non-empty strings, but patterns may be empty.
-    mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, parser: MacroConfigFileParser)
+    mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, line: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser)
 
     /// Invoked if an error, warning, or other diagnostic is detected.
     func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser)

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -134,6 +134,7 @@ import SWBMacro
         // Verify that the settings from the xcconfig were added.
         let XCCONFIG_USER_SETTING = try #require(settings.userNamespace.lookupMacroDeclaration("XCCONFIG_USER_SETTING"))
         #expect(settings.tableForTesting.lookupMacro(XCCONFIG_USER_SETTING)?.expression.stringRep == "from-xcconfig")
+        #expect(settings.tableForTesting.location(of: XCCONFIG_USER_SETTING) == MacroValueAssignmentLocation(path: .init("/tmp/xcconfigs/Base0.xcconfig"), line: 1, startColumn: 24, endColumn: 38))
 
         // Verify the user project settings.
         let USER_PROJECT_SETTING = try #require(settings.userNamespace.lookupMacroDeclaration("USER_PROJECT_SETTING"))

--- a/Tests/SWBMacroTests/MacroParsingTests.swift
+++ b/Tests/SWBMacroTests/MacroParsingTests.swift
@@ -790,7 +790,7 @@ fileprivate let testFileData = [
         }
         func endPreprocessorInclusion() {
         }
-        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, parser: MacroConfigFileParser) {
+        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, line: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
         }
 
         func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser) {
@@ -804,19 +804,41 @@ fileprivate let testFileData = [
         MacroConfigFileParser(byteString: "// [-Wnullability-completeness-on-arrays] \t\t\t(on)  Warns about missing nullability annotations on array parameters.", path: Path(""), delegate: delegate).parse()
         #expect(delegate.diagnosticMessages == [String]())
     }
+
+    @Test
+    func parserProvidesLocationInformation() throws {
+        TestMacroConfigFileParser("#include \"Multiline.xcconfig\"",
+                                  expectedAssignments: [
+                                    (macro: "FEATURE_DEFINES_A", conditions: [], value: "$(A) $(B) $(C)"),
+                                    (macro: "FEATURE_DEFINES_B", conditions: [], value: "$(D) $(E) $(F)"),
+                                    (macro: "FEATURE_DEFINES_C", conditions: [], value: "$(G) $(H)"),
+                                    (macro: "FEATURE_DEFINES_D", conditions: [], value: "$(I)")
+                                  ],
+                                  expectedDiagnostics: [],
+                                  expectedLocations: [
+                                    (macro: "FEATURE_DEFINES_A", path: .init("Multiline.xcconfig"), line: 2, startColumn: 20, endColumn: 37),
+                                    (macro: "FEATURE_DEFINES_B", path: .init("Multiline.xcconfig"), line: 5, startColumn: 20, endColumn: 87),
+                                    (macro: "FEATURE_DEFINES_C", path: .init("Multiline.xcconfig"), line: 9, startColumn: 20, endColumn: 61),
+                                    (macro: "FEATURE_DEFINES_D", path: .init("Multiline.xcconfig"), line: 11, startColumn: 20, endColumn: 45),
+                                  ],
+                                  expectedIncludeDirectivesCount: 1
+        )
+    }
 }
 
 // We used typealiased tuples for simplicity and readability.
 typealias ConditionInfo = (param: String, pattern: String)
 typealias AssignmentInfo = (macro: String, conditions: [ConditionInfo], value: String)
 typealias DiagnosticInfo = (level: MacroConfigFileDiagnostic.Level, kind: MacroConfigFileDiagnostic.Kind, line: Int)
+typealias LocationInfo = (macro: String, path: Path, line: Int, startColumn: Int, endColumn: Int)
 
-private func TestMacroConfigFileParser(_ string: String, expectedAssignments: [AssignmentInfo], expectedDiagnostics: [DiagnosticInfo], expectedIncludeDirectivesCount: Int, sourceLocation: SourceLocation = #_sourceLocation) {
+private func TestMacroConfigFileParser(_ string: String, expectedAssignments: [AssignmentInfo], expectedDiagnostics: [DiagnosticInfo], expectedLocations: [LocationInfo]? = nil, expectedIncludeDirectivesCount: Int, sourceLocation: SourceLocation = #_sourceLocation) {
 
     /// We use a custom delegate to test that we’re getting the expected results, which for the sake of convenience are just kept in (name, conds:[(cond-param, cond-value)], value) tuples, i.e. conditions is an array of two-element tuples.
     class ConfigFileParserTestDelegate : MacroConfigFileParserDelegate {
         var assignments = Array<AssignmentInfo>()
         var diagnostics = Array<DiagnosticInfo>()
+        var locations = Array<LocationInfo>()
 
         var includeDirectivesCount = 0
 
@@ -834,9 +856,10 @@ private func TestMacroConfigFileParser(_ string: String, expectedAssignments: [A
         func endPreprocessorInclusion() {
             self.includeDirectivesCount += 1
         }
-        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, parser: MacroConfigFileParser) {
+        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, line: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
             // print("\(parser.lineNumber): \(macroName)\(conditions.map({ "[\($0.param)=\($0.pattern)]" }).joinWithSeparator(""))=\(value)")
             assignments.append((macro: macroName, conditions: conditions, value: value))
+            locations.append((macro: macroName, path: path, line: line, startColumn: startColumn, endColumn: endColumn))
         }
         func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser) {
             // print("\(parser.lineNumber): \(diagnostic)")
@@ -856,6 +879,10 @@ private func TestMacroConfigFileParser(_ string: String, expectedAssignments: [A
 
     // Check the diagnostics that the delegate saw against the expected ones.
     #expect(delegate.diagnostics == expectedDiagnostics, "expected parse diagnostics \(expectedDiagnostics), but instead got \(delegate.diagnostics)", sourceLocation: sourceLocation)
+
+    if let expectedLocations {
+        #expect(delegate.locations == expectedLocations, "expected parse locations \(expectedLocations), but instead ogt \(delegate.locations)", sourceLocation: sourceLocation)
+    }
 
     #expect(delegate.includeDirectivesCount == expectedIncludeDirectivesCount, "expected number of configs parsed to be \(expectedIncludeDirectivesCount), but instead got \(delegate.includeDirectivesCount)", sourceLocation: sourceLocation)
 }
@@ -882,6 +909,14 @@ func ==(lhs: DiagnosticInfo, rhs: DiagnosticInfo) -> Bool {
 }
 
 func ==(lhs: [DiagnosticInfo], rhs: [DiagnosticInfo]) -> Bool {
+    return lhs.count == rhs.count && zip(lhs, rhs).filter({ return !($0.0 == $0.1) }).isEmpty
+}
+
+func ==(lhs: LocationInfo, rhs: LocationInfo) -> Bool {
+    return (lhs.macro == rhs.macro) && (lhs.path == rhs.path) && (lhs.line == rhs.line) && (lhs.startColumn == rhs.startColumn) && (lhs.endColumn == rhs.endColumn)
+}
+
+func ==(lhs: [LocationInfo], rhs: [LocationInfo]) -> Bool {
     return lhs.count == rhs.count && zip(lhs, rhs).filter({ return !($0.0 == $0.1) }).isEmpty
 }
 


### PR DESCRIPTION
This can be used to emit fix-its for XCConfigs files during the build process.
