### PR TITLE
Alter usage of async withExtendedLifetime that is causing crash in swift concurrency

### DIFF
--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -82,33 +82,42 @@ extension Process {
 extension Process {
     public static func getOutput(url: URL, arguments: [String], currentDirectoryURL: URL? = nil, environment: Environment? = nil, interruptible: Bool = true) async throws -> Processes.ExecutionResult {
         if #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) {
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+
             // Extend the lifetime of the pipes to avoid file descriptors being closed until the AsyncStream is finished being consumed.
-            return try await withExtendedLifetime((Pipe(), Pipe())) { (stdoutPipe, stderrPipe) in
-                let (exitStatus, output) = try await _getOutput(url: url, arguments: arguments, currentDirectoryURL: currentDirectoryURL, environment: environment, interruptible: interruptible) { process in
-                    let stdoutStream = process.makeStream(for: \.standardOutputPipe, using: stdoutPipe)
-                    let stderrStream = process.makeStream(for: \.standardErrorPipe, using: stderrPipe)
-                    return (stdoutStream, stderrStream)
-                } collect: { (stdoutStream, stderrStream) in
-                    let stdoutData = try await stdoutStream.collect()
-                    let stderrData = try await stderrStream.collect()
-                    return (stdoutData: stdoutData, stderrData: stderrData)
-                }
-                return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
+            defer { withExtendedLifetime(stdoutPipe) {} }
+            defer { withExtendedLifetime(stderrPipe) {} }
+
+            let (exitStatus, output) = try await _getOutput(url: url, arguments: arguments, currentDirectoryURL: currentDirectoryURL, environment: environment, interruptible: interruptible) { process in
+                let stdoutStream = process.makeStream(for: \.standardOutputPipe, using: stdoutPipe)
+                let stderrStream = process.makeStream(for: \.standardErrorPipe, using: stderrPipe)
+                return (stdoutStream, stderrStream)
+            } collect: { (stdoutStream, stderrStream) in
+                let stdoutData = try await stdoutStream.collect()
+                let stderrData = try await stderrStream.collect()
+                return (stdoutData: stdoutData, stderrData: stderrData)
             }
+            return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
         } else {
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+
             // Extend the lifetime of the pipes to avoid file descriptors being closed until the AsyncStream is finished being consumed.
-            return try await withExtendedLifetime((Pipe(), Pipe())) { (stdoutPipe, stderrPipe) in
-                let (exitStatus, output) = try await _getOutput(url: url, arguments: arguments, currentDirectoryURL: currentDirectoryURL, environment: environment, interruptible: interruptible) { process in
-                    let stdoutStream = process._makeStream(for: \.standardOutputPipe, using: stdoutPipe)
-                    let stderrStream = process._makeStream(for: \.standardErrorPipe, using: stderrPipe)
-                    return (stdoutStream, stderrStream)
-                } collect: { (stdoutStream, stderrStream) in
-                    let stdoutData = try await stdoutStream.collect()
-                    let stderrData = try await stderrStream.collect()
-                    return (stdoutData: stdoutData, stderrData: stderrData)
-                }
-                return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
+            defer { withExtendedLifetime(stdoutPipe) {} }
+            defer { withExtendedLifetime(stderrPipe) {} }
+
+            let (exitStatus, output) = try await _getOutput(url: url, arguments: arguments, currentDirectoryURL: currentDirectoryURL, environment: environment, interruptible: interruptible) { process in
+                let stdoutStream = process._makeStream(for: \.standardOutputPipe, using: stdoutPipe)
+                let stderrStream = process._makeStream(for: \.standardErrorPipe, using: stderrPipe)
+                return (stdoutStream, stderrStream)
+            } collect: { (stdoutStream, stderrStream) in
+                let stdoutData = try await stdoutStream.collect()
+                let stderrData = try await stderrStream.collect()
+                return (stdoutData: stdoutData, stderrData: stderrData)
             }
+            
+            return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
         }
     }
 


### PR DESCRIPTION
Alter usage of async withExtendedLifetime that is causing crash in swift concurrency