### PR TITLE
Support migratable features when diagnosing adoption

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1495,8 +1495,11 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             let matchingBuildSetting = feature.buildSettings?.first(where: {
                 if let macro = try? cbc.scope.namespace.declareBooleanMacro($0) {
                     return cbc.scope.evaluate(macro)
+                } else if let macro = try? cbc.scope.namespace.declareStringMacro($0) {
+                    return cbc.scope.evaluate(macro) == "YES"
+                } else {
+                    return false
                 }
-                return false
             })
             if matchingBuildSetting != nil {
                 continue


### PR DESCRIPTION
If a listed feature isn't boolean, eval it as a string as a fallback and check for a "YES" case

rdar://159684792

