### PR TITLE
Adapt QNX support to the introduction of LINKER_DRIVER

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2683,6 +2683,7 @@ public enum LinkerDriverChoice: String, Equatable, Hashable, EnumerationMacroTyp
 
     case clang
     case swiftc
+    case qcc
 }
 
 /// Enumeration macro type for the value of the `INFOPLIST_KEY_LSApplicationCategoryType` build setting.

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -275,6 +275,8 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
                     args += ["-compatibility_version", compatibilityVersion]
                 case .swiftc:
                     args += ["-Xlinker", "-compatibility_version", "-Xlinker", compatibilityVersion]
+                case .qcc:
+                    break
                 }
             }
 
@@ -285,6 +287,8 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
                     args += ["-current_version", currentVersion]
                 case .swiftc:
                     args += ["-Xlinker", "-current_version", "-Xlinker", currentVersion]
+                case .qcc:
+                    break
                 }
             }
         }

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -240,6 +240,8 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
             return cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "clang")
         case .swiftc:
             return cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "swiftc")
+        case .qcc:
+            return cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "qcc")
         }
     }
 

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -105,6 +105,8 @@ struct QNXSDKRegistryExtension: SDKRegistryExtension {
 
             "ARCH_NAME_x86_64": .plString("x86_64"),
             "ARCH_NAME_aarch64": .plString("aarch64le"),
+
+            "LINKER_DRIVER": "qcc",
         ]
 
         return [(qnxSdk.sysroot, qnxPlatform, [

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -175,7 +175,7 @@
             {
                 Name = "LD_OPTIMIZATION_LEVEL";
                 Type = String;
-                Condition = "$(LINKER_DRIVER) == clang";
+                Condition = "$(LINKER_DRIVER) == clang || $(LINKER_DRIVER) == qcc";
                 DefaultValue = "$(GCC_OPTIMIZATION_LEVEL)";
                 "CommandLinePrefixFlag" = "-O";
             },


### PR DESCRIPTION
_(migrated from #398 in accordance with our new policy to require PRs from forks)_