### PR TITLE
Track value locations in XCConfigs per assignment

### DIFF
--- a/Sources/SWBMacro/MacroEvaluationScope.swift
+++ b/Sources/SWBMacro/MacroEvaluationScope.swift
@@ -17,7 +17,7 @@ private extension MacroValueAssignmentTable {
     func lookupMacro(_ macro: MacroDeclaration, overrideLookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> MacroValueAssignment? {
         // See if we have an overriding binding.
         if let override = overrideLookup?(macro) {
-            return MacroValueAssignment(expression: override, conditions: nil, next: lookupMacro(macro))
+            return MacroValueAssignment(expression: override, conditions: nil, next: lookupMacro(macro), location: nil)
         }
 
         // Otherwise, return the normal lookup.


### PR DESCRIPTION
In #513, initial support for this was added, this PR moves the location to be per assignment which allows emitting fix its not just for the last seen assignments. This will also allow looking at any conditions of assignments when choosing the location for emitting fix its.
