### PR TITLE
[6.2] Simplify fallback developer directory calculation

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -31,8 +31,8 @@ import SWBTaskConstruction
 }
 
 struct AppleDeveloperDirectoryExtension: DeveloperDirectoryExtension {
-    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Path? {
-        try await hostOperatingSystem == .macOS ? Xcode.getActiveDeveloperDirectoryPath() : nil
+    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Core.DeveloperPath? {
+        try await hostOperatingSystem == .macOS ? .xcode(Xcode.getActiveDeveloperDirectoryPath()) : nil
     }
 }
 

--- a/Sources/SWBCore/Extensions/DeveloperDirectoryExtension.swift
+++ b/Sources/SWBCore/Extensions/DeveloperDirectoryExtension.swift
@@ -21,5 +21,5 @@ public struct DeveloperDirectoryExtensionPoint: ExtensionPoint {
 }
 
 public protocol DeveloperDirectoryExtension: Sendable {
-    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Path?
+    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Core.DeveloperPath?
 }

--- a/Sources/SWBCore/MacroConfigFileLoader.swift
+++ b/Sources/SWBCore/MacroConfigFileLoader.swift
@@ -133,7 +133,7 @@ final class MacroConfigFileLoader: Sendable {
                 // FIXME: Move this to its proper home, and support the other special cases Xcode has (PLATFORM_DIR and SDK_DIR). This should move to using a generic facility, e.g., source trees: <rdar://problem/23576831> Add search paths for .xcconfig macros to match what Xcode has
                 if path.str.hasPrefix("<DEVELOPER_DIR>") {
                     switch developerPath {
-                    case .xcode(let developerPath), .swiftToolchain(let developerPath, _), .fallback(let developerPath):
+                    case .xcode(let developerPath), .swiftToolchain(let developerPath, _):
                         path = Path(path.str.replacingOccurrences(of: "<DEVELOPER_DIR>", with: developerPath.str))
                     }
                 }

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1026,7 +1026,7 @@ extension WorkspaceContext {
 
             // Add the standard search paths.
             switch core.developerPath {
-            case .xcode(let path), .fallback(let path):
+            case .xcode(let path):
                 paths.append(path.join("usr").join("bin"))
                 paths.append(path.join("usr").join("local").join("bin"))
             case .swiftToolchain(let path, let xcodeDeveloperPath):

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -23,13 +23,13 @@ import Foundation
 }
 
 struct GenericUnixDeveloperDirectoryExtension: DeveloperDirectoryExtension {
-    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Path? {
+    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Core.DeveloperPath? {
         if hostOperatingSystem == .windows || hostOperatingSystem == .macOS {
             // Handled by the Windows and Apple plugins
             return nil
         }
 
-        return .root
+        return .swiftToolchain(.root, xcodeDeveloperPath: nil)
     }
 }
 

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -38,7 +38,7 @@ extension Core {
         if hostOperatingSystem == .macOS {
             developerPath = .xcode(try await Xcode.getActiveDeveloperDirectoryPath())
         } else {
-            developerPath = .fallback(Path.root)
+            developerPath = .swiftToolchain(.root, xcodeDeveloperPath: nil)
         }
         let delegate = TestingCoreDelegate()
         return await (try Core(delegate: delegate, hostOperatingSystem: hostOperatingSystem, pluginManager: PluginManager(skipLoadingPluginIdentifiers: []), developerPath: developerPath, resourceSearchPaths: [], inferiorProductsPath: nil, additionalContentPaths: [], environment: [:], buildServiceModTime: Date(), connectionMode: .inProcess), delegate.diagnostics)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -60,7 +60,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
                 paths.append(path)
             }
             switch core.developerPath {
-            case .xcode(let path), .fallback(let path):
+            case .xcode(let path):
                 paths.append(path.join("usr").join("bin"))
                 paths.append(path.join("usr").join("local").join("bin"))
             case .swiftToolchain(let path, xcodeDeveloperPath: let xcodeDeveloperPath):

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -53,14 +53,14 @@ public final class WindowsPlugin: Sendable {
 }
 
 struct WindowsDeveloperDirectoryExtension: DeveloperDirectoryExtension {
-    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Path? {
+    func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Core.DeveloperPath? {
         guard hostOperatingSystem == .windows else {
             return nil
         }
         guard let userProgramFiles = URL.userProgramFiles, let swiftPath = try? userProgramFiles.appending(component: "Swift").filePath else {
             throw StubError.error("Could not determine path to user program files")
         }
-        return swiftPath
+        return .swiftToolchain(swiftPath, xcodeDeveloperPath: nil)
     }
 }
 
@@ -94,15 +94,7 @@ struct WindowsPlatformExtension: PlatformInfoExtension {
             return []
         }
 
-        let platformsPath: Path
-        switch context.developerPath {
-        case .xcode(let path):
-            platformsPath = path.join("Platforms")
-        case .swiftToolchain(let path, _):
-            platformsPath = path.join("Platforms")
-        case .fallback(let path):
-            platformsPath = path.join("Platforms")
-        }
+        let platformsPath = context.developerPath.path.join("Platforms")
         return try context.fs.listdir(platformsPath).compactMap { version in
             let versionedPlatformsPath = platformsPath.join(version)
             guard context.fs.isDirectory(versionedPlatformsPath) else {

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -49,7 +49,7 @@ import SWBMacro
         }
 
         var developerPath: Core.DeveloperPath {
-            .fallback(Path.temporaryDirectory)
+            .swiftToolchain(.temporaryDirectory, xcodeDeveloperPath: nil)
         }
     }
 


### PR DESCRIPTION
Have the fallback logic specify the type of developer directory as well as just the location, and eliminate the initialization distinction on whether a Core was initialized with a "fallback" path vs one explicitly given, since it shouldn't matter.