### PR TITLE
License header check should ignore .swift-version

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -5,5 +5,6 @@
 **/Package.swift
 .dir-locals.el
 .editorconfig
+.swift-version
 CODEOWNERS
 Package.swift


### PR DESCRIPTION
_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
