### PR TITLE
Use SwiftSystem.Errno instead of calling strerror directly

### DIFF
--- a/Sources/SWBUtil/POSIX.swift
+++ b/Sources/SWBUtil/POSIX.swift
@@ -14,12 +14,10 @@ import SWBLibc
 
 public import protocol Foundation.LocalizedError
 
-#if os(Windows)
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
-#endif
+public import SystemPackage
 #endif
 
 public enum POSIX: Sendable {
@@ -78,12 +76,16 @@ public enum POSIX: Sendable {
 }
 
 public struct POSIXError: Error, LocalizedError, CustomStringConvertible, Equatable {
-    public let code: Int32
+    public let underlyingError: Errno
     public let context: String?
     public let arguments: [String]
 
+    public var code: Int32 {
+        underlyingError.rawValue
+    }
+
     public init(_ code: Int32, context: String? = nil, _ arguments: [String]) {
-        self.code = code
+        self.underlyingError = Errno(rawValue: code)
         self.context = context
         self.arguments = arguments
     }
@@ -93,7 +95,7 @@ public struct POSIXError: Error, LocalizedError, CustomStringConvertible, Equata
     }
 
     public var description: String {
-        let end = "\(String(cString: strerror(code))) (\(code))"
+        let end = "\(underlyingError.description) (\(code))"
         if let context {
             return "\(context)(\(arguments.joined(separator: ", "))): \(end)"
         }

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -432,7 +432,8 @@ fileprivate func copyTree(_ srcPath: Path, _ dstPath: Path, options: CopyOptions
         do {
             _srcPath = try localFS.realpath(srcPath)
         } catch let error as POSIXError {
-            outStream <<< "error: \(srcPath.str): \(String(cString: strerror(error.code)))\n"
+            // TODO: Does this really need to print specially for POSIXError?
+            outStream <<< "error: \(srcPath.str): \(error.underlyingError.description)\n"
             return false
         } catch {
             outStream <<< "error: \(srcPath.str): \(error.localizedDescription)\n"
@@ -441,7 +442,8 @@ fileprivate func copyTree(_ srcPath: Path, _ dstPath: Path, options: CopyOptions
         do {
             _dstPath = try localFS.realpath(dstPath)
         } catch let error as POSIXError {
-            outStream <<< "error: \(dstPath.str): \(String(cString: strerror(error.code)))\n"
+            // TODO: Does this really need to print specially for POSIXError?
+            outStream <<< "error: \(dstPath.str): \(error.underlyingError.description)\n"
             return false
         } catch {
             outStream <<< "error: \(srcPath.str): \(error.localizedDescription)\n"


### PR DESCRIPTION
This resolves some builds warnings on Windows, which helps log readability.

(Yes I know we could alternatively just disable those warnings, but technically strerror does have thread safety issues and if we're going to fix that it would be nice to just do it in SwiftSystem in one place only)