### PR TITLE
Adjusted expected number of CreateBuildDirectory tasks in TaskConstructionPerfTests.createBuildDirectoryTaskGenerationWith500Targets() now that explicit module directories are being created.

### DIFF
--- a/Tests/SWBTaskConstructionPerfTests/TaskConstructionPerfTests.swift
+++ b/Tests/SWBTaskConstructionPerfTests/TaskConstructionPerfTests.swift
@@ -54,7 +54,7 @@ fileprivate struct TaskConstructionPerfTests: CoreBasedTests, PerfTests {
             await measure {
                 await tester.checkBuild(runDestination: .macOS, checkTaskGraphIntegrity: false) { tester in
                     tester.checkTasks(.matchRuleType("CreateBuildDirectory")) { tasks in
-                        #expect(tasks.count == 1503)
+                        #expect(tasks.count == 2505)
                     }
                 }
             }


### PR DESCRIPTION
rdar://157621853
