### PR TITLE
Fix toolchain stack equality checks when checking if specialized targets are compatible

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -189,8 +189,8 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
     func isCompatible(with configuredTarget: ConfiguredTarget, settings: Settings, workspaceContext: WorkspaceContext) -> Bool {
         let toolchain = effectiveToolchainOverride(originalParameters: configuredTarget.parameters, workspaceContext: workspaceContext)
         return (platform == nil || platform === settings.platform) &&
-            (sdkVariant == nil || sdkVariant?.name == settings.sdkVariant?.name) &&
-            (toolchain == nil || toolchain == settings.globalScope.evaluate(BuiltinMacros.TOOLCHAINS)) &&
+        (sdkVariant == nil || sdkVariant?.name == settings.sdkVariant?.name) &&
+        (toolchain == nil || toolchain == settings.toolchains.map(\.identifier)) &&
         (canonicalNameSuffix == nil || canonicalNameSuffix?.nilIfEmpty == settings.sdk?.canonicalNameSuffix)
     }
 


### PR DESCRIPTION
When the downloadable Metal toolchain is installed in Xcode, it could cause specialization compatibility checks to fail, causing downstream errors specializing targets representing package plugins. This happened because the compatibility check compared the `toolchains` of `SpecializationParameters` with the `TOOLCHAINS` macro in the configured target's settings. We should use `settings.toolchains` on the RHS instead to ensure both sides of the comparison have a chance to inject the default toolchain during settings construction.

Closes https://github.com/swiftlang/swift-build/issues/614
Closes https://github.com/swiftlang/swift-build/issues/570