### PR TITLE
Fix task signatures for module dependencies

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2405,25 +2405,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     dependencyData = nil
                 }
 
-                let compilationRequirementAdditionalSignatureData: String
-                if let moduleDependenciesContext = cbc.producer.moduleDependenciesContext {
-                    do {
-                        let jsonData = try JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(moduleDependenciesContext)
-                        guard let signature = String(data: jsonData, encoding: .utf8) else {
-                            throw StubError.error("non-UTF-8 data")
-                        }
-                        compilationRequirementAdditionalSignatureData = additionalSignatureData + "|\(signature)"
-                    } catch {
-                        delegate.error("failed to serialize 'MODULE_DEPENDENCIES' context information: \(error)")
-                        return
-                    }
-                }
-                else {
-                    compilationRequirementAdditionalSignatureData = additionalSignatureData
-                }
-
                 // Compilation Requirements
-                delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo("SwiftDriver Compilation Requirements", targetName), additionalSignatureData: compilationRequirementAdditionalSignatureData, commandLine: ["builtin-Swift-Compilation-Requirements", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: allInputsNodes, outputs: compilationRequirementOutputs, action: delegate.taskActionCreationDelegate.createSwiftCompilationRequirementTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Unblock downstream dependents of $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: true, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.compilation, .compilationRequirement, .linkingRequirement, .blockedByTargetHeaders, .compilationForIndexableSourceFile], usesExecutionInputs: true, showInLog: true)
+                delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo("SwiftDriver Compilation Requirements", targetName), additionalSignatureData: additionalSignatureData, commandLine: ["builtin-Swift-Compilation-Requirements", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: allInputsNodes, outputs: compilationRequirementOutputs, action: delegate.taskActionCreationDelegate.createSwiftCompilationRequirementTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Unblock downstream dependents of $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: true, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.compilation, .compilationRequirement, .linkingRequirement, .blockedByTargetHeaders, .compilationForIndexableSourceFile], usesExecutionInputs: true, showInLog: true)
 
                 if case .compile = compilationMode {
                     // Unblocking compilation

--- a/Sources/SWBCore/SpecImplementations/Tools/ValidateDependencies.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ValidateDependencies.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+private import Foundation
 public import SWBUtil
 import SWBMacro
 
@@ -39,8 +40,17 @@ public final class ValidateDependenciesSpec: CommandLineToolSpec, SpecImplementa
         guard let configuredTarget = cbc.producer.configuredTarget else {
             return
         }
+
+        let jsonData: Data
+        do {
+            jsonData = try JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(payload)
+        } catch {
+            delegate.error("Error serializing \(payload): \(error)")
+            return
+        }
+        let signature = String(decoding: jsonData, as: UTF8.self)
         let output =  delegate.createVirtualNode("ValidateDependencies \(configuredTarget.guid)")
-        delegate.createTask(type: self, payload: payload, ruleInfo: ["ValidateDependencies"], commandLine: ["builtin-validate-dependencies"] + dependencyInfos.map { $0.path.str }, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: dependencyInfos + cbc.commandOrderingInputs, outputs: [output], action: delegate.taskActionCreationDelegate.createValidateDependenciesTaskAction(), preparesForIndexing: false, enableSandboxing: false)
+        delegate.createTask(type: self, payload: payload, ruleInfo: ["ValidateDependencies"], additionalSignatureData: signature, commandLine: ["builtin-validate-dependencies"] + dependencyInfos.map { $0.path.str }, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: dependencyInfos + cbc.commandOrderingInputs, outputs: [output], action: delegate.taskActionCreationDelegate.createValidateDependenciesTaskAction(), preparesForIndexing: false, enableSandboxing: false)
     }
 }
 


### PR DESCRIPTION
- `ValidateDependencies` needs to include the context as part of its signature
- Swift tasks no longer need to do this since they don't deal in module dependencies directly, only emitting a data file for use by `ValidateDependencies`
