### PR TITLE
Loosen test expectations in framework pruning tests

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -2928,12 +2928,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                 "Versions/A/Resources/Info.plist",
                 "Versions/A/Resources/ja.lproj",
                 "Versions/A/Resources/ja.lproj/Localizable.strings",
-                "Versions/A/_CodeSignature",
-                "Versions/A/_CodeSignature/CodeDirectory",
-                "Versions/A/_CodeSignature/CodeRequirements",
-                "Versions/A/_CodeSignature/CodeRequirements-1",
-                "Versions/A/_CodeSignature/CodeResources",
-                "Versions/A/_CodeSignature/CodeSignature",
                 "Versions/Current",
             ]
 
@@ -2970,12 +2964,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "Versions/A/Headers/AFwk.h",
                     "Versions/A/Resources/AResource.plist",
                     "Versions/A/Resources/Info.plist",
-                    "Versions/A/_CodeSignature",
-                    "Versions/A/_CodeSignature/CodeDirectory",
-                    "Versions/A/_CodeSignature/CodeRequirements",
-                    "Versions/A/_CodeSignature/CodeRequirements-1",
-                    "Versions/A/_CodeSignature/CodeResources",
-                    "Versions/A/_CodeSignature/CodeSignature",
                     "Versions/Current",
                 ])
             }
@@ -3061,7 +3049,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                 ]))
             }
 
-            let sourceDynamicFrameworkFiles = try tester.fs.traverse(sourceDynamicFrameworkPath, { $0.relativeSubpath(from: sourceDynamicFrameworkPath) }).sorted()
+            let sourceDynamicFrameworkFiles = try tester.fs.traverse(sourceDynamicFrameworkPath, { $0.relativeSubpath(from: sourceDynamicFrameworkPath) }).sorted().filter { !$0.contains("_CodeSignature") }
             if runDestination.platform == "macosx" {
                 XCTAssertEqualSequences(sourceDynamicFrameworkFiles, [
                     "ADynamicFwk",
@@ -3075,12 +3063,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "Versions/A/Resources",
                     "Versions/A/Resources/ADynamicResource.plist",
                     "Versions/A/Resources/Info.plist",
-                    "Versions/A/_CodeSignature",
-                    "Versions/A/_CodeSignature/CodeDirectory",
-                    "Versions/A/_CodeSignature/CodeRequirements",
-                    "Versions/A/_CodeSignature/CodeRequirements-1",
-                    "Versions/A/_CodeSignature/CodeResources",
-                    "Versions/A/_CodeSignature/CodeSignature",
                     "Versions/Current",
                 ])
             } else {
@@ -3090,8 +3072,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "Headers",
                     "Headers/ADynamicFwk.h",
                     "Info.plist",
-                    "_CodeSignature",
-                    "_CodeSignature/CodeResources",
                 ])
             }
 
@@ -3111,7 +3091,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                 ]))
             }
 
-            let sourceStaticFrameworkFiles = try tester.fs.traverse(sourceStaticFrameworkPath, { $0.relativeSubpath(from: sourceStaticFrameworkPath) }).sorted()
+            let sourceStaticFrameworkFiles = try tester.fs.traverse(sourceStaticFrameworkPath, { $0.relativeSubpath(from: sourceStaticFrameworkPath) }).sorted().filter { !$0.contains("_CodeSignature") }
             if runDestination.platform == "macosx" {
                 XCTAssertEqualSequences(sourceStaticFrameworkFiles, [
                     "AStaticFwk",
@@ -3125,12 +3105,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "Versions/A/Resources",
                     "Versions/A/Resources/AStaticResource.plist",
                     "Versions/A/Resources/Info.plist",
-                    "Versions/A/_CodeSignature",
-                    "Versions/A/_CodeSignature/CodeDirectory",
-                    "Versions/A/_CodeSignature/CodeRequirements",
-                    "Versions/A/_CodeSignature/CodeRequirements-1",
-                    "Versions/A/_CodeSignature/CodeResources",
-                    "Versions/A/_CodeSignature/CodeSignature",
                     "Versions/Current",
                 ])
             } else {
@@ -3140,12 +3114,6 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     "Headers",
                     "Headers/AStaticFwk.h",
                     "Info.plist",
-                    "_CodeSignature",
-                    "_CodeSignature/CodeDirectory",
-                    "_CodeSignature/CodeRequirements",
-                    "_CodeSignature/CodeRequirements-1",
-                    "_CodeSignature/CodeResources",
-                    "_CodeSignature/CodeSignature",
                 ])
             }
 
