### PR TITLE
Drop support for Focal in GitHub Actions CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,9 +13,9 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_os_versions: '["noble", "jammy", "focal", "rhel-ubi9"]'
+      linux_os_versions: '["noble", "jammy", "rhel-ubi9"]'
       linux_pre_build_command: |
-        if command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy, focal
+        if command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
           apt-get update -y
 
           # Build dependencies


### PR DESCRIPTION
Per https://forums.swift.org/t/dropping-support-for-ubuntu-20-04/81109, the Swift project is dropping support for Ubuntu 20.04 (Focal) beginning in Swift 6.2 and later, so remove it from our testing matrix (it's failing now anyways).