### PR TITLE
[6.2] Pass -add_mergeable_debug_hook to the linker when linking a mergeable library in a debug (unoptimized) build.

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -420,6 +420,7 @@ public final class BuiltinMacros {
 
     // MARK: Mergeable libraries macros
 
+    public static let ADD_MERGEABLE_DEBUG_HOOK = BuiltinMacros.declareBooleanMacro("ADD_MERGEABLE_DEBUG_HOOK")
     public static let AUTOMATICALLY_MERGE_DEPENDENCIES = BuiltinMacros.declareBooleanMacro("AUTOMATICALLY_MERGE_DEPENDENCIES")
     public static let MERGEABLE_LIBRARY = BuiltinMacros.declareBooleanMacro("MERGEABLE_LIBRARY")
     public static let DONT_EMBED_REEXPORTED_MERGEABLE_LIBRARIES = BuiltinMacros.declareBooleanMacro("DONT_EMBED_REEXPORTED_MERGEABLE_LIBRARIES")
@@ -1369,6 +1370,7 @@ public final class BuiltinMacros {
         ADDITIONAL_SDK_DIRS,
         AD_HOC_CODE_SIGNING_ALLOWED,
         __AD_HOC_CODE_SIGNING_NOT_ALLOWED_SUPPLEMENTAL_MESSAGE,
+        ADD_MERGEABLE_DEBUG_HOOK,
         AGGREGATE_TRACKED_DOMAINS,
         ALLOW_BUILD_REQUEST_OVERRIDES,
         ALLOW_DISJOINTED_DIRECTORIES_AS_DEPENDENCIES,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2164,9 +2164,14 @@ private class SettingsBuilder {
                 table.push(BuiltinMacros.MERGE_LINKED_LIBRARIES, literal: true)
             }
 
-            // If this is a mergeable library, then build it as mergeable if this is a release build.
-            if scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY), !scope.evaluate(BuiltinMacros.IS_UNOPTIMIZED_BUILD) {
-                table.push(BuiltinMacros.MAKE_MERGEABLE, literal: true)
+            // If this is a mergeable library, for a release build we want to build it as mergeable, whereas for a debug build we want to add the mergeable debug hook.
+            if scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) {
+                if scope.evaluate(BuiltinMacros.IS_UNOPTIMIZED_BUILD) {
+                    table.push(BuiltinMacros.ADD_MERGEABLE_DEBUG_HOOK, literal: true)
+                }
+                else {
+                    table.push(BuiltinMacros.MAKE_MERGEABLE, literal: true)
+                }
             }
 
             push(table, .exportedForNative)

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -379,6 +379,13 @@ extension CoreBasedTests {
         try await SWBCore.discoveredSwiftCompilerInfo(MockCommandProducer(core: getCore(), productTypeIdentifier: "com.apple.product-type.framework", platform: nil, useStandardExecutableSearchPaths: true, toolchain: nil, fs: PseudoFS()), AlwaysDeferredCoreClientDelegate(), at: toolPath, blocklistsPathOverride: nil)
     }
 
+    package func discoveredLdLinkerInfo(at toolPath: Path) async throws -> DiscoveredLdLinkerToolSpecInfo {
+        guard let info = try await SWBCore.discoveredLinkerToolsInfo(MockCommandProducer(core: getCore(), productTypeIdentifier: "com.apple.product-type.framework", platform: nil, useStandardExecutableSearchPaths: true, toolchain: nil, fs: PseudoFS()), AlwaysDeferredCoreClientDelegate(), at: toolPath) as? DiscoveredLdLinkerToolSpecInfo else {
+            throw StubError.error("Could not get tool spec info for LdLinkerSpec")
+        }
+        return info
+    }
+
     package func discoveredTAPIToolInfo(at toolPath: Path) async throws -> DiscoveredTAPIToolSpecInfo {
         try await SWBCore.discoveredTAPIToolInfo(MockCommandProducer(core: getCore(), productTypeIdentifier: "com.apple.product-type.framework", platform: nil, useStandardExecutableSearchPaths: true, toolchain: nil, fs: PseudoFS()), AlwaysDeferredCoreClientDelegate(), at: toolPath)
     }

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -665,6 +665,19 @@
                 };
             },
 
+            {   Name = LD_ADD_MERGEABLE_DEBUG_HOOK;
+                Type = Boolean;
+                DefaultValue = "$(ADD_MERGEABLE_DEBUG_HOOK)";
+                CommandLineArgs = {
+                    YES = (
+                        "-Xlinker",
+                        "-add_mergeable_debug_hook",
+                    );
+                    NO = ();
+                };
+                SupportedVersionRanges = ( "1217" );
+            },
+
             {
                 Name = "LD_SHARED_CACHE_ELIGIBLE";
                 Type = Enumeration;


### PR DESCRIPTION
rdar://151724474