### PR TITLE
🍒 SWIFT_SYSTEM_INCLUDE_PATHS doesn't work everywhere SWIFT_INCLUDE_PATHS does

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
@@ -82,6 +82,8 @@ public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIde
         for searchPath in SwiftCompilerSpec.collectInputSearchPaths(cbc, toolInfo: toolSpecInfo) {
             commandLine += ["-I", searchPath]
         }
+        // swift-api-digester doesn't support -Isystem or -Fsystem.
+        commandLine += cbc.scope.evaluate(BuiltinMacros.SWIFT_SYSTEM_INCLUDE_PATHS).flatMap { ["-I", $0] }
         commandLine += cbc.scope.evaluate(BuiltinMacros.SYSTEM_FRAMEWORK_SEARCH_PATHS).flatMap { ["-F", $0] }
         delegate.createTask(type: self,
                             payload: ABICheckerPayload(serializedDiagnosticsPath: serializedDiagsPath),

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
@@ -40,11 +40,13 @@ public final class SwiftABIGenerationToolSpec : GenericCommandLineToolSpec, Spec
 
         var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)).map(\.asString)
         commandLine += ["-o", baselineFile.normalize().str]
+        // swift-api-digester doesn't support -Fsystem or -Isystem.
         commandLine += cbc.scope.evaluate(BuiltinMacros.SYSTEM_FRAMEWORK_SEARCH_PATHS).flatMap { ["-F", $0] }
         // Add import search paths
         for searchPath in SwiftCompilerSpec.collectInputSearchPaths(cbc, toolInfo: toolSpecInfo) {
             commandLine += ["-I", searchPath]
         }
+        commandLine += cbc.scope.evaluate(BuiltinMacros.SWIFT_SYSTEM_INCLUDE_PATHS).flatMap { ["-I", $0] }
         delegate.createTask(type: self,
                             ruleInfo: defaultRuleInfo(cbc, delegate),
                             commandLine: commandLine,

--- a/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
@@ -40,6 +40,8 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                     "SWIFT_VERSION": swiftVersion,
                     "FRAMEWORK_SEARCH_PATHS": "/Target/Framework/Search/Path/A",
                     "SYSTEM_FRAMEWORK_SEARCH_PATHS": "/Target/System/Framework/Search/Path/A",
+                    "SWIFT_INCLUDE_PATHS": "/Target/Import/Search/Path/A",
+                    "SWIFT_SYSTEM_INCLUDE_PATHS": "/Target/System/Import/Search/Path/A",
                     "CODE_SIGNING_ALLOWED": "NO",
                     "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES",
                     "TAPI_EXEC": tapiToolPath.str,
@@ -68,6 +70,8 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                         "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
                         "-F", "/TEST/build/Debug-iphoneos",
                         "-module", "Fwk",
+                        "-I", "/Target/Import/Search/Path/A",
+                        "-I", "/Target/System/Import/Search/Path/A",
                         "-F", "/Target/System/Framework/Search/Path/A"
                     ])
                 }


### PR DESCRIPTION
There's a few spots where SWIFT_INCLUDE_PATHS is being used but SWIFT_SYSTEM_INCLUDE_PATHS isn't. Add those.

rdar://152384124