### PR TITLE
Refactor the plugin loading a bit to minimize compile-time differences

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -15,7 +15,7 @@ public import SWBCore
 import SWBMacro
 import Foundation
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     let plugin = AndroidPlugin()
     manager.register(AndroidPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(AndroidEnvironmentExtension(plugin: plugin), type: EnvironmentExtensionPoint.self)

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -17,7 +17,7 @@ import SWBProtocol
 import Foundation
 import SWBTaskConstruction
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     manager.register(AppleDeveloperDirectoryExtension(), type: DeveloperDirectoryExtensionPoint.self)
     manager.register(ApplePlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(ActoolInputFileGroupingStrategyExtension(), type: InputFileGroupingStrategyExtensionPoint.self)

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -14,7 +14,7 @@ public import SWBUtil
 import SWBCore
 import Foundation
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     let plugin = GenericUnixPlugin()
     manager.register(GenericUnixDeveloperDirectoryExtension(), type: DeveloperDirectoryExtensionPoint.self)
     manager.register(GenericUnixPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -15,7 +15,7 @@ import SWBCore
 import SWBMacro
 import Foundation
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     let plugin = QNXPlugin()
     manager.register(QNXPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(QNXEnvironmentExtension(plugin: plugin), type: EnvironmentExtensionPoint.self)

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -140,29 +140,29 @@ extension Core {
                 pluginManager.load(at: path)
             }
 
+            let staticPluginInitializers: [String: PluginInitializationFunction]
+
+            // This MUST be a compile-time check because the module dependencies on the plugins are conditional.
+            // Minimize the amount of code that is conditionally compiled to avoid breaking the build during refactoring.
             #if USE_STATIC_PLUGIN_INITIALIZATION
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBAndroidPlatformPlugin") {
-                SWBAndroidPlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBApplePlatformPlugin") {
-                SWBApplePlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBGenericUnixPlatformPlugin") {
-                SWBGenericUnixPlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBQNXPlatformPlugin") {
-                SWBQNXPlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBUniversalPlatformPlugin") {
-                SWBUniversalPlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBWebAssemblyPlatformPlugin") {
-                SWBWebAssemblyPlatform.initializePlugin(pluginManager)
-            }
-            if !skipLoadingPluginsNamed.contains("com.apple.dt.SWBWindowsPlatformPlugin") {
-                SWBWindowsPlatform.initializePlugin(pluginManager)
-            }
+            staticPluginInitializers = [
+                "Android": SWBAndroidPlatform.initializePlugin,
+                "Apple": SWBApplePlatform.initializePlugin,
+                "GenericUnix": SWBGenericUnixPlatform.initializePlugin,
+                "QNX": SWBQNXPlatform.initializePlugin,
+                "Universal": SWBUniversalPlatform.initializePlugin,
+                "WebAssembly": SWBWebAssemblyPlatform.initializePlugin,
+                "Windows": SWBWindowsPlatform.initializePlugin,
+            ]
+            #else
+            staticPluginInitializers = [:]
             #endif
+
+            if useStaticPluginInitialization {
+                for (infix, initializer) in staticPluginInitializers where !skipLoadingPluginsNamed.contains("com.apple.dt.SWB\(infix)PlatformPlugin") {
+                    initializer(pluginManager)
+                }
+            }
 
             registerExtraPlugins(pluginManager)
         }

--- a/Sources/SWBUniversalPlatform/Plugin.swift
+++ b/Sources/SWBUniversalPlatform/Plugin.swift
@@ -16,7 +16,7 @@ import Foundation
 import SWBTaskConstruction
 import SWBTaskExecution
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     manager.register(UniversalPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(UniversalPlatformTaskProducerExtension(), type: TaskProducerExtensionPoint.self)
     manager.register(UniversalPlatformTaskActionExtension(), type: TaskActionExtensionPoint.self)

--- a/Sources/SWBUtil/PluginManager.swift
+++ b/Sources/SWBUtil/PluginManager.swift
@@ -221,3 +221,13 @@ private final class ImmutablePluginManager: Sendable, PluginManager {
         }
     }
 }
+
+public typealias PluginInitializationFunction = @Sendable @PluginExtensionSystemActor (_ manager: MutablePluginManager) -> ()
+
+public var useStaticPluginInitialization: Bool {
+    #if USE_STATIC_PLUGIN_INITIALIZATION
+    true
+    #else
+    false
+    #endif
+}

--- a/Sources/SWBWebAssemblyPlatform/Plugin.swift
+++ b/Sources/SWBWebAssemblyPlatform/Plugin.swift
@@ -15,7 +15,7 @@ import SWBCore
 import SWBMacro
 import Foundation
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     manager.register(WebAssemblyPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(WebAssemblyPlatformExtension(), type: PlatformInfoExtensionPoint.self)
     manager.register(WebAssemblySDKRegistryExtension(), type: SDKRegistryExtensionPoint.self)

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -14,7 +14,7 @@ public import SWBUtil
 public import SWBCore
 import Foundation
 
-@PluginExtensionSystemActor public func initializePlugin(_ manager: MutablePluginManager) {
+public let initializePlugin: PluginInitializationFunction = { manager in
     let plugin = WindowsPlugin()
     manager.register(WindowsDeveloperDirectoryExtension(), type: DeveloperDirectoryExtensionPoint.self)
     manager.register(WindowsPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)


### PR DESCRIPTION
This narrows what's guarded by USE_STATIC_PLUGIN_INITIALIZATION as tightly as possible, to avoid unintentional build breakages during refactoring, for clients where this flag is turned off. It also fixes an issue which resulted from this during Core initialization where the wrong type of plugin manager was being passed into the plugin initialization function.