### PR TITLE
[6.2] Upstream: Log a deprecated API warning for use of the UIRequiresFullScreen info.plist key when linked on or after v26 releases

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
@@ -1489,11 +1489,11 @@ public final class InfoPlistProcessorTaskAction: TaskAction
                 .watchOS: Version(8)
             ]),
             "UIRequiresFullScreen": .init(moreInfo: .ignored("See the UIRequiresFullScreen documentation for more details."), deprecationVersions: [
-                .macOS: Version(16),
-                .iOS: Version(19),
-                .tvOS: Version(19),
-                .watchOS: Version(12),
-                .visionOS: Version(3),
+                .macOS: Version(26),
+                .iOS: Version(26),
+                .tvOS: Version(26),
+                .watchOS: Version(26),
+                .visionOS: Version(26),
             ])
         ]
 

--- a/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
@@ -1451,13 +1451,20 @@ public final class InfoPlistProcessorTaskAction: TaskAction
                 case iOS
                 case tvOS
                 case watchOS
+                case visionOS = "xrOS" // must be "xrOS" as it's compared against Platform.familyName
             }
 
             /// The values of the key that are deprecated, if only specific values are deprecated. `nil` indicates the key as a whole is deprecated.
             let values: [PropertyListItem]?
 
-            /// An infix to display in the "use (alternative) instead" portion of the deprecation message.
-            let alternate: String
+            enum MoreInfo {
+                /// An infix to display in the "use (alternative) instead" portion of the deprecation message.
+                case alternate(String)
+
+                case ignored(String)
+            }
+
+            let moreInfo: MoreInfo
 
             /// Mapping of platforms and the version of that platform beginning in which the deprecation warning should be shown.
             ///
@@ -1465,21 +1472,28 @@ public final class InfoPlistProcessorTaskAction: TaskAction
             /// If there is no version value present for a platform at all, no warning will ever be shown for that platform.
             let deprecationVersions: [DeprecationPlatform: Version]
 
-            init(values: [PropertyListItem]? = nil, alternate: String, deprecationVersions: [DeprecationPlatform: Version]) {
+            init(values: [PropertyListItem]? = nil, moreInfo: MoreInfo, deprecationVersions: [DeprecationPlatform: Version]) {
                 self.values = values
-                self.alternate = alternate
+                self.moreInfo = moreInfo
                 self.deprecationVersions = deprecationVersions
             }
         }
 
         let plistKeyDeprecationInfo: [PropertyListKeyPath: DeprecationInfo] = [
-            "UILaunchImages": .init(alternate: "launch storyboards", deprecationVersions: [.iOS: Version(), .tvOS: Version(13)]),
-            "CLKComplicationSupportedFamilies": .init(alternate: "the ClockKit complications API", deprecationVersions: [.watchOS: Version(7)]),
-            PropertyListKeyPath(.dict(.equal("NSAppTransportSecurity")), .dict(.equal("NSExceptionDomains")), .dict(.any), .any(.equal("NSExceptionMinimumTLSVersion"))): .init(values: [.plString("TLSv1.0"), .plString("TLSv1.1")], alternate: "TLSv1.2 or TLSv1.3", deprecationVersions: [
+            "UILaunchImages": .init(moreInfo: .alternate("launch storyboards"), deprecationVersions: [.iOS: Version(), .tvOS: Version(13)]),
+            "CLKComplicationSupportedFamilies": .init(moreInfo: .alternate("the ClockKit complications API"), deprecationVersions: [.watchOS: Version(7)]),
+            PropertyListKeyPath(.dict(.equal("NSAppTransportSecurity")), .dict(.equal("NSExceptionDomains")), .dict(.any), .any(.equal("NSExceptionMinimumTLSVersion"))): .init(values: [.plString("TLSv1.0"), .plString("TLSv1.1")], moreInfo: .alternate("TLSv1.2 or TLSv1.3"), deprecationVersions: [
                 .macOS: Version(12),
                 .iOS: Version(15),
                 .tvOS: Version(15),
                 .watchOS: Version(8)
+            ]),
+            "UIRequiresFullScreen": .init(moreInfo: .ignored("See the UIRequiresFullScreen documentation for more details."), deprecationVersions: [
+                .macOS: Version(16),
+                .iOS: Version(19),
+                .tvOS: Version(19),
+                .watchOS: Version(12),
+                .visionOS: Version(3),
             ])
         ]
 
@@ -1497,11 +1511,19 @@ public final class InfoPlistProcessorTaskAction: TaskAction
                         prefixPart = "'\(item.actualKeyPath.joined(separator: "' => '"))'"
                     }
 
+                    let suffixPart: String
+                    switch info.moreInfo {
+                    case let .alternate(alternate):
+                        suffixPart = ", use \(alternate) instead."
+                    case let .ignored(ignored):
+                        suffixPart = " and will be ignored in a future release. \(ignored)"
+                    }
+
                     let message: String
                     if deprecationVersion > Version() {
-                        message = "\(prefixPart) has been deprecated starting in \(context.platform?.familyDisplayName ?? "") \(deprecationVersion.canonicalDeploymentTargetForm.description), use \(info.alternate) instead."
+                        message = "\(prefixPart) has been deprecated starting in \(context.platform?.familyDisplayName ?? "") \(deprecationVersion.canonicalDeploymentTargetForm.description)\(suffixPart)"
                     } else {
-                        message = "\(prefixPart) has been deprecated, use \(info.alternate) instead."
+                        message = "\(prefixPart) has been deprecated\(suffixPart)"
                     }
 
                     if let deploymentTarget = deploymentTarget, deploymentTarget >= deprecationVersion {

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -227,8 +227,6 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
                                 "-F",
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-vfsoverlay",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-main.selection.preview-thunk.swift.json",
                                 "-no-color-diagnostics",
                                 "-g",
                                 "-debug-info-format=dwarf",
@@ -278,7 +276,9 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "-target-sdk-name",
                                 "iphonesimulator\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)",
                                 "-o",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.o"
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.o",
+                                "-vfsoverlay",
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-main.selection.preview-thunk.swift.json",
                             ]
                         )
                         #expect(previewInfo.thunkInfo?.thunkSourceFile == Path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.swift"))
