### PR TITLE
Remove duplicate module names in diagnostic about missing dependencies

### DIFF
--- a/Sources/SWBCore/Dependencies.swift
+++ b/Sources/SWBCore/Dependencies.swift
@@ -105,17 +105,17 @@ public struct ModuleDependenciesContext: Sendable, SerializableCodable {
 
         let moduleDependencyNames = moduleDependencies.map { $0.name }
         let fileNames = files.compactMap { findFrameworkName($0) }
-        let missingDeps = fileNames.filter {
+        let missingDeps = Set(fileNames.filter {
             return !moduleDependencyNames.contains($0)
         }.map {
             ModuleDependency(name: $0, accessLevel: .Private)
-        }
+        })
 
         guard !missingDeps.isEmpty else { return [] }
 
         let behavior: Diagnostic.Behavior = validate == .yesError ? .error : .warning
 
-        let fixIt = fixItContext?.makeFixIt(newModules: missingDeps)
+        let fixIt = fixItContext?.makeFixIt(newModules: Array(missingDeps))
         let fixIts = fixIt.map { [$0] } ?? []
 
         let message = "Missing entries in \(BuiltinMacros.MODULE_DEPENDENCIES.name): \(missingDeps.map { $0.asBuildSettingEntryQuotedIfNeeded }.sorted().joined(separator: " "))"

--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -481,7 +481,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
                                     "CLANG_ENABLE_MODULES": "YES",
                                     "CLANG_ENABLE_EXPLICIT_MODULES": "YES",
                                     "GENERATE_INFOPLIST_FILE": "YES",
-                                    "MODULE_DEPENDENCIES": "Foundation",
+                                    "MODULE_DEPENDENCIES": "Accelerate",
                                     "VALIDATE_MODULE_DEPENDENCIES": "YES_ERROR",
                                     "SDKROOT": "$(HOST_PLATFORM)",
                                     "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
@@ -507,6 +507,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
             try await tester.fs.writeFileContents(SRCROOT.join("Sources/CoreFoo.m")) { contents in
                 contents <<< """
                     #include <Foundation/Foundation.h>
+                    #include <Foundation/NSObject.h>
                     #include <Accelerate/Accelerate.h>
 
                     void f0(void) { };
@@ -515,7 +516,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
 
             // Expect complaint about undeclared dependency
             try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .host, persistent: true) { results in
-                results.checkError(.contains("Missing entries in MODULE_DEPENDENCIES: Accelerate"))
+                results.checkError(.contains("Missing entries in MODULE_DEPENDENCIES: Foundation (for task"))
             }
 
             // Declaring dependencies resolves the problem


### PR DESCRIPTION
The Clang tracing information currently shows each header file separately, so if there are multiple headers included from the same module, we get duplicates. We are investigating having Clang trace the modules directly and also investigating de-duplicating these diagnostics across targets, but this is easy to fix in the meantime.

rdar://156160529
