### PR TITLE
[#bundle support] Generate internal bundle access class for mergeable libraries

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -993,6 +993,7 @@ public final class BuiltinMacros {
     public static let SWIFT_ABI_CHECKER_EXCEPTIONS_FILE = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_EXCEPTIONS_FILE")
     public static let SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR")
     public static let SWIFT_ACCESS_NOTES_PATH = BuiltinMacros.declareStringMacro("SWIFT_ACCESS_NOTES_PATH")
+    public static let SWIFT_ACTIVE_COMPILATION_CONDITIONS = BuiltinMacros.declareStringListMacro("SWIFT_ACTIVE_COMPILATION_CONDITIONS")
     public static let SWIFT_ALLOW_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_ALLOW_INSTALL_OBJC_HEADER")
     public static let __SWIFT_ALLOW_INSTALL_OBJC_HEADER_MESSAGE = BuiltinMacros.declareStringMacro("__SWIFT_ALLOW_INSTALL_OBJC_HEADER_MESSAGE")
     public static let SWIFT_COMPILATION_MODE = BuiltinMacros.declareStringMacro("SWIFT_COMPILATION_MODE")
@@ -2159,6 +2160,7 @@ public final class BuiltinMacros {
         SWIFT_ABI_CHECKER_EXCEPTIONS_FILE,
         SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR,
         SWIFT_ACCESS_NOTES_PATH,
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS,
         SWIFT_ALLOW_INSTALL_OBJC_HEADER,
         __SWIFT_ALLOW_INSTALL_OBJC_HEADER_MESSAGE,
         SWIFT_COMPILATION_MODE,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1554,7 +1554,7 @@ private class SettingsBuilder {
         }
 
         // Push the target derived overriding settings.
-        addTargetDerivedSettings(self.target, boundProperties.platform, boundProperties.sdk, boundProperties.sdkVariant)
+        addTargetDerivedSettings(self.target, boundProperties.platform, boundProperties.sdk, boundProperties.sdkVariant, specLookupContext)
 
         if boundDeploymentTarget.platformDeploymentTargetMacro == BuiltinMacros.DRIVERKIT_DEPLOYMENT_TARGET, let deploymentTarget = boundDeploymentTarget.platformDeploymentTarget, deploymentTarget < Version(20) {
             var table = MacroValueAssignmentTable(namespace: userNamespace)
@@ -2039,13 +2039,13 @@ private class SettingsBuilder {
     /// Add the derived overriding settings for the target. These are settings whose values depend on the whole stack of build settings, and include settings which are forced to a value under certain conditions, and settings whose value is wholly derived from other settings.  They override settings from all lower levels, and thus cannot be overridden by (for example) xcodebuild or run destination overrides, so settings should only be assigned here when they represent true boundary conditions which users should never want to or be able to override.
     ///
     /// These are only added if we're constructing settings for a target.
-    func addTargetDerivedSettings(_ target: Target?, _ platform: Platform?, _ sdk: SDK?, _ sdkVariant: SDKVariant?) {
+    func addTargetDerivedSettings(_ target: Target?, _ platform: Platform?, _ sdk: SDK?, _ sdkVariant: SDKVariant?, _ specLookupContext: any SpecLookupContext) {
         guard target != nil else {
             return
         }
 
         push(getTargetDerivedSettings(platform, sdk, sdkVariant), .exportedForNative)
-        addSecondaryTargetDerivedSettings(sdk)
+        addSecondaryTargetDerivedSettings(sdk, specLookupContext)
     }
 
     /// Add the core derived overriding settings for the target.
@@ -2138,7 +2138,7 @@ private class SettingsBuilder {
     /// Add derived settings for the target which are themselves derived from the core target derived settings computed above. (Whee!)
     ///
     /// This is called from `addTargetDerivedSettings().
-    func addSecondaryTargetDerivedSettings(_ sdk: SDK?) {
+    func addSecondaryTargetDerivedSettings(_ sdk: SDK?, _ specLookupContext: any SpecLookupContext) {
         // Mergeable library/merged binary support.
         do {
             let scope = createScope(sdkToUse: sdk)
@@ -2173,13 +2173,22 @@ private class SettingsBuilder {
         }
         do {
             let scope = createScope(sdkToUse: sdk)
+            var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
 
             // If the product is being built as mergeable, then that overrides certain other settings.
             if scope.evaluate(BuiltinMacros.MAKE_MERGEABLE) {
-                var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
                 table.push(BuiltinMacros.STRIP_INSTALLED_PRODUCT, literal: false)
-                push(table, .exportedForNative)
             }
+
+            // Even if not being merged in this build, a mergeable library still uses a generated bundle lookup helper to power #bundle support.
+            if scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) {
+                let pathResolver = FilePathResolver(scope: scope)
+                if (target as? StandardTarget)?.sourcesBuildPhase?.containsSwiftSources(workspaceContext.workspace, specLookupContext, scope, pathResolver) ?? false {
+                    table.push(BuiltinMacros.SWIFT_ACTIVE_COMPILATION_CONDITIONS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE"]))
+                }
+            }
+
+            push(table, .exportedForNative)
         }
     }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -737,6 +737,9 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
         let packageTargetBundleAccessorResult = await generatePackageTargetBundleAccessorResult(scope)
         tasks += packageTargetBundleAccessorResult?.tasks ?? []
 
+        let bundleLookupHelperResult = await generateBundleLookupHelper(scope)
+        tasks += bundleLookupHelperResult?.tasks ?? []
+
         let embedInCodeAccessorResult: GeneratedResourceAccessorResult?
         if scope.evaluate(BuiltinMacros.GENERATE_EMBED_IN_CODE_ACCESSORS), let configuredTarget = context.configuredTarget, buildPhase.containsSwiftSources(context.workspaceContext.workspace, context, scope, context.filePathResolver) {
             let ownTargetBuildFilesToEmbed = ((context.workspaceContext.workspace.target(for: configuredTarget.target.guid) as? StandardTarget)?.buildPhases.compactMap { $0 as? BuildPhaseWithBuildFiles }.flatMap { $0.buildFiles }.filter { $0.resourceRule == .embedInCode }) ?? []
@@ -832,6 +835,10 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
 
                     if let packageTargetBundleAccessorResult {
                         result.append((packageTargetBundleAccessorResult.fileToBuild, packageTargetBundleAccessorResult.fileToBuildFileType, /* shouldUsePrefixHeader */ false))
+                    }
+
+                    if let bundleLookupHelperResult {
+                        result.append((bundleLookupHelperResult.fileToBuild, bundleLookupHelperResult.fileToBuildFileType, /* shouldUsePrefixHeader */ false))
                     }
 
                     if let embedInCodeAccessorResult {
@@ -1158,11 +1165,17 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
                 let buildFilesContext = BuildFilesProcessingContext(scope, belongsToPreferredArch: preferredArch == nil || preferredArch == arch, currentArchSpec: currentArchSpec)
                 var perArchTasks: [any PlannedTask] = []
                 await groupAndAddTasksForFiles(self, buildFilesContext, scope, filterToAPIRules: isForAPI, filterToHeaderRules: isForHeaders, &perArchTasks, extraResolvedBuildFiles: {
+                    var result: [(Path, FileTypeSpec, Bool)] = []
+
                     if let packageTargetBundleAccessorResult {
-                        return [(packageTargetBundleAccessorResult.fileToBuild, packageTargetBundleAccessorResult.fileToBuildFileType, /* shouldUsePrefixHeader */ false)]
-                    } else {
-                        return []
+                        result.append((packageTargetBundleAccessorResult.fileToBuild, packageTargetBundleAccessorResult.fileToBuildFileType, /* shouldUsePrefixHeader */ false))
                     }
+
+                    if let bundleLookupHelperResult {
+                        result.append((bundleLookupHelperResult.fileToBuild, bundleLookupHelperResult.fileToBuildFileType, /* shouldUsePrefixHeader */ false))
+                    }
+
+                    return result
                 }())
 
                 // Add all the collected per-arch tasks.
@@ -1691,7 +1704,43 @@ final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBase
         return GeneratedResourceAccessorResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
     }
 
+    /// Generates a task for creating the `__BundleLookupHelper` class to enable `#bundle` support in mergeable libraries.
+    private func generateBundleLookupHelper(_ scope: MacroEvaluationScope) async -> GeneratedResourceAccessorResult? {
+        // We generate a __BundleLookupHelper class that Foundation's #bundle macro can use to lookup the resource bundle.
+        // dyld knows how to map the class addresses to the correct bundle even though the code may be merged or re-exported.
+
+        // We only need this treatment for mergeable libraries at this time.
+        // Package targets do something similar but they generate the Bundle.module extensions and #bundle calls that.
+
+        // We need to do this for all mergeable libraries, even if it will just be re-exported in this build.
+        guard scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) else {
+            return nil
+        }
+
+        let workspace = self.context.workspaceContext.workspace
+
+        // #bundle is a Swift macro, so this is only needed for Swift code.
+        guard buildPhase.containsSwiftSources(workspace, context, scope, context.filePathResolver) else {
+            return nil
+        }
+
+        let filePath = scope.evaluate(BuiltinMacros.DERIVED_SOURCES_DIR).join("bundle_lookup_helper.swift")
+
+        // We need one class with a relatively unique name that #bundle can use for bundle lookup.
+        // It cannot be less visible than internal since the #bundle expansion needs to be able to resolve it AND so dyld can record the class->bundle mapping.
+        // We intentionally do not want a Foundation dependency in this generated code, so don't import Foundation.
+        let content = "internal class __BundleLookupHelper {}"
+
+        var tasks = [any PlannedTask]()
+        await appendGeneratedTasks(&tasks) { delegate in
+            context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: content), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
+        }
+        return GeneratedResourceAccessorResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
+    }
+
     /// Generates a task for creating the resource bundle accessor for package targets.
+    ///
+    /// This produces the `Bundle.module` accessor.
     private func generatePackageTargetBundleAccessorResult(_ scope: MacroEvaluationScope) async -> GeneratedResourceAccessorResult? {
         let bundleName = scope.evaluate(BuiltinMacros.PACKAGE_RESOURCE_BUNDLE_NAME)
         let isRegularPackage = scope.evaluate(BuiltinMacros.PACKAGE_RESOURCE_TARGET_KIND) == .regular


### PR DESCRIPTION
Mergeable libraries use a re-exported library in Debug mode and merge into the client in Release builds.
In both cases, we cannot simply rely on the `#dsohandle` for bundle lookup as `#bundle` does by default.

Instead, `dyld` includes special bundle loading hooks that allows `BundleForClass` to return the current resource bundle at runtime.

In this PR, we have mergeable libraries codegen a simple `__BundleLookupHelper` class and define the `SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE` compilation condition.
The implementation of `#bundle` in Foundation will then lookup `Bundle(for: __BundleLookupHelper.self)` under this condition.

This should allow `#bundle` to work correctly for mergeable libraries.