### PR TITLE
Read hardcoded deployment targets list from features.json instead

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -65,10 +65,6 @@ struct AndroidEnvironmentExtension: EnvironmentExtension {
 }
 
 struct AndroidPlatformExtension: PlatformInfoExtension {
-    func knownDeploymentTargetMacroNames() -> Set<String> {
-        ["ANDROID_DEPLOYMENT_TARGET"]
-    }
-    
     func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
         [
             (.root, [

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -207,17 +207,6 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
 }
 
 struct ApplePlatformInfoExtension: PlatformInfoExtension {
-    func knownDeploymentTargetMacroNames() -> Set<String> {
-        [
-            "MACOSX_DEPLOYMENT_TARGET",
-            "IPHONEOS_DEPLOYMENT_TARGET",
-            "TVOS_DEPLOYMENT_TARGET",
-            "WATCHOS_DEPLOYMENT_TARGET",
-            "DRIVERKIT_DEPLOYMENT_TARGET",
-            "XROS_DEPLOYMENT_TARGET",
-        ]
-    }
-
     func preferredArchValue(for platformName: String) -> String? {
         // FIXME: rdar://65011964 (Remove PLATFORM_PREFERRED_ARCH)
         // Don't add values for any new platforms

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -1440,7 +1440,8 @@ private struct AllExportedMacrosAndValuesMsg: MessageHandler {
         let settings = try getSettings(for: session, workspaceContext: workspaceContext, requestContext: message.context, purpose: .build)
 
         // Get the list of setting names and evaluated values.  We use the same algorithm as is used to export settings to shell script build phases.
-        let exportedMacrosAndValues = computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: workspaceContext)
+        // We explicitly pass an empty set for `allDeploymentTargetMacroNames` because in this context we are exporting the list of known macros and not applying the special case to only exported a single deployment target like we do in shell scripts.
+        let exportedMacrosAndValues = computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: workspaceContext, allDeploymentTargetMacroNames: [])
 
         return AllExportedMacrosAndValuesResponse(result: exportedMacrosAndValues)
     }

--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -207,7 +207,7 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
         delegate.targetPreparationStarted(self, configuredTarget: configuredTarget)
         delegate.targetStarted(self, configuredTarget: configuredTarget)
 
-        let (executable, arguments, workingDirectory, environment) = constructCommandLine(for: configuredTarget.target as! SWBCore.ExternalTarget, action: "clean", settings: settings, workspaceContext: workspaceContext, scope: settings.globalScope)
+        let (executable, arguments, workingDirectory, environment) = constructCommandLine(for: configuredTarget.target as! SWBCore.ExternalTarget, action: "clean", settings: settings, workspaceContext: workspaceContext, scope: settings.globalScope, allDeploymentTargetMacroNames: [])
         let commandLine = [executable] + arguments
 
         let specLookupContext = SpecLookupCtxt(specRegistry: workspaceContext.core.specRegistry, platform: settings.platform)

--- a/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
+++ b/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
@@ -22,8 +22,6 @@ public struct PlatformInfoExtensionPoint: ExtensionPoint, Sendable {
 }
 
 public protocol PlatformInfoExtension: Sendable {
-    func knownDeploymentTargetMacroNames() -> Set<String>
-
     func preferredArchValue(for: String) -> String?
 
     func additionalTestLibraryPaths(scope: MacroEvaluationScope, platform: Platform?, fs: any FSProxy) -> [Path]
@@ -40,10 +38,6 @@ public protocol PlatformInfoExtension: Sendable {
 }
 
 extension PlatformInfoExtension {
-    public func knownDeploymentTargetMacroNames() -> Set<String> {
-        []
-    }
-
     public func preferredArchValue(for: String) -> String? {
         nil
     }

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -142,7 +142,7 @@ public final class DiscoveredCommandLineToolSpecInfoCache: Sendable {
     }
 }
 
-/// Returns the set of 'feature' names detailed in a 'features.json' file that a tool may install alongside its executable.
+/// Represents the set of 'feature' names detailed in a 'features.json' file that a tool may install alongside its executable.
 /// The format is like this:
 ///
 ///   {
@@ -154,18 +154,17 @@ public final class DiscoveredCommandLineToolSpecInfoCache: Sendable {
 ///     ]
 ///   }
 ///
-func rawFeaturesFromToolFeaturesJSON(path: Path, fs: any FSProxy) throws -> Set<String> {
-    struct FeatureSet: Codable {
-        struct Feature: Codable {
-            let name: String
-        }
-        let features: [Feature]
+private struct FeatureSet: Codable {
+    struct Feature: Codable {
+        let name: String
+        let value: PropertyListItem?
     }
-    return try Set(JSONDecoder().decode(FeatureSet.self, from: path, fs: fs).features.map(\.name))
+    let features: [Feature]
 }
 
 /// Set of features from a 'features.json' file that may be installed alongside its executable, see `rawFeaturesFromToolFeaturesJSON`.
 public struct ToolFeatures<T>: Sendable where T: Sendable, T: Hashable, T: CaseIterable, T: RawRepresentable, T.RawValue == String {
+    private let featureSet: FeatureSet
     public let flags: Set<T>
 
     public static var none: ToolFeatures {
@@ -174,11 +173,13 @@ public struct ToolFeatures<T>: Sendable where T: Sendable, T: Hashable, T: CaseI
 
     public init(_ flags: Set<T>) {
         self.flags = flags
+        self.featureSet = .init(features: flags.map { .init(name: $0.rawValue, value: nil) })
     }
 
     public init(path: Path, fs: any FSProxy) throws {
         var flags: Set<T> = []
-        let raw = try rawFeaturesFromToolFeaturesJSON(path: path, fs: fs)
+        featureSet = try JSONDecoder().decode(FeatureSet.self, from: path, fs: fs)
+        let raw = Set(featureSet.features.map(\.name))
         for flag in T.allCases {
             if raw.contains(flag.rawValue) {
                 flags.insert(flag)
@@ -196,6 +197,10 @@ public struct ToolFeatures<T>: Sendable where T: Sendable, T: Hashable, T: CaseI
             return false
         }
         return has(flag)
+    }
+
+    public func value(_ flag: T) -> PropertyListItem? {
+        featureSet.features.first(where: { $0.name == flag.rawValue })?.value
     }
 }
 

--- a/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
+++ b/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
@@ -37,6 +37,7 @@ public struct DiscoveredClangToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
         case resourceDirUsesMajorVersionOnly = "resource-dir-uses-major-version-only"
         case wSystemHeadersInModule = "Wsystem-headers-in-module"
         case extractAPISupportsCPlusPlus = "extract-api-supports-cpp"
+        case deploymentTargetEnvironmentVariables = "deployment-target-environment-variables"
     }
     public var toolFeatures: ToolFeatures<FeatureFlag>
     public func hasFeature(_ feature: String) -> Bool {
@@ -55,6 +56,10 @@ public struct DiscoveredClangToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
     public func getResourceDirPath() -> Path? {
         let version = hasFeature(FeatureFlag.resourceDirUsesMajorVersionOnly.rawValue) ? llvmVersion?[0].description : llvmVersion?.description
         return version == nil ? nil : toolPath.dirname.dirname.join("lib").join("clang").join(version)
+    }
+
+    public func deploymentTargetEnvironmentVariableNames() -> Set<String> {
+        Set(toolFeatures.value(.deploymentTargetEnvironmentVariables)?.stringArrayValue ?? [])
     }
 }
 

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -53,10 +53,6 @@ struct QNXEnvironmentExtension: EnvironmentExtension {
 }
 
 struct QNXPlatformExtension: PlatformInfoExtension {
-    func knownDeploymentTargetMacroNames() -> Set<String> {
-        ["QNX_DEPLOYMENT_TARGET"]
-    }
-
     func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
         [
             (.root, [

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/BuildRuleTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/BuildRuleTaskProducer.swift
@@ -118,7 +118,7 @@ final class BuildRuleTaskProducer: StandardTaskProducer, TaskProducer, ShellBase
         let commandLine = [action.interpreterPath, "-c", action.scriptSource]
 
         // Compute the environment to use for the shell script.
-        var environment = computeScriptEnvironment(.shellScriptPhase, scope: cbc.scope, settings: context.settings, workspaceContext: context.workspaceContext)
+        var environment = await computeScriptEnvironment(.shellScriptPhase, scope: cbc.scope, settings: context.settings, workspaceContext: context.workspaceContext, allDeploymentTargetMacroNames: context.allDeploymentTargetMacroNames())
 
         // If we are in a headers build phase, expose visibility and output dir
         // information to the script and set the HEADER_OUTPUT_DIR macro value

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ShellScriptTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ShellScriptTaskProducer.swift
@@ -157,7 +157,7 @@ final class ShellScriptTaskProducer: PhasedTaskProducer, TaskProducer, ShellBase
         }
 
         // Compute the environment to use for the shell script.
-        var environment = computeScriptEnvironment(.shellScriptPhase, scope: scope, settings: context.settings, workspaceContext: context.workspaceContext)
+        var environment = await computeScriptEnvironment(.shellScriptPhase, scope: scope, settings: context.settings, workspaceContext: context.workspaceContext, allDeploymentTargetMacroNames: context.allDeploymentTargetMacroNames())
 
         // Create the set of resolved paths and export the proper variables to the script environment.
         var inputs = exportPaths(&environment, shellScriptBuildPhase.inputFilePaths, prefix: "SCRIPT_INPUT_FILE", considerAllPathsDirectories: true)
@@ -308,10 +308,10 @@ final class ShellScriptTaskProducer: PhasedTaskProducer, TaskProducer, ShellBase
     /// Construct the tasks for an individual shell-script build rule.
     ///
     /// NOTE: External targets are basically shell scripts. It lives here because the behavior shares some significant logical pieces with the behavior of shell script build phases.
-    static func constructTasksForExternalTarget(_ target: SWBCore.ExternalTarget, _ context: TaskProducerContext, cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) {
+    static func constructTasksForExternalTarget(_ target: SWBCore.ExternalTarget, _ context: TaskProducerContext, cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) async {
         let action = cbc.scope.evaluate(BuiltinMacros.ACTION)
 
-        let (executable, arguments, workingDirectory, environment) = constructCommandLine(for: target, action: action, settings: context.settings, workspaceContext: context.workspaceContext, scope: cbc.scope)
+        let (executable, arguments, workingDirectory, environment) = await constructCommandLine(for: target, action: action, settings: context.settings, workspaceContext: context.workspaceContext, scope: cbc.scope, allDeploymentTargetMacroNames: context.allDeploymentTargetMacroNames())
 
         // FIXME: Need the model name.
 

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
@@ -23,7 +23,7 @@ final class CustomTaskProducer: PhasedTaskProducer, TaskProducer {
             for customTask in context.configuredTarget?.target.customTasks ?? [] {
                 
                 let commandLine = customTask.commandLine.map { context.settings.globalScope.evaluate($0) }
-                var environmentAssignments = computeScriptEnvironment(.shellScriptPhase, scope: context.settings.globalScope, settings: context.settings, workspaceContext: context.workspaceContext)
+                var environmentAssignments = await computeScriptEnvironment(.shellScriptPhase, scope: context.settings.globalScope, settings: context.settings, workspaceContext: context.workspaceContext, allDeploymentTargetMacroNames: context.allDeploymentTargetMacroNames())
                 if context.workspaceContext.core.hostOperatingSystem != .macOS {
                     environmentAssignments = environmentAssignments.filter { $0.key.lowercased() != "path" }
                 }

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ExternalTargetTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ExternalTargetTaskProducer.swift
@@ -23,7 +23,7 @@ final class ExternalTargetTaskProducer: StandardTaskProducer, TaskProducer {
         let target = context.configuredTarget!.target as! ExternalTarget
         var tasks = [any PlannedTask]()
         await appendGeneratedTasks(&tasks) { delegate in
-            ShellScriptTaskProducer.constructTasksForExternalTarget(target, context, cbc: CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: []), delegate: delegate)
+            await ShellScriptTaskProducer.constructTasksForExternalTarget(target, context, cbc: CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: []), delegate: delegate)
         }
         return tasks
     }

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -435,6 +435,11 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         }
     }
 
+    /// The set of all known deployment target macro names, even if the platforms that use those settings are not installed.
+    func allDeploymentTargetMacroNames() async -> Set<String> {
+        await (clangSpec.discoveredCommandLineToolSpecInfo(self, settings.globalScope, delegate) as? DiscoveredClangToolSpecInfo)?.deploymentTargetEnvironmentVariableNames() ?? []
+    }
+
     /// Make an input path absolute, resolving relative to the current project.
     func makeAbsolute(_ path: Path) -> Path {
         return defaultWorkingDirectory.join(path)

--- a/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
+++ b/Tests/SWBCoreTests/ShellScriptEnvironmentTests.swift
@@ -49,7 +49,7 @@ import SWBProtocol
         let parameters = BuildParameters(action: .build, configuration: "Debug", overrides: [:])
         let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testTarget)
 
-        let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context)
+        let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context, allDeploymentTargetMacroNames: [])
 
         let expected: [String: String] =         [
             "ACTION": "build",
@@ -209,7 +209,7 @@ import SWBProtocol
             let parameters = BuildParameters(action: .build, configuration: "Debug", overrides: [:], toolchainOverride: "com.apple.ExtraToolchain")
             let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testTarget)
 
-            let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context)
+            let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context, allDeploymentTargetMacroNames: [])
 
             // Check that all of the settings defined as expected in the dictionary above appear as described.
             let expected: [String: String] = [
@@ -257,7 +257,7 @@ import SWBProtocol
         let parameters = BuildParameters(action: .build, configuration: "Debug", overrides: [:])
         let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testTarget)
 
-        let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context)
+        let env = SWBCore.computeScriptEnvironment(.shellScriptPhase, scope: settings.globalScope, settings: settings, workspaceContext: context, allDeploymentTargetMacroNames: [])
 
         let shouldNotBeExported = [
             "BUILD_DESCRIPTION_CACHE_DIR",


### PR DESCRIPTION
Eliminate the maintenance burden of having to manually maintain this list. Also, it wasn't correct for Android and QNX anyways, since those don't actually have deployment target environment variables recognized by clang.

rdar://91377944