@@ -3199,7 +3167,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                             task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-exclude", "Headers", "-exclude", "PrivateHeaders", "-exclude", "Modules", "-exclude", "*.tbd", "-resolve-src-symlinks"] + (keepStaticBinary ? [] : ["-remove-static-executable"]) + ["\(tmpDirPath.str)/ADynamicFwk.framework", frameworkDestinationDir])
 
                             let destDynamicFrameworkPath = Path("\(frameworkDestinationDir)/ADynamicFwk.framework")
-                            let delta = try Set(sourceDynamicFrameworkFiles).diff(against: tester.fs.traverse(destDynamicFrameworkPath, { $0.relativeSubpath(from: destDynamicFrameworkPath) }))
+                            let delta = try Set(sourceDynamicFrameworkFiles).diff(against: tester.fs.traverse(destDynamicFrameworkPath, { $0.relativeSubpath(from: destDynamicFrameworkPath) }).filter{ !$0.contains("_CodeSignature") })
                             XCTAssertEqualSequences(delta.right, [])
 
                             // Check that we removed all the headers
@@ -3221,7 +3189,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                             task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-exclude", "Headers", "-exclude", "PrivateHeaders", "-exclude", "Modules", "-exclude", "*.tbd", "-resolve-src-symlinks"] + (keepStaticBinary ? [] : ["-remove-static-executable"]) + ["\(tmpDirPath.str)/AStaticFwk.framework", frameworkDestinationDir])
 
                             let destStaticFrameworkPath = Path("\(frameworkDestinationDir)/AStaticFwk.framework")
-                            let delta = try Set(sourceStaticFrameworkFiles).diff(against: tester.fs.traverse(destStaticFrameworkPath, { $0.relativeSubpath(from: destStaticFrameworkPath) }))
+                            let delta = try Set(sourceStaticFrameworkFiles).diff(against: tester.fs.traverse(destStaticFrameworkPath, { $0.relativeSubpath(from: destStaticFrameworkPath) }).filter{ !$0.contains("_CodeSignature") })
                             XCTAssertEqualSequences(delta.right, [])
 
                             // Check that we removed all the headers, as well as the binary (since it is static), if configured
@@ -3240,22 +3208,10 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                                         "Headers/AStaticFwk.h",
                                     ])
                                 } else if useAppStoreCodelessFrameworksWorkaround {
-                                    let additionalFiles: [String]
-                                    if codesign {
-                                        additionalFiles = [
-                                            "_CodeSignature/CodeDirectory",
-                                            "_CodeSignature/CodeRequirements",
-                                            "_CodeSignature/CodeRequirements-1",
-                                            "_CodeSignature/CodeSignature",
-                                        ]
-                                    } else {
-                                        additionalFiles = []
-                                    }
-
                                     XCTAssertEqualSequences(delta.left.sorted(), [
                                         "Headers",
                                         "Headers/AStaticFwk.h",
-                                    ] + additionalFiles)
+                                    ])
                                 } else {
                                     XCTAssertEqualSequences(delta.left.sorted(), [
                                         "AStaticFwk",


### PR DESCRIPTION
These tests aren't intended to check for code signing behavior, so filter out the _CodeSignature folder to simplify comparisons

rdar://155531620

