### PR TITLE
[6.2] Swift: Add "Migrate" mode to some 6.2 language features

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -625,10 +625,16 @@
             },
             {
                 Name = "SWIFT_STRICT_MEMORY_SAFETY";
-                Type = Boolean;
+                Type = Enumeration;
+                Values = (
+                    YES,
+                    MIGRATE,
+                    NO,
+                );
                 DefaultValue = "NO";
                 CommandLineArgs = {
                     YES = ( "-strict-memory-safety" );
+                    MIGRATE = ( "-strict-memory-safety:migrate" );
                     NO = ();
                 };
                 DisplayName = "Strict Memory Safety";
@@ -820,10 +826,16 @@
 
             {
                 Name = "SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY";
-                Type = Boolean;
+                Type = Enumeration;
+                Values = (
+                    YES,
+                    MIGRATE,
+                    NO,
+                );
                 DefaultValue = NO;
                 CommandLineArgs = {
                     YES = ( "-enable-upcoming-feature", "MemberImportVisibility" );
+                    MIGRATE = ( "-enable-upcoming-feature", "MemberImportVisibility:migrate" );
                     NO  = ();
                 };
                 DisplayName = "Member Import Visibility";
@@ -852,10 +864,16 @@
 
             {
                 Name = "SWIFT_UPCOMING_FEATURE_INFER_ISOLATED_CONFORMANCES";
-                Type = Boolean;
+                Type = Enumeration;
+                Values = (
+                    YES,
+                    MIGRATE,
+                    NO,
+                );
                 DefaultValue = "$(SWIFT_APPROACHABLE_CONCURRENCY)";
                 CommandLineArgs = {
                     YES = ( "-enable-upcoming-feature", "InferIsolatedConformances" );
+                    MIGRATE = ( "-enable-upcoming-feature", "InferIsolatedConformances:migrate" );
                     NO  = ();
                 };
                 DisplayName = "Infer Isolated Conformances";


### PR DESCRIPTION
- **Explanation**: This PR is for 6.2 features for which migration mode was implemented after https://github.com/swiftlang/swift-build/pull/496 landed. The motivation is to enable users to select migration mode as a feature state in Xcode build settings, as opposed to figuring out the frontend option and where to add it. 
- **Scope**: Xcode user experience for enabling Swift features in migration mode.
- **Issues**: —
- **Original PRs**: https://github.com/swiftlang/swift-build/pull/737.
- **Risk**: Minimal.
- **Testing**: PR testing. No new regression tests (let me know if I should be adding one).
- **Reviewers**: @neonichu @jakepetroules 