### PR TITLE
Adopt clang API for diagnosing invalid stat cache entries

### DIFF
--- a/Sources/SWBCSupport/CLibclang.h
+++ b/Sources/SWBCSupport/CLibclang.h
@@ -107,6 +107,9 @@ CSUPPORT_EXPORT bool libclang_has_scanner(libclang_t lib);
 /// Whether libclang supports reporting structured scanning diagnostics.
 CSUPPORT_EXPORT bool libclang_has_structured_scanner_diagnostics(libclang_t lib);
 
+/// Whether libclang supports reporting negative stat caching diagnostics.
+CSUPPORT_EXPORT bool libclang_has_negative_stat_cache_diagnostics(libclang_t lib);
+
 /// Create a new scanner instance with optional CAS databases.
 CSUPPORT_EXPORT libclang_scanner_t libclang_scanner_create(libclang_t lib, libclang_casdatabases_t, libclang_casoptions_t);
 
@@ -183,6 +186,9 @@ CSUPPORT_EXPORT bool libclang_casdatabases_prune_ondisk_data(libclang_casdatabas
 typedef size_t (^module_lookup_output_t)(
     const char *module_name, const char *context_hash,
     clang_output_kind_t kind, char *output, size_t max_len);
+
+/// Reports invalid entries in the scanner's negative stat cache.
+CSUPPORT_EXPORT void libclang_scanner_diagnose_invalid_negative_stat_cache_entries(libclang_scanner_t scanner, void (^path_callback)(const char *));
 
 /// Scan the given Clang "cc1" invocation, looking for dependencies.
 ///

--- a/Sources/SWBCore/LibclangVendored/Libclang.swift
+++ b/Sources/SWBCore/LibclangVendored/Libclang.swift
@@ -91,6 +91,10 @@ public final class Libclang {
         libclang_has_structured_scanner_diagnostics(lib)
     }
 
+    public var supportsNegativeStatCacheDiagnostics: Bool {
+        libclang_has_negative_stat_cache_diagnostics(lib)
+    }
+
     public var supportsCASPruning: Bool {
         libclang_has_cas_pruning_feature(lib)
     }
@@ -272,6 +276,17 @@ public final class DependencyScanner {
             }
         }
         return fileDeps
+    }
+
+    public func diagnoseInvalidNegativeStatCacheEntries() -> [String] {
+        var entries: [String] = []
+        libclang_scanner_diagnose_invalid_negative_stat_cache_entries(scanner, { cString in
+            guard let cString else {
+                return
+            }
+            entries.append(String(cString: cString))
+        })
+        return entries
     }
 
     public func generateReproducer(

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1165,6 +1165,7 @@ public final class BuiltinMacros {
     public static let VERSION_INFO_STRING = BuiltinMacros.declareStringMacro("VERSION_INFO_STRING")
     public static let VERSION_INFO_SUFFIX = BuiltinMacros.declareStringMacro("VERSION_INFO_SUFFIX")
     public static let ValidateForStore = BuiltinMacros.declareBooleanMacro("ValidateForStore")
+    public static let VERIFY_CLANG_SCANNER_NEGATIVE_STAT_CACHE = BuiltinMacros.declareBooleanMacro("VERIFY_CLANG_SCANNER_NEGATIVE_STAT_CACHE")
     public static let WARNING_CFLAGS = BuiltinMacros.declareStringListMacro("WARNING_CFLAGS")
     public static let WARNING_LDFLAGS = BuiltinMacros.declareStringListMacro("WARNING_LDFLAGS")
     public static let WATCHKIT_2_SUPPORT_FOLDER_PATH = BuiltinMacros.declareStringMacro("WATCHKIT_2_SUPPORT_FOLDER_PATH")
@@ -2402,6 +2403,7 @@ public final class BuiltinMacros {
         VERSION_INFO_STRING,
         VERSION_INFO_SUFFIX,
         ValidateForStore,
+        VERIFY_CLANG_SCANNER_NEGATIVE_STAT_CACHE,
         WARNING_CFLAGS,
         WARNING_LDFLAGS,
         WATCHKIT_2_SUPPORT_FOLDER_PATH,

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
@@ -560,6 +560,17 @@ package final class ClangModuleDependencyGraph {
         return clangWithScanner.casDBs
     }
 
+    package func diagnoseInvalidNegativeStatCacheEntries() -> [String] {
+        registryQueue.blocking_sync {
+            self.scannerRegistry.values.flatMap { libClangWithScanner in
+                guard libClangWithScanner.scanner.libclang.supportsNegativeStatCacheDiagnostics else {
+                    return Array<String>()
+                }
+                return libClangWithScanner.scanner.diagnoseInvalidNegativeStatCacheEntries()
+            }
+        }
+    }
+
     package func generateReproducer(forFailedDependency dependency: DependencyInfo,
                                     libclangPath: Path, casOptions: CASOptions?) throws -> String? {
         let clangWithScanner = try libclangWithScanner(


### PR DESCRIPTION
This is sometimes useful to identify when missing dependencies may be introducing races in compilation
 rdar://150953611

