### PR TITLE
Fixup StackedSearchPathLookupError error message

### DIFF
--- a/Sources/SWBCore/Settings/StackedSearchPaths.swift
+++ b/Sources/SWBCore/Settings/StackedSearchPaths.swift
@@ -104,7 +104,7 @@ extension StackedSearchPathLookupError: CustomStringConvertible {
         switch self {
         case let .unableToFind(subject, operatingSystem, searchPaths):
             let candidates = searchPaths.flatMap { $0.paths.map { $0.join(subject.fileName(operatingSystem: operatingSystem)).str }}
-            return "unable to find \(subject.fileName(operatingSystem: operatingSystem)) among search paths: \(candidates.joined(separator: ", "))"
+            return "unable to find \(subject.fileName(operatingSystem: operatingSystem).str) among search paths: \(candidates.joined(separator: ", "))"
         }
     }
 }


### PR DESCRIPTION
The target file that could not be found was printing `Path(_str: "libclang.so")` instead of `libclang.so`.

Add the `.str` to the `Path` so just the filename is printed.
