### PR TITLE
Remove unnecessary version checks

### DIFF
--- a/Sources/SWBAndroidPlatform/AndroidSDK.swift
+++ b/Sources/SWBAndroidPlatform/AndroidSDK.swift
@@ -57,10 +57,6 @@ public import Foundation
 
             let metaPath = ndkPath.path.join("meta")
 
-            guard #available(macOS 14, *) else {
-                throw StubError.error("Unsupported macOS version")
-            }
-
             if version < Self.minimumNDKVersion {
                 throw Error.unsupportedVersion(path: ndkPath, minimumVersion: Self.minimumNDKVersion)
             }

--- a/Sources/SWBCore/SpecImplementations/Tools/CodeSign.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CodeSign.swift
@@ -191,10 +191,8 @@ public final class CodesignToolSpec : CommandLineToolSpec, SpecIdentifierType, @
             commandLine.append(contentsOf: ["--launch-constraint-responsible", responsibleProcessLaunchConstraint.str])
         }
 
-        if cbc.producer.systemInfo?.operatingSystemVersion >= Version(14) {
-            if let libraryLoadConstraint = cbc.producer.signingSettings?.libraryConstraint {
-                commandLine.append(contentsOf: ["--library-constraint", libraryLoadConstraint.str])
-            }
+        if let libraryLoadConstraint = cbc.producer.signingSettings?.libraryConstraint {
+            commandLine.append(contentsOf: ["--library-constraint", libraryLoadConstraint.str])
         }
 
         // Add the path to the file to sign.


### PR DESCRIPTION
The deployment target is now macOS 14.