### PR TITLE
Allow downgrading API breakage errors to warnings

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -997,6 +997,7 @@ public final class BuiltinMacros {
     public static let RPATH_ORIGIN = BuiltinMacros.declareStringMacro("RPATH_ORIGIN")
     public static let PLATFORM_USES_DSYMS = BuiltinMacros.declareBooleanMacro("PLATFORM_USES_DSYMS")
     public static let SWIFT_ABI_CHECKER_BASELINE_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_BASELINE_DIR")
+    public static let SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS = BuiltinMacros.declareBooleanMacro("SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS")
     public static let SWIFT_ABI_CHECKER_EXCEPTIONS_FILE = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_EXCEPTIONS_FILE")
     public static let SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR")
     public static let SWIFT_ACCESS_NOTES_PATH = BuiltinMacros.declareStringMacro("SWIFT_ACCESS_NOTES_PATH")
@@ -2171,6 +2172,7 @@ public final class BuiltinMacros {
         RPATH_ORIGIN,
         PLATFORM_USES_DSYMS,
         SWIFT_ABI_CHECKER_BASELINE_DIR,
+        SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS,
         SWIFT_ABI_CHECKER_EXCEPTIONS_FILE,
         SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR,
         SWIFT_ACCESS_NOTES_PATH,

--- a/Tests/SWBBuildSystemTests/APIDigesterBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/APIDigesterBuildOperationTests.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+
+import SWBBuildSystem
+import SWBCore
+import SWBTestSupport
+import SWBTaskExecution
+import SWBUtil
+import SWBProtocol
+
+@Suite
+fileprivate struct APIDigesterBuildOperationTests: CoreBasedTests {
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "Windows toolchains are missing swift-api-digester"))
+    func apiDigesterDisableFailOnError() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("foo.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ARCHS": "$(ARCHS_STANDARD)",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "$(HOST_PLATFORM)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                        "SWIFT_VERSION": swiftVersion,
+                        "CODE_SIGNING_ALLOWED": "NO",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "foo",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [:])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["foo.swift"]),
+                        ]
+                    ),
+                ])
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("foo.swift")) { stream in
+                stream <<< "public func foo() -> Int { 42 }"
+            }
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: [
+                "RUN_SWIFT_ABI_GENERATION_TOOL": "YES",
+                "SWIFT_API_DIGESTER_MODE": "api",
+                "SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR": tmpDir.join("baseline").join("ABI").str,
+            ]), runDestination: .host) { results in
+                results.checkNoErrors()
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("foo.swift")) { stream in
+                stream <<< "public func foo() -> String { \"hello, world!\" }"
+            }
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: [
+                "RUN_SWIFT_ABI_CHECKER_TOOL": "YES",
+                "SWIFT_API_DIGESTER_MODE": "api",
+                "SWIFT_ABI_CHECKER_BASELINE_DIR": tmpDir.join("baseline").str,
+                "SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS": "YES",
+            ]), runDestination: .host) { results in
+                results.checkWarning(.contains("func foo() has return type change from Swift.Int to Swift.String"))
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+}


### PR DESCRIPTION
In some cases, the API digester will report breakage as errors. In cases where we want to collect all breakages across multiple modules in the build, allow downgrading them to warnings while passing -disable-fail-on-error.