### PR TITLE
PlannedSwiftDriverJob - fix deserializer count

### DIFF
--- a/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
+++ b/Sources/SWBCore/LibSwiftDriver/PlannedBuild.swift
@@ -192,7 +192,7 @@ extension LibSwiftDriver {
             }
 
             public init(from deserializer: any Deserializer) throws {
-                try deserializer.beginAggregate(4)
+                try deserializer.beginAggregate(5)
                 try key = deserializer.deserialize()
                 try driverJob = deserializer.deserialize()
                 try dependencies = deserializer.deserialize()


### PR DESCRIPTION
I forgot to update this when adding the new field