### PR TITLE
Lookup swift-api-digester relative to the swiftc in use

### DIFF
--- a/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
@@ -55,7 +55,7 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
     }
 
     private func assetTagCombinations(catalogInputs inputs: [FileToBuild], _ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async throws -> Set<Set<String>> {
-        return try await executeExternalTool(cbc, delegate, commandLine: [resolveExecutablePath(cbc, cbc.scope.actoolExecutablePath()).str, "--print-asset-tag-combinations", "--output-format", "xml1"] + inputs.map { $0.absolutePath.str }, workingDirectory: cbc.producer.defaultWorkingDirectory, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute asset tag combinations") { output in
+        return try await executeExternalTool(cbc, delegate, commandLine: [resolveExecutablePath(cbc, cbc.scope.actoolExecutablePath(), delegate: delegate).str, "--print-asset-tag-combinations", "--output-format", "xml1"] + inputs.map { $0.absolutePath.str }, workingDirectory: cbc.producer.defaultWorkingDirectory, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute asset tag combinations") { output in
             struct AssetCatalogToolOutput: Decodable {
                 struct Diagnostic: Decodable {
                     let description: String

--- a/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
@@ -171,8 +171,8 @@ public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentif
         }
     }
 
-    override public func commandLineFromTemplate(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, optionContext: (any DiscoveredCommandLineToolSpecInfo)?, specialArgs: [String] = [], lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [CommandLineArgument] {
-        var commandLine = super.commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup)
+    override public func commandLineFromTemplate(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, optionContext: (any DiscoveredCommandLineToolSpecInfo)?, specialArgs: [String] = [], lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) async -> [CommandLineArgument] {
+        var commandLine = await super.commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup)
         guard let primaryOutput = evaluatedOutputs(cbc, delegate)?.first else {
             delegate.error("Unable to determine primary output for storyboard compilation")
             return []

--- a/Sources/SWBApplePlatform/MiGCompiler.swift
+++ b/Sources/SWBApplePlatform/MiGCompiler.swift
@@ -38,7 +38,7 @@ public final class MigCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecke
         return cbc.scope.migExecutablePath().str
     }
 
-    public override func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path) -> Path {
+    public override func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path, delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Path {
         return resolveExecutablePath(cbc.producer, Path(computeExecutablePath(cbc)))
     }
 

--- a/Sources/SWBApplePlatform/OpenCLCompiler.swift
+++ b/Sources/SWBApplePlatform/OpenCLCompiler.swift
@@ -69,7 +69,7 @@ final class OpenCLCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
             let executionDescription = "Create \(arch) bitcode for \(filePath.basename)"
 
-            var commandLine = [resolveExecutablePath(cbc, Path(openclc)).str]
+            var commandLine = [await resolveExecutablePath(cbc, Path(openclc), delegate: delegate).str]
             commandLine += ["-x", "cl", compilerVersionFlag]
             optimizationLevelFlag.map{ commandLine.append($0) }
             commandLine += preprocessorDefinitionsFlags
@@ -101,7 +101,7 @@ final class OpenCLCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
             let ruleInfo = ["Compile", filePath.str]
 
-            var commandLine = [resolveExecutablePath(cbc, Path(openclc)).str]
+            var commandLine = [await resolveExecutablePath(cbc, Path(openclc), delegate: delegate).str]
             commandLine += ["-x", "cl", compilerVersionFlag]
             if scope.evaluate(BuiltinMacros.OPENCL_MAD_ENABLE) {
                 commandLine.append("-cl-mad-enable")

--- a/Sources/SWBApplePlatform/ResMergerLinkerSpec.swift
+++ b/Sources/SWBApplePlatform/ResMergerLinkerSpec.swift
@@ -24,7 +24,7 @@ public final class ResMergerLinkerSpec : GenericLinkerSpec, SpecIdentifierType, 
 
         let environment: EnvironmentBindings = environmentFromSpec(cbc, delegate)
         do {
-            var commandLine = [resolveExecutablePath(cbc, Path("ResMerger")).str]
+            var commandLine = [await resolveExecutablePath(cbc, Path("ResMerger"), delegate: delegate).str]
 
             commandLine += BuiltinMacros.ifSet(BuiltinMacros.MACOS_TYPE, in: cbc.scope) { ["-fileType", $0] }
             commandLine += BuiltinMacros.ifSet(BuiltinMacros.MACOS_CREATOR, in: cbc.scope) { ["-fileCreator", $0] }
@@ -64,7 +64,7 @@ public final class ResMergerLinkerSpec : GenericLinkerSpec, SpecIdentifierType, 
                 outputPath = outputPath.join(cbc.scope.evaluate(BuiltinMacros.PRODUCT_NAME) + ".rsrc")
             }
 
-            var commandLine = [resolveExecutablePath(cbc, Path("ResMerger")).str]
+            var commandLine = [await resolveExecutablePath(cbc, Path("ResMerger"), delegate: delegate).str]
             commandLine.append(tmpOutputPath.str)
 
             commandLine += BuiltinMacros.ifSet(BuiltinMacros.MACOS_TYPE, in: cbc.scope) { ["-fileType", $0] }

--- a/Sources/SWBApplePlatform/XCStringsCompiler.swift
+++ b/Sources/SWBApplePlatform/XCStringsCompiler.swift
@@ -49,7 +49,7 @@ public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierTyp
         }
 
         if shouldGenerateSymbols(cbc) {
-            constructSymbolGenerationTask(cbc, delegate)
+            await constructSymbolGenerationTask(cbc, delegate)
         }
 
         if shouldCompileCatalog(cbc) {
@@ -138,10 +138,10 @@ public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierTyp
     }
 
     /// Generates a task for generating code symbols for strings.
-    private func constructSymbolGenerationTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) {
+    private func constructSymbolGenerationTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // The template spec file contains fields suitable for the compilation step.
         // But here we construct a custom command line for symbol generation.
-        let execPath = resolveExecutablePath(cbc, Path("xcstringstool"))
+        let execPath = await resolveExecutablePath(cbc, Path("xcstringstool"), delegate: delegate)
         var commandLine = [execPath.str, "generate-symbols"]
 
         // For now shouldGenerateSymbols only returns true if there are Swift sources.

--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -264,8 +264,8 @@ public struct FileCopyTaskActionContext {
 extension FileCopyTaskActionContext {
     public init(_ cbc: CommandBuildContext) {
         let compilerPath = cbc.producer.clangSpec.resolveExecutablePath(cbc, forLanguageOfFileType: cbc.producer.lookupFileType(languageDialect: .c))
-        let linkerPath = cbc.producer.ldLinkerSpec.resolveExecutablePath(cbc, Path(cbc.producer.ldLinkerSpec.computeExecutablePath(cbc)))
-        let lipoPath = cbc.producer.lipoSpec.resolveExecutablePath(cbc, Path(cbc.producer.lipoSpec.computeExecutablePath(cbc)))
+        let linkerPath = cbc.producer.ldLinkerSpec.resolveExecutablePath(cbc.producer, Path(cbc.producer.ldLinkerSpec.computeExecutablePath(cbc)))
+        let lipoPath = cbc.producer.lipoSpec.resolveExecutablePath(cbc.producer, Path(cbc.producer.lipoSpec.computeExecutablePath(cbc)))
 
         // If we couldn't find clang, skip the special stub binary handling. We may be using an Open Source toolchain which only has Swift. Also skip it for installLoc builds.
         if compilerPath.isEmpty || !compilerPath.isAbsolute || cbc.scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc") {

--- a/Sources/SWBCore/SpecImplementations/Tools/CodeSign.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CodeSign.swift
@@ -23,7 +23,7 @@ public final class CodesignToolSpec : CommandLineToolSpec, SpecIdentifierType, @
             codesign = Path("/usr/bin/codesign")
         }
         if !codesign.isAbsolute {
-            codesign = resolveExecutablePath(cbc, codesign)
+            codesign = resolveExecutablePath(cbc.producer, codesign)
         }
         return codesign.str
     }

--- a/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
@@ -129,7 +129,7 @@ public final class CopyToolSpec : CompilerSpec, SpecIdentifierType, @unchecked S
         // FIXME: The same comment above (w.r.t. how to bind this logic) applies here.
         if cbc.scope.evaluate(BuiltinMacros.PBXCP_STRIP_UNSIGNED_BINARIES, lookup: lookup) || !cbc.scope.evaluate(BuiltinMacros.PBXCP_STRIP_SUBPATHS, lookup: lookup).isEmpty {
             let insertIndex = commandLine.firstIndex(of: "-resolve-src-symlinks") ?? commandLine.endIndex
-            commandLine.replaceSubrange(insertIndex..<insertIndex, with: ["-strip-tool", resolveExecutablePath(cbc, Path("strip")).str])
+            commandLine.replaceSubrange(insertIndex..<insertIndex, with: ["-strip-tool", resolveExecutablePath(cbc.producer, Path("strip")).str])
         }
 
         // Skip the copy without erroring if the input item is missing. This is used for handling embedded bundles with the installloc action.

--- a/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
@@ -222,7 +222,7 @@ final public class DocumentationCompilerSpec: GenericCompilerSpec, SpecIdentifie
             return nil
         }
 
-        let commandLine = commandLineFromTemplate(cbc, delegate, optionContext: specInfo, specialArgs: symbolGraphArgs + documentationKindArgs, lookup: lookup).map(\.asString)
+        let commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: specInfo, specialArgs: symbolGraphArgs + documentationKindArgs, lookup: lookup).map(\.asString)
 
         // Attach a payload with information about what built documentation this task will output.
         let outputDir = cbc.scope.evaluate(BuiltinMacros.DOCC_ARCHIVE_PATH)

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -567,7 +567,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         }
 
         // Generate the command line.
-        var commandLine = commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup).map(\.asString)
+        var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup).map(\.asString)
 
         // Add flags to emit SDK imports info.
         let sdkImportsInfoFile = cbc.scope.evaluate(BuiltinMacros.LD_SDK_IMPORTS_FILE)
@@ -589,7 +589,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
         // Select the driver to use based on the input file types, replacing the value computed by commandLineFromTemplate().
         let usedCXX = usedTools.values.contains(where: { $0.contains(where: { $0.languageDialect?.isPlusPlus ?? false }) })
-        commandLine[0] = resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX)).str
+        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX), delegate: delegate).str
 
         let entitlementsSection = cbc.scope.evaluate(BuiltinMacros.LD_ENTITLEMENTS_SECTION)
         if !entitlementsSection.isEmpty {
@@ -831,11 +831,11 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         let optionContext = await discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)
 
         // Generate the command line.
