### PR TITLE
Enforce a minimum Xcode version for Open Source testing workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ When building SwiftPM from sources which include Swift Build integration, passin
 
 ### With Xcode
 
-Changes to swift-build can also be tested in Xcode using the `launch-xcode` command plugin provided by the package. Run `swift package --disable-sandbox launch-xcode` from your checkout of swift-build to launch a copy of the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. This workflow is currently supported when using Xcode 16.2.
+Changes to swift-build can also be tested in Xcode using the `launch-xcode` command plugin provided by the package. Run `swift package --disable-sandbox launch-xcode` from your checkout of swift-build to launch a copy of the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. This workflow is generally only supported when using the latest available Xcode version.
 
 ### With xcodebuild
 
-Changes to swift-build can also be tested in xcodebuild using the `run-xcodebuild` command plugin provided by the package. Run `swift package --disable-sandbox run-xcodebuild` from your checkout of swift-build to run xcodebuild from the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. Arguments followed by `--` will be forwarded to xcodebuild unmodified. This workflow is currently supported when using Xcode 16.2.
+Changes to swift-build can also be tested in xcodebuild using the `run-xcodebuild` command plugin provided by the package. Run `swift package --disable-sandbox run-xcodebuild` from your checkout of swift-build to run xcodebuild from the currently `xcode-select`ed Xcode.app configured to use your modified copy of the build system service. Arguments followed by `--` will be forwarded to xcodebuild unmodified. This workflow is generally only supported when using the latest available Xcode version.
 
 ### Debugging
 

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -245,6 +245,12 @@ public final class Core: Sendable {
                 // If the ProductBuildVersion key is missing, we use "UNKNOWN" as the value.
                 self.xcodeProductBuildVersion = info.productBuildVersion ?? ProductBuildVersion(major: 0, train: "A", build: 0, buildSuffix: "")
                 self.xcodeProductBuildVersionString = info.productBuildVersion?.description ?? "UNKNOWN"
+
+                // Enforce a minimum Xcode version for Open Source testing workflows
+                let minimumXcodeVersion = Version(16, 2)
+                if xcodeVersion < minimumXcodeVersion {
+                    throw StubError.error("This build of Swift Build requires a minimum Xcode version of \(minimumXcodeVersion.description) (current version: \(xcodeVersion.zeroTrimmed.description)).")
+                }
             } else {
                 // Set an arbitrary version for testing purposes.
                 self.xcodeVersion = Version(99, 99, 99)


### PR DESCRIPTION
This provides a user-visible error message when attempting to initialize a Core with an older version, and removes the explicit version listing from the README so it doesn't need to be updated in multiple places.