### PR TITLE
[6.2] Skip Windows tests triggering hangs in CI

### DIFF
--- a/Tests/SWBBuildServiceTests/BuildServiceTests.swift
+++ b/Tests/SWBBuildServiceTests/BuildServiceTests.swift
@@ -16,7 +16,8 @@ import SwiftBuild
 import SWBBuildService
 import SWBTestSupport
 
-@Suite fileprivate struct BuildServiceTests: CoreBasedTests {
+@Suite(.skipHostOS(.windows))
+fileprivate struct BuildServiceTests: CoreBasedTests {
     @Test func createXCFramework() async throws {
         do {
             let (result, message) = try await withBuildService { await $0.createXCFramework([], currentWorkingDirectory: Path.root.str, developerPath: nil) }

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -22,7 +22,7 @@ import SWBUtil
 import SWBTestSupport
 import SWBProtocol
 
-@Suite
+@Suite(.skipHostOS(.windows))
 fileprivate struct BuildOperationTests: CoreBasedTests {
     /// Check the basic behavior of an empty build.
     @Test

--- a/Tests/SwiftBuildTests/ConsoleCommands/CreateXCFrameworkCommandTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/CreateXCFrameworkCommandTests.swift
@@ -17,7 +17,7 @@ import SWBTestSupport
 
 // Note: The functionality of this class is heavily unit tested in `XCFrameworkTests.swift`. These tests are only to ensure that the command is indeed hooked up and registered properly.
 
-@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"))
+@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"), .skipHostOS(.windows))
 fileprivate struct CreateXCFrameworkCommandTests {
     @Test
     func commandInvocation() async throws {

--- a/Tests/SwiftBuildTests/ConsoleCommands/GeneralCommandsTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/GeneralCommandsTests.swift
@@ -15,7 +15,7 @@ import SwiftBuild
 import SWBTestSupport
 import SWBUtil
 
-@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"))
+@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"), .skipHostOS(.windows))
 fileprivate struct GeneralCommandsTests {
     @Test(.skipHostOS(.windows), // PTY not supported on Windows
         .requireHostOS(.macOS)) // something with terminal echo is different on macOS vs Linux

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -19,7 +19,7 @@ import SWBUtil
 import WinSDK
 #endif
 
-@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"))
+@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"), .skipHostOS(.windows))
 fileprivate struct ServiceConsoleTests {
     @Test
     func emptyInput() async throws {

--- a/Tests/SwiftBuildTests/ConsoleCommands/SessionCommandsTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/SessionCommandsTests.swift
@@ -14,7 +14,7 @@ import SWBTestSupport
 import Testing
 import SWBUtil
 
-@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"))
+@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"), .skipHostOS(.windows))
 fileprivate struct SessionCommandsTests {
     @Test(.skipHostOS(.windows), // PTY not supported on Windows
         .requireHostOS(.macOS)) // something with terminal echo is different on macOS vs Linux

--- a/Tests/SwiftBuildTests/ConsoleCommands/XcodeCommandsTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/XcodeCommandsTests.swift
@@ -14,7 +14,7 @@ import SWBTestSupport
 import Testing
 import SWBUtil
 
-@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"))
+@Suite(.skipInGitHubActions("failing in the GitHub actions runner environment"), .skipHostOS(.windows))
 fileprivate struct XcodeCommandsTests {
     @Test(.skipHostOS(.windows), // PTY not supported on Windows
         .requireHostOS(.macOS)) // something with terminal echo is different on macOS vs Linux

--- a/Tests/SwiftBuildTests/MacroEvaluationTests.swift
+++ b/Tests/SwiftBuildTests/MacroEvaluationTests.swift
@@ -18,7 +18,7 @@ import SWBTestSupport
 @_spi(Testing) import SWBUtil
 
 /// Test evaluating both using a scope, and directly against the model objects.
-@Suite
+@Suite(.skipHostOS(.windows))
 fileprivate struct MacroEvaluationTests {
     @Test
     func macroEvaluationBasics() async throws {
@@ -83,7 +83,7 @@ fileprivate struct MacroEvaluationTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .userDefaults(["EnablePluginManagerLogging": "0"]))
+    @Test(.requireSDKs(.host), .skipHostOS(.windows), .userDefaults(["EnablePluginManagerLogging": "0"]))
     func macroEvaluationAdvanced() async throws {
         try await withTemporaryDirectory { tmpDir in
             try await withAsyncDeferrable { deferrable in

--- a/Tests/SwiftBuildTests/PIFTests.swift
+++ b/Tests/SwiftBuildTests/PIFTests.swift
@@ -226,7 +226,7 @@ fileprivate struct PIFTests {
     typealias LookupObject = (@Sendable (SwiftBuildServicePIFObjectType, String) async throws -> SWBPropertyListItem)
 
     /// Check incremental PIF transfer.
-    @Test(.userDefaults(["EnablePluginManagerLogging": "0"]))
+    @Test(.skipHostOS(.windows), .userDefaults(["EnablePluginManagerLogging": "0"]))
     func sessionPIFLoading() async throws {
         let service = try await SWBBuildService()
 
@@ -327,7 +327,7 @@ fileprivate struct PIFTests {
     }
 
     /// Check PIF incremental cache.
-    @Test(.userDefaults(["EnablePluginManagerLogging": "0"]))
+    @Test(.skipHostOS(.windows), .userDefaults(["EnablePluginManagerLogging": "0"]))
     func sessionPIFCache() async throws {
         try await withTemporaryDirectory { tmpDir in
             try await withAsyncDeferrable { deferrable in


### PR DESCRIPTION
Cherrypick these workarounds since we're observing issues on the release branch as well