### PR TITLE
[6.2] Enforce VALID_ARCHS for simulator platforms

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -239,7 +239,7 @@ struct AppleSettingsBuilderExtension: SettingsBuilderExtension {
     func addPlatformSDKSettings(_ platform: SWBCore.Platform?, _ sdk: SDK, _ sdkVariant: SDKVariant?) -> [String : String] { [:] }
     func xcconfigOverrideData(fromParameters: BuildParameters) -> ByteString { ByteString() }
     func getTargetTestingSwiftPluginFlags(_ scope: MacroEvaluationScope, toolchainRegistry: ToolchainRegistry, sdkRegistry: SDKRegistry, activeRunDestination: RunDestinationInfo?, project: SWBCore.Project?) -> [String] { [] }
-    func shouldSkipPopulatingValidArchs(platform: SWBCore.Platform) -> Bool { false }
+    func shouldSkipPopulatingValidArchs(platform: SWBCore.Platform, sdk: SDK?) -> Bool { false }
     func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool { false }
     func overridingBuildSettings(_: MacroEvaluationScope, platform: SWBCore.Platform?, productType: ProductTypeSpec) -> [String : String] { [:] }
 }

--- a/Sources/SWBApplePlatform/Specs/iOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/iOSSimulator.xcspec
@@ -40,14 +40,6 @@
         SortNumber = 107;
     },
 
-    {
-        _Domain = iphonesimulator;
-        Type = Architecture;
-        Identifier = arm64e;
-        PerArchBuildSettingName = "arm64e";
-        SortNumber = 108;
-    },
-
     // DEPRECATED
 
     {

--- a/Sources/SWBApplePlatform/Specs/tvOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/tvOSSimulator.xcspec
@@ -49,14 +49,6 @@
         SortNumber = 107;
     },
 
-    {
-        _Domain = appletvsimulator;
-        Type = Architecture;
-        Identifier = arm64e;
-        PerArchBuildSettingName = "arm64e";
-        SortNumber = 108;
-    },
-
     // DEPRECATED
 
     {

--- a/Sources/SWBApplePlatform/Specs/watchOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/watchOSSimulator.xcspec
@@ -48,14 +48,6 @@
         SortNumber = 107;
     },
 
-    {
-        _Domain = watchsimulator;
-        Type = Architecture;
-        Identifier = arm64e;
-        PerArchBuildSettingName = "arm64e";
-        SortNumber = 108;
-    },
-
     // DEPRECATED
 
     {

--- a/Sources/SWBApplePlatform/Specs/xrOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/xrOSSimulator.xcspec
@@ -40,14 +40,6 @@
         SortNumber = 107;
     },
 
-    {
-        _Domain = xrsimulator;
-        Type = Architecture;
-        Identifier = arm64e;
-        PerArchBuildSettingName = "arm64e";
-        SortNumber = 108;
-    },
-
     // DEPRECATED
 
     {

--- a/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
+++ b/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
@@ -48,7 +48,7 @@ public protocol SettingsBuilderExtension {
     // Provides a list of flags to configure testing plugins
     func getTargetTestingSwiftPluginFlags(_ scope: MacroEvaluationScope, toolchainRegistry: ToolchainRegistry, sdkRegistry: SDKRegistry, activeRunDestination: RunDestinationInfo?, project: Project?) -> [String]
     // Override valid architectures enforcement for a platform
-    func shouldSkipPopulatingValidArchs(platform: Platform) -> Bool
+    func shouldSkipPopulatingValidArchs(platform: Platform, sdk: SDK?) -> Bool
 
     func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool
 

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2626,23 +2626,19 @@ private class SettingsBuilder {
                 core.pluginManager.extensions(of: SettingsBuilderExtensionPoint.self)
             }
 
-            func shouldPopulateValidArchs(platform: Platform) -> Bool {
+            func shouldPopulateValidArchs(platform: Platform, sdk: SDK?) -> Bool {
                 // For now, we only do this for some platforms to avoid behavior changes.
                 // Later, we should extend this to more SDKs via <rdar://66001997>
                 switch platform.name {
                 case "macosx",
                     "iphoneos",
-                    "iphonesimulator",
                     "appletvos",
-                    "appletvsimulator",
                     "watchos",
-                    "watchsimulator",
-                    "xros",
-                    "xrsimulator":
+                    "xros":
                     return false
                 default:
                     for settingsExtension in settingsExtensions() {
-                        if settingsExtension.shouldSkipPopulatingValidArchs(platform: platform) {
+                        if settingsExtension.shouldSkipPopulatingValidArchs(platform: platform, sdk: sdk) {
                             return false
                         }
                     }
@@ -2651,7 +2647,7 @@ private class SettingsBuilder {
             }
 
             // VALID_ARCHS should be based on the SDK's SupportedTargets dictionary.
-            if let archs = sdkVariant?.archs, !archs.isEmpty, let platform, shouldPopulateValidArchs(platform: platform) {
+            if let archs = sdkVariant?.archs, !archs.isEmpty, let platform, shouldPopulateValidArchs(platform: platform, sdk: sdk) {
                 table.push(BuiltinMacros.VALID_ARCHS, literal: archs)
             }
 


### PR DESCRIPTION
This allows projects to build more smoothly across platforms when architectures like arm64e are unconditionally appended to ARCHS. Simulators have never supported arm64e in any capacity.

rdar://153143584