### PR TITLE
[swift] Get correct ExitStatus if swift tasks receives signal

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverJobTaskAction.swift
@@ -469,6 +469,10 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
                 }
 
                 func processFinished(result: CommandExtendedResult) {
+                    guard let status = Processes.ExitStatus.init(rawValue: result.exitStatus) else {
+                        // nil means the job is stopped or continued. It should not call finished.
+                        return
+                    }
                     // This may be updated by commandStarted in the case of certain failures,
                     // so only update the exit status in output delegate if it is nil.
                     if outputDelegate.result == nil {
@@ -476,7 +480,7 @@ public final class SwiftDriverJobTaskAction: TaskAction, BuildValueValidatingTas
                     }
                     self._commandResult = result.result
                     do {
-                        try plannedBuild?.jobFinished(job: driverJob, arguments: arguments, pid: pid.pid, environment: environment, exitStatus: .exit(result.exitStatus), output: output)
+                        try plannedBuild?.jobFinished(job: driverJob, arguments: arguments, pid: pid.pid, environment: environment, exitStatus: status, output: output)
                     } catch {
                         executionError = error.localizedDescription
                     }


### PR DESCRIPTION
When swift tasks failed with signal, make sure the build system tag that as a signal/exception instead of a regular exit with non-zero error code.
