### PR TITLE
Add Metal 4 Deployment Target

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -252,6 +252,7 @@
                     Metal30,
                     Metal31,
                     Metal32,
+                    Metal40,
                 );
                 Category = BuildOptions;
             },
@@ -272,6 +273,7 @@
                     Metal30,
                     Metal31,
                     Metal32,
+                    Metal40,
                 );
                 CommandLineArgs = {
                     UseDeploymentTarget = (  );
@@ -286,6 +288,7 @@
                     Metal30 = ( "-std=metal3.0", );
                     Metal31 = ( "-std=metal3.1", );
                     Metal32 = ( "-std=metal3.2", );
+                    Metal40 = ( "-std=metal4.0", );
                 };
             },
             {

--- a/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
@@ -83,6 +83,7 @@
                     Metal30 = ( "-std=metal3.0", );
                     Metal31 = ( "-std=metal3.1", );
                     Metal32 = ( "-std=metal3.2", );
+                    Metal40 = ( "-std=metal4.0", );
                 };
             },
             {

--- a/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.metal.strings
+++ b/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.metal.strings
@@ -90,6 +90,8 @@
 "[MTL_LANGUAGE_REVISION]-description-[Metal31]" = "Metal 3.1";
 "[MTL_LANGUAGE_REVISION]-value-[Metal32]" = "Metal 3.2";
 "[MTL_LANGUAGE_REVISION]-description-[Metal32]" = "Metal 3.2";
+"[MTL_LANGUAGE_REVISION]-value-[Metal40]" = "Metal 4.0";
+"[MTL_LANGUAGE_REVISION]-description-[Metal40]" = "Metal 4.0";
 
 "[MTL_ENABLE_DEBUG_INFO]-name" = "Produce Debugging Information";
 "[MTL_ENABLE_DEBUG_INFO]-description" = "Debugging information is required for shader debugging and profiling.";

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -1567,6 +1567,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["macosx", "Metal30"] : "-std=metal3.0",
                                   ["macosx", "Metal31"] : "-std=metal3.1",
                                   ["macosx", "Metal32"] : "-std=metal3.2",
+                                  ["macosx", "Metal40"] : "-std=metal4.0",
 
                                   ["iphoneos", "UseDeploymentTarget"] : "",
                                   ["iphoneos", "iOSMetal10"] : "-std=ios-metal1.0",
@@ -1580,6 +1581,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["iphoneos", "Metal30"] : "-std=metal3.0",
                                   ["iphoneos", "Metal31"] : "-std=metal3.1",
                                   ["iphoneos", "Metal32"] : "-std=metal3.2",
+                                  ["iphoneos", "Metal40"] : "-std=metal4.0",
 
                                   ["appletvos", "UseDeploymentTarget"] : "",
                                   ["appletvos", "Metal11"] : "-std=ios-metal1.1",
@@ -1592,10 +1594,12 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["appletvos", "Metal30"] : "-std=metal3.0",
                                   ["appletvos", "Metal31"] : "-std=metal3.1",
                                   ["appletvos", "Metal32"] : "-std=metal3.2",
+                                  ["appletvos", "Metal40"] : "-std=metal4.0",
 
                                   ["xros", "UseDeploymentTarget"] : "",
                                   ["xros", "Metal31"] : "-std=metal3.1",
                                   ["xros", "Metal32"] : "-std=metal3.2",
+                                  ["xros", "Metal40"] : "-std=metal4.0",
         ]
 
         for (language, expectedOption) in optionForLanguage {


### PR DESCRIPTION
Since Metal 4 was announced, this change adds the Metal4 deployment target for MSL.

