### PR TITLE
Adapt QNX support to the introduction of LINKER_DRIVER

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2706,6 +2706,7 @@ public enum LinkerDriverChoice: String, Equatable, Hashable, EnumerationMacroTyp
     public static let defaultValue: LinkerDriverChoice = .clang
 
     case clang
+    case qcc
     case swiftc
     case auto
 }

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -275,6 +275,8 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
                     args += ["-compatibility_version", compatibilityVersion]
                 case .swiftc:
                     args += ["-Xlinker", "-compatibility_version", "-Xlinker", compatibilityVersion]
+                case .qcc:
+                    break
                 case .auto:
                     preconditionFailure("Expected LINKER_DRIVER to be bound to a concrete value")
                 }
@@ -287,6 +289,8 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
                     args += ["-current_version", currentVersion]
                 case .swiftc:
                     args += ["-Xlinker", "-current_version", "-Xlinker", currentVersion]
+                case .qcc:
+                    break
                 case .auto:
                     preconditionFailure("Expected LINKER_DRIVER to be bound to a concrete value")
                 }

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -298,8 +298,10 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         switch cbc.scope.evaluate(BuiltinMacros.LINKER_DRIVER) {
         case .clang:
             return .clang
+        case .qcc:
+            return .qcc
         case .swiftc:
-            return.swiftc
+            return .swiftc
         case .auto:
             if Self.isUsingSwift(usedTools) {
                 return .swiftc
@@ -1169,6 +1171,12 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
                 return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "clang++"))
             } else {
                 return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "clang"))
+            }
+        case .qcc:
+            if usedCXX {
+                return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "q++"))
+            } else {
+                return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "qcc"))
             }
         case .swiftc:
             return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "swiftc"))

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -101,6 +101,8 @@ struct QNXSDKRegistryExtension: SDKRegistryExtension {
 
             "ARCH_NAME_x86_64": .plString("x86_64"),
             "ARCH_NAME_aarch64": .plString("aarch64le"),
+
+            "LINKER_DRIVER": "qcc",
         ]
 
         return [(qnxSdk.sysroot, qnxPlatform, [

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -175,7 +175,7 @@
             {
                 Name = "LD_OPTIMIZATION_LEVEL";
                 Type = String;
-                Condition = "$(LINKER_DRIVER) == clang";
+                Condition = "$(LINKER_DRIVER) == clang || $(LINKER_DRIVER) == qcc";
                 DefaultValue = "$(GCC_OPTIMIZATION_LEVEL)";
                 "CommandLinePrefixFlag" = "-O";
             },


### PR DESCRIPTION
_(migrated from #398 in accordance with our new policy to require PRs from forks)_