-        var commandLine = commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup).map(\.asString)
+        var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup).map(\.asString)
 
         // Select the driver to use based on the input file types, replacing the value computed by commandLineFromTemplate().
         let usedCXX = usedTools.values.contains(where: { $0.contains(where: { $0.languageDialect?.isPlusPlus ?? false }) })
-        commandLine[0] = resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX)).str
+        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX), delegate: delegate).str
 
         let entitlementsSection = cbc.scope.evaluate(BuiltinMacros.LD_ENTITLEMENTS_SECTION)
         if !entitlementsSection.isEmpty {
@@ -916,7 +916,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         }
 
         // Generate the command line.
-        let commandLine = commandLineFromTemplate(
+        let commandLine = await commandLineFromTemplate(
             cbc,
             delegate,
             optionContext: optionContext,
@@ -1599,7 +1599,7 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
         let optionContext = await discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)
 
         // Generate the command line.
-        let commandLine = commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs).map(\.asString)
+        let commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs).map(\.asString)
 
         // Compute the inputs and outputs.
         var inputs = inputPaths.map{ delegate.createNode($0) }

--- a/Sources/SWBCore/SpecImplementations/Tools/Lipo.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/Lipo.swift
@@ -35,7 +35,7 @@ public final class LipoToolSpec: GenericCommandLineToolSpec, SpecIdentifierType,
     }
 
     private func lipoToolPath(_ cbc: CommandBuildContext) -> Path {
-        return resolveExecutablePath(cbc, Path(computeExecutablePath(cbc)))
+        return resolveExecutablePath(cbc.producer, Path(computeExecutablePath(cbc)))
     }
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {

--- a/Sources/SWBCore/SpecImplementations/Tools/ModulesVerifierTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ModulesVerifierTool.swift
@@ -24,7 +24,7 @@ public final class ModulesVerifierToolSpec : GenericCommandLineToolSpec, SpecIde
         let ruleInfo = defaultRuleInfo(cbc, delegate)
 
         let clangSpec = try! cbc.producer.getSpec() as ClangCompilerSpec
-        let clangPath = clangSpec.resolveExecutablePath(cbc, Path("clang"))
+        let clangPath = await clangSpec.resolveExecutablePath(cbc, Path("clang"), delegate: delegate)
         let specialArguments = ["--clang", clangPath.str, "--diagnostic-filename-map", fileNameMapPath.str]
 
         let commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate), specialArgs: specialArguments).map(\.asString)

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
@@ -25,6 +25,15 @@ public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIde
         }
     }
 
