### PR TITLE
Update swift-system to 1.5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -456,7 +456,7 @@ if useLocalDependencies {
 } else {
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.4.1")),
+        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.5.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),
     ]
     if !useLLBuildFramework {


### PR DESCRIPTION
This is required for System.FilePath to work correctly on Windows in release mode.