### PR TITLE
[6.2] Add a hostRuntimeEnvironment test helper function

### DIFF
--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -296,6 +296,26 @@ extension RunDestinationInfo {
             return .elf
         }
     }
+
+    /// An `Environment` object with `PATH` or `LD_LIBRARY_PATH` set appropriately pointing into the toolchain to be able to run a built Swift binary in tests.
+    ///
+    /// - note: On macOS, the OS provided Swift runtime is used, so `DYLD_LIBRARY_PATH` is never set for Mach-O destinations.
+    package func hostRuntimeEnvironment(_ core: Core, initialEnvironment: Environment = Environment()) -> Environment {
+        var environment = initialEnvironment
+        guard let toolchain = core.toolchainRegistry.defaultToolchain else {
+            return environment
+        }
+        switch imageFormat(core) {
+        case .elf:
+            environment.prependPath(key: "LD_LIBRARY_PATH", value: toolchain.path.join("usr/lib/swift/\(platform)").str)
+        case .pe:
+            environment.prependPath(key: .path, value: core.developerPath.path.join("Runtimes").join(toolchain.version.description).join("usr/bin").str)
+        case .macho:
+            // Fall back to the OS provided Swift runtime
+            break
+        }
+        return environment
+    }
 }
 
 extension _RunDestinationInfo {

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -30,12 +30,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
             let destination: RunDestinationInfo = .host
             let core = try await getCore()
             let toolchain = try #require(core.toolchainRegistry.defaultToolchain)
-            let environment: [String: String]
-            if  destination.imageFormat(core) == .elf {
-                environment = ["LD_LIBRARY_PATH": toolchain.path.join("usr/lib/swift/\(destination.platform)").str]
-            } else {
-                environment = ProcessInfo.processInfo.environment.filter { $0.key.uppercased() == "PATH" } // important to allow swift to be looked up in PATH on Windows/Linux
-            }
+            let environment = destination.hostRuntimeEnvironment(core)
 
             let testProject = TestProject(
                 "aProject",
@@ -69,7 +64,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
                         customTasks: [
                             TestCustomTask(
                                 commandLine: ["$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/tool\(destination == .windows ? ".exe" : "")"],
-                                environment: environment,
+                                environment: .init(environment),
                                 workingDirectory: tmpDir.str,
                                 executionDescription: "My Custom Task",
                                 inputs: ["$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/tool\(destination == .windows ? ".exe" : "")"],


### PR DESCRIPTION
This will fix the few tests which are failing due to missing DLLs on Windows in certain environments.