### PR TITLE
Add compiler build settings for Enhanced Security

### DIFF
--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3535,6 +3535,33 @@ For more information on mergeable libraries, see [Configuring your project to us
                 Category = BuildOptions;
                 Description = "Enables building with code coverage instrumentation. This is only used when the build has code coverage enabled, which is typically done via the Xcode scheme or test plan settings.";
             },
+            {   Name = ENABLE_ENHANCED_SECURITY;
+                Type = Boolean;
+                DefaultValue = NO;
+                Category = SecurityPolicy;
+            },
+            {   Name = ENABLE_POINTER_AUTHENTICATION;
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_ENHANCED_SECURITY)";
+                Category = SecurityPolicy;
+            },
+            {   Name = ENABLE_SECURITY_COMPILER_WARNINGS;
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_ENHANCED_SECURITY)";
+                Category = SecurityPolicy;
+            },
+            {
+                Name = "ENABLE_C_BOUNDS_SAFETY";
+                Type = Boolean;
+                DefaultValue = NO;
+                Category = Security;
+            },
+            {
+                Name = "ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS";
+                Type = Boolean;
+                DefaultValue = NO;
+                Category = Security;
+            },
             {   Name = ENABLE_TESTABILITY;
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
+++ b/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
@@ -669,6 +669,35 @@ Typically this path is not set per target, but is provided as an option on the c
 "[MODULE_STOP]-name" = "Module Stop Routine";
 "[MODULE_STOP]-description" = "This defines the name of the kernel module stop routine. This is only used when building kernel extensions.";
 
+// Security Settings
+
+"[SecurityPolicy]-category" = "Security";
+
+"[ENABLE_ENHANCED_SECURITY]-name" = "Enable Enhanced Security";
+"[ENABLE_ENHANCED_SECURITY]-description" = "Enables a set of security build settings, including pointer authentication, typed allocator support, hardened C++ standard library, and security-related compiler warnings. These settings can be disabled individually.";
+"[ENABLE_ENHANCED_SECURITY]-value-[YES]" = "Yes";
+"[ENABLE_ENHANCED_SECURITY]-value-[NO]" = "No";
+
+"[ENABLE_POINTER_AUTHENTICATION]-name" = "Enable Pointer Authentication";
+"[ENABLE_POINTER_AUTHENTICATION]-description" = "Builds the target with pointer authentication enabled. Adds an additional architectural slice (arm64e) with pointer authentication instructions.";
+"[ENABLE_POINTER_AUTHENTICATION]-value-[YES]" = "Yes";
+"[ENABLE_POINTER_AUTHENTICATION]-value-[NO]" = "No";
+
+"[ENABLE_SECURITY_COMPILER_WARNINGS]-name" = "Enable Security-Relevant Compiler Warnings";
+"[ENABLE_SECURITY_COMPILER_WARNINGS]-description" = "Enables a set of security-relevant compiler warnings that check for common bounds-safety and lifetime-safety issues.";
+"[ENABLE_SECURITY_COMPILER_WARNINGS]-value-[YES]" = "Yes";
+"[ENABLE_SECURITY_COMPILER_WARNINGS]-value-[NO]" = "No";
+
+"[ENABLE_C_BOUNDS_SAFETY]-name" = "Enable Language Extension for Bounds Safety in C";
+"[ENABLE_C_BOUNDS_SAFETY]-description" = "Enables the -fbounds-safety language extension, which guarantees bounds safety for C";
+"[ENABLE_C_BOUNDS_SAFETY]-value-[NO]" = "No";
+"[ENABLE_C_BOUNDS_SAFETY]-value-[YES]" = "Yes";
+
+"[ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS]-name" = "Enforce Bounds-Safe Buffer Usage in C++";
+"[ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS]-description" = "Enables a strict programming model that guarantees bounds safety in C++ by rejecting raw pointer arithmetic (enabling the -Wunsafe-buffer-usage warning as an error) and requiring the use of hardened C++ Standard Library APIs for buffer manipulation.";
+"[ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS]-value-[NO]" = "No";
+"[ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS]-value-[YES]" = "Yes";
+
 // Compiler Version
 
 "[GCC_VERSION]-name" = "Compiler for C/C++/Objective-C";

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -536,7 +536,7 @@
                 FileTypes = (
                     "sourcecode.c.c",
                 );
-                DefaultValue = NO;
+                DefaultValue = "$(ENABLE_C_BOUNDS_SAFETY)";
                 CommandLineArgs = {
                     YES = ( "-fbounds-safety" );
                     NO  = ();
@@ -640,14 +640,74 @@
                 Category = LanguageCXX;
             },
             {
-                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_0;
+                Name = __ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES_YES;
+                Type = String;
+                DefaultValue = "YES";
+            },
+            {
+                Name = __ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES_NO;
+                Type = String;
+                DefaultValue = "YES";
+            },
+            {
+                Name = __ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_NO_YES;
+                Type = String;
+                DefaultValue = "YES";
+            },
+            {
+                Name = __ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_NO_NO;
+                Type = String;
+                DefaultValue = "NO";
+            },
+            {
+                Name = __ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS;
+                Type = String;
+                DefaultValue = "$(__ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_$(ENABLE_ENHANCED_SECURITY)_$(ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS))";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_0_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
                 Type = String;
                 DefaultValue = "debug";
             },
             {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_0_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_NO;
+                Type = String;
+                DefaultValue = "debug";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_1_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_2_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_3_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_s_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_fast_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
+                Name = __LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_z_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_YES;
+                Type = String;
+                DefaultValue = "fast";
+            },
+            {
                 Name = __LIBRARY_HARDENING_DEFAULT_VALUE;
                 Type = String;
-                DefaultValue = "$(__LIBRARY_HARDENING_DEFAULT_VALUE_$(GCC_OPTIMIZATION_LEVEL))";
+                DefaultValue = "$(__LIBRARY_HARDENING_DEFAULT_VALUE_OPT_LEVEL_$(GCC_OPTIMIZATION_LEVEL)_ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS_$(__ENHANCED_SECURITY_OR_BOUNDS_SAFE_BUFFERS))";
             },
             {
                 Name = "CLANG_CXX_STANDARD_LIBRARY_HARDENING";
@@ -737,10 +797,25 @@
                 Category = LanguageCXX;
             },
             {
+                Name = "_UNSAFE_BUFFER_USAGE_DEFAULT_ENABLE_SAFE_BUFFERS_NO";
+                Type = String;
+                DefaultValue = "DEFAULT";
+            },
+            {
+                Name = "_UNSAFE_BUFFER_USAGE_DEFAULT_ENABLE_SAFE_BUFFERS_YES";
+                Type = String;
+                DefaultValue = "YES_ERROR";
+            },
+            {
+                Name = "_UNSAFE_BUFFER_USAGE_DEFAULT";
+                Type = String;
+                DefaultValue = "$(_UNSAFE_BUFFER_USAGE_DEFAULT_ENABLE_SAFE_BUFFERS_$(ENABLE_CPLUSPLUS_BOUNDS_SAFE_BUFFERS))";
+            },
+            {
                 Name = "CLANG_WARN_UNSAFE_BUFFER_USAGE";
                 Type = Enumeration;
                 Values = ( DEFAULT, YES, YES_ERROR, NO );
-                DefaultValue = DEFAULT;
+                DefaultValue = "$(_UNSAFE_BUFFER_USAGE_DEFAULT)";
                 CommandLineArgs = {
                     DEFAULT = ();
                     NO = ( "-Wno-unsafe-buffer-usage" );
@@ -801,7 +876,7 @@
             {
                 Name = "GCC_OPTIMIZATION_LEVEL";
                 Type = Enumeration;
-                // NOTE: Updating these values requires updating LLVM_OPTIMIZATION_LEVEL_VAL_X.
+                // NOTE: Updating these values requires updating LLVM_OPTIMIZATION_LEVEL_VAL_X and CLANG_CXX_STANDARD_LIBRARY_HARDENING.
                 Values = (
                     0,
                     1,
@@ -944,6 +1019,22 @@
                     NO = ();
                 };
                 Category = WarningsPolicy;
+            },
+            {   Name = CLANG_ENABLE_SECURITY_COMPILER_WARNINGS;
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_SECURITY_COMPILER_WARNINGS)";
+                CommandLineArgs = {
+                  YES = ("-Wbuiltin-memcpy-chk-size",
+                         "-Wformat-nonliteral",
+                         "-Warray-bounds",
+                         "-Warray-bounds-pointer-arithmetic",
+                         "-Wsuspicious-memaccess",
+                         "-Wsizeof-array-div",
+                         "-Wsizeof-pointer-div",
+                         "-Wreturn-stack-address");
+                  NO  = ();
+                };
+                // Hidden.
             },
             {
                 Name = "GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS";
@@ -1381,7 +1472,7 @@
             {
                 Name = "CLANG_WARN_EMPTY_BODY";
                 Type = Boolean;
-                DefaultValue = NO;
+                DefaultValue = "$(CLANG_ENABLE_SECURITY_COMPILER_WARNINGS)";
                 CommandLineArgs = {
                     YES = ( "-Wempty-body" );
                     NO = ( "-Wno-empty-body" );
@@ -1447,7 +1538,7 @@
             {
                 Name = "GCC_WARN_SHADOW";
                 Type = Boolean;
-                DefaultValue = NO;
+                DefaultValue = "$(CLANG_ENABLE_SECURITY_COMPILER_WARNINGS)";
                 CommandLineArgs = {
                     YES = (
                         "-Wshadow",
@@ -1801,6 +1892,27 @@
                 Category = Warnings;
             },
             {
+                Name = "CLANG_ENABLE_STACK_ZERO_INIT";
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_ENHANCED_SECURITY)";
+                Category = Security;
+            },
+            {
+                Name = "_CLANG_TRIVIAL_AUTO_VAR_INIT_DEFAULT_ENABLE_ZERO_INIT_YES";
+                Type = Boolean;
+                DefaultValue = "zero";
+            },
+            {
+                Name = "_CLANG_TRIVIAL_AUTO_VAR_INIT_DEFAULT_ENABLE_ZERO_INIT_NO";
+                Type = Boolean;
+                DefaultValue = "default";
+            },
+            {
+                Name = "_CLANG_TRIVIAL_AUTO_VAR_INIT_DEFAULT";
+                Type = String;
+                DefaultValue = "$(_CLANG_TRIVIAL_AUTO_VAR_INIT_DEFAULT_ENABLE_ZERO_INIT_$(CLANG_ENABLE_STACK_ZERO_INIT))";
+            },
+            {
                 Name = "CLANG_TRIVIAL_AUTO_VAR_INIT";
                 Type = Enumeration;
                 Values = (
@@ -1809,7 +1921,7 @@
                     zero,
                     pattern,
                 );
-                DefaultValue = default;
+                DefaultValue = "$(_CLANG_TRIVIAL_AUTO_VAR_INIT_DEFAULT)";
                 CommandLineArgs = {
                     default = ( );
                     uninitialized = ( "-ftrivial-auto-var-init=uninitialized" );
@@ -2900,7 +3012,17 @@
                 Condition = "$(CLANG_UNDEFINED_BEHAVIOR_SANITIZER_TRAP_ON_SECURITY_ISSUES) && $(GCC_OPTIMIZATION_LEVEL) != 0";
             },
             {
-                Name = "CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT";
+                Name = "_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT_ENHANCED_SECURITY_YES";
+                Type = Enumeration;
+                Values = (
+                    compiler-default,
+                    YES,
+                    NO,
+                );
+                DefaultValue = YES;
+            },
+            {
+                Name = "_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT_ENHANCED_SECURITY_NO";
                 Type = Enumeration;
                 Values = (
                     compiler-default,
@@ -2908,11 +3030,32 @@
                     NO,
                 );
                 DefaultValue = compiler-default;
+            },
+            {
+                Name = "_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT";
+                Type = Enumeration;
+                Values = (
+                    compiler-default,
+                    YES,
+                    NO,
+                );
+                DefaultValue = "$(_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT_ENHANCED_SECURITY_$(ENABLE_ENHANCED_SECURITY))";
+            },
+            {
+                Name = "CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT";
+                Type = Enumeration;
+                Values = (
+                    compiler-default,
+                    YES,
+                    NO,
+                );
+                DefaultValue = "$(_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT)";
                 CommandLineArgs = {
                   compiler-default = ();
                   YES = ("-ftyped-memory-operations");
                   NO  = ("-fno-typed-memory-operations");
                 };
+                Category = Language;
             },
             {
                 Name = "CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT";
@@ -2922,7 +3065,7 @@
                     YES,
                     NO,
                 );
-                DefaultValue = compiler-default;
+                DefaultValue = "$(_CLANG_ENABLE_TYPED_ALLOCATOR_SUPPORT_DEFAULT)";
                 CommandLineArgs = {
                   compiler-default = ();
                   YES = ("-ftyped-cxx-new-delete", "-ftyped-cxx-delete");
@@ -2933,6 +3076,7 @@
                     YES = ("-ftyped-cxx-new-delete", "-ftyped-cxx-delete");
                     NO = ();
                 };
+                Category = LanguageCXX;
             },
             // Index-while-building options, not visible in build settings.
             {

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -736,7 +736,6 @@
                     );
                 };
             },
-
             {
                 Name = "__CREATE_INFOPLIST_SECTION_IN_BINARY";
                 Type = Boolean;

--- a/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
+++ b/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
@@ -695,6 +695,23 @@ The restrictions on `offsetof` may be relaxed in a future version of the C++ sta
 "[CLANG_ENABLE_MODULES]-value-[YES]" = "Yes";
 "[CLANG_ENABLE_MODULES]-value-[NO]" = "No";
 
+"[CLANG_ENABLE_STACK_ZERO_INIT]-name" = "Enable Stack Zero Initialization";
+"[CLANG_ENABLE_STACK_ZERO_INIT]-description" = "Automatically initializes stack variables to zero as a security protection.";
+"[CLANG_ENABLE_STACK_ZERO_INIT]-value-[YES]" = "Yes";
+"[CLANG_ENABLE_STACK_ZERO_INIT]-value-[NO]" = "No";
+
+"[CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT]-name" = "Enable Typed Allocator in C";
+"[CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT]-description" = "Enables compiler rewriting of allocation calls in C to provide type information to the allocator. Mitigates use-after-free security vulnerabilities.";
+"[CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT]-value-[YES]" = "Yes";
+"[CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT]-value-[NO]" = "No";
+"[CLANG_ENABLE_C_TYPED_ALLOCATOR_SUPPORT]-value-[compiler-default]" = "Compiler Default";
+
+"[CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT]-name" = "Enable Typed Allocator in C++";
+"[CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT]-description" = "Enables compiler rewriting of allocation calls in C++ to provide type information to the allocator. Mitigates use-after-free security vulnerabilities.";
+"[CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT]-value-[YES]" = "Yes";
+"[CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT]-value-[NO]" = "No";
+"[CLANG_ENABLE_CPLUSPLUS_TYPED_ALLOCATOR_SUPPORT]-value-[compiler-default]" = "Compiler Default";
+
 "[CLANG_MODULES_AUTOLINK]-name" = "Link Frameworks Automatically";
 "[CLANG_MODULES_AUTOLINK]-description" = "Automatically link SDK frameworks that are referenced using `#import` or `#include`. This feature requires also enabling support for modules. This build setting only applies to C-family languages.";
 "[CLANG_MODULES_AUTOLINK]-value-[YES]" = "Yes (when modules are enabled)";

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -6680,10 +6680,10 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     @Test(.requireSDKs(.iOS))
-    func pointerAuthenticationBuildSetting() async throws {
+    func pointerAuthenticationBuildSetting_iOS() async throws {
         func test(buildSettings: [String: String], expectedArchs: [String], line: UInt = #line) async throws {
 
-            try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            try await withTemporaryDirectory { (tmpDirPath: Path) async throws -> Void in
                 let testWorkspace = try await TestWorkspace(
                     "Test",
                     sourceRoot: tmpDirPath.join("Test"),
@@ -6719,8 +6719,80 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                     try await tester.fs.writeFileContents(swiftFile) { stream in }
                 }
 
-                try await tester.checkBuild(runDestination: .anyiOSDevice) { results in
+                try await tester.checkBuild(runDestination: .anyiOSDevice) { results -> Void in
                     results.checkNoErrors()
+
+                    for arch in expectedArchs {
+                        results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("File.c")), .matchRuleItem(arch)) { _ in }
+                        results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("File.m")), .matchRuleItem(arch)) { _ in }
+                        results.checkTask(.matchRuleType("SwiftCompile"), .matchRuleItem(arch)) { _ in }
+                        results.checkTask(.matchRuleType("SwiftEmitModule"), .matchRuleItem(arch)) { _ in }
+
+                    }
+                }
+            }
+        }
+
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["arm64"])
+
+        // ENABLE_ENHANCED_SECURITY enables pointer authentication unless ENABLE_POINTER_AUTHENTICATION is explicitly disabled.
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES"], expectedArchs: ["arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO"], expectedArchs: ["arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES", "ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["arm64e"])
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func pointerAuthenticationBuildSetting_macOS() async throws {
+        func test(buildSettings: [String: String], expectedArchs: [String], line: UInt = #line) async throws {
+
+            try await withTemporaryDirectory { (tmpDirPath: Path) async throws -> Void in
+                let testWorkspace = try await TestWorkspace(
+                    "Test",
+                    sourceRoot: tmpDirPath.join("Test"),
+                    projects: [
+                        TestProject(
+                            "aProject",
+                            groupTree: TestGroup("Sources", children: [
+                                TestFile("File.c"),
+                                TestFile("File.swift"),
+                                TestFile("File.m"),
+                            ]),
+                            buildConfigurations: [TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SDKROOT": "macosx",
+                                    "DONT_GENERATE_INFOPLIST_FILE": "YES",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_VERSION": swiftVersion,
+                                ])],
+                            targets: [
+                                TestStandardTarget(
+                                    "aFramework", type: .framework,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: buildSettings)],
+                                    buildPhases: [
+                                        TestSourcesBuildPhase(["File.c", "File.swift", "File.m"]),
+                                    ]),
+                                TestStandardTarget(
+                                    "anApp", type: .application,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: buildSettings)],
+                                    buildPhases: [
+                                        TestSourcesBuildPhase(["File.c", "File.swift", "File.m"]),
+                                    ])
+                            ])])
+
+                let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+                // create the files
+                for file in ["File.swift", "File.c", "File.m"] {
+                    let swiftFile = testWorkspace.sourceRoot.join("aProject/\(file)")
+                    try await tester.fs.writeFileContents(swiftFile) { stream in }
+                }
+
+                try await tester.checkBuild(runDestination: .anyMac) { results -> Void in
+                    results.checkNoErrors()
+
 
                     for arch in expectedArchs {
                         results.checkTask(.matchRuleType("CompileC"), .matchRuleItemPattern(.suffix("File.c")), .matchRuleItem(arch)) { _ in }
@@ -6732,8 +6804,14 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             }
         }
 
-        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["arm64", "arm64e"])
-        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["arm64"])
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["x86_64", "arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["x86_64", "arm64"])
+
+        // ENABLE_ENHANCED_SECURITY enables pointer authentication unless ENABLE_POINTER_AUTHENTICATION is explicitly disabled.
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES"], expectedArchs: ["x86_64", "arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO"], expectedArchs: ["x86_64", "arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES", "ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["x86_64", "arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["x86_64", "arm64e"])
     }
 
     @Test(.requireSDKs(.macOS))


### PR DESCRIPTION
Add a new "Security" build settings group and an
"Enhanced Security" build setting that enables a number of security settings at once, including:
    * Enabling pointer authentication
    * Enabling the typed allocator
    * Enabling hardened libc++
    * Enabling stack zero initialization
    * Enabling security relevant compiler warnings

The goal is that enabling the Enhanced Security build setting should enable all of these other settings by default and that projects will be able to explicitly disable individual settings if needed.

rdar://151195113