### PR TITLE
Define an RPATH_ORIGIN variable for constructing valid cross-platform paths

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -992,6 +992,7 @@ public final class BuiltinMacros {
     public static let SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH = BuiltinMacros.declarePathMacro("SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH")
     public static let PLATFORM_REQUIRES_SWIFT_AUTOLINK_EXTRACT = BuiltinMacros.declareBooleanMacro("PLATFORM_REQUIRES_SWIFT_AUTOLINK_EXTRACT")
     public static let PLATFORM_REQUIRES_SWIFT_MODULEWRAP = BuiltinMacros.declareBooleanMacro("PLATFORM_REQUIRES_SWIFT_MODULEWRAP")
+    public static let RPATH_ORIGIN = BuiltinMacros.declareStringMacro("RPATH_ORIGIN")
     public static let SWIFT_ABI_CHECKER_BASELINE_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_BASELINE_DIR")
     public static let SWIFT_ABI_CHECKER_EXCEPTIONS_FILE = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_EXCEPTIONS_FILE")
     public static let SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR")
@@ -2162,6 +2163,7 @@ public final class BuiltinMacros {
         SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH,
         PLATFORM_REQUIRES_SWIFT_AUTOLINK_EXTRACT,
         PLATFORM_REQUIRES_SWIFT_MODULEWRAP,
+        RPATH_ORIGIN,
         SWIFT_ABI_CHECKER_BASELINE_DIR,
         SWIFT_ABI_CHECKER_EXCEPTIONS_FILE,
         SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2545,6 +2545,9 @@ private class SettingsBuilder {
             sdkTable.push(BuiltinMacros.DYNAMIC_LIBRARY_EXTENSION, literal: imageFormat.dynamicLibraryExtension)
             sdkTable.push(BuiltinMacros.PLATFORM_REQUIRES_SWIFT_AUTOLINK_EXTRACT, literal: imageFormat.requiresSwiftAutolinkExtract)
             sdkTable.push(BuiltinMacros.PLATFORM_REQUIRES_SWIFT_MODULEWRAP, literal: imageFormat.requiresSwiftModulewrap)
+            if let origin = imageFormat.rpathOrigin {
+                sdkTable.push(BuiltinMacros.RPATH_ORIGIN, literal: origin)
+            }
         }
 
         // Add additional SDK default settings.

--- a/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
@@ -35,6 +35,9 @@
             SWIFT_INDEX_STORE_ENABLE = YES;
             // Testability is needed to generate code to invoke discovered XCTest tests
             SWIFT_ENABLE_TESTABILITY = YES;
+            EXECUTABLE_SUFFIX = ".$(EXECUTABLE_EXTENSION)";
+            EXECUTABLE_EXTENSION = "so";
+            LD_DYLIB_INSTALL_NAME = "$(EXECUTABLE_PATH)";
         };
     },
 

--- a/Sources/SWBUtil/ProcessInfo.swift
+++ b/Sources/SWBUtil/ProcessInfo.swift
@@ -219,6 +219,26 @@ extension ImageFormat {
             return true
         }
     }
+
+    public var usesRpaths: Bool {
+        switch self {
+            case .macho, .elf:
+                return true
+            case .pe:
+                return false
+        }
+    }
+
+    public var rpathOrigin: String? {
+        switch self {
+            case .macho:
+                return "@loader_path"
+            case .elf:
+                return "$ORIGIN"
+            default:
+                return nil
+        }
+    }
 }
 
 extension FixedWidthInteger {

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -426,8 +426,9 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         "UnitTestRunner",
                         type: .swiftpmTestRunner,
                         buildConfigurations: [
-                            TestBuildConfiguration("Debug",
-                                                   buildSettings: [:]),
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "LD_RUNPATH_SEARCH_PATHS": "$(RPATH_ORIGIN)",
+                            ]),
                         ],
                         buildPhases: [
                             TestSourcesBuildPhase(),
@@ -442,8 +443,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         type: .unitTest,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
-                                "DYLIB_INSTALL_NAME_BASE": "$ORIGIN",
-                                "LD_RUNPATH_SEARCH_PATHS": "@loader_path/",
+                                "LD_RUNPATH_SEARCH_PATHS": "$(RPATH_ORIGIN)",
+                                "LD_DYLIB_INSTALL_NAME": "MyTests.so"
                             ])
                         ],
                         buildPhases: [
@@ -461,8 +462,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         type: .dynamicLibrary,
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
-                                "DYLIB_INSTALL_NAME_BASE": "$ORIGIN",
-                                "LD_RUNPATH_SEARCH_PATHS": "@loader_path/",
+                                "LD_RUNPATH_SEARCH_PATHS": "$(RPATH_ORIGIN)",
+                                "LD_DYLIB_INSTALL_NAME": "liblibrary.so",
 
                                 // FIXME: Find a way to make these default
                                 "EXECUTABLE_PREFIX": "lib",
@@ -516,11 +517,11 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
 
                 do {
                     let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix)").join(core.hostOperatingSystem.imageFormat.executableName(basename: "UnitTestRunner")).str), arguments: [], environment: environment)
-                    #expect(String(decoding: executionResult.stdout, as: UTF8.self).contains("Executed 1 test, with 0 failures"))
+                    #expect(String(decoding: executionResult.stdout, as: UTF8.self).contains("Executed 1 test"))
                 }
                 do {
                     let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix)").join(core.hostOperatingSystem.imageFormat.executableName(basename: "UnitTestRunner")).str), arguments: ["--testing-library", "swift-testing"], environment: environment)
-                    #expect(String(decoding: executionResult.stderr, as: UTF8.self).contains("Test run with 1 test in 1 suite passed"))
+                    #expect(String(decoding: executionResult.stderr, as: UTF8.self).contains("Test run with 1 test "))
                 }
             }
         }


### PR DESCRIPTION
Also, fix up the install name of linux unit tests