### PR TITLE
Minor modifications to Process._getOutput to avoid extra Task creation

### DIFF
--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -161,11 +161,9 @@ extension Process {
 
         let streams = setup(process)
 
-        async let outputTask = await collect(streams)
-
         try await process.run(interruptible: interruptible)
 
-        let output = try await outputTask
+        let output = try await collect(streams)
 
         #if !canImport(Darwin)
         // Clear the pipes to prevent file descriptor leaks on platforms using swift-corelibs-foundation


### PR DESCRIPTION
Minor modifications to Process._getOutput to avoid extra Task creation