### PR TITLE
Add additional flags for symbol graph generation options

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1097,7 +1097,9 @@ public final class BuiltinMacros {
     public static let SDKDB_TO_SYMGRAPH_EXEC = BuiltinMacros.declarePathMacro("SDKDB_TO_SYMGRAPH_EXEC")
     public static let CLANG_EXTRACT_API_EXEC = BuiltinMacros.declareStringMacro("CLANG_EXTRACT_API_EXEC")
     public static let DOCC_ARCHIVE_PATH = BuiltinMacros.declareStringMacro("DOCC_ARCHIVE_PATH")
+    public static let DOCC_PRETTY_PRINT = BuiltinMacros.declareBooleanMacro("DOCC_PRETTY_PRINT")
     public static let DOCC_EXTRACT_SPI_DOCUMENTATION = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_SPI_DOCUMENTATION")
+    public static let DOCC_SKIP_SYNTHESIZED_MEMBERS = BuiltinMacros.declareBooleanMacro("DOCC_SKIP_SYNTHESIZED_MEMBERS")
     public static let DOCC_EXTRACT_EXTENSION_SYMBOLS = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_EXTENSION_SYMBOLS")
     public static let DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS")
     public static let DOCC_EXTRACT_OBJC_INFO_FOR_SWIFT_SYMBOLS = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_OBJC_INFO_FOR_SWIFT_SYMBOLS")
@@ -1646,6 +1648,8 @@ public final class BuiltinMacros {
         DISABLE_TEST_HOST_PLATFORM_PROCESSING,
         DISABLE_XCFRAMEWORK_SIGNATURE_VALIDATION,
         DOCC_ARCHIVE_PATH,
+        DOCC_PRETTY_PRINT,
+        DOCC_SKIP_SYNTHESIZED_MEMBERS,
         DOCC_EXTRACT_SPI_DOCUMENTATION,
         DOCC_EXTRACT_EXTENSION_SYMBOLS,
         DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS,

--- a/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
@@ -77,9 +77,19 @@ final public class DocumentationCompilerSpec: GenericCompilerSpec, SpecIdentifie
     ) -> [String] {
         var additionalFlags = [String]()
 
+        // Check if pretty print is requested
+        if cbc.scope.evaluate(BuiltinMacros.DOCC_PRETTY_PRINT) && swiftCompilerInfo.toolFeatures.has(.emitExtensionBlockSymbols) {
+            additionalFlags.append("-symbol-graph-pretty-print")
+        }
+
         // Check if extension symbol documentation is requested
         if cbc.scope.evaluate(BuiltinMacros.DOCC_EXTRACT_EXTENSION_SYMBOLS) && swiftCompilerInfo.toolFeatures.has(.emitExtensionBlockSymbols) {
             additionalFlags.append("-emit-extension-block-symbols")
+        }
+
+        // Check if synthesized members should be skipped
+        if cbc.scope.evaluate(BuiltinMacros.DOCC_SKIP_SYNTHESIZED_MEMBERS) && swiftCompilerInfo.toolFeatures.has(.emitExtensionBlockSymbols) {
+            additionalFlags.append("-symbol-graph-skip-synthesized-members")
         }
 
         switch DocumentationType(from: cbc) {

--- a/Sources/SWBUniversalPlatform/Specs/Documentation.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Documentation.xcspec
@@ -161,6 +161,20 @@
                 DefaultValue = NO;
             },
 
+            // If the Swift compiler / Swift symbol graph extractor should pretty print the symbol graph.
+            {
+                Name = DOCC_PRETTY_PRINT;
+                Type = bool;
+                DefaultValue = NO;
+            },
+
+            // If the Swift compiler / Swift symbol graph extractor should skip synthesized members.
+            {
+                Name = DOCC_SKIP_SYNTHESIZED_MEMBERS;
+                Type = bool;
+                DefaultValue = NO;
+            },
+
             {
                 Name = DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS;
                 Type = bool;


### PR DESCRIPTION
Add flags for pretty print and skip synthesized members to Swift Build so that
clients can request these options when generating symbol graphs for DocC
documentation.

SwiftPM requires control over these options when extracting symbol graphs
for targets, and allows clients to use these options through the command
plugins.