### PR TITLE
Add VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS build setting

### DIFF
--- a/Sources/SWBCore/Dependencies.swift
+++ b/Sources/SWBCore/Dependencies.swift
@@ -88,8 +88,9 @@ public struct ModuleDependenciesContext: Sendable, SerializableCodable {
     public init?(settings: Settings) {
         let validate = settings.globalScope.evaluate(BuiltinMacros.VALIDATE_MODULE_DEPENDENCIES)
         guard validate != .no else { return nil }
+        let downgrade = settings.globalScope.evaluate(BuiltinMacros.VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS)
         let fixItContext = ModuleDependenciesContext.FixItContext(settings: settings)
-        self.init(validate: validate, moduleDependencies: settings.moduleDependencies, fixItContext: fixItContext)
+        self.init(validate: downgrade ? .yes : validate, moduleDependencies: settings.moduleDependencies, fixItContext: fixItContext)
     }
 
     /// Compute missing module dependencies.
@@ -269,8 +270,9 @@ public struct HeaderDependenciesContext: Sendable, SerializableCodable {
     public init?(settings: Settings) {
         let validate = settings.globalScope.evaluate(BuiltinMacros.VALIDATE_HEADER_DEPENDENCIES)
         guard validate != .no else { return nil }
+        let downgrade = settings.globalScope.evaluate(BuiltinMacros.VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS)
         let fixItContext = HeaderDependenciesContext.FixItContext(settings: settings)
-        self.init(validate: validate, headerDependencies: settings.headerDependencies, fixItContext: fixItContext)
+        self.init(validate: downgrade ? .yes : validate, headerDependencies: settings.headerDependencies, fixItContext: fixItContext)
     }
 
     /// Make diagnostics for missing header dependencies.

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1145,6 +1145,7 @@ public final class BuiltinMacros {
     public static let VALIDATE_PLIST_FILES_WHILE_COPYING = BuiltinMacros.declareBooleanMacro("VALIDATE_PLIST_FILES_WHILE_COPYING")
     public static let VALIDATE_PRODUCT = BuiltinMacros.declareBooleanMacro("VALIDATE_PRODUCT")
     public static let VALIDATE_DEPENDENCIES = BuiltinMacros.declareEnumMacro("VALIDATE_DEPENDENCIES") as EnumMacroDeclaration<BooleanWarningLevel>
+    public static let VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS = BuiltinMacros.declareBooleanMacro("VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS")
     public static let VALIDATE_DEVELOPMENT_ASSET_PATHS = BuiltinMacros.declareEnumMacro("VALIDATE_DEVELOPMENT_ASSET_PATHS") as EnumMacroDeclaration<BooleanWarningLevel>
     public static let VALIDATE_HEADER_DEPENDENCIES = BuiltinMacros.declareEnumMacro("VALIDATE_HEADER_DEPENDENCIES") as EnumMacroDeclaration<BooleanWarningLevel>
     public static let VALIDATE_MODULE_DEPENDENCIES = BuiltinMacros.declareEnumMacro("VALIDATE_MODULE_DEPENDENCIES") as EnumMacroDeclaration<BooleanWarningLevel>
@@ -2375,6 +2376,7 @@ public final class BuiltinMacros {
         VALIDATE_CAS_EXEC,
         VALIDATE_PRODUCT,
         VALIDATE_DEPENDENCIES,
+        VALIDATE_DEPENDENCIES_DOWNGRADE_ERRORS,
         VALIDATE_DEVELOPMENT_ASSET_PATHS,
         VALIDATE_HEADER_DEPENDENCIES,
         VALIDATE_MODULE_DEPENDENCIES,


### PR DESCRIPTION
When VALIDATE_MODULE_DEPENDENCIES or VALIDATE_HEADER_DEPENDENCIES is set to YES_ERROR, this new setting can downgrade those errors to warnings. Since the dependency validation is a new feature that is still evolving, we need a way to keep it from breaking builds in some contexts.

rdar://157863457