### PR TITLE
Remove FILETextOutputStream, etc.

### DIFF
--- a/Sources/SWBCLibc/include/SWBCLibc.h
+++ b/Sources/SWBCLibc/include/SWBCLibc.h
@@ -10,11 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdio.h>
-
-extern FILE * const swb_stdout();
-extern FILE * const swb_stderr();
-
 #if defined(__linux__) && !defined(__ANDROID__)
 #include <fcntl.h>
 #include <fnmatch.h>

--- a/Sources/SWBCLibc/libc.c
+++ b/Sources/SWBCLibc/libc.c
@@ -18,22 +18,3 @@ int swb_clibc_anchor(void);
 int swb_clibc_anchor(void) {
     return 0;
 }
-
-#include <stdio.h>
-
-extern FILE * const swb_stdout();
-extern FILE * const swb_stderr();
-
-#if defined(_WIN32)
-__declspec(dllexport)
-#endif
-FILE * const swb_stdout() {
-    return stdout;
-}
-
-#if defined(_WIN32)
-__declspec(dllexport)
-#endif
-FILE * const swb_stderr() {
-    return stderr;
-}

--- a/Sources/SWBUtil/Misc.swift
+++ b/Sources/SWBUtil/Misc.swift
@@ -65,36 +65,6 @@ public func parseUmbrellaHeaderName(_ string: String) -> String? {
     return Static.regex.matchGroups(in: string).first?[0]
 }
 
-#if os(Android)
-public typealias FILEPointer = OpaquePointer
-#else
-public typealias FILEPointer = UnsafeMutablePointer<FILE>
-#endif
-
-/// Adapts a FILE to a TextOutputStream. Does not own or automatically close the file.
-public struct FILETextOutputStream: TextOutputStream {
-    let stream: FILEPointer
-
-    public init(_ stream: FILEPointer) {
-        self.stream = stream
-    }
-
-    public func write(_ string: String) {
-        fputs(string, stream)
-    }
-
-    public static var stdout: Self {
-        .init(SWBLibc.swb_stdout())
-    }
-
-    public static var stderr: Self {
-        .init(SWBLibc.swb_stderr())
-    }
-}
-
-@available(*, unavailable)
-extension FILETextOutputStream: Sendable { }
-
 #if canImport(Darwin)
 public import func Foundation.autoreleasepool
 #endif


### PR DESCRIPTION
This needed to be tweaked recently to migrate SWBUtil to Swift 6, and caused a build breakage in the process. Turns out this is dead code and not needed, so just eliminate it.