### PR TITLE
Add minimum access level as a setting for the symbol graph extraction

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1099,6 +1099,7 @@ public final class BuiltinMacros {
     public static let DOCC_ARCHIVE_PATH = BuiltinMacros.declareStringMacro("DOCC_ARCHIVE_PATH")
     public static let DOCC_PRETTY_PRINT = BuiltinMacros.declareBooleanMacro("DOCC_PRETTY_PRINT")
     public static let DOCC_EXTRACT_SPI_DOCUMENTATION = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_SPI_DOCUMENTATION")
+    public static let DOCC_MINIMUM_ACCESS_LEVEL = BuiltinMacros.declareEnumMacro("DOCC_MINIMUM_ACCESS_LEVEL") as EnumMacroDeclaration<DoccMinimumAccessLevel>
     public static let DOCC_SKIP_SYNTHESIZED_MEMBERS = BuiltinMacros.declareBooleanMacro("DOCC_SKIP_SYNTHESIZED_MEMBERS")
     public static let DOCC_EXTRACT_EXTENSION_SYMBOLS = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_EXTENSION_SYMBOLS")
     public static let DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS = BuiltinMacros.declareBooleanMacro("DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS")
@@ -1650,6 +1651,7 @@ public final class BuiltinMacros {
         DOCC_ARCHIVE_PATH,
         DOCC_PRETTY_PRINT,
         DOCC_SKIP_SYNTHESIZED_MEMBERS,
+        DOCC_MINIMUM_ACCESS_LEVEL,
         DOCC_EXTRACT_SPI_DOCUMENTATION,
         DOCC_EXTRACT_EXTENSION_SYMBOLS,
         DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS,
@@ -2755,6 +2757,18 @@ public enum LinkerDriverChoice: String, Equatable, Hashable, EnumerationMacroTyp
     case qcc
     case swiftc
     case auto
+}
+
+public enum DoccMinimumAccessLevel: String, Equatable, Hashable, EnumerationMacroType {
+    public static let defaultValue = DoccMinimumAccessLevel.none
+
+    case none = ""
+    case `private` = "private"
+    case `fileprivate` = "fileprivate"
+    case `internal` = "internal"
+    case `package` = "package"
+    case `public` = "public"
+    case `open` = "open"
 }
 
 /// Enumeration macro type for the value of the `INFOPLIST_KEY_LSApplicationCategoryType` build setting.

--- a/Sources/SWBCore/SpecImplementations/PropertyDomainSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/PropertyDomainSpec.swift
@@ -118,6 +118,8 @@ private final class EnumBuildOptionType : BuildOptionType {
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<SwiftAPIDigesterMode>
         case "LINKER_FILE_LIST_FORMAT":
             return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<LinkerFileListFormat>
+        case "DOCC_MINIMUM_ACCESS_LEVEL":
+            return try namespace.declareEnumMacro(name) as EnumMacroDeclaration<DoccMinimumAccessLevel>
         default:
             return try namespace.declareStringMacro(name)
         }

--- a/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/DocumentationCompiler.swift
@@ -105,17 +105,17 @@ final public class DocumentationCompilerSpec: GenericCompilerSpec, SpecIdentifie
                 return additionalFlags
             }
         case .private:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "private"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "private"])
         case .fileprivate:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "fileprivate"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "fileprivate"])
         case .internal:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "internal"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "internal"])
         case .package:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "package"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "package"])
         case .public:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "public"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "public"])
         case .open:
-            return additionalFlags.appending(contentsOf: ["symbol-graph-minimum-access-level", "open"])
+            return additionalFlags.appending(contentsOf: ["-symbol-graph-minimum-access-level", "open"])
         }
     }
 

--- a/Sources/SWBUniversalPlatform/Specs/Documentation.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Documentation.xcspec
@@ -175,6 +175,22 @@
                 DefaultValue = NO;
             },
 
+            // The minimum access level for API for the symbol graph extractor to generate
+            {
+                Name = DOCC_MINIMUM_ACCESS_LEVEL;
+                Type = Enumeration;
+                Values = (
+                    none,
+                    private,
+                    fileprivate,
+                    internal,
+                    package,
+                    public,
+                    open,
+                );
+                DefaultValue = none;
+            },
+
             {
                 Name = DOCC_EXTRACT_SWIFT_INFO_FOR_OBJC_SYMBOLS;
                 Type = bool;

--- a/Tests/SWBCoreTests/DocumentationCompilerSpecTests.swift
+++ b/Tests/SWBCoreTests/DocumentationCompilerSpecTests.swift
@@ -33,9 +33,57 @@ import SWBMacro
             swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
         )
         #expect(frameworkArgs == [])
+
+        let publicArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .public),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(publicArgs == ["-symbol-graph-minimum-access-level", "public"])
+
+        let privateArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .private),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(privateArgs == ["-symbol-graph-minimum-access-level", "private"])
+
+        let filePrivateArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .fileprivate),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(filePrivateArgs == ["-symbol-graph-minimum-access-level", "fileprivate"])
+
+        let internalArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .internal),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(internalArgs == ["-symbol-graph-minimum-access-level", "internal"])
+
+        let openArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .open),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(openArgs == ["-symbol-graph-minimum-access-level", "open"])
+
+        let packageArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, minimumAccessLevel: .package),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(packageArgs == ["-symbol-graph-minimum-access-level", "package"])
+
+        let prettyPrintArgs = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, prettyPrint: true),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(prettyPrintArgs == ["-symbol-graph-pretty-print"])
+
+        let skipSynthesizedMembers = await DocumentationCompilerSpec.additionalSymbolGraphGenerationArgs(
+            try mockApplicationBuildContext(application: false, skipSynthesizedMembers: true),
+            swiftCompilerInfo: try mockSwiftCompilerSpec(swiftVersion: "5.6", swiftTag: "swiftlang-5.6.0.0")
+        )
+        #expect(skipSynthesizedMembers == ["-symbol-graph-skip-synthesized-members"])
     }
 
-    private func mockApplicationBuildContext(application: Bool) async throws -> CommandBuildContext {
+    private func mockApplicationBuildContext(application: Bool, minimumAccessLevel: DoccMinimumAccessLevel = .none, prettyPrint: Bool = false, skipSynthesizedMembers: Bool = false) async throws -> CommandBuildContext {
         let core = try await getCore()
 
         let producer = try MockCommandProducer(
@@ -47,6 +95,16 @@ import SWBMacro
         var mockTable = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         if application {
             mockTable.push(BuiltinMacros.MACH_O_TYPE, literal: "mh_execute")
+        }
+
+        mockTable.push(BuiltinMacros.DOCC_MINIMUM_ACCESS_LEVEL, literal: minimumAccessLevel)
+
+        if prettyPrint {
+            mockTable.push(BuiltinMacros.DOCC_PRETTY_PRINT, literal: true)
+        }
+
+        if skipSynthesizedMembers {
+            mockTable.push(BuiltinMacros.DOCC_SKIP_SYNTHESIZED_MEMBERS, literal: skipSynthesizedMembers)
         }
 
         let mockScope = MacroEvaluationScope(table: mockTable)


### PR DESCRIPTION
This setting wasn't present before, so this is added as a build setting enumeration with
a special "none" default value that performs the fallback that is based on the kind of the
module.

Remove the swift compiler feature checks for the previously added settings since the
feature is unrelated to them.