### PR TITLE
[TEST-ONLY] Try renable compilation caching tests

### DIFF
--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -299,7 +299,10 @@ extension Trait where Self == Testing.ConditionTrait {
     /// Constructs a condition trait that causes a test to be disabled if not running against a version of Xcode within the given range.
     package static func requireXcodeBuildVersions<R: RangeExpression>(in range: @Sendable @autoclosure @escaping () throws -> R, sourceLocation: SourceLocation = #_sourceLocation) -> Self where R.Bound == ProductBuildVersion {
         enabled("Xcode version is not suitable", sourceLocation: sourceLocation, {
-            return try await range().contains(InstalledXcode.currentlySelected().productBuildVersion())
+            guard let installedVersion =  try? await InstalledXcode.currentlySelected().productBuildVersion() else {
+                return true
+            }
+            return try range().contains(installedVersion)
         })
     }
 

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -19,7 +19,7 @@ import SWBTestSupport
 import SWBUtil
 
 @Suite(.skipHostOS(.windows, "Windows platform has no CAS support yet"),
-       .requireDependencyScannerPlusCaching, .skipInXcodeCloud("flaky tests"))
+       .requireDependencyScannerPlusCaching, .skipInXcodeCloud("flaky tests"), .requireXcode26())
 fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
     let canUseCASPlugin: Bool
     let canUseCASPruning: Bool

--- a/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
@@ -192,7 +192,7 @@ fileprivate struct ClangModuleVerifierTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching,
-          .skipInXcodeCloud("flaky tests"))
+          .skipInXcodeCloud("flaky tests"), .requireXcode26())
     func cachedBuild() async throws {
         try await withTemporaryDirectory { (tmpDirPath: Path) in
             let archs = ["arm64", "x86_64"]

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -20,7 +20,7 @@ import SWBTaskExecution
 import SWBProtocol
 
 @Suite(.requireSwiftFeatures(.compilationCaching),
-       .skipInXcodeCloud("flaky tests"))
+       .skipInXcodeCloud("flaky tests"), .requireXcode26())
 fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))
     func swiftCachingSimple() async throws {


### PR DESCRIPTION
Try again to re-enable caching tests which was marked flaky due to unstable tests on Xcode Cloud. Re-enable compilation caching tests except on Xcode Cloud.

