### PR TITLE
[6.2] Update metal tests to account for a downloaded metal toolchain

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -325,6 +325,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
 
     @Test(.requireSDKs(.macOS), .requireXcode16())
     func singleFileCompileMetal() async throws {
+        let core = try await getCore()
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = try await TestWorkspace(
                 "Test",
@@ -337,6 +338,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                             "Debug",
                             buildSettings: ["PRODUCT_NAME": "$(TARGET_NAME)",
                                             "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
+                                            "TOOLCHAINS": core.environment["TOOLCHAINS"] ?? "$(inherited)",
                                             "SWIFT_VERSION": swiftVersion])],
                         targets: [
                             TestStandardTarget(
@@ -348,7 +350,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                     )
                 ]
             )
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let tester = try await BuildOperationTester(core, testWorkspace, simulated: false)
 
             let metalFile = testWorkspace.sourceRoot.join("aProject/Metal.metal")
             try await tester.fs.writeFileContents(metalFile) { stream in }

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -5756,6 +5756,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
 
     @Test(.requireSDKs(.macOS))
     func incrementalMetalLinkWithCodeSign() async throws {
+        let core = try await getCore()
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = try await TestWorkspace(
                 "Test",
@@ -5773,6 +5774,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                                             "CODE_SIGN_IDENTITY": "-",
                                             "INFOPLIST_FILE": "Info.plist",
                                             "CODESIGN": "/usr/bin/true",
+                                            "TOOLCHAINS": core.environment["TOOLCHAINS"] ?? "$(inherited)",
                                             "SWIFT_VERSION": swiftVersion])],
                         targets: [
                             TestStandardTarget(
@@ -5781,7 +5783,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                                 buildPhases: [
                                     TestSourcesBuildPhase(["SwiftFile.swift", "Metal.metal"]),
                                 ])])])
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false, fileSystem: localFS)
+            let tester = try await BuildOperationTester(core, testWorkspace, simulated: false, fileSystem: localFS)
             let signableTargets: Set<String> = ["aFramework"]
 
             // Create the input files.


### PR DESCRIPTION
Update metal tests to account for a downloaded metal toolchain. If needed, run xcodebuild -showComponent metalToolchain --json to fetch the external toolchain info and inject it into tests which rely on the Metal compiler,

rdar://146431505
