### PR TITLE
Add String Catalog symbol generation support to SwiftBuild

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -202,7 +202,7 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
     }
 
     func fileTypesCompilingToSwiftSources() -> [String] {
-        return []
+        return ["text.json.xcstrings"]
     }
 }
 

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -901,7 +901,9 @@ private struct GetLocalizationInfoMsg: MessageHandler {
                     for (buildPortion, paths) in infoOutput.producedStringsdataPaths {
                         stringsdataPaths[LocalizationInfoBuildPortion(effectivePlatformName: buildPortion.effectivePlatformName, variant: buildPortion.variant, architecture: buildPortion.architecture)] = paths
                     }
-                    return LocalizationInfoMessagePayload(targetIdentifier: infoOutput.targetIdentifier, compilableXCStringsPaths: infoOutput.compilableXCStringsPaths, producedStringsdataPaths: stringsdataPaths)
+                    var payload = LocalizationInfoMessagePayload(targetIdentifier: infoOutput.targetIdentifier, compilableXCStringsPaths: infoOutput.compilableXCStringsPaths, producedStringsdataPaths: stringsdataPaths, effectivePlatformName: infoOutput.effectivePlatformName)
+                    payload.generatedSymbolFilesByXCStringsPath = infoOutput.generatedSymbolFilesByXCStringsPath
+                    return payload
                 }))
                 return response
             } catch {

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -979,6 +979,7 @@ public final class BuiltinMacros {
     public static let SHALLOW_BUNDLE = BuiltinMacros.declareBooleanMacro("SHALLOW_BUNDLE")
     public static let SHARED_FRAMEWORKS_FOLDER_PATH = BuiltinMacros.declarePathMacro("SHARED_FRAMEWORKS_FOLDER_PATH")
     public static let SHARED_SUPPORT_FOLDER_PATH = BuiltinMacros.declarePathMacro("SHARED_SUPPORT_FOLDER_PATH")
+    public static let STRING_CATALOG_GENERATE_SYMBOLS = BuiltinMacros.declareBooleanMacro("STRING_CATALOG_GENERATE_SYMBOLS")
     public static let STRINGS_FILE_INPUT_ENCODING = BuiltinMacros.declareStringMacro("STRINGS_FILE_INPUT_ENCODING")
     public static let STRINGS_FILE_OUTPUT_ENCODING = BuiltinMacros.declareStringMacro("STRINGS_FILE_OUTPUT_ENCODING")
     public static let STRINGS_FILE_OUTPUT_FILENAME = BuiltinMacros.declareStringMacro("STRINGS_FILE_OUTPUT_FILENAME")
@@ -2132,6 +2133,7 @@ public final class BuiltinMacros {
         SOURCE_ROOT,
         SPECIALIZATION_SDK_OPTIONS,
         SRCROOT,
+        STRING_CATALOG_GENERATE_SYMBOLS,
         STRINGSDATA_DIR,
         STRINGS_FILE_INPUT_ENCODING,
         STRINGS_FILE_OUTPUT_ENCODING,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4157,6 +4157,7 @@ private class SettingsBuilder {
         if let project, project.isPackage, project.developmentRegion != nil {
             table.push(BuiltinMacros.LOCALIZATION_EXPORT_SUPPORTED, literal: true)
             table.push(BuiltinMacros.SWIFT_EMIT_LOC_STRINGS, literal: true)
+            table.push(BuiltinMacros.STRING_CATALOG_GENERATE_SYMBOLS, literal: true)
         }
 
         return table

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -1163,12 +1163,21 @@ public struct TaskGenerateLocalizationInfoOutput {
     /// Paths to .stringsdata files produced by this task, grouped by build attributes such as platform and architecture.
     public let producedStringsdataPaths: [LocalizationBuildPortion: [Path]]
 
+    /// The name of the primary platform we were building for.
+    ///
+    /// Mac Catalyst is treated as its own platform.
+    public var effectivePlatformName: String?
+
+    /// Paths to generated source code files holding string symbols, keyed by xcstrings file path.
+    public var generatedSymbolFilesByXCStringsPath = [Path: [Path]]()
+
     /// Create output to describe some portion of localization info for a Task.
     ///
     /// - Parameters:
     ///   - compilableXCStringsPaths: Paths to input source .xcstrings files.
     ///   - producedStringsdataPaths: Paths to output .stringsdata files.
-    public init(compilableXCStringsPaths: [Path] = [], producedStringsdataPaths: [LocalizationBuildPortion: [Path]] = [:]) {
+    public init(compilableXCStringsPaths: [Path] = [],
+                producedStringsdataPaths: [LocalizationBuildPortion: [Path]] = [:]) {
         self.compilableXCStringsPaths = compilableXCStringsPaths
         self.producedStringsdataPaths = producedStringsdataPaths
     }

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -1128,6 +1128,11 @@ public struct SwiftBuildFileType: Sendable {
         fileTypeIdentifier: "folder.abstractassetcatalog"
     )
 
+    public static let xcstrings: SwiftBuildFileType = SwiftBuildFileType(
+        fileType: "xcstrings",
+        fileTypeIdentifier: "text.json.xcstrings"
+    )
+
     public static let xcdatamodeld: SwiftBuildFileType = SwiftBuildFileType(
         fileType: "xcdatamodeld",
         fileTypeIdentifier: "wrapper.xcdatamodeld"
@@ -1165,6 +1170,7 @@ public struct SwiftBuildFileType: Sendable {
 
     public static let all: [SwiftBuildFileType] = [
         .xcassets,
+        .xcstrings,
         .xcdatamodeld,
         .xcdatamodel,
         .xcmappingmodel,

--- a/Sources/SWBProtocol/MessageSupport.swift
+++ b/Sources/SWBProtocol/MessageSupport.swift
@@ -542,9 +542,21 @@ public struct LocalizationInfoMessagePayload: SerializableCodable, Equatable, Se
     /// Paths to .stringsdata files produced by this target, grouped by build attributes such as platform and architecture.
     public let producedStringsdataPaths: [LocalizationInfoBuildPortion: Set<Path>]
 
-    public init(targetIdentifier: String, compilableXCStringsPaths: Set<Path>, producedStringsdataPaths: [LocalizationInfoBuildPortion: Set<Path>]) {
+    /// The name of the primary platform we were building for.
+    ///
+    /// Mac Catalyst is treated as its own platform.
+    public let effectivePlatformName: String?
+
+    /// Paths to generated source code files holding string symbols, keyed by xcstrings file path.
+    public var generatedSymbolFilesByXCStringsPath = [Path: Set<Path>]()
+
+    public init(targetIdentifier: String,
+                compilableXCStringsPaths: Set<Path>,
+                producedStringsdataPaths: [LocalizationInfoBuildPortion: Set<Path>],
+                effectivePlatformName: String?) {
         self.targetIdentifier = targetIdentifier
         self.compilableXCStringsPaths = compilableXCStringsPaths
         self.producedStringsdataPaths = producedStringsdataPaths
+        self.effectivePlatformName = effectivePlatformName
     }
 }

--- a/Sources/SwiftBuild/SWBBuildServiceSession.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceSession.swift
@@ -279,11 +279,21 @@ public final class SWBBuildServiceSession: Sendable {
         var targetInfos = [String: SWBLocalizationTargetInfo]()
         for payload in msg.targetInfos {
             let xcstrings = payload.compilableXCStringsPaths.map { $0.normalize().str }
+
             var stringsdata = [SWBLocalizationBuildPortion: Set<String>]()
             for (buildPortion, paths) in payload.producedStringsdataPaths {
                 stringsdata[SWBLocalizationBuildPortion(effectivePlatformName: buildPortion.effectivePlatformName, variant: buildPortion.variant, architecture: buildPortion.architecture)] = Set(paths.map({ $0.normalize().str }))
             }
-            targetInfos[payload.targetIdentifier] = SWBLocalizationTargetInfo(compilableXCStringsPaths: Set(xcstrings), stringsdataPathsByBuildPortion: stringsdata)
+
+            var swbTargetInfo = SWBLocalizationTargetInfo(compilableXCStringsPaths: Set(xcstrings), stringsdataPathsByBuildPortion: stringsdata, effectivePlatformName: payload.effectivePlatformName)
+
+            var generatedFiles = [String: Set<String>]()
+            for (xcstringsPath, generatedPaths) in payload.generatedSymbolFilesByXCStringsPath {
+                generatedFiles[xcstringsPath.normalize().str] = Set(generatedPaths.map({ $0.normalize().str }))
+            }
+            swbTargetInfo.generatedSymbolFilesByXCStringsPath = generatedFiles
+
+            targetInfos[payload.targetIdentifier] = swbTargetInfo
         }
 
         return SWBLocalizationInfo(infoByTarget: targetInfos)

--- a/Sources/SwiftBuild/SWBLocalizationSupport.swift
+++ b/Sources/SwiftBuild/SWBLocalizationSupport.swift
@@ -33,6 +33,15 @@ public struct SWBLocalizationTargetInfo: Sendable {
     public var producedStringsdataPaths: Set<String> {
         return stringsdataPathsByBuildPortion.values.reduce([]) { $0.union($1) }
     }
+
+    /// The name of the primary platform we were building for.
+    ///
+    /// Mac Catalyst is treated as its own platform.
+    public let effectivePlatformName: String?
+
+    /// Paths to generated source code files holding string symbols, keyed by xcstrings file path.
+    public internal(set) var generatedSymbolFilesByXCStringsPath = [String: Set<String>]()
+
 }
 
 /// Describes attributes of a portion of a build, for example platform and architecture, that are relevant to distinguishing localized strings extracted during a build.

--- a/Tests/SWBTaskConstructionTests/XCStringsSymbolGenTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCStringsSymbolGenTests.swift
@@ -1,0 +1,1073 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Data
+import struct Foundation.UUID
+
+import Testing
+
+import SWBUtil
+import enum SWBProtocol.ExternalToolResult
+import SWBCore
+import SWBTaskConstruction
+import SWBTestSupport
+
+@Suite
+fileprivate struct XCStringsSymbolGenTests: CoreBasedTests {
+
+    @Test(.requireSDKs(.macOS))
+    func symbolGenerationPlusCompile() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES" // This is what we're primarily testing
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Mock xcstringstool since it will be called for --dry-run.
+        // Pretend our xcstrings file contains English and German strings, and that they have variations.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "xcstringstool", "compile",
+            "--dry-run",
+            "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build",
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let swiftFeatures = try await self.swiftFeatures
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // There should not be any generic CpResource tasks because that would indicate that the xcstrings file is just being copied as is.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CpResource"))
+
+                // First there should be symbol gen.
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { task in
+
+                    // Input is source xcstrings file.
+                    task.checkInputs(contain: [.path("/tmp/Test/Project/Sources/Localizable.xcstrings")])
+
+                    // Output is .swift file.
+                    task.checkOutputs([
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift"),
+                    ])
+
+                    task.checkCommandLine([
+                        "xcstringstool", "generate-symbols",
+                        "--language", "swift",
+                        "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources",
+                        "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+                    ])
+                }
+
+                // The output of that should be compiled by Swift.
+                let targetArchitecture = results.runDestinationTargetArchitecture
+                if swiftFeatures.has(.emitLocalizedStrings) {
+                    results.checkTask(.matchTarget(target), .matchRule(["SwiftDriver Compilation", "MyFramework", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                } else {
+                    results.checkTask(.matchTarget(target), .matchRule(["CompileSwiftSources", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                }
+
+                // We need a task to compile the XCStrings into .strings and .stringsdict files.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { task in
+
+                    // Input is source xcstrings file.
+                    task.checkInputs(contain: [.path("/tmp/Test/Project/Sources/Localizable.xcstrings")])
+
+                    // Outputs are .strings and .stringsdicts in the TempResourcesDir.
+                    task.checkOutputs([
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.stringsdict"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.stringsdict"),
+                    ])
+
+                    task.checkCommandLine([
+                        "xcstringstool", "compile",
+                        "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build",
+                        "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+                    ])
+                }
+
+
+                // Then we need the standard CopyStringsFile tasks to have the compiled .strings/dict as input.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.stringsdict"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.stringsdict"])) { _ in }
+
+                // And these should be the only CopyStringsFile tasks.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func multipleXCStringsSymbolGenerationPlusCompile() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                    TestFile("CustomTable.xcstrings"),
+                    TestFile("Table with spaces.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings",
+                            "CustomTable.xcstrings",
+                            "Table with spaces.xcstrings",
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings files contain English and German strings, without variation.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" : [
+                "en.lproj/Localizable.strings",
+                "de.lproj/Localizable.strings",
+            ],
+            "/tmp/Test/Project/Sources/CustomTable.xcstrings" : [
+                "en.lproj/CustomTable.strings",
+                "de.lproj/CustomTable.strings",
+            ],
+            "/tmp/Test/Project/Sources/Table with spaces.xcstrings" : [
+                "en.lproj/Table with spaces.strings",
+                "de.lproj/Table with spaces.strings",
+            ],
+        ], requiredCommandLine: nil)
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let swiftFeatures = try await self.swiftFeatures
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // We should have two separate GenerateStringSymbols tasks.
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_CustomTable.swift", "/tmp/Test/Project/Sources/CustomTable.xcstrings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Table with spaces.swift", "/tmp/Test/Project/Sources/Table with spaces.xcstrings"])) { _ in }
+
+                // Both of those output files should be consumed by the Swift Driver.
+                let targetArchitecture = results.runDestinationTargetArchitecture
+                if swiftFeatures.has(.emitLocalizedStrings) {
+                    results.checkTask(.matchTarget(target), .matchRule(["SwiftDriver Compilation", "MyFramework", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift"),
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_CustomTable.swift"),
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Table with spaces.swift"),
+                        ])
+                    }
+                } else {
+                    results.checkTask(.matchTarget(target), .matchRule(["CompileSwiftSources", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift"),
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_CustomTable.swift"),
+                            .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Table with spaces.swift"),
+                        ])
+                    }
+                }
+
+                // We should have two separate CompileXCStrings tasks.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/CustomTable.xcstrings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Table with spaces.xcstrings"])) { _ in }
+
+                // We should then have 4 CopyStringsFile tasks consuming those outputs.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/CustomTable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/CustomTable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Table with spaces.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Table with spaces.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/CustomTable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/CustomTable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Table with spaces.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Table with spaces.strings"])) { _ in }
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    // An xcstrings file in Copy Files rather than a Resources build phase should just be copied.
+    // (Assuming APPLY_RULES_IN_COPY_FILES has not been set.)
+    @Test(.requireSDKs(.macOS))
+    func inCopyFilesStillNoSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestCopyFilesBuildPhase([
+                            "Localizable.xcstrings",
+                        ], destinationSubfolder: .resources, onlyForDeployment: false)
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // xcstringstool shouldn't be called.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [:], requiredCommandLine: ["don't call me"])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // Just copy it.
+                results.checkTask(.matchTarget(target), .matchRule(["Copy", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/Localizable.xcstrings", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+
+                // Don't do anything else with it.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("GenerateStringSymbols"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CompileXCStrings"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    // Make sure everything still works if a clever developer explicitly puts the xcstrings in Compile Sources for symbol generation.
+    @Test(.requireSDKs(.macOS))
+    func inSources() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES" // This is what we're primarily testing
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift",
+                            "Localizable.xcstrings"
+                        ]),
+                        TestResourcesBuildPhase([
+
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Mock xcstringstool since it will be called for --dry-run.
+        // Pretend our xcstrings file contains English and German strings, and that they have variations.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "xcstringstool", "compile",
+            "--dry-run",
+            "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build",
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let swiftFeatures = try await self.swiftFeatures
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // There should not be any generic CpResource tasks because that would indicate that the xcstrings file is just being copied as is.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CpResource"))
+
+                // First there should be symbol gen.
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { task in
+
+                    // Input is source xcstrings file.
+                    task.checkInputs(contain: [.path("/tmp/Test/Project/Sources/Localizable.xcstrings")])
+
+                    // Output is .swift file.
+                    task.checkOutputs([
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift"),
+                    ])
+
+                    task.checkCommandLine([
+                        "xcstringstool", "generate-symbols",
+                        "--language", "swift",
+                        "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources",
+                        "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+                    ])
+                }
+
+                // The output of that should be compiled by Swift.
+                let targetArchitecture = results.runDestinationTargetArchitecture
+                if swiftFeatures.has(.emitLocalizedStrings) {
+                    results.checkTask(.matchTarget(target), .matchRule(["SwiftDriver Compilation", "MyFramework", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                } else {
+                    results.checkTask(.matchTarget(target), .matchRule(["CompileSwiftSources", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                }
+
+                // We need a task to compile the XCStrings into .strings and .stringsdict files.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { task in
+
+                    // Input is source xcstrings file.
+                    task.checkInputs(contain: [.path("/tmp/Test/Project/Sources/Localizable.xcstrings")])
+
+                    // Outputs are .strings and .stringsdicts in the TempResourcesDir.
+                    task.checkOutputs([
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.stringsdict"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"),
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.stringsdict"),
+                    ])
+
+                    task.checkCommandLine([
+                        "xcstringstool", "compile",
+                        "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build",
+                        "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+                    ])
+                }
+
+
+                // Then we need the standard CopyStringsFile tasks to have the compiled .strings/dict as input.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.stringsdict"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.stringsdict"])) { _ in }
+
+                // And these should be the only CopyStringsFile tasks.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    // Test both .xcstrings and .strings tables when symbol generation is enabled.
+    @Test(.requireSDKs(.macOS))
+    func mixedProjectWithSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                    TestVariantGroup("CustomTable.strings", children: [
+                        TestFile("en.lproj/CustomTable.strings", regionVariantName: "en"),
+                        TestFile("de.lproj/CustomTable.strings", regionVariantName: "de"),
+                    ]),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings",
+                            "CustomTable.strings"
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings files contain English and German strings, without variation.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" : [
+                "en.lproj/Localizable.strings",
+                "de.lproj/Localizable.strings",
+            ],
+        ], requiredCommandLine: nil)
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // GenerateStringSymbols
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+
+                // CompileXCStrings
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CompileXCStrings"))
+
+                // We should then have 4 CopyStringsFile tasks.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/CustomTable.strings", "/tmp/Test/Project/Sources/en.lproj/CustomTable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/CustomTable.strings", "/tmp/Test/Project/Sources/de.lproj/CustomTable.strings"])) { _ in }
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    // Don't generate symbols if the project doesn't have Swift files.
+    @Test(.requireSDKs(.macOS))
+    func testNoSwiftSourcesNoSymbolGen() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.h"),
+                    TestFile("MyFramework.m"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES"
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestHeadersBuildPhase([
+                            "MyFramework.h"
+                        ]),
+                        TestSourcesBuildPhase([
+                            "MyFramework.m"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Mock xcstringstool since it will be called for --dry-run.
+        // Pretend our xcstrings file contains English and German strings, and that they have variations.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "xcstringstool", "compile",
+            "--dry-run",
+            "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build",
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // There should not be any generic CpResource tasks because that would indicate that the xcstrings file is just being copied as is.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CpResource"))
+
+                // No symbol gen
+                results.checkNoTask(.matchRuleType("GenerateStringSymbols"))
+
+                // We need a task to compile the XCStrings into .strings and .stringsdict files.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+
+
+                // Then we need the standard CopyStringsFile tasks to have the compiled .strings/dict as input.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/en.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/en.lproj/Localizable.stringsdict"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/Localizable.stringsdict"])) { _ in }
+
+                // And these should be the only CopyStringsFile tasks.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func symbolGenPlusTableOverlap() async throws {
+        let catalog1 = TestFile("Dupe.xcstrings", guid: UUID().uuidString)
+        let catalog2 = TestFile("Dupe.xcstrings", guid: UUID().uuidString)
+
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                    TestVariantGroup("Localizable.strings", children: [
+                        TestFile("en.lproj/Localizable.strings", regionVariantName: "en"),
+                        TestFile("de.lproj/Localizable.strings", regionVariantName: "de"),
+                    ]),
+                    catalog1,
+                    TestGroup("Subdir", path: "Subdir", children: [
+                        catalog2
+                    ]),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES"
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings",
+                            "Localizable.strings",
+                            TestBuildFile(catalog1),
+                            TestBuildFile(catalog2),
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings files contain English and German strings, without variation.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" : [
+                "en.lproj/Localizable.strings",
+                "de.lproj/Localizable.strings",
+            ],
+            "/tmp/Test/Project/Sources/Dupe.xcstrings" : [
+                "en.lproj/Dupe.strings",
+                "de.lproj/Dupe.strings",
+            ],
+        ], requiredCommandLine: nil)
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            // This is not a supported configuration.
+
+            results.checkError(.and(.contains("Localizable.xcstrings cannot co-exist with other .strings or .stringsdict tables with the same name."), .prefix("/tmp/Test/Project/Sources/Localizable.xcstrings")))
+
+            results.checkError(.contains("Cannot have multiple Dupe.xcstrings files in same target."))
+        }
+    }
+
+    @Test(.requireSDKs(.iOS))
+    func installlocNoSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Release", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT" : "iphoneos",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Release", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_ALLOW_INSTALL_OBJC_HEADER": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings file contains English and German strings, and that they have variations.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "xcstringstool", "compile",
+            "--dry-run",
+            "-l", "de", // installloc builds are language-specific
+            "--output-directory", "/tmp/Test/Project/build/Project.build/Release-iphoneos/MyFramework.build",
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "de"]), runDestination: .iOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // No symbol gen in installloc.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("GenerateStringSymbols"))
+
+                // We need a task to compile the XCStrings into .strings and .stringsdict files.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Release-iphoneos/MyFramework.build/", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { _ in }
+
+
+                // Then we need the standard CopyStringsFile tasks to have the compiled .strings/dict as input.
+                // Only the German variants should be copied.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/UninstalledProducts/iphoneos/MyFramework.framework/de.lproj/Localizable.strings", "/tmp/Test/Project/build/Project.build/Release-iphoneos/MyFramework.build/de.lproj/Localizable.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/UninstalledProducts/iphoneos/MyFramework.framework/de.lproj/Localizable.stringsdict", "/tmp/Test/Project/build/Project.build/Release-iphoneos/MyFramework.build/de.lproj/Localizable.stringsdict"])) { _ in }
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+
+                // And nothing else other than the usuals.
+                results.checkTasks(.matchRuleType("Gate")) { _ in }
+                results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
+                results.checkTasks(.matchRuleType("SymLink")) { _ in }
+                results.checkTasks(.matchRuleType("MkDir")) { _ in }
+                results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
+                results.checkNoTask()
+            }
+        }
+    }
+
+    // xcstrings files should be skipped entirely during installloc if they're in the Copy Files build phase.
+    // We can revisit if we find a legit use case where one would be needed.
+    @Test(.requireSDKs(.iOS))
+    func installlocCopyFileNoSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Release", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT" : "iphoneos",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Release", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_ALLOW_INSTALL_OBJC_HEADER": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestCopyFilesBuildPhase([
+                            "Localizable.xcstrings"
+                        ], destinationSubfolder: .resources, onlyForDeployment: false)
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings file contains English and German strings, and that they have variations.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "xcstringstool", "compile",
+            "--dry-run",
+            "-l", "de", // installloc builds are language-specific
+            "--output-directory", "/tmp/Test/Project/build/Project.build/Release-iphoneos/MyFramework.build",
+            "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Release", overrides: ["INSTALLLOC_LANGUAGE": "de"]), runDestination: .iOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // Should be skipped.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CpResource"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("GenerateStringSymbols"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CompileXCStrings"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+
+            // And nothing else other than the usuals.
+            results.checkTasks(.matchRuleType("Gate")) { _ in }
+            results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
+            results.checkTasks(.matchRuleType("SymLink")) { _ in }
+            results.checkTasks(.matchRuleType("MkDir")) { _ in }
+            results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
+            results.checkNoTask()
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func xcstringsInVariantGroupNoSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestVariantGroup("View.xib", children: [
+                        TestFile("Base.lproj/View.xib", regionVariantName: "Base"),
+                        TestFile("mul.lproj/View.xcstrings", regionVariantName: "mul"), // mul is the ISO code for multi-lingual
+                    ]),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "IBC_EXEC": ibtoolPath.str,
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "View.xib",
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // Pretend our xcstrings file contains French and German strings.
+        // We won't have English because those are in the IB file itself and not typically overridden by xcstrings.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [
+            "/tmp/Test/Project/Sources/mul.lproj/View.xcstrings" : [
+                "fr.lproj/View.strings",
+                "de.lproj/View.strings",
+            ],
+        ], requiredCommandLine: nil)
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // xib should get compiled by ibtool.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXIB", "/tmp/Test/Project/Sources/Base.lproj/View.xib"])) { _ in }
+
+                // No symbol generation for xcstrings in variant groups because those are only used by IB.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("GenerateStringSymbols"))
+
+                // xcstrings should get compiled separately by xcstringstool.
+                results.checkTask(.matchTarget(target), .matchRule(["CompileXCStrings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/", "/tmp/Test/Project/Sources/mul.lproj/View.xcstrings"])) { _ in }
+
+                // Each xcstrings output needs a corresponding CopyStringsFile action.
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/fr.lproj/View.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/fr.lproj/View.strings"])) { _ in }
+                results.checkTask(.matchTarget(target), .matchRule(["CopyStringsFile", "/tmp/Test/Project/build/Debug/MyFramework.framework/Versions/A/Resources/de.lproj/View.strings", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/de.lproj/View.strings"])) { _ in }
+
+                // And these should be the only CopyStringsFile tasks.
+                // LegacyView should not have one because ibtool is responsible for copying those .strings files.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func exportLocSymbolGeneration() async throws {
+        let testProject = try await TestProject(
+            "Project",
+            groupTree: TestGroup(
+                "ProjectSources",
+                path: "Sources",
+                children: [
+                    TestFile("MyFramework.swift"),
+                    TestFile("Localizable.xcstrings"),
+                ]
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "MyFramework",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES"
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyFramework.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+            ],
+            developmentRegion: "en"
+        )
+
+        // xcstringstool should not be called during planning since exportloc should not compile xcstrings.
+        let xcstringsTool = MockXCStringsTool(relativeOutputFilePaths: [ "/tmp/Test/Project/Sources/Localizable.xcstrings" : [ // input
+            "en.lproj/Localizable.strings",
+            "en.lproj/Localizable.stringsdict",
+            "de.lproj/Localizable.strings",
+            "de.lproj/Localizable.stringsdict",
+        ]], requiredCommandLine: [
+            "don't call me"
+        ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let swiftFeatures = try await self.swiftFeatures
+
+        await tester.checkBuild(BuildParameters(action: .exportLoc, configuration: "Debug"), runDestination: .macOS, clientDelegate: xcstringsTool) { results in
+            results.checkNoDiagnostics()
+
+            results.checkTarget("MyFramework") { target in
+                // We DO expect symbol generation.
+                results.checkTask(.matchTarget(target), .matchRule(["GenerateStringSymbols", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift", "/tmp/Test/Project/Sources/Localizable.xcstrings"])) { task in
+
+                    // Input is source xcstrings file.
+                    task.checkInputs(contain: [.path("/tmp/Test/Project/Sources/Localizable.xcstrings")])
+
+                    // Output is .swift file.
+                    task.checkOutputs([
+                        .path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift"),
+                    ])
+
+                    task.checkCommandLine([
+                        "xcstringstool", "generate-symbols",
+                        "--language", "swift",
+                        "--output-directory", "/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources",
+                        "/tmp/Test/Project/Sources/Localizable.xcstrings" // input file
+                    ])
+                }
+
+                // The output of that should be compiled by Swift.
+                let targetArchitecture = results.runDestinationTargetArchitecture
+                if swiftFeatures.has(.emitLocalizedStrings) {
+                    results.checkTask(.matchTarget(target), .matchRule(["SwiftDriver Compilation", "MyFramework", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                } else {
+                    results.checkTask(.matchTarget(target), .matchRule(["CompileSwiftSources", "normal", targetArchitecture, "com.apple.xcode.tools.swift.compiler"])) { task in
+                        task.checkInputs(contain: [.path("/tmp/Test/Project/build/Project.build/Debug/MyFramework.build/DerivedSources/GeneratedStringSymbols_Localizable.swift")])
+                    }
+                }
+
+                // No actual catalog compilation.
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CompileXCStrings"))
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyStringsFile"))
+            }
+        }
+    }
+
+}

--- a/Tests/SwiftBuildTests/LocalizationInfoSymbolGenTests.swift
+++ b/Tests/SwiftBuildTests/LocalizationInfoSymbolGenTests.swift
@@ -1,0 +1,246 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBTestSupport
+import SwiftBuildTestSupport
+
+import SWBUtil
+import SwiftBuild
+
+@Suite(.requireHostOS(.macOS))
+fileprivate struct LocalizationInfoSymbolGenTests {
+
+    @Test(.requireSDKs(.macOS))
+    func includesSymbolFiles() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let tmpDir = temporaryDirectory.path
+                let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let target = TestStandardTarget(
+                    "MyApp",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx",
+                            "ONLY_ACTIVE_ARCH": "NO",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyApp.swift",
+                            "Supporting.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+
+                let testWorkspace = TestWorkspace("MyWorkspace", sourceRoot: tmpDir, projects: [
+                    TestProject(
+                        "Project",
+                        groupTree: TestGroup(
+                            "ProjectSources",
+                            path: "Sources",
+                            children: [
+                                TestFile("MyApp.swift"),
+                                TestFile("Supporting.swift"),
+                                TestFile("Localizable.xcstrings"),
+                            ]
+                        ),
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                            ])
+                        ],
+                        targets: [
+                            target
+                        ],
+                        developmentRegion: "en"
+                    )
+                ])
+
+                // Describe the workspace to the build system.
+                try await testSession.sendPIF(testWorkspace)
+
+                let runDestination = SWBRunDestinationInfo.macOS
+                let buildParams = SWBBuildParameters(configuration: "Debug", activeRunDestination: runDestination)
+                var request = SWBBuildRequest()
+                request.add(target: SWBConfiguredTarget(guid: target.guid, parameters: buildParams))
+
+                let delegate = BuildOperationDelegate()
+
+                // Now run a build (plan only)
+                request.buildDescriptionID = try await testSession.runBuildDescriptionCreationOperation(request: request, delegate: delegate).buildDescriptionID
+
+                let info = try await testSession.session.generateLocalizationInfo(for: request, delegate: delegate)
+
+                #expect(info.infoByTarget.count == 1) // 1 target
+
+                let targetInfo = try #require(info.infoByTarget[target.guid])
+
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.count == 1)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.key.hasSuffix("Localizable.xcstrings") ?? false)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.value.count == 1)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.value.first?.hasSuffix("GeneratedStringSymbols_Localizable.swift") ?? false)
+                #expect(targetInfo.effectivePlatformName == "macosx")
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func XCStringsNotNeedingBuilt() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let tmpDir = temporaryDirectory.path
+                let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let target = TestStandardTarget(
+                    "MyApp",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SKIP_INSTALL": "YES",
+                            "SWIFT_VERSION": "5.5",
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx",
+                            "ONLY_ACTIVE_ARCH": "NO"
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "MyApp.swift",
+                            "Supporting.swift"
+                        ]),
+                        TestResourcesBuildPhase([
+                            "Localizable.xcstrings"
+                        ])
+                    ]
+                )
+
+                let testWorkspace = TestWorkspace("MyWorkspace", sourceRoot: tmpDir, projects: [
+                    TestProject(
+                        "Project",
+                        groupTree: TestGroup(
+                            "ProjectSources",
+                            path: "Sources",
+                            children: [
+                                TestFile("MyApp.swift"),
+                                TestFile("Supporting.swift"),
+                                TestFile("Localizable.xcstrings"),
+                            ]
+                        ),
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                            ])
+                        ],
+                        targets: [
+                            target
+                        ],
+                        developmentRegion: "en"
+                    )
+                ])
+
+                // Describe the workspace to the build system.
+                try await testSession.sendPIF(testWorkspace)
+
+                let runDestination = SWBRunDestinationInfo.macOS
+                let buildParams = SWBBuildParameters(configuration: "Debug", activeRunDestination: runDestination)
+                var request = SWBBuildRequest()
+                request.add(target: SWBConfiguredTarget(guid: target.guid, parameters: buildParams))
+
+                // Return empty paths from xcstringstool compile --dryrun, which means we won't actually generate any tasks for it.
+                // But we still need to detect its presence as part of the build inputs.
+                let delegate = BuildOperationDelegate(returnEmpty: true)
+
+                // Now run a build (plan only)
+                request.buildDescriptionID = try await testSession.runBuildDescriptionCreationOperation(request: request, delegate: delegate).buildDescriptionID
+
+                let info = try await testSession.session.generateLocalizationInfo(for: request, delegate: delegate)
+
+                #expect(info.infoByTarget.count == 1) // 1 target
+
+                let targetInfo = try #require(info.infoByTarget[target.guid])
+
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.count == 1)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.key.hasSuffix("Localizable.xcstrings") ?? false)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.value.count == 1)
+                #expect(targetInfo.generatedSymbolFilesByXCStringsPath.first?.value.first?.hasSuffix("GeneratedStringSymbols_Localizable.swift") ?? false)
+                #expect(targetInfo.effectivePlatformName == "macosx")
+            }
+        }
+    }
+
+}
+
+private final class BuildOperationDelegate: SWBLocalizationDelegate {
+    private let delegate = TestBuildOperationDelegate()
+    private let returnEmpty: Bool
+
+    init(returnEmpty: Bool = false) {
+        self.returnEmpty = returnEmpty
+    }
+
+    func provisioningTaskInputs(targetGUID: String, provisioningSourceData: SWBProvisioningTaskInputsSourceData) async -> SWBProvisioningTaskInputs {
+        return await delegate.provisioningTaskInputs(targetGUID: targetGUID, provisioningSourceData: provisioningSourceData)
+    }
+
+    func executeExternalTool(commandLine: [String], workingDirectory: String?, environment: [String : String]) async throws -> SWBExternalToolResult {
+        guard let command = commandLine.first, command.hasSuffix("xcstringstool") else {
+            return .deferred
+        }
+
+        guard !returnEmpty else {
+            // We were asked to return empty, simulating an xcstrings file that does not need to build at all.
+            return .result(status: .exit(0), stdout: Data(), stderr: Data())
+        }
+
+        // We need to intercept and handle xcstringstool compile --dry-run commands.
+        // These tests are not testing the XCStringsCompiler, we just need to produce something so the build plan doesn't fail.
+        // So we'll just produce a single same-named .strings file.
+
+        // Last arg is input.
+        guard let inputPath = commandLine.last.map(Path.init) else {
+            return .result(status: .exit(1), stdout: Data(), stderr: "Couldn't find input file in command line.".data(using: .utf8)!)
+        }
+
+        // Second to last arg is output directory.
+        guard let outputDir = commandLine[safe: commandLine.endIndex - 2].map(Path.init) else {
+            return .result(status: .exit(1), stdout: Data(), stderr: "Couldn't find output directory in command line.".data(using: .utf8)!)
+        }
+
+        let output = outputDir.join("en.lproj/\(inputPath.basenameWithoutSuffix).strings")
+
+        return .result(status: .exit(0), stdout: Data(output.str.utf8), stderr: Data())
+    }
+}


### PR DESCRIPTION
This change adds String Catalog symbol generation support to SwiftBuild.

I will follow-up with a PR to factor out String Catalog (and some Asset Catalog) nuance out of the core build system.