### PR TITLE
Avoid error if missing xattr support

### DIFF
--- a/Sources/SWBCore/WorkspaceContext.swift
+++ b/Sources/SWBCore/WorkspaceContext.swift
@@ -401,10 +401,20 @@ extension FSProxy {
         return try getExtendedAttribute(path, key: Self.CreatedByBuildSystemAttribute) == Self.CreatedByBuildSystemAttributeOnValue
     }
 
+    /// Sets the "CreatedByBuildSystem" extended attribute on the specified
+    /// path.
+    ///
+    /// - Important: The caller is responsible for catching and handling
+    ///   failures if the filesystem does not support extended attributes. Many
+    ///   filesystems (e.g. various non-ext4 temporary filesystems on Linux)
+    ///   don't support xattrs and will return `ENOTSUP`. In particular, tmpfs
+    ///   doesn't support xattrs on Linux unless `CONFIG_TMPFS_XATTR` is enabled
+    ///   in the kernel config.
+    ///
+    /// - Parameter path: The path on which to set the extended attribute.
+    /// - Throws: An error if the operation fails, including when the filesystem
+    ///   doesn't support extended attributes.
     public func setCreatedByBuildSystemAttribute(_ path: Path) throws {
-        // Many filesystems on other platforms (e.g. various non-ext4 temporary filesystems on Linux) don't support xattrs and will return ENOTSUP.
-        // In particular, tmpfs doesn't support xattrs on Linux unless `CONFIG_TMPFS_XATTR` is enabled in the kernel config.
-        // FIXME: Detect whether the FS supports xattrs at runtime
         try setExtendedAttribute(path, key: Self.CreatedByBuildSystemAttribute, value: Self.CreatedByBuildSystemAttributeOnValue)
     }
 

--- a/Sources/SWBCore/WorkspaceContext.swift
+++ b/Sources/SWBCore/WorkspaceContext.swift
@@ -405,9 +405,7 @@ extension FSProxy {
         // Many filesystems on other platforms (e.g. various non-ext4 temporary filesystems on Linux) don't support xattrs and will return ENOTSUP.
         // In particular, tmpfs doesn't support xattrs on Linux unless `CONFIG_TMPFS_XATTR` is enabled in the kernel config.
         // FIXME: Detect whether the FS supports xattrs at runtime
-        #if canImport(Darwin)
         try setExtendedAttribute(path, key: Self.CreatedByBuildSystemAttribute, value: Self.CreatedByBuildSystemAttributeOnValue)
-        #endif
     }
 
     public func commandLineArgumentsToApplyCreatedByBuildSystemAttribute(to path: Path) -> [String] {

--- a/Sources/SWBTaskExecution/TaskActions/CreateBuildDirectoryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/CreateBuildDirectoryTaskAction.swift
@@ -28,12 +28,22 @@ public final class CreateBuildDirectoryTaskAction: TaskAction {
 
         do {
             try fs.createDirectory(directoryPath, recursive: true)
-            try fs.setCreatedByBuildSystemAttribute(directoryPath)
-            return .succeeded
         } catch {
             outputDelegate?.emitError(error.localizedDescription)
             return .failed
         }
+
+        // Warn on darwin if we are unable to set the "CreateByBuildSystem"
+        // attribute
+        do {
+            try fs.setCreatedByBuildSystemAttribute(directoryPath)
+        } catch {
+            #if canImport(Darwin)
+            outputDelegate?.emitWarning("Failed to set build system attribute on \(directoryPath.str): \(error.localizedDescription)")
+            #endif
+        }
+
+        return .succeeded
     }
 
     public override func performTaskAction(

--- a/Sources/SWBTaskExecution/TaskActions/CreateBuildDirectoryTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/CreateBuildDirectoryTaskAction.swift
@@ -33,7 +33,7 @@ public final class CreateBuildDirectoryTaskAction: TaskAction {
             return .failed
         }
 
-        // Warn on darwin if we are unable to set the "CreateByBuildSystem"
+        // Warn on Darwin if we are unable to set the "CreatedByBuildSystem"
         // attribute
         do {
             try fs.setCreatedByBuildSystemAttribute(directoryPath)


### PR DESCRIPTION
When building on a darwin host (e.g. macOS) using a file-system that doesn't support xattrs (e.g. tmpfs) swift-build would fail trying to set the "CreatedByBuildSystem" xattribute. This commit changes swift-build to warn instead, allowing the build to complete.