### PR TITLE
Cleanup compilation caching feature availability flags

### DIFF
--- a/Sources/SWBCore/Extensions/FeatureAvailabilityExtension.swift
+++ b/Sources/SWBCore/Extensions/FeatureAvailabilityExtension.swift
@@ -21,5 +21,4 @@ public struct FeatureAvailabilityExtensionPoint: ExtensionPoint {
 }
 
 public protocol FeatureAvailabilityExtension: Sendable {
-    var supportsCompilationCaching: Bool { get }
 }

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -764,15 +764,6 @@ public final class Settings: PlatformBuildContext, Sendable {
             (scope.evaluate(BuiltinMacros.IS_ZIPPERED) && scope.evaluate(BuiltinMacros.INDEX_ENABLE_BUILD_ARENA))
     }
 
-    public static func supportsCompilationCaching(_ core: Core) -> Bool {
-        @preconcurrency @PluginExtensionSystemActor func featureAvailabilityExtensions() -> [any FeatureAvailabilityExtensionPoint.ExtensionProtocol] {
-            core.pluginManager.extensions(of: FeatureAvailabilityExtensionPoint.self)
-        }
-        return featureAvailabilityExtensions().contains {
-            $0.supportsCompilationCaching
-        }
-    }
-
     public var enableTargetPlatformSpecialization: Bool {
         return Settings.targetPlatformSpecializationEnabled(scope: globalScope)
     }

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -824,8 +824,6 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         language: GCCCompatibleLanguageDialect,
         clangInfo: DiscoveredClangToolSpecInfo?
     ) -> Bool {
-        guard cbc.producer.supportsCompilationCaching else { return false }
-
         // Disabling compilation caching for index build, for now.
         guard !cbc.scope.evaluate(BuiltinMacros.INDEX_ENABLE_BUILD_ARENA) else {
             return false

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1414,8 +1414,6 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
     }
 
     private func swiftCachingEnabled(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, _ moduleName: String, _ useIntegratedDriver: Bool, _ explicitModuleBuildEnabled: Bool, _ disabledPCHCompile: Bool) async -> Bool {
-        guard cbc.producer.supportsCompilationCaching else { return false }
-
         guard cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE) else {
             return false
         }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -264,8 +264,6 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
 
     var targetShouldBuildModuleForInstallAPI: Bool { get }
 
-    var supportsCompilationCaching: Bool { get }
-
     func lookupLibclang(path: Path) -> (libclang: Libclang?, version: Version?)
 
     var userPreferences: UserPreferences { get }

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1390,10 +1390,6 @@ extension TaskProducerContext: CommandProducer {
         return globalProductPlan.targetsWhichShouldBuildModulesDuringInstallAPI?.contains(configuredTarget) ?? false
     }
 
-    public var supportsCompilationCaching: Bool {
-        return Settings.supportsCompilationCaching(workspaceContext.core)
-    }
-
     public var systemInfo: SystemInfo? {
         return workspaceContext.systemInfo
     }

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -183,7 +183,7 @@ package final class BuildDescriptionManager: Sendable {
 
         var casValidationInfos: OrderedSet<BuildDescription.CASValidationInfo> = []
         let buildGraph = planRequest.buildGraph
-        let shouldValidateCAS = Settings.supportsCompilationCaching(plan.workspaceContext.core) && UserDefaults.enableCASValidation
+        let shouldValidateCAS = UserDefaults.enableCASValidation
 
         // Add the SFR identifier for target-independent tasks.
         staleFileRemovalIdentifierPerTarget[nil] = plan.staleFileRemovalTaskIdentifier(for: nil)

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -243,14 +243,6 @@ extension CoreBasedTests {
         }
     }
 
-    /// If compilation caching is supported.
-    package var supportsCompilationCaching: Bool {
-        get async throws {
-            let core = try await getCore()
-            return Settings.supportsCompilationCaching(core)
-        }
-    }
-
     package var supportsSDKImports: Bool {
         get async throws {
             #if os(macOS)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -229,10 +229,6 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         false
     }
 
-    package var supportsCompilationCaching: Bool {
-        false
-    }
-
     package var systemInfo: SystemInfo? {
         return nil
     }

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -367,12 +367,6 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    package static var requireCompilationCaching: Self {
-        enabled("compilation caching is not supported") {
-            try await ConditionTraitContext.shared.supportsCompilationCaching
-        }
-    }
-
     package static var requireDependencyScannerPlusCaching: Self {
         disabled {
             let libclang = try #require(try await ConditionTraitContext.shared.libclang)
@@ -397,7 +391,7 @@ extension Trait where Self == Testing.ConditionTrait {
 
     package static var requireCASValidation: Self {
         enabled {
-            guard try await ConditionTraitContext.shared.supportsCompilationCaching, UserDefaults.enableCASValidation else {
+            guard UserDefaults.enableCASValidation else {
                 return false
             }
             guard let path = try? await ConditionTraitContext.shared.llvmCasToolPath else {

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -19,7 +19,7 @@ import SWBTestSupport
 import SWBUtil
 
 @Suite(.skipHostOS(.windows, "Windows platform has no CAS support yet"),
-       .requireCompilationCaching, .requireDependencyScannerPlusCaching,
+       .requireDependencyScannerPlusCaching,
        .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
 fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
     let canUseCASPlugin: Bool

--- a/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
@@ -191,7 +191,7 @@ fileprivate struct ClangModuleVerifierTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching, .requireCompilationCaching,
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching,
           .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
     func cachedBuild() async throws {
         try await withTemporaryDirectory { (tmpDirPath: Path) in

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -19,7 +19,7 @@ import SWBUtil
 import SWBTaskExecution
 import SWBProtocol
 
-@Suite(.requireSwiftFeatures(.compilationCaching), .requireCompilationCaching,
+@Suite(.requireSwiftFeatures(.compilationCaching),
        .flaky("A handful of Swift Build CAS tests fail when running the entire test suite"), .bug("rdar://146781403"))
 fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -5146,7 +5146,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.compilationCaching), .skipSwiftPackage)
     func ensureIdenticalCommandLinesWithDifferentDependenciesAreNotDeduplicated() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testWorkspace = try await TestWorkspace(

--- a/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
@@ -17,7 +17,7 @@ import SWBCore
 
 @Suite
 fileprivate struct CompilationCachingTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS, comment: "Caching requires explicit modules, which requires libclang and is only available on macOS"), .requireCompilationCaching)
+    @Test(.requireSDKs(.macOS, comment: "Caching requires explicit modules, which requires libclang and is only available on macOS"))
     func settingRemoteCacheSupportedLanguages() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
The `supportsCompilationCaching` should no longer be needed - clean up the associated checks.