### PR TITLE
Support invoking the API digester in API mode in addition to ABI mode

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -974,6 +974,7 @@ public final class BuiltinMacros {
     public static let REZ_PREFIX_FILE = BuiltinMacros.declarePathMacro("REZ_PREFIX_FILE")
     public static let REZ_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("REZ_SEARCH_PATHS")
     public static let RUN_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("RUN_CLANG_STATIC_ANALYZER")
+    public static let SWIFT_API_DIGESTER_MODE = BuiltinMacros.declareEnumMacro("SWIFT_API_DIGESTER_MODE") as EnumMacroDeclaration<SwiftAPIDigesterMode>
     public static let RUN_SWIFT_ABI_CHECKER_TOOL = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL")
     public static let RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER")
     public static let RUN_SWIFT_ABI_GENERATION_TOOL = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_GENERATION_TOOL")
@@ -2107,6 +2108,7 @@ public final class BuiltinMacros {
         SKIP_BUILDING_DOCUMENTATION,
         RUN_SYMBOL_GRAPH_EXTRACT,
         SYSTEM_EXTENSIONS_FOLDER_PATH,
+        SWIFT_API_DIGESTER_MODE,
         RUN_SWIFT_ABI_CHECKER_TOOL,
         RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER,
         RUN_SWIFT_ABI_GENERATION_TOOL,
@@ -2638,6 +2640,13 @@ public enum SwiftEnableExplicitModulesSetting: String, Equatable, Hashable, Enum
     case notset = "NOT_SET"
     case enabled = "YES"
     case disabled = "NO"
+}
+
+public enum SwiftAPIDigesterMode: String, Equatable, Hashable, EnumerationMacroType {
+    public static let defaultValue: SwiftAPIDigesterMode = .abi
+
+    case abi = "abi"
+    case api = "api"
 }
 
 public enum SwiftDependencyRegistrationMode: String, Equatable, Hashable, EnumerationMacroType {

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -772,6 +772,10 @@ public class StandaloneExecutableProductTypeSpec : ProductTypeSpec, SpecClassTyp
     public class var className: String {
         return "XCStandaloneExecutableProductType"
     }
+
+    public override var supportsSwiftABIChecker: Bool {
+        true
+    }
 }
 
 public class LibraryProductTypeSpec: StandaloneExecutableProductTypeSpec, @unchecked Sendable {

--- a/Sources/SWBCore/SpecImplementations/PropertyDomainSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/PropertyDomainSpec.swift
@@ -113,6 +113,8 @@ private final class EnumBuildOptionType : BuildOptionType {
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
         case "LINKER_DRIVER":
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<LinkerDriverChoice>
+        case "SWIFT_API_DIGESTER_MODE":
+            return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<SwiftAPIDigesterMode>
         default:
             return try namespace.declareStringMacro(name)
         }

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1411,7 +1411,7 @@
     RuleName = "CheckSwiftABI $(CURRENT_VARIANT) $(CURRENT_ARCH)";
     ExecDescription = "Check ABI stability for $(PRODUCT_MODULE_NAME).swiftinterface";
     ProgressDescription = "Checking ABI stability for $(PRODUCT_MODULE_NAME).swiftinterface";
-    CommandLine = "swift-api-digester -diagnose-sdk -abort-on-module-fail -abi -compiler-style-diags [options]";
+    CommandLine = "swift-api-digester -diagnose-sdk -abort-on-module-fail -compiler-style-diags [options]";
     CommandOutputParser = "XCGccCommandOutputParser";
     Options = (
           {
@@ -1440,9 +1440,25 @@
               CommandLineArgs = (
                 "-module",
                 "$(value)",
-                "-use-interface-for-module",
-                "$(value)",
               );
+          },
+          {
+              Name = "SWIFT_API_DIGESTER_MODE";
+              Type = Enumeration;
+              Values = (
+                  abi,
+                  api,
+              );
+              DefaultValue = abi;
+              CommandLineArgs = {
+                  abi = (
+                      "-abi",
+                      "-use-interface-for-module",
+                      "$(SWIFT_MODULE_NAME)",
+                  );
+                  api = (
+                  );
+              };
           },
           {
               Name = "OTHER_SWIFT_ABI_CHECKER_FLAGS";
@@ -1461,7 +1477,7 @@
     RuleName = "GenerateSwiftABIBaseline $(CURRENT_VARIANT) $(CURRENT_ARCH)";
     ExecDescription = "Generate ABI baseline for $(PRODUCT_MODULE_NAME).swiftinterface";
     ProgressDescription = "Generating ABI baseline for $(PRODUCT_MODULE_NAME).swiftinterface";
-    CommandLine = "swift-api-digester -dump-sdk -abort-on-module-fail -abi -swift-only -avoid-tool-args [options]";
+    CommandLine = "swift-api-digester -dump-sdk -abort-on-module-fail -swift-only -avoid-tool-args [options]";
     CommandOutputParser = "XCGccCommandOutputParser";
     Options = (
           {
@@ -1490,9 +1506,25 @@
               CommandLineArgs = (
                 "-module",
                 "$(value)",
-                "-use-interface-for-module",
-                "$(value)",
               );
+          },
+          {
+              Name = "SWIFT_API_DIGESTER_MODE";
+              Type = Enumeration;
+              Values = (
+                  abi,
+                  api,
+              );
+              DefaultValue = abi;
+              CommandLineArgs = {
+                  abi = (
+                      "-abi",
+                      "-use-interface-for-module",
+                      "$(SWIFT_MODULE_NAME)",
+                  );
+                  api = (
+                  );
+              };
           },
           {
               Name = "OTHER_SWIFT_ABI_CHECKER_FLAGS";

--- a/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftABICheckerTaskConstructionTests.swift
@@ -139,6 +139,59 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.iOS))
+    func swiftABIBaselineGenerationModes() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            sourceRoot: Path("/TEST"),
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("Fwk.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "ARCHS": "arm64",
+                    "SDKROOT": "iphoneos",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "RUN_SWIFT_ABI_GENERATION_TOOL": "YES",
+                    "SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR": "/tmp/user_given_generated_baseline",
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "SWIFT_VERSION": swiftVersion,
+                    "CODE_SIGNING_ALLOWED": "NO",
+                    "TAPI_EXEC": tapiToolPath.str,
+                ])],
+            targets: [
+                TestStandardTarget(
+                    "Fwk",
+                    type: .framework,
+                    buildPhases: [
+                        TestSourcesBuildPhase(["Fwk.swift"])
+                    ]),
+            ])
+        let core = try await getCore()
+        let tester = try TaskConstructionTester(core, testProject)
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_API_DIGESTER_MODE": "abi"]), runDestination: .anyiOSDevice) { results in
+            results.checkError(.contains("Swift ABI checker is only functional when BUILD_LIBRARY_FOR_DISTRIBUTION = YES"))
+        }
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_API_DIGESTER_MODE": "abi", "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"]), runDestination: .anyiOSDevice) { results in
+            results.checkNoDiagnostics()
+            results.checkTask(.matchRuleType("GenerateSwiftABIBaseline")) { task in
+                task.checkCommandLineContains(["-abi"])
+                task.checkCommandLineContains(["-use-interface-for-module"])
+            }
+        }
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_API_DIGESTER_MODE": "api"]), runDestination: .anyiOSDevice) { results in
+            results.checkNoDiagnostics()
+            results.checkTask(.matchRuleType("GenerateSwiftABIBaseline")) { task in
+                task.checkCommandLineDoesNotContain("-abi")
+                task.checkCommandLineDoesNotContain("-use-interface-for-module")
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.iOS))
     func swiftABICheckerUsingSpecifiedBaseline() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -189,7 +242,6 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                     "swift-api-digester",
                     "-diagnose-sdk",
                     "-abort-on-module-fail",
