### PR TITLE
Dependencies: validate Swift imports against MODULE_DEPENDENCIES and provide fix-its (rdar://150314567)

### DIFF
--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(SWBCore
   ConfiguredTarget.swift
   Core.swift
   CustomTaskTypeDescription.swift
+  Dependencies.swift
   DependencyInfoEditPayload.swift
   DependencyResolution.swift
   DiagnosticSupport.swift

--- a/Sources/SWBCore/Dependencies.swift
+++ b/Sources/SWBCore/Dependencies.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+import SWBMacro
+
+public struct ModuleDependency: Hashable, Sendable, SerializableCodable {
+    public let name: String
+    public let accessLevel: AccessLevel
+
+    public enum AccessLevel: String, Hashable, Sendable, CaseIterable, Codable, Serializable {
+        case Private = "private"
+        case Package = "package"
+        case Public = "public"
+
+        public init(_ string: String) throws {
+            guard let accessLevel = AccessLevel(rawValue: string) else {
+                throw StubError.error("unexpected access modifier '\(string)', expected one of: \(AccessLevel.allCases.map { $0.rawValue }.joined(separator: ", "))")
+            }
+
+            self = accessLevel
+        }
+    }
+
+    public init(name: String, accessLevel: AccessLevel) {
+        self.name = name
+        self.accessLevel = accessLevel
+    }
+
+    public init(entry: String) throws {
+        var it = entry.split(separator: " ").makeIterator()
+        switch (it.next(), it.next(), it.next()) {
+        case (let .some(name), nil, nil):
+            self.name = String(name)
+            self.accessLevel = .Private
+
+        case (let .some(accessLevel), let .some(name), nil):
+            self.name = String(name)
+            self.accessLevel = try AccessLevel(String(accessLevel))
+
+        default:
+            throw StubError.error("expected 1 or 2 space-separated components in: \(entry)")
+        }
+    }
+
+    public var asBuildSettingEntry: String {
+        "\(accessLevel == .Private ? "" : "\(accessLevel.rawValue) ")\(name)"
+    }
+
+    public var asBuildSettingEntryQuotedIfNeeded: String {
+        let e = asBuildSettingEntry
+        return e.contains(" ") ? "\"\(e)\"" : e
+    }
+}
+
+public struct ModuleDependenciesContext: Sendable, SerializableCodable {
+    var validate: BooleanWarningLevel
+    var moduleDependencies: [ModuleDependency]
+    var fixItContext: FixItContext?
+
+    init(validate: BooleanWarningLevel, moduleDependencies: [ModuleDependency], fixItContext: FixItContext? = nil) {
+        self.validate = validate
+        self.moduleDependencies = moduleDependencies
+        self.fixItContext = fixItContext
+    }
+
+    public init?(settings: Settings) {
+        let validate = settings.globalScope.evaluate(BuiltinMacros.VALIDATE_MODULE_DEPENDENCIES)
+        guard validate != .no else { return nil }
+        let fixItContext = ModuleDependenciesContext.FixItContext(settings: settings)
+        self.init(validate: validate, moduleDependencies: settings.moduleDependencies, fixItContext: fixItContext)
+    }
+
+    /// Nil `imports` means the current toolchain doesn't have the features to gather imports. This is temporarily required to support running against older toolchains.
+    public func makeDiagnostics(imports: [(ModuleDependency, importLocations: [Diagnostic.Location])]?) -> [Diagnostic] {
+        guard validate != .no else { return [] }
+        guard let imports else {
+            return [Diagnostic(
+                behavior: .error,
+                location: .unknown,
+                data: DiagnosticData("The current toolchain does not support \(BuiltinMacros.VALIDATE_MODULE_DEPENDENCIES.name)"))]
+        }
+
+        let missingDeps = imports.filter {
+            // ignore module deps without source locations, these are inserted by swift / swift-build and we should treat them as implementation details which we can track without needing the user to declare them
+            if $0.importLocations.isEmpty { return false }
+
+            // TODO: if the difference is just the access modifier, we emit a new entry, but ultimately our fixit should update the existing entry or emit an error about a conflict
+            if moduleDependencies.contains($0.0) { return false }
+            return true
+        }
+
+        guard !missingDeps.isEmpty else { return [] }
+
+        let behavior: Diagnostic.Behavior = validate == .yesError ? .error : .warning
+
+        let fixIt = fixItContext?.makeFixIt(newModules: missingDeps.map { $0.0 })
+        let fixIts = fixIt.map { [$0] } ?? []
+
+        let importDiags: [Diagnostic] = missingDeps
+            .flatMap { dep in
+                dep.1.map {
+                    return Diagnostic(
+                        behavior: behavior,
+                        location: $0,
+                        data: DiagnosticData("Missing entry in \(BuiltinMacros.MODULE_DEPENDENCIES.name): \(dep.0.asBuildSettingEntryQuotedIfNeeded)"),
+                        fixIts: fixIts)
+                }
+            }
+
+        let message = "Missing entries in \(BuiltinMacros.MODULE_DEPENDENCIES.name): \(missingDeps.map { $0.0.asBuildSettingEntryQuotedIfNeeded }.sorted().joined(separator: " "))"
+
+        let location: Diagnostic.Location = fixIt.map {
+            Diagnostic.Location.path($0.sourceRange.path, line: $0.sourceRange.endLine, column: $0.sourceRange.endColumn)
+        } ?? Diagnostic.Location.buildSetting(BuiltinMacros.MODULE_DEPENDENCIES)
+
+        return [Diagnostic(
+            behavior: behavior,
+            location: location,
+            data: DiagnosticData(message),
+            fixIts: fixIts,
+            childDiagnostics: importDiags)]
+    }
+
+    struct FixItContext: Sendable, SerializableCodable {
+        var sourceRange: Diagnostic.SourceRange
+        var modificationStyle: ModificationStyle
+
+        init(sourceRange: Diagnostic.SourceRange, modificationStyle: ModificationStyle) {
+            self.sourceRange = sourceRange
+            self.modificationStyle = modificationStyle
+        }
+
+        init?(settings: Settings) {
+            guard let target = settings.target else { return nil }
+            let thisTargetCondition = MacroCondition(parameter: BuiltinMacros.targetNameCondition, valuePattern: target.name)
+
+            if let assignment = (settings.globalScope.table.lookupMacro(BuiltinMacros.MODULE_DEPENDENCIES)?.sequence.first {
+                   $0.location != nil && ($0.conditions?.conditions == [thisTargetCondition] || ($0.conditions?.conditions.isEmpty ?? true))
+               }),
+               let location = assignment.location
+            {
+                self.init(sourceRange: .init(path: location.path, startLine: location.endLine, startColumn: location.endColumn, endLine: location.endLine, endColumn: location.endColumn), modificationStyle: .appendToExistingAssignment)
+            }
+            else if let path = settings.constructionComponents.targetXcconfigPath {
+                self.init(sourceRange: .init(path: path, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0), modificationStyle: .insertNewAssignment(targetNameCondition: nil))
+            }
+            else if let path = settings.constructionComponents.projectXcconfigPath {
+                self.init(sourceRange: .init(path: path, startLine: 0, startColumn: 0, endLine: 0, endColumn: 0), modificationStyle: .insertNewAssignment(targetNameCondition: target.name))
+            }
+            else {
+                return nil
+            }
+        }
+
+        enum ModificationStyle: Sendable, SerializableCodable, Hashable {
+            case appendToExistingAssignment
+            case insertNewAssignment(targetNameCondition: String?)
+        }
+
+        func makeFixIt(newModules: [ModuleDependency]) -> Diagnostic.FixIt {
+            let stringValue = newModules.map { $0.asBuildSettingEntryQuotedIfNeeded }.sorted().joined(separator: " ")
+            let newText: String
+            switch modificationStyle {
+            case .appendToExistingAssignment:
+                newText = " \(stringValue)"
+            case .insertNewAssignment(let targetNameCondition):
+                let targetCondition = targetNameCondition.map { "[target=\($0)]" } ?? ""
+                newText = "\n\(BuiltinMacros.MODULE_DEPENDENCIES.name)\(targetCondition) = $(inherited) \(stringValue)\n"
+            }
+
+            return Diagnostic.FixIt(sourceRange: sourceRange, newText: newText)
+        }
+    }
+}

--- a/Sources/SWBCore/LinkageDependencyResolver.swift
+++ b/Sources/SWBCore/LinkageDependencyResolver.swift
@@ -375,7 +375,7 @@ actor LinkageDependencyResolver {
             buildRequestContext.getCachedSettings($0.parameters, target: $0.target).globalScope.evaluate(BuiltinMacros.PRODUCT_MODULE_NAME)
         })
 
-        for moduleDependencyName in configuredTargetSettings.moduleDependencies.map { $0.name } {
+        for moduleDependencyName in (configuredTargetSettings.moduleDependencies.map { $0.name }) {
             if !moduleNamesOfExplicitDependencies.contains(moduleDependencyName), let implicitDependency = await implicitDependency(forModuleName: moduleDependencyName, from: configuredTarget, imposedParameters: imposedParameters, source: .moduleDependency(name: moduleDependencyName, buildSetting: BuiltinMacros.MODULE_DEPENDENCIES)) {
                 await result.append(ResolvedTargetDependency(target: implicitDependency, reason: .implicitBuildSetting(settingName: BuiltinMacros.MODULE_DEPENDENCIES.name, options: [moduleDependencyName])))
             }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2631,7 +2631,7 @@ public extension BuiltinMacros {
 }
 
 /// Enumeration macro type for tri-state booleans, typically used for warnings which can be set to "No", "Yes", or "Yes (Error)".
-public enum BooleanWarningLevel: String, Equatable, Hashable, Serializable, EnumerationMacroType, Encodable {
+public enum BooleanWarningLevel: String, Equatable, Hashable, Serializable, EnumerationMacroType, Codable {
     public static let defaultValue = BooleanWarningLevel.no
 
     case yesError = "YES_ERROR"

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -446,7 +446,9 @@ public struct SwiftTaskPayload: ParentTaskPayload {
     /// The preview build style in effect (dynamic replacement or XOJIT), if any.
     public let previewStyle: PreviewStyleMessagePayload?
 
-    init(moduleName: String, indexingPayload: SwiftIndexingPayload, previewPayload: SwiftPreviewPayload?, localizationPayload: SwiftLocalizationPayload?, numExpectedCompileSubtasks: Int, driverPayload: SwiftDriverPayload?, previewStyle: PreviewStyle?) {
+    public let moduleDependenciesContext: ModuleDependenciesContext?
+
+    init(moduleName: String, indexingPayload: SwiftIndexingPayload, previewPayload: SwiftPreviewPayload?, localizationPayload: SwiftLocalizationPayload?, numExpectedCompileSubtasks: Int, driverPayload: SwiftDriverPayload?, previewStyle: PreviewStyle?, moduleDependenciesContext: ModuleDependenciesContext?) {
         self.moduleName = moduleName
         self.indexingPayload = indexingPayload
         self.previewPayload = previewPayload
@@ -461,10 +463,11 @@ public struct SwiftTaskPayload: ParentTaskPayload {
         case nil:
             self.previewStyle = nil
         }
+        self.moduleDependenciesContext = moduleDependenciesContext
     }
 
     public func serialize<T: Serializer>(to serializer: T) {
-        serializer.serializeAggregate(7) {
+        serializer.serializeAggregate(8) {
             serializer.serialize(moduleName)
             serializer.serialize(indexingPayload)
             serializer.serialize(previewPayload)
@@ -472,11 +475,12 @@ public struct SwiftTaskPayload: ParentTaskPayload {
             serializer.serialize(numExpectedCompileSubtasks)
             serializer.serialize(driverPayload)
             serializer.serialize(previewStyle)
+            serializer.serialize(moduleDependenciesContext)
         }
     }
 
     public init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(7)
+        try deserializer.beginAggregate(8)
         self.moduleName = try deserializer.deserialize()
         self.indexingPayload = try deserializer.deserialize()
         self.previewPayload = try deserializer.deserialize()
@@ -484,6 +488,7 @@ public struct SwiftTaskPayload: ParentTaskPayload {
         self.numExpectedCompileSubtasks = try deserializer.deserialize()
         self.driverPayload = try deserializer.deserialize()
         self.previewStyle = try deserializer.deserialize()
+        self.moduleDependenciesContext = try deserializer.deserialize()
     }
 }
 
@@ -2289,7 +2294,6 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 ]
             }
 
-
             // BUILT_PRODUCTS_DIR here is guaranteed to be absolute by `getCommonTargetTaskOverrides`.
             let payload = SwiftTaskPayload(
                 moduleName: moduleName,
@@ -2306,7 +2310,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 previewPayload: previewPayload,
                 localizationPayload: localizationPayload,
                 numExpectedCompileSubtasks: isUsingWholeModuleOptimization ? 1 : cbc.inputs.count,
-                driverPayload: await driverPayload(uniqueID: String(args.hashValue), scope: cbc.scope, delegate: delegate, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, args: args, tempDirPath: objectFileDir, explicitModulesTempDirPath: Path(cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH)), variant: variant, arch: arch + compilationMode.moduleBaseNameSuffix, commandLine: ["builtin-SwiftDriver", "--"] + args, ruleInfo: ruleInfo(compilationMode.ruleNameIntegratedDriver, targetName), casOptions: casOptions, linkerResponseFilePath: moduleLinkerArgsPath), previewStyle: cbc.scope.previewStyle
+                driverPayload: await driverPayload(uniqueID: String(args.hashValue), scope: cbc.scope, delegate: delegate, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, args: args, tempDirPath: objectFileDir, explicitModulesTempDirPath: Path(cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH)), variant: variant, arch: arch + compilationMode.moduleBaseNameSuffix, commandLine: ["builtin-SwiftDriver", "--"] + args, ruleInfo: ruleInfo(compilationMode.ruleNameIntegratedDriver, targetName), casOptions: casOptions, linkerResponseFilePath: moduleLinkerArgsPath),
+                previewStyle: cbc.scope.previewStyle,
+                moduleDependenciesContext: cbc.producer.moduleDependenciesContext
             )
 
             // Finally, assemble the input and output paths and create the Swift compiler command.

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -269,6 +269,8 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     var userPreferences: UserPreferences { get }
 
     var hostOperatingSystem: OperatingSystem { get }
+
+    var moduleDependenciesContext: ModuleDependenciesContext? { get }
 }
 
 extension CommandProducer {

--- a/Sources/SWBMacro/MacroValueAssignmentTable.swift
+++ b/Sources/SWBMacro/MacroValueAssignmentTable.swift
@@ -183,7 +183,7 @@ public struct MacroValueAssignmentTable: Serializable, Sendable {
                     if effectiveConditionValue.evaluate(condition) == true {
                         // Condition evaluates to true, so we push an assignment with a condition set that excludes the condition.
                         let filteredConditions = conditions.conditions.filter{ $0.parameter != parameter }
-                        table.push(macro, assignment.expression, conditions: filteredConditions.isEmpty ? nil : MacroConditionSet(conditions: filteredConditions))
+                        table.push(macro, assignment.expression, conditions: filteredConditions.isEmpty ? nil : MacroConditionSet(conditions: filteredConditions), location: assignment.location)
                     }
                     else {
                         // Condition evaluates to false, so we elide the assignment.
@@ -191,7 +191,7 @@ public struct MacroValueAssignmentTable: Serializable, Sendable {
                 }
                 else {
                     // Assignment isn't conditioned on the specified parameter, so we just push it as-is.
-                    table.push(macro, assignment.expression, conditions: assignment.conditions)
+                    table.push(macro, assignment.expression, conditions: assignment.conditions, location: assignment.location)
                 }
             }
             bindAndPushAssignment(firstAssignment)

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -121,6 +121,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     /// Whether a task planned by this producer has requested frontend command line emission.
     var emitFrontendCommandLines: Bool
 
+    public let moduleDependenciesContext: ModuleDependenciesContext?
+
     private struct State: Sendable {
         fileprivate var onDemandResourcesAssetPacks: [ODRTagSet: ODRAssetPackInfo] = [:]
         fileprivate var onDemandResourcesAssetPackSubPaths: [String: Set<String>] = [:]
@@ -433,6 +435,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         for note in settings.notes {
             delegate.note(context, note)
         }
+
+        self.moduleDependenciesContext = ModuleDependenciesContext(settings: settings)
     }
 
     /// The set of all known deployment target macro names, even if the platforms that use those settings are not installed.

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -238,4 +238,8 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
         core.lookupPlatformInfo(platform: platform)
     }
+
+    package var moduleDependenciesContext: SWBCore.ModuleDependenciesContext? {
+        nil
+    }
 }


### PR DESCRIPTION
Dependencies: validate Swift imports against MODULE_DEPENDENCIES and provide fix-its (rdar://150314567)

Also includes fixes for:
- Macro: fix an issue where locations from xcconfig files are lost across condition binding

This is a repeat of https://github.com/swiftlang/swift-build/pull/620 because we're locking down the repo and PRs have to come from forks now.