### PR TITLE
Tighten up some logic around file permissions

### DIFF
--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -298,8 +298,9 @@ fileprivate func copyRegular(_ srcPath: Path, _ srcParentPath: Path, _ dstPath: 
 
 func _copyFile(_ srcPath: Path, _ dstPath: Path) throws {
     do {
+        let existingPermissions: FilePermissions = try localFS.getFilePermissions(srcPath)
         var permissions: FilePermissions = [.ownerRead, .ownerWrite, .groupRead, .groupWrite, .otherRead, .otherWrite]
-        if try localFS.isExecutable(srcPath) {
+        if existingPermissions.contains(.ownerExecute) {
             permissions.insert([.ownerExecute, .groupExecute, .otherExecute])
         }
         let dstFd = try FileDescriptor.open(FilePath(dstPath.str), .writeOnly, options: [.create, .truncate], permissions: permissions)

--- a/Tests/SWBUtilTests/FSProxyTests.swift
+++ b/Tests/SWBUtilTests/FSProxyTests.swift
@@ -350,11 +350,21 @@ import SWBTestSupport
             // Test setting file permissions.
             let execPath = tmpDir.join("script.sh")
             try localFS.write(execPath, contents: [])
+            #expect(try localFS.getFilePermissions(execPath) == 0o644)
+            #expect(try localFS.getFileInfo(execPath).permissions == 0o644)
             #expect(try !localFS.isExecutable(execPath))
-
             try localFS.setFilePermissions(execPath, permissions: 0o755)
             #expect(try localFS.getFilePermissions(execPath) == 0o755)
+            #expect(try localFS.getFileInfo(execPath).permissions == 0o755)
             #expect(try localFS.isExecutable(execPath))
+
+            let linkPath = tmpDir.join("script")
+            try localFS.symlink(linkPath, target: Path("script.sh"))
+            #expect(try localFS.getFilePermissions(linkPath) == 0o755)
+            #expect(try localFS.getFileInfo(linkPath).permissions == 0o755)
+            try localFS.setFilePermissions(linkPath, permissions: 0o644)
+            #expect(try localFS.getFilePermissions(linkPath) == 0o644)
+            #expect(try localFS.getFileInfo(linkPath).permissions == 0o644)
         }
     }
 
@@ -804,16 +814,28 @@ import SWBTestSupport
 
         // Test default permissions.
         #expect(try fs.getFilePermissions(.root) == 0o755)
+        #expect(try fs.getFileInfo(.root).permissions == 0o755)
         let filePath = Path.root.join("file.txt")
         try fs.write(filePath, contents: [])
         #expect(try fs.getFilePermissions(filePath) == 0o644)
+        #expect(try fs.getFileInfo(filePath).permissions == 0o644)
 
         // Test setting file permissions.
         let execPath = Path.root.join("script.sh")
         try fs.write(execPath, contents: [])
         #expect(try fs.getFilePermissions(execPath) == 0o644)
+        #expect(try fs.getFileInfo(execPath).permissions == 0o644)
         try fs.setFilePermissions(execPath, permissions: 0o755)
         #expect(try fs.getFilePermissions(execPath) == 0o755)
+        #expect(try fs.getFileInfo(execPath).permissions == 0o755)
+
+        let linkPath = Path.root.join("script")
+        try fs.symlink(linkPath, target: Path("script.sh"))
+        #expect(try fs.getFilePermissions(linkPath) == 0o755)
+        #expect(try fs.getFileInfo(linkPath).permissions == 0o755)
+        try fs.setFilePermissions(linkPath, permissions: 0o644)
+        #expect(try fs.getFilePermissions(linkPath) == 0o644)
+        #expect(try fs.getFileInfo(linkPath).permissions == 0o644)
     }
 
     @Test


### PR DESCRIPTION
Fix a regression (from #565) in PbxCp which caused files to inappropriately gain the execute bit. `isExecutable` is conceptually a higher level operation which (per POSIX) can return true even if the file has no execute permission bits set:

"If execute permission is requested, access shall be granted if execute permission is granted to at least one user by the file permission bits or by an alternate access control mechanism"

No test because it's not clear what the concrete conditions are under which this occurs. That said, copying now checks against the owner permission bit specifically, as that's the actual intent of what the code is meaning to do and matches the original behavior.

Additionally, fix some missing permission information in getFileInfo for the PseudoFS implementation and increase test coverage a bit. Avoids it coming back to bite later.

rdar://154663442