### PR TITLE
Export swb_stdout and swb_stderr on Windows

### DIFF
--- a/Sources/SWBCLibc/libc.c
+++ b/Sources/SWBCLibc/libc.c
@@ -24,10 +24,16 @@ int swb_clibc_anchor(void) {
 extern FILE * const swb_stdout();
 extern FILE * const swb_stderr();
 
+#if defined(_WIN32)
+__declspec(dllexport)
+#endif
 FILE * const swb_stdout() {
     return stdout;
 }
 
+#if defined(_WIN32)
+__declspec(dllexport)
+#endif
 FILE * const swb_stderr() {
     return stderr;
 }


### PR DESCRIPTION
This is preventing the Windows toolchain build from succeeding.