### PR TITLE
Assert that no two message types with the same name are registered

### DIFF
--- a/Sources/SWBProtocol/Message.swift
+++ b/Sources/SWBProtocol/Message.swift
@@ -1222,6 +1222,14 @@ public struct IPCMessage: Serializable, Sendable {
     /// Reverse name mapping.
     static let messageNameToID: [String: any Message.Type] = {
         var result = [String: any Message.Type]()
+        #if DEBUG
+        var seenMessageNames: Set<String> = []
+        for messageType in messageTypes {
+            if !seenMessageNames.insert(messageType.name).inserted {
+                assertionFailure("Multiple message types registered for same name: \(messageType.name)")
+            }
+        }
+        #endif
         for type in IPCMessage.messageTypes {
             result[type.name] = type
         }


### PR DESCRIPTION
This simplifies debugging issues that arise from accidentally trying to register multiple message types with the same name.