### PR TITLE
Ensure the path to Swift Testing's macro plugin is specified correctly when using a non-default Xcode toolchain

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4273,17 +4273,20 @@ private class SettingsBuilder {
         }
 
         let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
-        guard let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }) else {
+        guard let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }),
+              let defaultToolchain = core.toolchainRegistry.defaultToolchain
+        else {
             return []
         }
 
         enum ToolchainStyle {
-            case xcodeDefault
+            case xcode(isDefault: Bool)
             case other
 
             init(_ toolchain: Toolchain) {
-                if toolchain.identifier == ToolchainRegistry.defaultToolchainIdentifier {
-                    self = .xcodeDefault
+                if toolchain.identifier.hasPrefix(ToolchainRegistry.appleToolchainIdentifierPrefix) {
+                    let isDefault = toolchain.identifier == ToolchainRegistry.defaultToolchainIdentifier
+                    self = .xcode(isDefault: isDefault)
                 } else {
                     self = .other
                 }
@@ -4292,11 +4295,12 @@ private class SettingsBuilder {
 
         let testingPluginsPath = "/usr/lib/swift/host/plugins/testing"
         switch (ToolchainStyle(toolchain)) {
-        case .xcodeDefault:
-            // This target is building using the same toolchain as the one used
-            // to build the testing libraries which it is using, so it can use
-            // non-external plugin flags.
-            return ["-plugin-path", "$(TOOLCHAIN_DIR)\(testingPluginsPath)"]
+        case let .xcode(isDefault):
+            // This target is using a built-in Xcode toolchain, and that should
+            // match the toolchain which was used to build the testing libraries
+            // this target is using, so it can use non-external plugin flags.
+            let toolchainPathPrefix = isDefault ? "$(TOOLCHAIN_DIR)" : defaultToolchain.path.str
+            return ["-plugin-path", "\(toolchainPathPrefix)\(testingPluginsPath)"]
         case .other:
             // This target is using the testing libraries from Xcode,
             // which were built using the XcodeDefault toolchain, but it's using


### PR DESCRIPTION
This resolves an issue which can occur when using Xcode 26 Beta with the downloadable Metal toolchain installed, if a target imports Swift Testing. A toolchain override is specified in this scenario, and this causes the existing logic modified by this PR to incorrectly believe it's using a non-Xcode toolchain, which in turn causes the wrong Swift macro plugin flags to be passed, ultimately leading to a failure locating the `TestingMacros` plugin.

The fix is to recognize all toolchains which have Xcode's prefix, and ensure the default toolchain prefix is used whenever any Xcode toolchain is in use.

Fixes rdar://152440128
