### PR TITLE
Fixup cross platform specs handling of DEAD_CODE_STRIPPING

### DIFF
--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -103,6 +103,16 @@
                 Condition = "$(ALTERNATE_LINKER) == gold";
             },
             {
+                Name = "DEAD_CODE_STRIPPING";
+                Type = Boolean;
+                DefaultValue = NO;
+                Condition = "$(MACH_O_TYPE) != mh_object";
+                CommandLineArgs = {
+                    YES = ("-Xlinker", "--gc-sections");
+                    NO = ();
+                };
+            },
+            {
                 // Frameworks are Mac specific
                 Name = "SYSTEM_FRAMEWORK_SEARCH_PATHS";
                 Type = PathList;

--- a/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
@@ -97,6 +97,11 @@
                 Condition = "$(ALTERNATE_LINKER) == gold";
             },
             {
+                Name = "DEAD_CODE_STRIPPING";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Frameworks are Mac specific
                 Name = "SYSTEM_FRAMEWORK_SEARCH_PATHS";
                 Type = PathList;

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -459,7 +459,10 @@
                 Type = Boolean;
                 DefaultValue = NO;
                 Condition = "$(MACH_O_TYPE) != mh_object";
-                CommandLineFlag = "-dead_strip";
+                CommandLineArgs = {
+                    YES = ("-dead_strip");
+                    NO = ();
+                };
             },
             {
                 Name = "BUNDLE_LOADER";

--- a/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
@@ -65,6 +65,16 @@
                 };
             },
             {
+                Name = "DEAD_CODE_STRIPPING";
+                Type = Boolean;
+                DefaultValue = NO;
+                Condition = "$(MACH_O_TYPE) != mh_object";
+                CommandLineArgs = {
+                    YES = ("-Xlinker", "--gc-sections");
+                    NO = ();
+                };
+            },
+            {
                 // Frameworks are Mac specific
                 Name = "SYSTEM_FRAMEWORK_SEARCH_PATHS";
                 Type = PathList;

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -103,6 +103,16 @@
                 Condition = "NO";
             },
             {
+                Name = "DEAD_CODE_STRIPPING";
+                Type = Boolean;
+                DefaultValue = NO;
+                Condition = "$(MACH_O_TYPE) != mh_object";
+                CommandLineArgs = {
+                    YES = ("-Xlinker", "/OPT:REF");
+                    NO = ();
+                };
+            },
+            {
                 // No such concept
                 Name = "LD_RUNPATH_SEARCH_PATHS";
                 //Note: Cannot be of type 'PathList' as value is used with relative '../' paths


### PR DESCRIPTION
Properly handle the various spellings of this operation