### PR TITLE
Turn on `AppSandboxConflictingValuesEmitsWarning` 

### DIFF
--- a/Sources/SWBCore/SWBFeatureFlag.swift
+++ b/Sources/SWBCore/SWBFeatureFlag.swift
@@ -157,5 +157,5 @@ public enum SWBFeatureFlag {
 
     public static let enableCacheMetricsLogs = SWBFeatureFlagProperty("EnableCacheMetricsLogs", defaultValue: false)
 
-    public static let enableAppSandboxConflictingValuesEmitsWarning = SWBFeatureFlagProperty("AppSandboxConflictingValuesEmitsWarning", defaultValue: false)
+    public static let enableAppSandboxConflictingValuesEmitsWarning = SWBFeatureFlagProperty("AppSandboxConflictingValuesEmitsWarning", defaultValue: true)
 }


### PR DESCRIPTION
Turn on `AppSandboxConflictingValuesEmitsWarning` to ensure app sandbox build setting and entitlements don't conflict