+    override public func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path, delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Path {
+        let swiftInfo = await cbc.producer.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)
+        if let prospectivePath = swiftInfo?.toolPath.dirname.join(path), cbc.producer.executableSearchPaths.fs.exists(prospectivePath) {
+            return prospectivePath
+        }
+
+        return await super.resolveExecutablePath(cbc, path, delegate: delegate)
+    }
+
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // FIXME: We should ensure this cannot happen.
         fatalError("unexpected direct invocation")

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
@@ -25,6 +25,15 @@ public final class SwiftABIGenerationToolSpec : GenericCommandLineToolSpec, Spec
         }
     }
 
+    override public func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path, delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Path {
+        let swiftInfo = await cbc.producer.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)
+        if let prospectivePath = swiftInfo?.toolPath.dirname.join(path), cbc.producer.executableSearchPaths.fs.exists(prospectivePath) {
+            return prospectivePath
+        }
+
+        return await super.resolveExecutablePath(cbc, path, delegate: delegate)
+    }
+
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // FIXME: We should ensure this cannot happen.
         fatalError("unexpected direct invocation")

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2391,7 +2391,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
             if cbc.scope.evaluate(BuiltinMacros.PLATFORM_REQUIRES_SWIFT_AUTOLINK_EXTRACT) {
                 let toolName = cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "swift-autolink-extract")
