### PR TITLE
Use -Isystem and -Fsystem for swift-api-digester

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
@@ -82,9 +82,6 @@ public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIde
         for searchPath in SwiftCompilerSpec.collectInputSearchPaths(cbc, toolInfo: toolSpecInfo) {
             commandLine += ["-I", searchPath]
         }
-        // swift-api-digester doesn't support -Isystem or -Fsystem.
-        commandLine += cbc.scope.evaluate(BuiltinMacros.SWIFT_SYSTEM_INCLUDE_PATHS).flatMap { ["-I", $0] }
-        commandLine += cbc.scope.evaluate(BuiltinMacros.SYSTEM_FRAMEWORK_SEARCH_PATHS).flatMap { ["-F", $0] }
         delegate.createTask(type: self,
                             payload: ABICheckerPayload(serializedDiagnosticsPath: serializedDiagsPath),
                             ruleInfo: defaultRuleInfo(cbc, delegate),

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
@@ -40,13 +40,10 @@ public final class SwiftABIGenerationToolSpec : GenericCommandLineToolSpec, Spec
 
         var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)).map(\.asString)
         commandLine += ["-o", baselineFile.normalize().str]
-        // swift-api-digester doesn't support -Fsystem or -Isystem.
-        commandLine += cbc.scope.evaluate(BuiltinMacros.SYSTEM_FRAMEWORK_SEARCH_PATHS).flatMap { ["-F", $0] }
         // Add import search paths
         for searchPath in SwiftCompilerSpec.collectInputSearchPaths(cbc, toolInfo: toolSpecInfo) {
             commandLine += ["-I", searchPath]
         }
-        commandLine += cbc.scope.evaluate(BuiltinMacros.SWIFT_SYSTEM_INCLUDE_PATHS).flatMap { ["-I", $0] }
         delegate.createTask(type: self,
                             ruleInfo: defaultRuleInfo(cbc, delegate),
                             commandLine: commandLine,

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1428,6 +1428,20 @@
               CommandLineFlag = "-F";
           },
           {
+              Name = SYSTEM_FRAMEWORK_SEARCH_PATHS;
+              Type = PathList;
+              DefaultValue = "$(SYSTEM_FRAMEWORK_SEARCH_PATHS)";
+              FlattenRecursiveSearchPathsInValue = YES;
+              CommandLineFlag = "-Fsystem";
+          },
+          {
+              Name = SWIFT_SYSTEM_INCLUDE_PATHS;
+              Type = PathList;
+              DefaultValue = "$(SWIFT_SYSTEM_INCLUDE_PATHS)";
+              FlattenRecursiveSearchPathsInValue = YES;
+              CommandLineFlag = "-Isystem";
+          },
+          {
               Name = SDKROOT;
               Type = Path;
               CommandLineFlag = "-sdk";
@@ -1476,6 +1490,20 @@
               DefaultValue = "$(FRAMEWORK_SEARCH_PATHS)";
               FlattenRecursiveSearchPathsInValue = YES;
               CommandLineFlag = "-F";
+          },
+          {
+              Name = SYSTEM_FRAMEWORK_SEARCH_PATHS;
+              Type = PathList;
+              DefaultValue = "$(SYSTEM_FRAMEWORK_SEARCH_PATHS)";
+              FlattenRecursiveSearchPathsInValue = YES;
+              CommandLineFlag = "-Fsystem";
+          },
+          {
+              Name = SWIFT_SYSTEM_INCLUDE_PATHS;
+              Type = PathList;
+              DefaultValue = "$(SWIFT_SYSTEM_INCLUDE_PATHS)";
+              FlattenRecursiveSearchPathsInValue = YES;
+              CommandLineFlag = "-Isystem";
           },
           {
               Name = SDKROOT;

--- a/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
@@ -69,10 +69,10 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                         "-diagnose-sdk",
                         "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
                         "-F", "/TEST/build/Debug-iphoneos",
+                        "-Fsystem", "/Target/System/Framework/Search/Path/A",
+                        "-Isystem", "/Target/System/Import/Search/Path/A",
                         "-module", "Fwk",
                         "-I", "/Target/Import/Search/Path/A",
-                        "-I", "/Target/System/Import/Search/Path/A",
-                        "-F", "/Target/System/Framework/Search/Path/A"
                     ])
                 }
             }
@@ -125,8 +125,8 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                         "swift-api-digester",
                         "-dump-sdk", "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
                         "-F", "/TEST/build/Debug-iphoneos",
+                        "-Fsystem", "/Target/System/Framework/Search/Path/A",
                         "-module", "Fwk", "-o",
-                        "/Target/System/Framework/Search/Path/A",
                     ])
                     // Ensure SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR is used.
                     task.checkOutputs([


### PR DESCRIPTION
swift-api-digester now supports -Isystem and -Fsystem in the driver and tool. Use those arguments instead of -I and -F so that system paths are used for both baselines and checks.

rdar://152747822