### PR TITLE
Still emit per-task C diagnostics if errors are requested

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1002,6 +1002,10 @@ extension BuildOperation: TaskExecutionDelegate {
     package var emitFrontendCommandLines: Bool {
         buildDescription.emitFrontendCommandLines
     }
+
+    package var continueBuildingAfterErrors: Bool {
+        request.continueBuildingAfterErrors
+    }
 }
 
 // BuildOperation uses reference semantics.

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1368,7 +1368,8 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             extraInputs = []
         }
 
-        if let moduleDependenciesContext {
+        // If validation is set to `YES_ERROR`, individual Clang tasks emit diagnostics, so they need this data in their signature. Otherwise, diagnostics are handled by the per-target validation action so individual compiles are not affected by changes to validation-related build settings.
+        if let moduleDependenciesContext, moduleDependenciesContext.validate == .yesError {
             do {
                 let jsonData = try JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(moduleDependenciesContext)
                 guard let signature = String(data: jsonData, encoding: .utf8) else {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2405,25 +2405,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     dependencyData = nil
                 }
 
-                let compilationRequirementAdditionalSignatureData: String
-                if let moduleDependenciesContext = cbc.producer.moduleDependenciesContext {
-                    do {
-                        let jsonData = try JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(moduleDependenciesContext)
-                        guard let signature = String(data: jsonData, encoding: .utf8) else {
-                            throw StubError.error("non-UTF-8 data")
-                        }
-                        compilationRequirementAdditionalSignatureData = additionalSignatureData + "|\(signature)"
-                    } catch {
-                        delegate.error("failed to serialize 'MODULE_DEPENDENCIES' context information: \(error)")
-                        return
-                    }
-                }
-                else {
-                    compilationRequirementAdditionalSignatureData = additionalSignatureData
-                }
-
                 // Compilation Requirements
-                delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo("SwiftDriver Compilation Requirements", targetName), additionalSignatureData: compilationRequirementAdditionalSignatureData, commandLine: ["builtin-Swift-Compilation-Requirements", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: allInputsNodes, outputs: compilationRequirementOutputs, action: delegate.taskActionCreationDelegate.createSwiftCompilationRequirementTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Unblock downstream dependents of $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: true, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.compilation, .compilationRequirement, .linkingRequirement, .blockedByTargetHeaders, .compilationForIndexableSourceFile], usesExecutionInputs: true, showInLog: true)
+                delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo("SwiftDriver Compilation Requirements", targetName), additionalSignatureData: additionalSignatureData, commandLine: ["builtin-Swift-Compilation-Requirements", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: allInputsNodes, outputs: compilationRequirementOutputs, action: delegate.taskActionCreationDelegate.createSwiftCompilationRequirementTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Unblock downstream dependents of $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: true, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.compilation, .compilationRequirement, .linkingRequirement, .blockedByTargetHeaders, .compilationForIndexableSourceFile], usesExecutionInputs: true, showInLog: true)
 
                 if case .compile = compilationMode {
                     // Unblocking compilation

--- a/Sources/SWBTaskExecution/Task.swift
+++ b/Sources/SWBTaskExecution/Task.swift
@@ -583,6 +583,8 @@ public protocol TaskExecutionDelegate
 
     var namespace: MacroNamespace { get }
 
+    var continueBuildingAfterErrors: Bool { get }
+
     /// Notifies the delegate that this task has discovered a target dependency which must exist to ensure deterministic builds.
     func taskDiscoveredRequiredTargetDependency(target: ConfiguredTarget, antecedent: ConfiguredTarget, reason: RequiredTargetDependencyReason, warningLevel: BooleanWarningLevel)
 }

--- a/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
@@ -42,6 +42,7 @@ struct MockExecutionDelegate: TaskExecutionDelegate {
     var namespace: MacroNamespace
     var requestContext: SWBCore.BuildRequestContext { fatalError() }
     var emitFrontendCommandLines: Bool { false }
+    var continueBuildingAfterErrors: Bool { false }
     private var core: Core?
 
     func taskDiscoveredRequiredTargetDependency(target: ConfiguredTarget, antecedent: ConfiguredTarget, reason: RequiredTargetDependencyReason, warningLevel: BooleanWarningLevel) {}


### PR DESCRIPTION
We want to group diagnostics to avoid duplicates, but also avoid building the entire target if we already know about errors. So for C compiles specifically, we'll continue emitting diagnostics per-task if errors are enabled.

Additionally, this PR fixes up the signature data related to dependency diagnostics. The `ValidateDependencies` task needs to depend on the `MODULE_DEPENDENCIES` build setting, but the Swift planning task shouldn't anymore. For Clang tasks, this is now also dependent on whether errors are enabled or not.
