### PR TITLE
Do not guard check for duplicate message names behind `DEBUG` compilation condition

### DIFF
--- a/Sources/SWBProtocol/Message.swift
+++ b/Sources/SWBProtocol/Message.swift
@@ -1222,16 +1222,10 @@ public struct IPCMessage: Serializable, Sendable {
     /// Reverse name mapping.
     static let messageNameToID: [String: any Message.Type] = {
         var result = [String: any Message.Type]()
-        #if DEBUG
-        var seenMessageNames: Set<String> = []
-        for messageType in messageTypes {
-            if !seenMessageNames.insert(messageType.name).inserted {
-                assertionFailure("Multiple message types registered for same name: \(messageType.name)")
-            }
-        }
-        #endif
         for type in IPCMessage.messageTypes {
-            result[type.name] = type
+            if let oldValue = result.updateValue(type, forKey: type.name) {
+                fatalError("Multiple message types registered for same name: \(type.name): \(type) vs \(oldValue)")
+            }
         }
         return result
     }()


### PR DESCRIPTION
As suggested in https://github.com/swiftlang/swift-build/pull/759#discussion_r2312689408