### PR TITLE
Enable the static Linux SDK build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,8 @@ jobs:
       linux_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'swift test --no-parallel'
+      enable_linux_static_sdk_build: true
+      linux_static_sdk_build_command: SWIFTBUILD_STATIC_LINK=1 LLBUILD_STATIC_LINK=1 swift build
   cmake-smoke-test:
     name: cmake-smoke-test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let appleOS = true
 let appleOS = false
 #endif
 
+let isStaticBuild = Context.environment["SWIFTBUILD_STATIC_LINK"] != nil
 let useLocalDependencies = Context.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil
 let useLLBuildFramework = Context.environment["SWIFTBUILD_LLBUILD_FWK"] != nil
 
@@ -444,6 +445,12 @@ for target in package.targets {
     // Add dependencies on "plugins" so they can be loaded in the build service and in tests, as we don't have true plugin targets.
     if ["SWBBuildService", "SWBTestSupport"].contains(target.name) {
         target.dependencies += pluginTargetNames.map { .target(name: $0) }
+    }
+}
+
+if isStaticBuild {
+    package.targets = package.targets.filter { target in
+        target.type != .test && !target.name.hasSuffix("TestSupport")
     }
 }
 

--- a/Tests/SwiftBuildTests/ServiceTests.swift
+++ b/Tests/SwiftBuildTests/ServiceTests.swift
@@ -240,7 +240,7 @@ fileprivate struct ServiceTests {
 
     @Test(.requireSDKs(.macOS), .skipSwiftPackage, .skipIfEnvironment(key: "DYLD_IMAGE_SUFFIX", value: "_asan"), .disabled(if: getEnvironmentVariable("CI")?.isEmpty == false))
     func ASanBuildService() async throws {
-        let testBundleExecutableFilePath = Library.locate(Self.self)
+        let testBundleExecutableFilePath = try Library.locate(Self.self)
 
         // Whether the current XCTest executable is running in ASan mode. Most likely never true.
         let runningWithASanSupport = testBundleExecutableFilePath.str.hasSuffix("_asan")


### PR DESCRIPTION
Helps keep the codebase free of unintentional Glibc-isms. There are also some interesting testing use cases enabled by building Swift Build using the static SDK.