### PR TITLE
Create one Android SDK per Swift SDK

### DIFF
--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -281,7 +281,7 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting Android generic device, using the public SDK.
     package static var android: Self {
-        return .init(platform: "android", sdk: "android", sdkVariant: "android", targetArchitecture: "undefined_arch", supportedArchitectures: ["armv7", "aarch64", "riscv64", "i686", "x86_64"], disableOnlyActiveArch: true)
+        return .init(platform: "android", sdk: "android.ndk", sdkVariant: "android", targetArchitecture: "undefined_arch", supportedArchitectures: ["armv7", "aarch64", "riscv64", "i686", "x86_64"], disableOnlyActiveArch: true)
     }
 
     /// A run destination targeting QNX generic device, using the public SDK.

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -39,7 +39,7 @@ fileprivate struct AndroidBuildOperationTests: CoreBasedTests {
                         "CODE_SIGNING_ALLOWED": "NO",
                         "DEFINES_MODULE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
-                        "SDKROOT": "android",
+                        "SDKROOT": "android.ndk",
                         "SUPPORTED_PLATFORMS": "android",
                         "ANDROID_DEPLOYMENT_TARGET": "22.0",
                         "ANDROID_DEPLOYMENT_TARGET[arch=riscv64]": "35.0",


### PR DESCRIPTION
This matches what WebAssembly is doing, and avoids an issue where multiple installed Android Swift SDKs would cause the build to fail.