-                let toolPath = resolveExecutablePath(cbc, toolSpecInfo.toolPath.dirname.join(toolName))
+                let toolPath = await resolveExecutablePath(cbc, toolSpecInfo.toolPath.dirname.join(toolName), delegate: delegate)
 
                 delegate.createTask(
                     type: self,

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
@@ -33,7 +33,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
         return cbc.scope.tapiExecutablePath()
     }
 
-    public override func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path) -> Path {
+    public override func resolveExecutablePath(_ cbc: CommandBuildContext, _ path: Path, delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Path {
         // Ignore "tapi" from the spec and go through TAPI_EXEC
         // FIXME: We should go through the normal spec mechanisms...
         return resolveExecutablePath(cbc.producer, Path(computeExecutablePath(cbc)))
@@ -104,7 +104,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
         let toolInfo = await discoveredCommandLineToolSpecInfo(cbc.producer, scope, delegate)
 
         // Compute the command line.
-        var commandLine: [String] = commandLineFromTemplate(cbc, delegate, optionContext: toolInfo, lookup: lookup).map(\.asString)
+        var commandLine: [String] = await commandLineFromTemplate(cbc, delegate, optionContext: toolInfo, lookup: lookup).map(\.asString)
 
         // Compute inputs.
         var inputs = cbc.inputs.map({ delegate.createNode($0.absolutePath) }) as [PlannedPathNode]

--- a/Sources/SWBCore/SpecImplementations/Tools/UnifdefTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/UnifdefTool.swift
@@ -35,7 +35,7 @@ public final class UnifdefToolSpec : CommandLineToolSpec, SpecIdentifierType, @u
 
         // Set the exit status mode to 2, which is "exit status is 0 on success". (The default is 0 if nothing
         // changed and 1 if something changed.)
-        var args = [resolveExecutablePath(cbc, Path("unifdef")).str, "-x", "2"]
+        var args = [resolveExecutablePath(cbc.producer, Path("unifdef")).str, "-x", "2"]
         args += extraFlags
         if cbc.scope.evaluate(BuiltinMacros.IS_UNOPTIMIZED_BUILD) && !extraFlags.contains("-B") {
             // Add empty lines for any removed lines so that the source locations still match and thus we can go to

--- a/Sources/SWBCore/SpecImplementations/Tools/ValidateEmbeddedBinaryTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ValidateEmbeddedBinaryTool.swift
@@ -21,7 +21,7 @@ public final class ValidateEmbeddedBinaryToolSpec: GenericCommandLineToolSpec, S
         let outputPath = input.absolutePath
 
         var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate), lookup: lookup).map(\.asString)
-        commandLine[0] = resolveExecutablePath(cbc, Path("embeddedBinaryValidationUtility")).str
+        commandLine[0] = resolveExecutablePath(cbc.producer, Path("embeddedBinaryValidationUtility")).str
 
         let inputs: [any PlannedNode] = [delegate.createNode(input.absolutePath)] + cbc.commandOrderingInputs
         let outputs: [any PlannedNode] = [delegate.createNode(outputPath)] + (cbc.commandOrderingOutputs.isEmpty ? [delegate.createVirtualNode("ValidateEmbeddedBinary \(outputPath.str)")] : cbc.commandOrderingOutputs)

--- a/Sources/SWBUniversalPlatform/LexCompiler.swift
+++ b/Sources/SWBUniversalPlatform/LexCompiler.swift
@@ -42,7 +42,7 @@ final class LexCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecked Senda
         let lexFlags = cbc.scope.evaluate(BuiltinMacros.LEXFLAGS)
 
         // Compute the command line arguments.
-        var commandLine = [resolveExecutablePath(cbc, cbc.scope.evaluate(BuiltinMacros.LEX)).str]
+        var commandLine = [await resolveExecutablePath(cbc, cbc.scope.evaluate(BuiltinMacros.LEX), delegate: delegate).str]
         commandLine += await commandLineFromOptions(cbc, delegate, optionContext: discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate)).map(\.asString)
         commandLine += lexFlags
         if let perFileArgs = input.additionalArgs {

--- a/Sources/SWBUniversalPlatform/TestEntryPointGenerationTool.swift
+++ b/Sources/SWBUniversalPlatform/TestEntryPointGenerationTool.swift
@@ -17,8 +17,8 @@ import SWBCore
 final class TestEntryPointGenerationToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
     static let identifier = "org.swift.test-entry-point-generator"
 
-    override func commandLineFromTemplate(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, optionContext: (any DiscoveredCommandLineToolSpecInfo)?, specialArgs: [String] = [], lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [CommandLineArgument] {
-        var args = super.commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup)
+    override func commandLineFromTemplate(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, optionContext: (any DiscoveredCommandLineToolSpecInfo)?, specialArgs: [String] = [], lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) async -> [CommandLineArgument] {
+        var args = await super.commandLineFromTemplate(cbc, delegate, optionContext: optionContext, specialArgs: specialArgs, lookup: lookup)
         for (toolchainPath, toolchainLibrarySearchPath) in cbc.producer.toolchains.map({ ($0.path, $0.librarySearchPaths) }) {
             if let path = toolchainLibrarySearchPath.findLibrary(operatingSystem: cbc.producer.hostOperatingSystem, basename: "IndexStore") {
                 args.append(contentsOf: ["--index-store-library-path", .path(path)])
@@ -41,7 +41,7 @@ final class TestEntryPointGenerationToolSpec: GenericCommandLineToolSpec, SpecId
     }
 
     public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, indexStorePaths: [Path], indexUnitBasePaths: [Path]) async {
-        var commandLine = commandLineFromTemplate(cbc, delegate, optionContext: nil)
+        var commandLine = await commandLineFromTemplate(cbc, delegate, optionContext: nil)
 
         for indexStorePath in indexStorePaths {
             commandLine.append(contentsOf: ["--index-store", .path(indexStorePath)])

--- a/Sources/SWBUniversalPlatform/YaccCompiler.swift
+++ b/Sources/SWBUniversalPlatform/YaccCompiler.swift
@@ -64,7 +64,7 @@ final class YaccCompilerSpec : CompilerSpec, SpecIdentifierType, @unchecked Send
         delegate.declareGeneratedSourceFile(outputHeaderPath)
 
         // Compute the command arguments.
-        var args = [resolveExecutablePath(cbc, cbc.scope.evaluate(BuiltinMacros.YACC)).str]
+        var args = [await resolveExecutablePath(cbc, cbc.scope.evaluate(BuiltinMacros.YACC), delegate: delegate).str]
         // FIXME: Add the auto-generated options.
         args += cbc.scope.evaluate(BuiltinMacros.YACCFLAGS)
         if let perFileArgs = input.additionalArgs {


### PR DESCRIPTION
This ensures that it is always able to load the modules from the current build.