### PR TITLE
[6.2][Preview] Fix preview support for swift caching build (#562)

### DIFF
--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -227,8 +227,6 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
                                 "-F",
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-vfsoverlay",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-main.selection.preview-thunk.swift.json",
                                 "-no-color-diagnostics",
                                 "-g",
                                 "-debug-info-format=dwarf",
@@ -278,7 +276,9 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "-target-sdk-name",
                                 "iphonesimulator\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)",
                                 "-o",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.o"
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.o",
+                                "-vfsoverlay",
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-main.selection.preview-thunk.swift.json",
                             ]
                         )
                         #expect(previewInfo.thunkInfo?.thunkSourceFile == Path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.swift"))
@@ -531,8 +531,6 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
                                 "-F",
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-vfsoverlay",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-File1.selection.preview-thunk.swift.json",
                                 "-no-color-diagnostics",
                                 "-g",
                                 "-debug-info-format=dwarf",
@@ -582,7 +580,9 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "-target-sdk-name",
                                 "iphonesimulator\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)",
                                 "-o",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.o"
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.o",
+                                "-vfsoverlay",
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-File1.selection.preview-thunk.swift.json",
                             ]
                         )
                         #expect(previewInfo.thunkInfo?.thunkSourceFile == Path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.swift"))

--- a/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
+++ b/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
@@ -160,14 +160,13 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                         .anySequence,
                         "-sdk", "\(sdkroot)",
                         .anySequence,
-                        "-vfsoverlay", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/vfsoverlay-TestFile4.canary.preview-thunk.swift.json",
-                        .anySequence,
                         "-Onone",
                         .anySequence,
                         "-module-name", "App",
                         "-target-sdk-version", "\(deploymentTarget)",
                         "-target-sdk-name", "iphoneos\(deploymentTarget)",
                         "-o", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/TestFile4.canary.preview-thunk.o",
+                        "-vfsoverlay", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/vfsoverlay-TestFile4.canary.preview-thunk.swift.json",
                         .end
                     ])
                     // Also spot-check that some options which were removed in SwiftCompilerSpec.generatePreviewInfo() for XOJIT are not present.


### PR DESCRIPTION
Add support for swift caching build when swift compiler supports the new option that allows swift compiler performs an uncached build but loading module dependencies from CAS.

It also does few adjustment to make sure preview build shares the same dependencies with regular build as caching build has a stricter rule for invalidation:

* The VFS overlay used by preview is applied after swift driver invocation and onto the frontend invocation directly. This makes sure the VFS overlay doesn't invalidate all the module dependencies.
* BridgingHeader PCH was disabled as a workaround when swift driver doesn't produce deterministic output path when planning for PCH jobs. Properly fix this issue by requesting the same path when planning both build and don't use this workaround in certain configurations.

This should allow preview to build thunk correctly when swift caching is enabled for the regular build.

rdar://152107465
(cherry picked from commit 6c6309e4b37a0775db191f8bcc503f90c7c9edc7)