-                    "-abi",
                     "-compiler-style-diags",
                     "-target",
                     "arm64e-apple-ios\(core.loadSDK(.iOS).version)",
@@ -201,6 +253,7 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                     "\(core.loadSDK(.iOS).path.str)",
                     "-module",
                     "Fwk",
+                    "-abi",
                     "-use-interface-for-module",
                     "-serialize-diagnostics-path",
                     "/TEST/build/aProject.build/Debug-iphoneos/Fwk.build/Fwk/SwiftABIChecker/normal/arm64e-ios.dia",
@@ -213,6 +266,64 @@ fileprivate struct SwiftABICheckerTaskConstructionTests: CoreBasedTests {
                 ])
             }
             results.checkNoTask(.matchRuleType("SwiftDriver"))
+        }
+    }
+
+    @Test(.requireSDKs(.iOS))
+    func swiftABICheckerModes() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            sourceRoot: Path("/TEST"),
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("Fwk.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "ARCHS": "arm64e",
+                    "SDKROOT": "iphoneos",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "RUN_SWIFT_ABI_CHECKER_TOOL": "YES",
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "SWIFT_VERSION": swiftVersion,
+                    "FRAMEWORK_SEARCH_PATHS": "/Target/Framework/Search/Path/A",
+                    "CODE_SIGNING_ALLOWED": "NO",
+                    "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES",
+                    "SWIFT_ABI_CHECKER_BASELINE_DIR": "/tmp/mybaseline",
+                    "SWIFT_ABI_CHECKER_EXCEPTIONS_FILE": "/tmp/allow.txt",
+                    "TAPI_EXEC": tapiToolPath.str,
+                ])],
+            targets: [
+                TestStandardTarget(
+                    "Fwk",
+                    type: .framework,
+                    buildPhases: [
+                        TestSourcesBuildPhase(["Fwk.swift"])
+                    ]),
+            ])
+        let core = try await getCore()
+        let tester = try TaskConstructionTester(core, testProject)
+
+        let fs = PseudoFS()
+        try fs.createDirectory(.root.join("tmp"))
+        try fs.write(.root.join("tmp").join("allow.txt"), contents: "")
+        try await fs.writeJSON(.root.join("tmp/mybaseline/ABI/arm64e-ios.json"), .plDict([:]))
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_API_DIGESTER_MODE": "abi"]), runDestination: .iOS, fs: fs) { results in
+            results.checkNoDiagnostics()
+            results.checkTask(.matchRuleType("CheckSwiftABI")) { task in
+                task.checkCommandLineContains(["-abi"])
+                task.checkCommandLineContains(["-use-interface-for-module"])
+            }
+        }
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["SWIFT_API_DIGESTER_MODE": "api"]), runDestination: .iOS, fs: fs) { results in
+            results.checkNoDiagnostics()
+            results.checkTask(.matchRuleType("CheckSwiftABI")) { task in
+                task.checkCommandLineDoesNotContain("-abi")
+                task.checkCommandLineDoesNotContain("-use-interface-for-module")
+            }
         }
     }
 


### PR DESCRIPTION
This will allow us to use it as the backend for `swift package diagnose-api-breaking-changes`