### PR TITLE
Build Setting: Add a SWIFT_DISABLE_PARSE_AS_LIBRARY Setting

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1046,6 +1046,7 @@ public final class BuiltinMacros {
     public static let SWIFT_INDEX_STORE_PATH = BuiltinMacros.declarePathMacro("SWIFT_INDEX_STORE_PATH")
     public static let SWIFT_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALL_OBJC_HEADER")
     public static let SWIFT_INSTALLAPI_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALLAPI_LAZY_TYPECHECK")
+    public static let SWIFT_DISABLE_PARSE_AS_LIBRARY = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_PARSE_AS_LIBRARY")
     public static let SWIFT_LIBRARIES_ONLY = BuiltinMacros.declareBooleanMacro("SWIFT_LIBRARIES_ONLY")
     public static let SWIFT_LIBRARY_LEVEL = BuiltinMacros.declareStringMacro("SWIFT_LIBRARY_LEVEL")
     public static let SWIFT_LIBRARY_PATH = BuiltinMacros.declarePathMacro("SWIFT_LIBRARY_PATH")
@@ -2222,6 +2223,7 @@ public final class BuiltinMacros {
         _SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP,
         _SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5,
         _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES,
+        SWIFT_DISABLE_PARSE_AS_LIBRARY,
         SWIFT_ENABLE_BARE_SLASH_REGEX,
         SWIFT_ENABLE_EMIT_CONST_VALUES,
         SWIFT_ENABLE_OPAQUE_TYPE_ERASURE,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1628,7 +1628,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // If there is only a single input, ensure we pass -parse-as-library as appropriate.
             if cbc.inputs.count == 1 {
                 let filename = cbc.inputs[0].absolutePath.basename
-                if filename != SwiftCompilerSpec.mainFileName && !cbc.scope.evaluate(BuiltinMacros.SWIFT_LIBRARIES_ONLY) {
+                if filename != SwiftCompilerSpec.mainFileName && !cbc.scope.evaluate(BuiltinMacros.SWIFT_LIBRARIES_ONLY) && !cbc.scope.evaluate(BuiltinMacros.SWIFT_DISABLE_PARSE_AS_LIBRARY) {
                     // Add -parse-as-library if the only input's file name isn't main.swift and if we didn't already add it due to SWIFT_LIBRARIES_ONLY.
                     args.append("-parse-as-library")
                 }

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -99,6 +99,7 @@ extension ProjectModel {
             case STRIP_INSTALLED_PRODUCT
             case SUPPORTS_TEXT_BASED_API
             case SUPPRESS_WARNINGS
+            case SWIFT_DISABLE_PARSE_AS_LIBRARY
             case SWIFT_ENABLE_BARE_SLASH_REGEX
             case SWIFT_INDEX_STORE_ENABLE
             case SWIFT_INSTALL_MODULE


### PR DESCRIPTION
Add a new build setting named `SWIFT_DISABLE_PARSE_AS_LIBRARY`, that, when set, will not send `-parse-as-library` compiler command line argument.

Relates to: https://github.com/swiftlang/swift-package-manager/issues/9040