### PR TITLE
Adapt test code to SE-0481

### DIFF
--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -1701,7 +1701,6 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                 let service: SWBBuildService? = try await SWBBuildService()
                 await deferrable.addBlock { [weak service] in
                     await service?.close()
-                    service = nil
                 }
 
                 func start() async throws -> (SWBBuildOperation, AsyncStream<SwiftBuildMessage>) {
@@ -1711,7 +1710,6 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         await #expect(throws: Never.self) {
                             try await session?.close()
                         }
-                        session = nil
                     }
 
                     let testTarget: TestStandardTarget


### PR DESCRIPTION
These weak captures are now treated as immutable, and I don't see any reason we need to nil them out here