### PR TITLE
Don't require objc in modulemaps generated for Swift compatibility headers

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
@@ -404,7 +404,6 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
                 outputStream <<< "module \(try moduleName.asModuleIdentifierString()).Swift {\n"
             }
             outputStream <<< "  header \"\(interfaceHeaderName.asCStringLiteralContent)\"\n"
-            outputStream <<< "  requires objc\n"
             outputStream <<< "}\n"
 
             return outputStream.bytes

--- a/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleMapTaskConstructionTests.swift
@@ -584,7 +584,6 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                     #expect(contents == (OutputByteStream()
                                          <<< "framework module SwiftOnly {\n"
                                          <<< "  header \"SwiftOnly-Swift.h\"\n"
-                                         <<< "  requires objc\n"
                                          <<< "}\n").bytes)
                 }
 
@@ -629,7 +628,6 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                                          <<< "\n"
                                          <<< "module ObjCCompatibilityHeader.Swift {\n"
                                          <<< "  header \"ObjCCompatibilityHeader-Swift.h\"\n"
-                                         <<< "  requires objc\n"
                                          <<< "}\n").bytes)
                 }
 
@@ -978,7 +976,6 @@ fileprivate struct ModuleMapTaskConstructionTests: CoreBasedTests {
                                                      <<< "\n"
                                                      <<< "module \(targetName).Swift {\n"
                                                      <<< "  header \"\(targetName)-Swift.h\"\n"
-                                                     <<< "  requires objc\n"
                                                      <<< "}\n").bytes)
                             }
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -606,7 +606,6 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 #expect(contents == (OutputByteStream()
                                      <<< "framework module CoreFoo {\n"
                                      <<< "  header \"CoreFoo-Swift.h\"\n"
-                                     <<< "  requires objc\n"
                                      <<< "}\n").bytes)
             }
         }
@@ -1086,7 +1085,6 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     stream <<< "\n"
                     stream <<< "module CoreFoo.Swift {\n"
                     stream <<< "  header \"CoreFoo-Swift.h\"\n"
-                    stream <<< "  requires objc\n"
                     stream <<< "}\n"
                     #expect(contents == stream.bytes)
 


### PR DESCRIPTION
Let's remove the `requires objc` from the module map file generated for the compatibility header. This condition triggered an error when importing the compatibility header from a C source file.

The `require objc` isn't necessary, the compatibility header is already printed in a way where the Objective-C code is protected behind a language check. C clients can safely import the current compatibility header even if they may not see any content.

Let's lift this restriction. It isn't currently necessary and we're adding C content to the compatibility header with the official support for `@cdecl` that is independent of Objective-C.

swiftpm equivalent change: https://github.com/swiftlang/swift-package-manager/pull/8736