### PR TITLE
Add settings to control frame pointer omission

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -2934,6 +2934,25 @@
                     NO = ();
                 };
             },
+            {
+                Name = "CLANG_OMIT_FRAME_POINTERS";
+                Type = Enumeration;
+                Values = (
+                    "compiler-default",
+                    YES,
+                    NO,
+                );
+                CommandLineArgs = {
+                    YES = (
+                        "-fomit-frame-pointer",
+                    );
+                    NO = (
+                        "-fno-omit-frame-pointer",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "compiler-default";
+            },
             // Index-while-building options, not visible in build settings.
             {
                 Name = "CLANG_INDEX_STORE_PATH";

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -996,6 +996,25 @@
                 Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS) && $(DEBUG_INFORMATION_FORMAT) != \"\"";
             },
             {
+                Name = "SWIFT_OMIT_FRAME_POINTERS";
+                Type = Enumeration;
+                Values = (
+                    "compiler-default",
+                    YES,
+                    NO,
+                );
+                CommandLineArgs = {
+                    YES = (
+                        "-Xcc", "-fomit-frame-pointer",
+                    );
+                    NO = (
+                        "-Xcc", "-fno-omit-frame-pointer",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "compiler-default";
+            },
+            {
                 Name = "CLANG_MODULE_CACHE_PATH";
                 Type = Path;
                 CommandLineFlag = "-module-cache-path";


### PR DESCRIPTION
Addresses https://github.com/swiftlang/swift-build/issues/561

This will allow SwiftPM to disable frame pointer omission to support better backtraces