### PR TITLE
Unskip tests blocked by requireThreadSafeWorkingDirectory

### DIFF
--- a/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
@@ -55,7 +55,7 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
     }
 
     private func assetTagCombinations(catalogInputs inputs: [FileToBuild], _ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async throws -> Set<Set<String>> {
-        return try await executeExternalTool(cbc, delegate, commandLine: [resolveExecutablePath(cbc, cbc.scope.actoolExecutablePath()).str, "--print-asset-tag-combinations", "--output-format", "xml1"] + inputs.map { $0.absolutePath.str }, workingDirectory: cbc.producer.defaultWorkingDirectory.str, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute asset tag combinations") { output in
+        return try await executeExternalTool(cbc, delegate, commandLine: [resolveExecutablePath(cbc, cbc.scope.actoolExecutablePath()).str, "--print-asset-tag-combinations", "--output-format", "xml1"] + inputs.map { $0.absolutePath.str }, workingDirectory: cbc.producer.defaultWorkingDirectory, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute asset tag combinations") { output in
             struct AssetCatalogToolOutput: Decodable {
                 struct Diagnostic: Decodable {
                     let description: String

--- a/Sources/SWBApplePlatform/CoreDataCompiler.swift
+++ b/Sources/SWBApplePlatform/CoreDataCompiler.swift
@@ -67,7 +67,7 @@ public final class CoreDataModelCompilerSpec : GenericCompilerSpec, SpecIdentifi
             // Mark the entire directory structure as being watched by the build system.
             delegate.access(path: input.absolutePath)
 
-            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: [commandLine[0]] + ["--dry-run"] + commandLine[1...], workingDirectory: cbc.producer.defaultWorkingDirectory.str, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute data model \(input.absolutePath.basename) code generation output paths") { output in
+            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: [commandLine[0]] + ["--dry-run"] + commandLine[1...], workingDirectory: cbc.producer.defaultWorkingDirectory, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute data model \(input.absolutePath.basename) code generation output paths") { output in
                 return output.unsafeStringValue.split(separator: "\n").map(Path.init).map { $0.prependingPrivatePrefixIfNeeded(otherPath: outputDir) }
             }
             guard !generatedFiles.isEmpty else {

--- a/Sources/SWBApplePlatform/CoreMLCompiler.swift
+++ b/Sources/SWBApplePlatform/CoreMLCompiler.swift
@@ -241,7 +241,7 @@ public final class CoreMLCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
             // Mark the file as being watched by the build system to invalidate the build description.
             delegate.access(path: input.absolutePath)
 
-            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: commandLine[0...3] + ["--dry-run", "yes"] + commandLine[4...], workingDirectory: cbc.producer.defaultWorkingDirectory.str, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute CoreML model \(input.absolutePath.basename) code generation output paths") { output in
+            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: commandLine[0...3] + ["--dry-run", "yes"] + commandLine[4...], workingDirectory: cbc.producer.defaultWorkingDirectory, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute CoreML model \(input.absolutePath.basename) code generation output paths") { output in
                 return output.unsafeStringValue.split(separator: "\n").map(Path.init)
             }
             guard !generatedFiles.isEmpty else {

--- a/Sources/SWBApplePlatform/IntentsCompiler.swift
+++ b/Sources/SWBApplePlatform/IntentsCompiler.swift
@@ -194,7 +194,7 @@ public final class IntentsCompilerSpec : GenericCompilerSpec, SpecIdentifierType
             // Mark the file as being watched by the build system to invalidate the build description.
             delegate.access(path: input.absolutePath)
 
-            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: commandLine[0...1] + ["-dryRun"] + commandLine[2...], workingDirectory: cbc.producer.defaultWorkingDirectory.str, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute Intent Definition \(input.absolutePath.basename) code generation output paths") { output in
+            generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: commandLine[0...1] + ["-dryRun"] + commandLine[2...], workingDirectory: cbc.producer.defaultWorkingDirectory, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute Intent Definition \(input.absolutePath.basename) code generation output paths") { output in
                 return output.unsafeStringValue.split(separator: "\n").map(Path.init).map { $0.prependingPrivatePrefixIfNeeded(otherPath: outputDir) }
             }
             guard !generatedFiles.isEmpty else {

--- a/Sources/SWBApplePlatform/XCStringsCompiler.swift
+++ b/Sources/SWBApplePlatform/XCStringsCompiler.swift
@@ -62,7 +62,7 @@ public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierTyp
             // xcstringstool compile --dry-run
             dryRunCommandLine.insert("--dry-run", at: 2)
 
-            outputs = try await generatedFilePaths(cbc, delegate, commandLine: dryRunCommandLine, workingDirectory: cbc.producer.defaultWorkingDirectory.str, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute XCStrings \(cbc.input.absolutePath.basename) output paths") { output in
+            outputs = try await generatedFilePaths(cbc, delegate, commandLine: dryRunCommandLine, workingDirectory: cbc.producer.defaultWorkingDirectory, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute XCStrings \(cbc.input.absolutePath.basename) output paths") { output in
                 return output.unsafeStringValue.split(separator: "\n").map(Path.init)
             }
         } catch {

--- a/Sources/SWBBuildService/BuildDependencyInfo.swift
+++ b/Sources/SWBBuildService/BuildDependencyInfo.swift
@@ -469,7 +469,7 @@ extension BuildDependencyInfo {
 
 /// Special `CoreClientDelegate`-conforming struct because our use of `GlobalProductPlan` here should never be running external tools.
 fileprivate struct UnsupportedCoreClientDelegate: CoreClientDelegate {
-    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         throw StubError.error("Running external tools is not supported when computing build dependency target info.")
     }
 }

--- a/Sources/SWBBuildService/ClientExchangeDelegate.swift
+++ b/Sources/SWBBuildService/ClientExchangeDelegate.swift
@@ -33,7 +33,7 @@ final class ClientExchangeDelegate: ClientDelegate {
         self.session = session
     }
 
-    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         // Create a synchronous client exchange which the session uses to handle the response from the client, to make the communication synchronous from the point of view of our caller.
         let exchange = SynchronousClientExchange<ExternalToolExecutionResponse>(session)
 

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1122,14 +1122,14 @@ private struct OperatorSystemAdaptorDynamicContext: DynamicTaskExecutionDelegate
     }
 
     @discardableResult
-    func spawn(commandLine: [String], environment: [String: String], workingDirectory: String, processDelegate: any ProcessDelegate) async throws -> Bool {
+    func spawn(commandLine: [String], environment: [String: String], workingDirectory: Path, processDelegate: any ProcessDelegate) async throws -> Bool {
         guard let jobContext else {
             throw StubError.error("API misuse. Spawning processes is only allowed from `performTaskAction`.")
         }
 
         // This calls into llb_buildsystem_command_interface_spawn, which can block, so ensure it's shunted to a new thread so as not to block the Swift Concurrency thread pool. This shouldn't risk thread explosion because this function is only allowed to be called from performTaskAction, which in turn should be bounded to ncores based on the number of active llbuild lane threads.
         return await _Concurrency.Task.detachNewThread(name: "llb_buildsystem_command_interface_spawn") { [commandInterface, jobContext, processDelegate] in
-            commandInterface.spawn(jobContext, commandLine: commandLine, environment: environment, workingDirectory: workingDirectory, processDelegate: processDelegate)
+            commandInterface.spawn(jobContext, commandLine: commandLine, environment: environment, workingDirectory: workingDirectory.str, processDelegate: processDelegate)
         }
     }
 

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1393,7 +1393,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         return Base.instance.shouldStart(task, buildCommand: buildCommand)
     }
 
-    public func executeExternalTool<T>(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: String?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> T) async throws -> T {
+    public func executeExternalTool<T>(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: Path?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> T) async throws -> T {
         let executionResult = try await delegate.executeExternalTool(commandLine: commandLine, workingDirectory: workingDirectory, environment: environment, executionDescription: executionDescription)
         guard executionResult.exitStatus.isSuccess else {
             throw RunProcessNonZeroExitError(args: commandLine, workingDirectory: workingDirectory, environment: .init(environment), status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
@@ -1401,7 +1401,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         return try parse(ByteString(executionResult.stdout))
     }
 
-    public func generatedFilePaths(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: String?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> [Path]) async throws -> [Path] {
+    public func generatedFilePaths(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: Path?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> [Path]) async throws -> [Path] {
         return try await executeExternalTool(cbc, delegate, commandLine: commandLine, workingDirectory: workingDirectory, environment: environment, executionDescription: executionDescription, parse)
     }
 }

--- a/Sources/SWBProtocol/ClientExchangeMessages.swift
+++ b/Sources/SWBProtocol/ClientExchangeMessages.swift
@@ -21,10 +21,10 @@ public struct ExternalToolExecutionRequest: ClientExchangeMessage, Equatable {
     public let exchangeHandle: String
 
     public let commandLine: [String]
-    public let workingDirectory: String?
+    public let workingDirectory: Path?
     public let environment: [String: String]
 
-    public init(sessionHandle: String, exchangeHandle: String, commandLine: [String], workingDirectory: String?, environment: [String: String]) {
+    public init(sessionHandle: String, exchangeHandle: String, commandLine: [String], workingDirectory: Path?, environment: [String: String]) {
         self.sessionHandle = sessionHandle
         self.exchangeHandle = exchangeHandle
         self.commandLine = commandLine

--- a/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangCompileTaskAction.swift
@@ -266,7 +266,7 @@ public final class ClangCompileTaskAction: TaskAction, BuildValueValidatingTaskA
                 let commandLine = command.arguments
                 let delegate = TaskProcessDelegate(outputDelegate: outputDelegate)
                 // The frontend invocations should be unaffected by the environment, pass an empty one.
-                try await spawn(commandLine: commandLine, environment: [:], workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
+                try await spawn(commandLine: commandLine, environment: [:], workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
                 lastResult = delegate.commandResult
 
                 if lastResult == .succeeded {

--- a/Sources/SWBTaskExecution/TaskActions/CodeSignTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/CodeSignTaskAction.swift
@@ -37,7 +37,7 @@ public final class CodeSignTaskAction: TaskAction {
                 commandLine.insert(preEncryptHashesFlag, at: 1)
             }
 
-            try await spawn(commandLine: commandLine, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+            try await spawn(commandLine: commandLine, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
         } catch {
             outputDelegate.error(error.localizedDescription)
             return .failed

--- a/Sources/SWBTaskExecution/TaskActions/CopyTiffTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/CopyTiffTaskAction.swift
@@ -145,7 +145,7 @@ public final class CopyTiffTaskAction: TaskAction {
 
                 let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
                 do {
-                    try await spawn(commandLine: tiffutilCommand, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+                    try await spawn(commandLine: tiffutilCommand, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
                 } catch {
                     outputDelegate.error(error.localizedDescription)
                     return .failed

--- a/Sources/SWBTaskExecution/TaskActions/DeferredExecutionTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/DeferredExecutionTaskAction.swift
@@ -24,7 +24,7 @@ public final class DeferredExecutionTaskAction: TaskAction {
     public override func performTaskAction(_ task: any ExecutableTask, dynamicExecutionDelegate: any DynamicTaskExecutionDelegate, executionDelegate: any TaskExecutionDelegate, clientDelegate: any TaskExecutionClientDelegate, outputDelegate: any TaskOutputDelegate) async -> CommandResult {
         let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
         do {
-            try await spawn(commandLine: Array(task.commandLineAsStrings), environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+            try await spawn(commandLine: Array(task.commandLineAsStrings), environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
         } catch {
             outputDelegate.error(error.localizedDescription)
             return .failed
@@ -50,7 +50,7 @@ fileprivate extension CommandResult {
 }
 
 extension TaskAction {
-    func spawn(commandLine: [String], environment: [String: String], workingDirectory: String, dynamicExecutionDelegate: any DynamicTaskExecutionDelegate, clientDelegate: any TaskExecutionClientDelegate, processDelegate: any ProcessDelegate) async throws {
+    func spawn(commandLine: [String], environment: [String: String], workingDirectory: Path, dynamicExecutionDelegate: any DynamicTaskExecutionDelegate, clientDelegate: any TaskExecutionClientDelegate, processDelegate: any ProcessDelegate) async throws {
         guard dynamicExecutionDelegate.allowsExternalToolExecution else {
             try await dynamicExecutionDelegate.spawn(commandLine: commandLine, environment: environment, workingDirectory: workingDirectory, processDelegate: processDelegate)
             return

--- a/Sources/SWBTaskExecution/TaskActions/EmbedSwiftStdLibTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/EmbedSwiftStdLibTaskAction.swift
@@ -515,7 +515,7 @@ public final class EmbedSwiftStdLibTaskAction: TaskAction {
 
             let capturingDelegate = CapturingOutputDelegate(outputDelegate: outputDelegate)
             let processDelegate = TaskProcessDelegate(outputDelegate: capturingDelegate)
-            try await taskAction.spawn(commandLine: args, environment: effectiveEnvironment, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+            try await taskAction.spawn(commandLine: args, environment: effectiveEnvironment, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
             if let error = processDelegate.executionError {
                 throw StubError.error(error)
             }
@@ -526,7 +526,7 @@ public final class EmbedSwiftStdLibTaskAction: TaskAction {
             }
 
             guard !failed else {
-                throw RunProcessNonZeroExitError(args: args, workingDirectory: task.workingDirectory.str, environment: .init(effectiveEnvironment), status: {
+                throw RunProcessNonZeroExitError(args: args, workingDirectory: task.workingDirectory, environment: .init(effectiveEnvironment), status: {
                     if case let .exit(exitStatus, _) = processDelegate.outputDelegate.result {
                         return exitStatus
                     }

--- a/Sources/SWBTaskExecution/TaskActions/FileCopyTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/FileCopyTaskAction.swift
@@ -132,7 +132,7 @@ public final class FileCopyTaskAction: TaskAction
                     }
 
                     for commandLine in commandLine.compileAndLink.flatMap({ [$0.compile, $0.link] }) + [commandLine.lipo] {
-                        try await spawn(commandLine: commandLine, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+                        try await spawn(commandLine: commandLine, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
                     }
                 }
             }

--- a/Sources/SWBTaskExecution/TaskActions/GenericCachingTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/GenericCachingTaskAction.swift
@@ -197,7 +197,7 @@ public final class GenericCachingTaskAction: TaskAction {
                 }
 
                 emitCacheDebuggingRemark("running sandboxed command")
-                try await spawn(commandLine: sandboxArgs + remappedCommandLine, environment: remappedEnvironment.bindingsDictionary, workingDirectory: cacheKey.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+                try await spawn(commandLine: sandboxArgs + remappedCommandLine, environment: remappedEnvironment.bindingsDictionary, workingDirectory: cacheKey.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
 
                 if processDelegate.commandResult == .succeeded {
                     try await withThrowingTaskGroup(of: Void.self) { group in

--- a/Sources/SWBTaskExecution/TaskActions/LSRegisterURLTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/LSRegisterURLTaskAction.swift
@@ -23,7 +23,7 @@ public final class LSRegisterURLTaskAction: TaskAction {
     override public func performTaskAction(_ task: any ExecutableTask, dynamicExecutionDelegate: any DynamicTaskExecutionDelegate, executionDelegate: any TaskExecutionDelegate, clientDelegate: any TaskExecutionClientDelegate, outputDelegate: any TaskOutputDelegate) async -> CommandResult {
         let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
         do {
-            try await spawn(commandLine: Array(task.commandLineAsStrings), environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+            try await spawn(commandLine: Array(task.commandLineAsStrings), environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
         } catch {
             outputDelegate.error(error.localizedDescription)
             return .failed

--- a/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
@@ -198,7 +198,7 @@ final public class PrecompileClangModuleTaskAction: TaskAction, BuildValueValida
 
             let delegate = TaskProcessDelegate(outputDelegate: outputDelegate)
             // The frontend invocations should be unaffected by the environment, pass an empty one.
-            try await spawn(commandLine: commandLine, environment: [:], workingDirectory: dependencyInfo.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
+            try await spawn(commandLine: commandLine, environment: [:], workingDirectory: dependencyInfo.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
 
             let result = delegate.commandResult ?? .failed
             if result == .succeeded {

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -520,7 +520,7 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
                     return .succeeded
             }
 
-            try await spawn(commandLine: options.commandLine, environment: environment, workingDirectory: task.workingDirectory.str, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
+            try await spawn(commandLine: options.commandLine, environment: environment, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: delegate)
 
             if let error = delegate.executionError {
                 outputDelegate.error(error)

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -229,7 +229,7 @@ public protocol DynamicTaskExecutionDelegate: ActivityReporter {
     func spawn(
         commandLine: [String],
         environment: [String: String],
-        workingDirectory: String,
+        workingDirectory: Path,
         processDelegate: any ProcessDelegate
     ) async throws -> Bool
 

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1777,7 +1777,7 @@ extension BuildOperationTester.BuildDescriptionResults: Sendable { }
 package final class MockTestClientDelegate: ClientDelegate, Sendable {
     package init() {}
 
-    package func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
+    package func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String: String]) async throws -> ExternalToolResult {
         return .deferred
     }
 }
@@ -1973,7 +1973,7 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
                     if !self.hadErrors {
                         switch result {
                         case let .exit(exitStatus, _) where !exitStatus.isSuccess && !exitStatus.wasCanceled:
-                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory.str, environment: .init(task.environment.bindingsDictionary), status: exitStatus, mergedOutput: output).description)"))))
+                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory, environment: .init(task.environment.bindingsDictionary), status: exitStatus, mergedOutput: output).description)"))))
                         case .failedSetup:
                             self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed setup."))))
                         case .exit, .skipped:

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -106,7 +106,7 @@ package class CapturingTaskGenerationDelegate: TaskGenerationDelegate, CoreClien
     package func fileExists(at path: Path) -> Bool { return true }
     package var taskActionCreationDelegate: any TaskActionCreationDelegate { return self }
     package var clientDelegate: any CoreClientDelegate { return self }
-    package func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
+    package func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String: String]) async throws -> ExternalToolResult {
         return .deferred
     }
 }

--- a/Sources/SWBTestSupport/CommandLineToolSpecDiscoveredInfo.swift
+++ b/Sources/SWBTestSupport/CommandLineToolSpecDiscoveredInfo.swift
@@ -61,7 +61,7 @@ private class ToolSpecCapturingTaskGenerationDelegate: CapturingTaskGenerationDe
         try super.init(producer: producer, userPreferences: userPreferences)
     }
 
-    override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
+    override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String: String]) async throws -> ExternalToolResult {
         result
     }
 }

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -365,7 +365,7 @@ private final class AlwaysDeferredCoreClientDelegate: CoreClientDelegate, CoreCl
         _diagnosticsEngine.hasErrors
     }
 
-    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         .deferred
     }
 }

--- a/Sources/SWBTestSupport/Misc.swift
+++ b/Sources/SWBTestSupport/Misc.swift
@@ -39,7 +39,7 @@ package extension Sequence where Element: Equatable {
 /// - throws: ``StubError`` if the arguments list is an empty array.
 /// - throws: ``RunProcessNonZeroExitError`` if the process exited with a nonzero status code or uncaught signal.
 @discardableResult
-package func runProcess(_ args: [String], workingDirectory: String? = nil, environment: Environment = .init(), interruptible: Bool = true, redirectStderr: Bool = false) async throws -> String {
+package func runProcess(_ args: [String], workingDirectory: Path? = nil, environment: Environment = .init(), interruptible: Bool = true, redirectStderr: Bool = false) async throws -> String {
     guard let first = args.first else {
         throw StubError.error("Invalid number of arguments")
     }
@@ -48,13 +48,13 @@ package func runProcess(_ args: [String], workingDirectory: String? = nil, envir
     }
     let arguments = Array(args.dropFirst())
     if redirectStderr {
-        let (exitStatus, output) = try await Process.getMergedOutput(url: url, arguments: arguments, currentDirectoryURL: workingDirectory.map(URL.init(fileURLWithPath:)), environment: environment, interruptible: interruptible)
+        let (exitStatus, output) = try await Process.getMergedOutput(url: url, arguments: arguments, currentDirectoryURL: workingDirectory.map { URL(fileURLWithPath: $0.str) }, environment: environment, interruptible: interruptible)
         guard exitStatus.isSuccess else {
             throw RunProcessNonZeroExitError(args: args, workingDirectory: workingDirectory, environment: environment, status: exitStatus, mergedOutput: ByteString(output))
         }
         return String(decoding: output, as: UTF8.self)
     } else {
-        let executionResult = try await Process.getOutput(url: url, arguments: arguments, currentDirectoryURL: workingDirectory.map(URL.init(fileURLWithPath:)), environment: environment, interruptible: interruptible)
+        let executionResult = try await Process.getOutput(url: url, arguments: arguments, currentDirectoryURL: workingDirectory.map { URL(fileURLWithPath: $0.str) }, environment: environment, interruptible: interruptible)
         guard executionResult.exitStatus.isSuccess else {
             throw RunProcessNonZeroExitError(args: args, workingDirectory: workingDirectory, environment: environment, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
         }
@@ -65,14 +65,14 @@ package func runProcess(_ args: [String], workingDirectory: String? = nil, envir
 /// Runs the command specified by `args` with the `DEVELOPER_DIR` environment variable set.
 ///
 /// This method will use the current value of `DEVELOPER_DIR` in the environment by default, or the value of `overrideDeveloperDirectory` if specified.
-package func runProcessWithDeveloperDirectory(_ args: [String], workingDirectory: String? = nil, overrideDeveloperDirectory: String? = nil, interruptible: Bool = true, redirectStderr: Bool = true) async throws -> String {
+package func runProcessWithDeveloperDirectory(_ args: [String], workingDirectory: Path? = nil, overrideDeveloperDirectory: String? = nil, interruptible: Bool = true, redirectStderr: Bool = true) async throws -> String {
     let environment = Environment.current
         .filter(keys: ["DEVELOPER_DIR", "LLVM_PROFILE_FILE"])
         .addingContents(of: overrideDeveloperDirectory.map { Environment(["DEVELOPER_DIR": $0]) } ?? .init())
     return try await runProcess(args, workingDirectory: workingDirectory, environment: environment, interruptible: interruptible, redirectStderr: redirectStderr)
 }
 
-package func runHostProcess(_ args: [String], workingDirectory: String? = nil, interruptible: Bool = true, redirectStderr: Bool = true) async throws -> String {
+package func runHostProcess(_ args: [String], workingDirectory: Path? = nil, interruptible: Bool = true, redirectStderr: Bool = true) async throws -> String {
     switch try ProcessInfo.processInfo.hostOperatingSystem() {
     case .macOS:
         return try await InstalledXcode.currentlySelected().xcrun(args, workingDirectory: workingDirectory, redirectStderr: redirectStderr)

--- a/Sources/SWBTestSupport/PerfTestSupport.swift
+++ b/Sources/SWBTestSupport/PerfTestSupport.swift
@@ -39,11 +39,11 @@ extension PerfTests {
 
 extension Trait where Self == Testing.ConditionTrait {
     package static var performance: Self {
-        disabled("Skipping performance test") {
+        enabled("Skipping performance test") {
             #if DEBUG
-            return true
+            return getEnvironmentVariable("SWB_PERF_TESTS_ENABLE")?.boolValue ?? false
             #else
-            return false
+            return true
             #endif
         }
     }

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -146,17 +146,9 @@ extension Trait where Self == Testing.ConditionTrait {
         })
     }
 
-    /// Constructs a condition trait that causes a test to be disabled if the Foundation process spawning implementation is not using `posix_spawn_file_actions_addchdir`.
+    /// Constructs a condition trait that causes a test to be disabled if the Foundation process spawning implementation is not thread-safe.
     package static var requireThreadSafeWorkingDirectory: Self {
-        disabled("Thread-safe process working directory support is unavailable.", {
-            switch try ProcessInfo.processInfo.hostOperatingSystem() {
-            case .linux:
-                // Amazon Linux 2 has glibc 2.26, and glibc 2.29 is needed for posix_spawn_file_actions_addchdir_np support
-                FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false
-            default:
-                false
-            }
-        })
+        disabled(if: try Process.hasUnsafeWorkingDirectorySupport, "Foundation.Process working directory support is not thread-safe.")
     }
 
     /// Constructs a condition trait that causes a test to be disabled if the specified llbuild API version requirement is not met.

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -15,7 +15,7 @@ public import enum SWBProtocol.ExternalToolResult
 public import struct SWBProtocol.BuildOperationTaskEnded
 public import SWBTaskConstruction
 import SWBTaskExecution
-package import SWBUtil
+public import SWBUtil
 import Testing
 package import SWBMacro
 import Foundation
@@ -192,7 +192,7 @@ package extension Array where Element == TaskCondition {
 open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unchecked Sendable {
     package init() {}
 
-    open func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
+    open func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String: String]) async throws -> ExternalToolResult {
         let args = commandLine.dropFirst()
         switch commandLine.first.map(Path.init)?.basenameWithoutSuffix {
         case "actool" where args == ["--version", "--output-format", "xml1"]:

--- a/Sources/SWBTestSupport/Xcode.swift
+++ b/Sources/SWBTestSupport/Xcode.swift
@@ -31,7 +31,7 @@ package struct InstalledXcode: Sendable {
         return try await Path(xcrun(["-f", tool] + toolchainArgs).trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
-    package func xcrun(_ args: [String], workingDirectory: String? = nil, redirectStderr: Bool = true) async throws -> String {
+    package func xcrun(_ args: [String], workingDirectory: Path? = nil, redirectStderr: Bool = true) async throws -> String {
         return try await runProcessWithDeveloperDirectory(["/usr/bin/xcrun"] + args, workingDirectory: workingDirectory, overrideDeveloperDirectory: self.developerDirPath.str, redirectStderr: redirectStderr)
     }
 

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -80,7 +80,7 @@ fileprivate func xSecCodePathIsSigned(_ path: Path) throws -> Bool {
 
 // FIXME: Move this fully to Swift Concurrency and execute the process via llbuild after PbxCp is fully converted to Swift
 /// Spawns a process and waits for it to finish, closing stdin and redirecting stdout and stderr to fdout. Failure to launch, non-zero exit code, or exit with a signal will throw an error.
-fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ environment: Environment?, _ workingDirPath: String?, _ dryRun: Bool, _ stream: OutputByteStream) async throws {
+fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ environment: Environment?, _ workingDirPath: Path?, _ dryRun: Bool, _ stream: OutputByteStream) async throws {
     stream <<< launchPath.str
     for arg in arguments ?? [] {
         stream <<< " \(arg)"
@@ -91,7 +91,7 @@ fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ 
         return
     }
 
-    let (exitStatus, output) = try await Process.getMergedOutput(url: URL(fileURLWithPath: launchPath.str), arguments: arguments ?? [], currentDirectoryURL: workingDirPath.map { URL(fileURLWithPath: $0, isDirectory: true) }, environment: environment)
+    let (exitStatus, output) = try await Process.getMergedOutput(url: URL(fileURLWithPath: launchPath.str), arguments: arguments ?? [], currentDirectoryURL: workingDirPath.map { URL(fileURLWithPath: $0.str, isDirectory: true) }, environment: environment)
 
     // Copy the process output to the output stream.
     stream <<< "\(String(decoding: output, as: UTF8.self))"

--- a/Sources/SWBUtil/URL.swift
+++ b/Sources/SWBUtil/URL.swift
@@ -35,6 +35,13 @@ extension URL {
     }
 }
 
-fileprivate enum FileURLError: Error {
+fileprivate enum FileURLError: Error, CustomStringConvertible {
     case notRepresentable(URL)
+
+    var description: String {
+        switch self {
+        case .notRepresentable(let url):
+            return "URL \(url) cannot be represented as an absolute file path"
+        }
+    }
 }

--- a/Sources/SwiftBuild/SWBClientExchangeSupport.swift
+++ b/Sources/SwiftBuild/SWBClientExchangeSupport.swift
@@ -42,7 +42,7 @@ fileprivate extension Processes.ExitStatus {
         return await session.service.send(ErrorResponse("No delegate for response."))
     }
 
-    let result = await Result.catching { try await delegate.executeExternalTool(commandLine: message.commandLine, workingDirectory: message.workingDirectory, environment: message.environment) }
+    let result = await Result.catching { try await delegate.executeExternalTool(commandLine: message.commandLine, workingDirectory: message.workingDirectory?.str, environment: message.environment) }
     let reply = ExternalToolExecutionResponse(sessionHandle: message.sessionHandle, exchangeHandle: message.exchangeHandle, value: result.map(ExternalToolResult.init).mapError { .error("\($0)") })
     return await session.service.send(reply)
 }

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -19,7 +19,7 @@ import SWBCore
 
 @Suite
 fileprivate struct AndroidBuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.android), .requireThreadSafeWorkingDirectory, arguments: ["armv7", "aarch64", "riscv64", "i686", "x86_64"])
+    @Test(.requireSDKs(.android), arguments: ["armv7", "aarch64", "riscv64", "i686", "x86_64"])
     func androidCommandLineTool(arch: String) async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = TestProject(

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -30,7 +30,7 @@ import SWBTestSupport
 
 @Suite(.requireXcode16())
 fileprivate struct BuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory, arguments: ["clang", "swiftc"])
+    @Test(.requireSDKs(.host), arguments: ["clang", "swiftc"])
     func commandLineTool(linkerDriver: String) async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = try await TestProject(
@@ -164,7 +164,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func commandLineToolAutolinkingFoundation() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = try await TestProject(
@@ -223,7 +223,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func debuggableCommandLineTool() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = try await TestProject(
@@ -397,7 +397,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.macOS), .skipHostOS(.windows, "cannot find testing library"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.macOS), .skipHostOS(.windows, "cannot find testing library"))
     func unitTestWithGeneratedEntryPoint() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = try await TestProject(
@@ -842,7 +842,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func missingShellScriptInputs() async throws {
         // Test that shell scripts run, even if their inputs are missing.
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
@@ -884,7 +884,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check that target dependencies are honored.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func simulatedTargetDependencies() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(
@@ -948,7 +948,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check that "build targets not in parallel" is honored.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func simulatedNonParallelTargetBuild() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(
@@ -990,7 +990,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check that build phase order is honored.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func simulatedBuildPhaseOrder() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(
@@ -2392,7 +2392,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check non-UTF8 encoded shell scripts don't cause any unexpected issues.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireSystemPackages(apt: "xxd", yum: "vim-common"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireSystemPackages(apt: "xxd", yum: "vim-common"))
     func nonUTF8ShellScript() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testWorkspace = TestWorkspace(
@@ -2461,7 +2461,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check special shell script dependency handling
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func shellScriptIncrementalBehaviors() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             // Test that an incremental rebuild of an empty project does nothing.
@@ -2532,7 +2532,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check chown/chmod dependency handling.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func setFileAttributesIncrementalBehaviors() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             // Test that an incremental rebuild of an empty project does nothing.
@@ -2736,7 +2736,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check the handling of a minimal copied bundle.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func minimalCopiedBundle() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(
@@ -4201,7 +4201,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check that PCH file dependencies are respected.
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func prefixHeaderDependencies() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -81,7 +81,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
     // FIXME: We should migrate these tests to primarily only use internal execution nodes, and not end up running tools (except for tests which are explicitly trying to test that behavior).
 
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory, .skipHostOS(.windows, "no /bin/echo"))
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /bin/echo"))
     func simulatedSingleInputlessOutputlessCommand() async throws {
         let echoTask = createTask(ruleInfo: ["echo", "hi"], commandLine: ["/bin/echo", "hi"], inputs: [], outputs: [MakePlannedVirtualNode("<ECHO>")], action: nil)
 
@@ -207,7 +207,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
     /// Stress concurrent access to the build system cache during rapid cancel
     /// then build scenarios.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"), .requireThreadSafeWorkingDirectory,
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"),
           // To aid in establishing the subtle concurrent
           // timing required to trigger chaos, we disable early build operation
           // cancellation.
@@ -307,7 +307,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
     }
 
     /// Check that we honor specs which are unsafe to interrupt.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no bash shell"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no bash shell"))
     func unsafeToInterrupt() async throws {
         let fs = localFS
         let output = MakePlannedVirtualNode("<WAIT>")
@@ -382,7 +382,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
     }
 
     /// Check the behavior of gate tasks.
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"))
     func simulatedTasksWithGate() async throws {
         let aNode = MakePlannedVirtualNode("A")
         let bNode = MakePlannedVirtualNode("B")
@@ -406,7 +406,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /bin/echo"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /bin/echo"))
     func simulatedDiamondGraph() async throws {
         let tasksToMake = [
             ("START", inputs: ["/INPUT"]),
@@ -442,7 +442,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"))
     func simulatedMustPrecede() async throws {
         let tasksToMake = ["A", "B", "C", "D"]
         var tasks: [any PlannedTask] = []
@@ -902,7 +902,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
     }
 
     /// Check the handling of directory tree nodes.
-    @Test(.skipHostOS(.windows, "no /usr/bin/find"), .requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.skipHostOS(.windows, "no /usr/bin/find"), .requireSDKs(.host))
     func directoryTreeInputs() async throws {
         try await withTemporaryDirectory { tmpDir in
             let fs = localFS
@@ -953,7 +953,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /bin/echo"), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /bin/echo"))
     func additionalInfoOutput() async throws {
         let echoTask = createTask(ruleInfo: ["echo", "additional-output"], commandLine: ["/bin/echo", "additional-output"], additionalOutput: ["just some extra output"], inputs: [], outputs: [MakePlannedVirtualNode("<ECHO>")], action: nil)
 

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -24,7 +24,7 @@ import class Foundation.ProcessInfo
 
 @Suite
 fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func outputParsing() async throws {
         try await withTemporaryDirectory { tmpDir in
             let destination: RunDestinationInfo = .host

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -181,7 +181,7 @@ fileprivate struct LinkerTests: CoreBasedTests {
     /// * The clang output on Windows has paths that have double slashes, not
     ///   quite valid command quoted. i.e. "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC"
     ///   This needs to be taken into account.
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func alternateLinkerSelection() async throws {
         let runDestination: RunDestinationInfo = .host
         let swiftVersion = try await self.swiftVersion

--- a/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildTraceTests.swift
@@ -20,7 +20,7 @@ import SWBTaskExecution
 
 @Suite
 fileprivate struct SwiftBuildTraceTests: CoreBasedTests {
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory)
+    @Test(.requireSDKs(.host))
     func swiftBuildTraceEmission() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             try await withEnvironment(["SWIFTBUILD_TRACE_FILE": tmpDirPath.join(".SWIFTBUILD_TRACE").str]) {
@@ -71,7 +71,6 @@ fileprivate struct SwiftBuildTraceTests: CoreBasedTests {
                 }
 
                 let trace = try tester.fs.read(tmpDirPath.join(".SWIFTBUILD_TRACE")).asString
-                print(trace)
                 #expect(try #/\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true,\"name\":\"Test\",\"path\":\".*\"\}\n\{\"buildDescriptionSignature\":\".*\",\"isTargetParallelizationEnabled\":true,\"name\":\"Test\",\"path\":\".*\"\}\n/#.wholeMatch(in: trace) != nil)
             }
         }

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -236,7 +236,7 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
 }
 
 extension CapturingTaskGenerationDelegate: CoreClientDelegate {
-    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String: String]) async throws -> ExternalToolResult {
+    func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String: String]) async throws -> ExternalToolResult {
         return .emptyResult
     }
 }

--- a/Tests/SWBCoreTests/ClangSerializedDiagnosticsTests.swift
+++ b/Tests/SWBCoreTests/ClangSerializedDiagnosticsTests.swift
@@ -28,11 +28,11 @@ fileprivate struct ClangSerializedDiagnosticsTests: CoreBasedTests {
     }
 
     /// Test that Clang serialized diagnostics are supported.
-    @Test
+    @Test(.requireThreadSafeWorkingDirectory)
     func clangSerializedDiagnosticSupported() async throws {
         try await withTemporaryDirectory { tmpDir in
             let diagnosticsPath = tmpDir.join("foo.diag")
-            _ = try? await runHostProcess(["clang", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: tmpDir.str)
+            _ = try? await runHostProcess(["clang", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: tmpDir)
 
             let libclang = try #require(await Libclang(path: libclangPath))
             libclang.leak()
@@ -53,7 +53,7 @@ fileprivate struct ClangSerializedDiagnosticsTests: CoreBasedTests {
             let cFilePath = tmpDir.join("dir/foo.c")
             try localFS.write(cFilePath, contents: "#include \"other/foo.h\"\nint main() { return 0; }")
             let taskWorkingDirectory = cFilePath.dirname
-            _ = try? await runHostProcess(["clang", "-I../", "-Wall", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: taskWorkingDirectory.str)
+            _ = try? await runHostProcess(["clang", "-I../", "-Wall", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: taskWorkingDirectory)
             
             let libclang = try #require(await Libclang(path: libclangPath))
             libclang.leak()
@@ -82,7 +82,7 @@ fileprivate struct ClangSerializedDiagnosticsTests: CoreBasedTests {
             let cFilePath = tmpDir.join("dir/foo.c")
             try localFS.write(cFilePath, contents: "#include \"other/foo.h\"\nint main() { return 0; }")
             let taskWorkingDirectory = cFilePath.dirname
-            _ = try? await runHostProcess(["clang", "-I../", "-Wall", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: taskWorkingDirectory.str)
+            _ = try? await runHostProcess(["clang", "-I../", "-Wall", "-serialize-diagnostics", diagnosticsPath.str, "foo.c"], workingDirectory: taskWorkingDirectory)
 
             let libclang = try #require(await Libclang(path: libclangPath))
             libclang.leak()
@@ -106,7 +106,7 @@ fileprivate struct ClangSerializedDiagnosticsTests: CoreBasedTests {
             try localFS.write(swiftFilePath, contents: "#warning(\"custom warning\")")
             let taskWorkingDirectory = swiftFilePath.dirname
             let diagnosticsPath = taskWorkingDirectory.join("foo.dia")
-            _ = try? await runHostProcess(["swiftc", "-c", "-serialize-diagnostics", "foo.swift"], workingDirectory: taskWorkingDirectory.str)
+            _ = try? await runHostProcess(["swiftc", "-c", "-serialize-diagnostics", "foo.swift"], workingDirectory: taskWorkingDirectory)
 
             let libclang = try #require(await Libclang(path: libclangPath))
             libclang.leak()

--- a/Tests/SWBProtocolTests/MessageSerializationTests.swift
+++ b/Tests/SWBProtocolTests/MessageSerializationTests.swift
@@ -105,7 +105,7 @@ import Testing
     }
 
     @Test func clientExchangeMessagesRoundTrip() {
-        assertMsgPackMessageRoundTrip(ExternalToolExecutionRequest(sessionHandle: "theSession", exchangeHandle: "handle", commandLine: ["echo", "foo"], workingDirectory: "/foo", environment: ["FOO": "BAR"]))
+        assertMsgPackMessageRoundTrip(ExternalToolExecutionRequest(sessionHandle: "theSession", exchangeHandle: "handle", commandLine: ["echo", "foo"], workingDirectory: .root.join("foo"), environment: ["FOO": "BAR"]))
 
         assertMsgPackMessageRoundTrip(ExternalToolExecutionResponse(sessionHandle: "theSession", exchangeHandle: "handle", value: .success(.result(status: .exit(1), stdout: Data("foo".utf8), stderr: Data("bar".utf8)))))
         assertMsgPackMessageRoundTrip(ExternalToolExecutionResponse(sessionHandle: "theSession", exchangeHandle: "handle", value: .failure(StubError.error("broken!"))))

--- a/Tests/SWBQNXPlatformTests/SWBQNXPlatformTests.swift
+++ b/Tests/SWBQNXPlatformTests/SWBQNXPlatformTests.swift
@@ -19,7 +19,7 @@ import SWBCore
 
 @Suite
 fileprivate struct QNXBuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.qnx), .skipHostOS(.macOS), .requireThreadSafeWorkingDirectory, arguments: ["aarch64", "x86_64"])
+    @Test(.requireSDKs(.qnx), .skipHostOS(.macOS), arguments: ["aarch64", "x86_64"])
     func qnxCommandLineTool(arch: String) async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             let testProject = TestProject(

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -245,7 +245,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         /// Client to generate files from the core data model.
         final class TestCoreDataCompilerTaskPlanningClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename != "momc" {
                     return try await super.executeExternalTool(commandLine: commandLine, workingDirectory: workingDirectory, environment: environment)
                 }
@@ -469,7 +469,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
 
         /// Client to generate files from the CoreML model.
         final class TestCoreMLCompilerTaskPlanningClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "coremlc",
                    let outputDir = commandLine[safe: 3].map(Path.init),
                    let input = commandLine.firstIndex(where: { $0.hasSuffix(".mlmodel") || $0.hasSuffix(".mlpackage") }).map({ Path(commandLine[$0]) }),
@@ -1172,7 +1172,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                 self.moduleName = moduleName
             }
 
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "intentbuilderc",
                    let outputDir = commandLine.elementAfterElements(["-output"]).map(Path.init),
                    let classPrefix = commandLine.elementAfterElements(["-classPrefix"]),

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -196,7 +196,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                 super.init()
             }
 
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first == mockClangPath {
                     return .result(status: .exit(0), stdout: Data(), stderr: Data())
                 }

--- a/Tests/SWBTaskConstructionTests/EagerCompilationTests.swift
+++ b/Tests/SWBTaskConstructionTests/EagerCompilationTests.swift
@@ -1256,7 +1256,7 @@ fileprivate struct EagerCompilationTests: CoreBasedTests {
             let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: true, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
 
             final class Delegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-                override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+                override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                     switch commandLine.first.map(Path.init)?.basename {
                     case "intentbuilderc"?:
                         do {

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -1797,7 +1797,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
         final class Delegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "intentbuilderc",
                    let outputDir = commandLine.elementAfterElements(["-output"]).map(Path.init),
                    let classPrefix = commandLine.elementAfterElements(["-classPrefix"]),

--- a/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
@@ -901,7 +901,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
 }
 
 fileprivate final class TestIntentsCompilerTaskPlanningClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-    override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         let commandName = commandLine.first.map(Path.init)?.basename
         switch commandName {
         case "intentbuilderc":

--- a/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/OnDemandResourcesTaskConstructionTests.swift
@@ -67,7 +67,7 @@ fileprivate struct OnDemandResourcesTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         final class ClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "actool", commandLine.dropFirst().first != "--version" {
                     return .result(status: .exit(0), stdout: Data("{}".utf8), stderr: Data())
                 }

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -1245,7 +1245,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
 
         /// Client to generate files from the core data model.
         final class TestCoreDataCompilerTaskPlanningClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "momc", let outputDir = commandLine.last.map(Path.init) {
                     return .result(status: .exit(0), stdout: Data([
                         outputDir.join("EntityOne+CoreDataClass.swift"),

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -807,7 +807,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             ])
 
             final class ClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-                override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+                override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                     if commandLine.first.map(Path.init)?.basename == "actool", commandLine.dropFirst().first != "--version" {
                         return .result(status: .exit(0), stdout: Data("{}".utf8), stderr: Data())
                     }
@@ -984,7 +984,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             ])
 
             final class ClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-                override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+                override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                     if commandLine.first.map(Path.init)?.basename == "actool", commandLine.dropFirst().first != "--version" {
                         return .result(status: .exit(0), stdout: Data("{}".utf8), stderr: Data())
                     }
@@ -1074,7 +1074,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             ])
 
             final class ClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-                override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+                override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                     if commandLine.first.map(Path.init)?.basename == "actool", commandLine.dropFirst().first != "--version" {
                         return .result(status: .exit(0), stdout: Data("{}".utf8), stderr: Data())
                     }
@@ -1175,7 +1175,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
             ])
 
             final class ClientDelegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-                override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+                override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                     if commandLine.first.map(Path.init)?.basename == "actool", commandLine.dropFirst().first != "--version" {
                         return .result(status: .exit(0), stdout: Data("{}".utf8), stderr: Data())
                     }

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -7287,7 +7287,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
         /// Client to generate files from the core data model.
         class TestCoreDataCompilerTaskPlanningClientDelegate: TaskPlanningClientDelegate {
-            func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 return .emptyResult
             }
         }
@@ -7393,7 +7393,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         let tester = try await TaskConstructionTester(getCore(), testWorkspace)
 
         final class Delegate: MockTestTaskPlanningClientDelegate, @unchecked Sendable {
-            override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+            override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
                 if commandLine.first.map(Path.init)?.basename == "intentbuilderc",
                    let outputDir = commandLine.elementAfterElements(["-output"]).map(Path.init),
                    let classPrefix = commandLine.elementAfterElements(["-classPrefix"]),

--- a/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
@@ -32,7 +32,7 @@ private final class MockXCStringsTool: MockTestTaskPlanningClientDelegate, @unch
         self.requiredCommandLine = requiredCommandLine
     }
 
-    override func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    override func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         switch commandLine.first.map(Path.init)?.basename {
         case "xcstringstool":
             break

--- a/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
@@ -59,7 +59,7 @@ struct MockExecutionDelegate: TaskExecutionDelegate {
 }
 
 struct MockTaskExecutionClientDelegate: TaskExecutionClientDelegate {
-    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> ExternalToolResult {
+    func executeExternalTool(commandLine: [String], workingDirectory: Path?, environment: [String : String]) async throws -> ExternalToolResult {
         .deferred
     }
 }

--- a/Tests/SWBTaskExecutionTests/TaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/TaskTestSupport.swift
@@ -56,14 +56,14 @@ class MockDynamicTaskExecutionDelegate: DynamicTaskExecutionDelegate {
     func spawn(
         commandLine: [String],
         environment: [String: String],
-        workingDirectory: String,
+        workingDirectory: Path,
         processDelegate: any ProcessDelegate
     ) async throws -> Bool {
         if commandLine.isEmpty {
             throw StubError.error("Invalid number of arguments")
         }
 
-        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: commandLine[0]), arguments: Array(commandLine.dropFirst()), currentDirectoryURL: URL(fileURLWithPath: workingDirectory), environment: .init(environment))
+        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: commandLine[0]), arguments: Array(commandLine.dropFirst()), currentDirectoryURL: URL(fileURLWithPath: workingDirectory.str), environment: .init(environment))
 
         // FIXME: Pass the real PID
         let pid = llbuild_pid_t.invalid

--- a/Tests/SWBUtilTests/MachOTests.swift
+++ b/Tests/SWBUtilTests/MachOTests.swift
@@ -448,7 +448,7 @@ fileprivate struct MachOTests {
         try await withTemporaryDirectory { path in
             let expectedVersion = Version(11, 2, 3)
             try localFS.write(path.join("main.c"), contents: "int main() { return 0; }")
-            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos\(expectedVersion)", "main.c"], workingDirectory: path.str)
+            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos\(expectedVersion)", "main.c"], workingDirectory: path)
             let machOPath = path.join("a.out")
 
             let files: [BinaryReader] = try allReaders(machOPath)
@@ -475,7 +475,7 @@ fileprivate struct MachOTests {
     func rPaths() async throws {
         try await withTemporaryDirectory { path in
             try localFS.write(path.join("main.c"), contents: "int main() { return 0; }")
-            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos11.0", "-rpath", "@loader_path/Frameworks", "-rpath", "@loader_path/../Frameworks", "main.c"], workingDirectory: path.str)
+            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos11.0", "-rpath", "@loader_path/Frameworks", "-rpath", "@loader_path/../Frameworks", "main.c"], workingDirectory: path)
             let machOPath = path.join("a.out")
 
             let files: [BinaryReader] = try allReaders(machOPath)
@@ -501,7 +501,7 @@ fileprivate struct MachOTests {
     func atomInfo() async throws {
         try await withTemporaryDirectory { path in
             try localFS.write(path.join("file.c"), contents: "const int foo = 0;")
-            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos11.0", "-dynamiclib", "-Xlinker", "-make_mergeable", "file.c"], workingDirectory: path.str)
+            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos11.0", "-dynamiclib", "-Xlinker", "-make_mergeable", "file.c"], workingDirectory: path)
             let machOPath = path.join("a.out")
 
             let files: [BinaryReader] = try allReaders(machOPath)

--- a/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
+++ b/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
@@ -21,7 +21,6 @@ import SWBUtil
 fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
     @Test(
         .requireSDKs(.wasi),
-        .requireThreadSafeWorkingDirectory,
         .skipXcodeToolchain,
         arguments: ["wasm32"], [true, false]
     )
@@ -132,7 +131,7 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.wasi), .requireThreadSafeWorkingDirectory, .skipXcodeToolchain, arguments: ["wasm32"])
+    @Test(.requireSDKs(.wasi), .skipXcodeToolchain, arguments: ["wasm32"])
     func wasiCommandWithCAndCxx(arch: String) async throws {
         let sdkroot = try await #require(getCore().loadSDK(llvmTargetTripleSys: "wasi")).path.str
 

--- a/Tests/SwiftBuildPerfTests/BuildOperationPerfTests.swift
+++ b/Tests/SwiftBuildPerfTests/BuildOperationPerfTests.swift
@@ -21,7 +21,7 @@ import SWBTestSupport
 
 import Testing
 
-@Suite(.performance, .requireThreadSafeWorkingDirectory)
+@Suite(.performance)
 fileprivate struct BuildOperationPerfTests: PerfTests {
     /// Run a test of a synthetic project with a given number of targets and files.
     ///

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -288,7 +288,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory) // version info discovery isn't working on Windows
+    @Test(.requireSDKs(.macOS), .skipHostOS(.windows)) // version info discovery isn't working on Windows
     func onlyCreateBuildDescription() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -445,8 +445,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
 
     @Test(
         .requireSDKs(.host),
-        .skipHostOS(.windows),
-        .requireThreadSafeWorkingDirectory /* version info discovery isn't working on Windows */,
+        .skipHostOS(.windows), /* version info discovery isn't working on Windows */
         .flaky("Test occasionally crashes in linux CI"),
         .bug("https://github.com/swiftlang/swift-build/issues/528")
     )
@@ -1777,7 +1776,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
     }
 
     /// Check scraped build issues.
-    @Test(.requireSDKs(.macOS), .skipHostOS(.windows), .requireThreadSafeWorkingDirectory) // relies on UNIX shell, consider adding Windows command shell support for script phases?
+    @Test(.requireSDKs(.macOS), .skipHostOS(.windows)) // relies on UNIX shell, consider adding Windows command shell support for script phases?
     func buildScriptIssues() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in

--- a/Tests/SwiftBuildTests/DocumentationTests.swift
+++ b/Tests/SwiftBuildTests/DocumentationTests.swift
@@ -20,7 +20,7 @@ import Testing
 @Suite
 fileprivate struct DocumentationBuildTests: CoreBasedTests {
     // docc fails on Windows for some reason
-    @Test(.requireSDKs(.host), .requireThreadSafeWorkingDirectory, .skipHostOS(.windows))
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
     func documentationBuild() async throws {
         try await withTemporaryDirectory { tmpDir in
             let fs: any FSProxy = localFS

--- a/Tests/SwiftBuildTests/ServiceTests.swift
+++ b/Tests/SwiftBuildTests/ServiceTests.swift
@@ -406,7 +406,7 @@ fileprivate struct ServiceTests {
             let osv = ProcessInfo.processInfo.operatingSystemVersion
             let osVersion = try Version(osv)
             let deploymentTarget = Version(Version.Component(osv.majorVersion), Version.Component(osv.minorVersion), UInt(osv.patchVersion) + 1)
-            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos\(deploymentTarget.canonicalDeploymentTargetForm)", "main.c"], workingDirectory: path.str)
+            _ = try await InstalledXcode.currentlySelected().xcrun(["-sdk", "macosx", "clang", "-target", "\(#require(Architecture.host.stringValue))-apple-macos\(deploymentTarget.canonicalDeploymentTargetForm)", "main.c"], workingDirectory: path)
 
             _ = await withEnvironment(["SWBBUILDSERVICE_PATH": path.join("a.out").str]) {
                 await #expect(performing: {

--- a/Tests/SwiftBuildTests/ValidationTests.swift
+++ b/Tests/SwiftBuildTests/ValidationTests.swift
@@ -40,7 +40,7 @@ fileprivate struct ValidationTests: CoreBasedTests {
         // Run the subprocess, check the result, and return the output if we succeeded.
         let executionResult = try await Process.getOutput(url: url, arguments: args, currentDirectoryURL: URL(fileURLWithPath: workingDirectory.str), environment: environment)
         if !executionResult.exitStatus.isSuccess {
-            throw RunProcessNonZeroExitError(args: [url.path] + args, workingDirectory: workingDirectory.str, environment: environment, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
+            throw RunProcessNonZeroExitError(args: [url.path] + args, workingDirectory: workingDirectory, environment: environment, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
         }
     }
 


### PR DESCRIPTION
Now that llbuild has fork/exec support, the tests can be enabled on Amazon Linux 2, OpenBSD, etc.