### PR TITLE
Handle cross-language duplications for missing dependencies

### DIFF
--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -155,6 +155,14 @@ extension CoreBasedTests {
         }
     }
 
+    /// The path to clang in the default toolchain.
+    public var defaultClangPath: Path {
+        get async throws {
+            let clangInfo = try await clangInfo
+            return clangInfo.toolPath
+        }
+    }
+
     /// The path to the libClang.dylib compiler in the default toolchain.
     package var libClangPath: Path {
         get async throws {

--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -601,19 +601,21 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
             try await tester.fs.writeFileContents(SRCROOT.join("Sources/Swift.swift")) { stream in
                 stream <<< """
                     import Foundation
+                    import AppKit
                 """
             }
 
             try await tester.fs.writeFileContents(SRCROOT.join("Sources/CoreFoo.m")) { contents in
                 contents <<< """
                     #include <Foundation/Foundation.h>
+                    #include <Accelerate/Accelerate.h>
 
                     void f(void) { };
                 """
             }
 
             try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .host, persistent: true) { results in
-                results.checkError(.contains("Missing entries in MODULE_DEPENDENCIES: Foundation"))
+                results.checkError(.contains("Missing entries in MODULE_DEPENDENCIES: Accelerate AppKit Foundation"))
             }
         }
     }

--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -529,4 +529,76 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host), .requireClangFeatures(.printHeadersDirectPerFile), .skipHostOS(.windows, "toolchain too old"), .skipHostOS(.linux, "toolchain too old"))
+    func validateModuleDependenciesMixedSource() async throws {
+        try await withTemporaryDirectory { tmpDir async throws -> Void in
+            let testWorkspace = try await TestWorkspace(
+                "Test",
+                sourceRoot: tmpDir.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources", path: "Sources",
+                            children: [
+                                TestFile("CoreFoo.m"),
+                                TestFile("Swift.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "CLANG_ENABLE_MODULES": "YES",
+                                    "CLANG_ENABLE_EXPLICIT_MODULES": "YES",
+                                    "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                                    "SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT": "YES",
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "GENERATE_INFOPLIST_FILE": "YES",
+                                    "VALIDATE_MODULE_DEPENDENCIES": "YES_ERROR",
+                                    "SDKROOT": "$(HOST_PLATFORM)",
+                                    "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                                    "DSTROOT": tmpDir.join("dstroot").str,
+
+                                    // Temporarily override to use the latest toolchain in CI because we depend on swift and swift-driver changes which aren't in the baseline tools yet
+                                    "TOOLCHAINS": "swift",
+                                    // We still want to use the default clang since that is used to gate the test
+                                    "CC": defaultClangPath.str,
+                                ]
+                            )
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "CoreFoo", type: .framework,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["CoreFoo.m", "Swift.swift"]),
+                                    TestFrameworksBuildPhase()
+                                ])
+                        ])
+                ]
+            )
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/Swift.swift")) { stream in
+                stream <<< """
+                    import Foundation
+                """
+            }
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/CoreFoo.m")) { contents in
+                contents <<< """
+                    #include <Foundation/Foundation.h>
+
+                    void f(void) { };
+                """
+            }
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .host, persistent: true) { results in
+                results.checkError(.contains("Missing entries in MODULE_DEPENDENCIES: Foundation"))
+            }
+        }
+    }
+
 }

--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -19,6 +19,23 @@ import SWBMacro
 
 @Suite
 fileprivate struct DependencyValidationTests: CoreBasedTests {
+    @Test
+    func moduleDependencyAccessLevelComparable() async throws {
+        #expect(ModuleDependency.AccessLevel.Private == .Private)
+        #expect(ModuleDependency.AccessLevel.Private < .Package)
+        #expect(ModuleDependency.AccessLevel.Private < .Public)
+
+        #expect(ModuleDependency.AccessLevel.Package == .Package)
+        #expect(ModuleDependency.AccessLevel.Package < .Public)
+        #expect(ModuleDependency.AccessLevel.Package > .Private)
+
+        #expect(ModuleDependency.AccessLevel.Public == .Public)
+        #expect(ModuleDependency.AccessLevel.Public > .Private)
+        #expect(ModuleDependency.AccessLevel.Public > .Package)
+
+        #expect(max(ModuleDependency.AccessLevel.Public, ModuleDependency.AccessLevel.Private) == .Public)
+    }
+
     @Test(.requireSDKs(.macOS))
     func dependencyValidation() async throws {
         try await testDependencyValidation(BuildParameters(configuration: "Debug"))


### PR DESCRIPTION
Instead of emitting diagnostics separately per language, this emits them together by first computing missing dependencies for each language and then merging and deduplicating them before diagnostic generation.

The code here will be forward compatible when we extend the Clang implementation to respect access levels and/or provide import locations.
