### PR TITLE
Avoid building empty objects in tests

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -51,11 +51,11 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
 
             // Create the input files.
             let cFile = testWorkspace.sourceRoot.join("aProject/CFile.c")
-            try await tester.fs.writeFileContents(cFile) { stream in }
+            try await tester.fs.writeFileContents(cFile) { stream in stream <<< "void foo(void) {}" }
             let swiftFile = testWorkspace.sourceRoot.join("aProject/SwiftFile.swift")
-            try await tester.fs.writeFileContents(swiftFile) { stream in }
+            try await tester.fs.writeFileContents(swiftFile) { stream in stream <<< "public func bar() {}" }
             let objcFile = testWorkspace.sourceRoot.join("aProject/ObjCFile.m")
-            try await tester.fs.writeFileContents(objcFile) { stream in }
+            try await tester.fs.writeFileContents(objcFile) { stream in stream <<< "void baz(void) {}" }
 
             // Create a build request context to compute the output paths - can't use one from the tester because it's an _output_ of checkBuild.
             let buildRequestContext = BuildRequestContext(workspaceContext: tester.workspaceContext)
@@ -296,7 +296,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
 
                 // Create the input files.
                 let cFile = testWorkspace.sourceRoot.join("aProject/CFile.c")
-                try await tester.fs.writeFileContents(cFile) { stream in }
+                try await tester.fs.writeFileContents(cFile) { stream in stream <<< "void foo(void) {}" }
 
                 let runDestination = RunDestinationInfo.host
                 let parameters = BuildParameters(configuration: "Debug", activeRunDestination: runDestination)

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -72,6 +72,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
 
             try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
                 results.checkNoTask(.matchRuleType("ScanDependencies"))
+                results.checkedWarnings = true
             }
         }
     }
@@ -146,6 +147,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/t.cpp")) { stream in
                 stream <<<
                 """
+                void foo(void) {}
                 """
             }
 
@@ -353,7 +355,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 let arena = ArenaInfo.buildArena(derivedDataRoot: derivedDataPath)
@@ -370,7 +372,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 try await tester.checkBuild(runDestination: .macOS) { results in
@@ -440,7 +442,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 let arena = ArenaInfo.buildArena(derivedDataRoot: derivedDataPath)
@@ -459,7 +461,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 try await tester.checkBuild(runDestination: .macOS) { results in
@@ -541,7 +543,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 let arena = ArenaInfo.buildArena(derivedDataRoot: derivedDataPath)
@@ -562,7 +564,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 try await tester.checkBuild(runDestination: .macOS) { results in
@@ -618,7 +620,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 try await tester.fs.writeFileContents(blockListFilePath) { file in
@@ -644,7 +646,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             do {
                 let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
                 try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
-                    stream <<< ""
+                    stream <<< "void foo(void) {}"
                 }
 
                 try await tester.fs.writeFileContents(blockListFilePath) { file in
@@ -1550,6 +1552,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                     stream <<<
                     """
                     #include "other.h"
+                    void foo(void) {}
                     """
                 }
                 try await tester.fs.writeFileContents(moduleDir.join("other.h")) { stream in
@@ -1762,7 +1765,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                 """
             }
             try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/generated1.c.fake-customrule")) { stream in
-                stream <<< ""
+                stream <<< "void foo(void) {}"
             }
 
             try await tester.checkBuild(runDestination: .macOS) { results in
@@ -1813,6 +1816,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/t.c")) { stream in
                 stream <<<
                 """
+                void foo(void) {}
                 """
             }
 

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -1224,6 +1224,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 stream <<<
                 """
                 #include "mod.h"
+                void foo(void) {}
                 """
             }
 
@@ -1231,6 +1232,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 stream <<<
                 """
                 #include "mod.h"
+                void bar(void) {}
                 """
             }
 
@@ -1345,6 +1347,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 stream <<<
             """
             #include "mod.h"
+            void foo(void) {}
             """
             }
 
@@ -1352,6 +1355,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 stream <<<
             """
             #include "mod.h"
+            void bar(void) {}
             """
             }
 

--- a/Tests/SWBBuildSystemTests/SDKImportsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SDKImportsBuildOperationTests.swift
@@ -204,7 +204,7 @@ fileprivate struct SDKImportsBuildOperationTests: CoreBasedTests {
                 let destination: RunDestinationInfo = .host
                 try await tester.checkBuild(runDestination: destination, signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs) { results in
                     results.checkNoErrors()
-                    results.checkWarning(.prefix("-ld_classic is deprecated"))
+                    results.checkWarning(.contains("-ld_classic is deprecated"))
 
                     let derivedData = tmpDir.join("build/Debug")
                     let appResources = derivedData.join("tool.app/Contents/Resources")


### PR DESCRIPTION
Prevent emitting warnings when using an archiver which warns about empty object files

