### PR TITLE
Use `Invoke-Program` for the Windows build command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       linux_build_command: 'swift test --no-parallel'
       linux_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_swift_versions: '["nightly-main"]'
-      windows_build_command: 'swift test --no-parallel'
+      windows_build_command: 'Invoke-Program swift test --no-parallel'
       enable_linux_static_sdk_build: true
       linux_static_sdk_build_command: SWIFTBUILD_STATIC_LINK=1 LLBUILD_STATIC_LINK=1 swift build
   cmake-smoke-test:


### PR DESCRIPTION
Windows does not stop scripts when native commands exit with non-zero. Instead, their exit status has to be checked manually. This can be done through an `Invoke-Program` function that is added to the script running `windows_build_command`, which also previously prefixed the given command. This is changing in
https://github.com/swiftlang/github-workflows/pull/154 since it doesn't help with multi-line commands - update our modified `windows_build_command` to use `Invoke-Program` instead.