### PR TITLE
Add build setting to enable version-independent APINotes processing mode

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1028,6 +1028,7 @@ public final class BuiltinMacros {
     public static let SWIFT_ENABLE_EXPLICIT_MODULES = BuiltinMacros.declareEnumMacro("SWIFT_ENABLE_EXPLICIT_MODULES") as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
     public static let _SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP = BuiltinMacros.declareBooleanMacro("_SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP")
     public static let _SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5 = BuiltinMacros.declareBooleanMacro("_SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5")
+    public static let SWIFT_ENABLE_VERSION_INDEPENDENT_APINOTES = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_VERSION_INDEPENDENT_APINOTES")
     public static let _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES = BuiltinMacros.declareEnumMacro("_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES") as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
     public static let SWIFT_ENABLE_TESTABILITY = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_TESTABILITY")
     public static let SWIFT_EXEC = BuiltinMacros.declarePathMacro("SWIFT_EXEC")
@@ -2200,6 +2201,7 @@ public final class BuiltinMacros {
         SWIFT_ENABLE_EXPLICIT_MODULES,
         _SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP,
         _SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5,
+        SWIFT_ENABLE_VERSION_INDEPENDENT_APINOTES,
         _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES,
         SWIFT_ENABLE_BARE_SLASH_REGEX,
         SWIFT_ENABLE_EMIT_CONST_VALUES,

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1354,6 +1354,19 @@
                 };
             },
 
+            {
+                Name = "SWIFT_ENABLE_VERSION_INDEPENDENT_APINOTES";
+                Type = Boolean;
+                DefaultValue = NO;
+                CommandLineArgs = {
+                    YES = (
+                        "-Xfrontend",
+                        "-version-independent-apinotes",
+                    );
+                    NO = ();
+                };
+            },
+
             // Hidden clang importer options to control C++ behavior
             // in the clang importer, not visible in build settings.
             {


### PR DESCRIPTION
We are adding a new mode for loading/using APINotes in the Swift compiler which is behind an opt-in flag `-version-independent-apinotes`: https://github.com/swiftlang/swift/pull/75893. 

This new mode's goal is to eventually become default and remove the need for `_SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5`. Until then, having this build setting will help with rolling this mode out to clients and testing. 