@@ -531,8 +531,6 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
                                 "-F",
                                 "\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-vfsoverlay",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-File1.selection.preview-thunk.swift.json",
                                 "-no-color-diagnostics",
                                 "-g",
                                 "-debug-info-format=dwarf",
@@ -582,7 +580,9 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "-target-sdk-name",
                                 "iphonesimulator\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)",
                                 "-o",
-                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.o"
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.o",
+                                "-vfsoverlay",
+                                "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/vfsoverlay-File1.selection.preview-thunk.swift.json",
                             ]
                         )
                         #expect(previewInfo.thunkInfo?.thunkSourceFile == Path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.swift"))

--- a/Tests/SWBBuildSystemTests/WatchKitTests.swift
+++ b/Tests/SWBBuildSystemTests/WatchKitTests.swift
@@ -125,13 +125,18 @@ fileprivate struct WatchKitTests: CoreBasedTests {
         // Check expected deployment target
         for slice in try macho.slices() {
             let buildVersions = try Set(slice.buildVersions().map { $0.minOSVersion })
+            guard let buildVersion = buildVersions.only else {
+                let buildVersionsString = buildVersions.compactMap({ $0.description }).sorted().joined(separator: " ")
+                Issue.record("Expected one build version for architecture \(slice.arch) but found '\(buildVersionsString)'")
+                continue
+            }
             switch slice.arch {
             case "armv7k", "arm64_32", "x86_64":
-                #expect(buildVersions == [Version(2)])
+                #expect(buildVersion == Version(2))
             case "arm64" where sdkPath.str.contains("WatchSimulator"):
-                #expect(buildVersions == [Version(7)])
+                #expect(buildVersion == Version(7))
             case "arm64", "arm64e":
-                #expect(buildVersions == [Version(9)])
+                #expect(buildVersion >= Version(9))
             case "i386":
                 break
             default:

--- a/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
+++ b/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
@@ -160,14 +160,13 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                         .anySequence,
                         "-sdk", "\(sdkroot)",
                         .anySequence,
-                        "-vfsoverlay", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/vfsoverlay-TestFile4.canary.preview-thunk.swift.json",
-                        .anySequence,
                         "-Onone",
                         .anySequence,
                         "-module-name", "App",
                         "-target-sdk-version", "\(deploymentTarget)",
                         "-target-sdk-name", "iphoneos\(deploymentTarget)",
                         "-o", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/TestFile4.canary.preview-thunk.o",
+                        "-vfsoverlay", "\(tmpDir.str)/Test/build/Test.build/Debug-iphoneos/App.build/Objects-normal/\(activeRunDestination.targetArchitecture)/vfsoverlay-TestFile4.canary.preview-thunk.swift.json",
                         .end
                     ])
                     // Also spot-check that some options which were removed in SwiftCompilerSpec.generatePreviewInfo() for XOJIT are not present.


### PR DESCRIPTION
rdar://142654612