### PR TITLE
Fix incorrect error code propagation in CodeSignatureInfo.load

### DIFF
--- a/Sources/SWBUtil/Signatures.swift
+++ b/Sources/SWBUtil/Signatures.swift
@@ -191,7 +191,7 @@ public struct CodeSignatureInfo: Codable, Sendable {
 
         let result2 = SecCodeCopySigningInformation(code!, [SecCSFlags(rawValue: kSecCSSigningInformation)], &info)
         if result2 != 0 {
-            throw MacError(result)
+            throw MacError(result2)
         }
 
         if !skipValidation {


### PR DESCRIPTION
In the CodeSignatureInfo.load method, when SecCodeCopySigningInformation fails, the code was incorrectly throwing MacError(result) instead of MacError(result2). This caused misleading error messages since it propagated the error code from the previous SecStaticCodeCreateWithPath call rather than the actual failing SecCodeCopySigningInformation call.

The fix ensures accurate error reporting for code signing verification failures.