### PR TITLE
Update automerger PR workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,8 @@ jobs:
     name: Create PR to merge main into release branch
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
-      base_branch: release/6.2
+      head_branch: release/6.2
+      base_branch: main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
We'd like to stop including all changes from main in the release/6.2 branch. Flip the direction of the automerger so we can periodically review that all changes to 6.2 do make it to main