### PR TITLE
Skip XCTest discovery if tests are not built with -enable-testing

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -867,7 +867,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     }
 
     /// Report a note from task construction.
-    func note(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
+    public func note(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
         if let configuredTarget {
             delegate.note(.overrideTarget(configuredTarget), message, location: location, component: component)
         } else {
@@ -876,7 +876,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     }
 
     /// Report a warning from task construction.
-    func warning(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
+    public func warning(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
         if let configuredTarget {
             delegate.warning(.overrideTarget(configuredTarget), message, location: location, component: component)
         } else {
@@ -894,7 +894,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     }
 
     /// Report a remark from task construction.
-    func remark(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
+    public func remark(_ message: String, location: Diagnostic.Location = .unknown, component: Component = .default) {
         if let configuredTarget {
             delegate.remark(.overrideTarget(configuredTarget), message, location: location, component: component)
         } else {

--- a/Sources/SWBUniversalPlatform/TestEntryPointTaskProducer.swift
+++ b/Sources/SWBUniversalPlatform/TestEntryPointTaskProducer.swift
@@ -36,12 +36,17 @@ class TestEntryPointTaskProducer: PhasedTaskProducer, TaskProducer {
                     guard settings.productType?.conformsTo(identifier: "com.apple.product-type.bundle.unit-test") == true else {
                         continue
                     }
+                    guard settings.globalScope.evaluate(BuiltinMacros.SWIFT_ENABLE_TESTABILITY) || settings.globalScope.evaluate(BuiltinMacros.OTHER_SWIFT_FLAGS).contains("-enable-testing") else {
+                        context.warning("Skipping XCTest discovery for '\(directDependency.target.name)' because it was not built for testing")
+                        continue
+                    }
                     guard settings.globalScope.evaluate(BuiltinMacros.SWIFT_INDEX_STORE_ENABLE) else {
-                        context.error("Cannot perform test discovery for '\(directDependency.target.name)' because index while building is disabled")
+                        context.warning("Skipping XCTest discovery for '\(directDependency.target.name)' because indexing was disabled")
                         continue
                     }
                     let path = settings.globalScope.evaluate(BuiltinMacros.SWIFT_INDEX_STORE_PATH)
                     guard !path.isEmpty else {
+                        context.warning("Skipping XCTest discovery for '\(directDependency.target.name)' because the index store path could not be determined")
                         continue
                     }
                     indexStoreDirectories.append(path)


### PR DESCRIPTION
Otherwise, entry point code will be generated using @testable imports and fail to compile.