### PR TITLE
Add API to allow clients to manage build description lifecycle

### DIFF
--- a/Sources/SWBBuildService/BuildDescriptionMessages.swift
+++ b/Sources/SWBBuildService/BuildDescriptionMessages.swift
@@ -54,7 +54,8 @@ fileprivate extension Request {
                 message.buildDescriptionID,
                 request: buildRequest,
                 buildRequestContext: buildRequestContext,
-                workspaceContext: workspaceContext
+                workspaceContext: workspaceContext,
+                retain: false
             ), clientDelegate: clientDelegate, constructionDelegate: operation
         )?.buildDescription
 
@@ -218,5 +219,13 @@ struct IndexBuildSettingsMsg: MessageHandler {
             throw FailedToGetCompilerArgumentsError()
         }
         return IndexBuildSettingsResponse(compilerArguments: compilerArguments)
+    }
+}
+
+struct ReleaseBuildDescriptionMsg: MessageHandler {
+    func handle(request: Request, message: ReleaseBuildDescriptionRequest) async throws -> VoidResponse {
+        let session = try request.session(for: message)
+        session.buildDescriptionManager.releaseBuildDescription(id: message.buildDescriptionID)
+        return VoidResponse()
     }
 }

--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -165,7 +165,7 @@ final class ActiveBuild: ActiveBuildOperation {
     /// Whether this operation is intended only for creating and reporting the build description.
     let onlyCreatesBuildDescription: Bool
 
-    /// Whether this operation should retain the build description is uses.
+    /// Whether this operation should retain the build description it uses.
     let retainBuildDescription: Bool
 
     /// The current state of the build.

--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -165,6 +165,9 @@ final class ActiveBuild: ActiveBuildOperation {
     /// Whether this operation is intended only for creating and reporting the build description.
     let onlyCreatesBuildDescription: Bool
 
+    /// Whether this operation should retain the build description is uses.
+    let retainBuildDescription: Bool
+
     /// The current state of the build.
     var state: State
 
@@ -194,6 +197,7 @@ final class ActiveBuild: ActiveBuildOperation {
         self.id = request.buildService.nextBuildOperationID()
 
         self.onlyCreatesBuildDescription = message.onlyCreateBuildDescription
+        self.retainBuildDescription = message.retainBuildDescription == true
 
         self.session = try request.session(for: message)
         guard let workspaceContext = session.workspaceContext else {
@@ -420,7 +424,7 @@ final class ActiveBuild: ActiveBuildOperation {
             let preparationDelegate = self.preparationProgressDelegate!
             let clientDelegate = ClientExchangeDelegate(request: self.request, session: self.session)
             // FIXME: We should have a channel for reporting errors here which don't make it look like there was an internal service error. E.g., if we fail to create or write the build description or manifest because of some error outside of our control, we should simply report that and not make it look like we might have a bug.
-            let description = try await MacroNamespace.withExpressionInterningEnabled { try await self.session.buildDescriptionManager.getBuildDescription(planRequest, clientDelegate: clientDelegate, constructionDelegate: preparationDelegate) }
+            let description = try await MacroNamespace.withExpressionInterningEnabled { try await self.session.buildDescriptionManager.getBuildDescription(planRequest, retained: retainBuildDescription, clientDelegate: clientDelegate, constructionDelegate: preparationDelegate) }
             return description
         } catch {
             self.abortBuild(error)
@@ -445,7 +449,7 @@ final class ActiveBuild: ActiveBuildOperation {
 
         do {
             let clientDelegate = ClientExchangeDelegate(request: self.request, session: self.session)
-            let descRequest = BuildDescriptionManager.BuildDescriptionRequest.cachedOnly(buildDescriptionID, request: self.buildRequest, buildRequestContext: self.buildRequestContext, workspaceContext: self.workspaceContext)
+            let descRequest = BuildDescriptionManager.BuildDescriptionRequest.cachedOnly(buildDescriptionID, request: self.buildRequest, buildRequestContext: self.buildRequestContext, workspaceContext: self.workspaceContext, retain: self.retainBuildDescription)
             let retrievedBuildDescription = try await self.session.buildDescriptionManager.getNewOrCachedBuildDescription(descRequest, clientDelegate: clientDelegate, constructionDelegate: self.preparationProgressDelegate!)
             return retrievedBuildDescription?.buildDescription
         } catch {

--- a/Sources/SWBBuildService/DocumentationInfo.swift
+++ b/Sources/SWBBuildService/DocumentationInfo.swift
@@ -51,7 +51,7 @@ extension BuildDescriptionManager {
         // Get the complete build description.
         let buildDescription: BuildDescription
         do {
-            if let retrievedBuildDescription = try await getBuildDescription(planRequest, clientDelegate: delegate.clientDelegate, constructionDelegate: delegate) {
+            if let retrievedBuildDescription = try await getBuildDescription(planRequest, retained: false, clientDelegate: delegate.clientDelegate, constructionDelegate: delegate) {
                 buildDescription = retrievedBuildDescription
             } else {
                 // If we don't receive a build description it means we were cancelled.

--- a/Sources/SWBBuildService/LocalizationInfo.swift
+++ b/Sources/SWBBuildService/LocalizationInfo.swift
@@ -68,7 +68,7 @@ extension BuildDescriptionManager {
 
         let buildDescription: BuildDescription
         do {
-            if let retrievedBuildDescription = try await getNewOrCachedBuildDescription(.cachedOnly(descriptionID, request: buildRequest, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext), clientDelegate: delegate.clientDelegate, constructionDelegate: delegate)?.buildDescription {
+            if let retrievedBuildDescription = try await getNewOrCachedBuildDescription(.cachedOnly(descriptionID, request: buildRequest, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext, retain: false), clientDelegate: delegate.clientDelegate, constructionDelegate: delegate)?.buildDescription {
                 buildDescription = retrievedBuildDescription
             } else {
                 // If we don't receive a build description it means we were cancelled.

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -585,7 +585,7 @@ fileprivate enum ResultOrErrorMessage<T> {
 fileprivate func getIndexBuildDescriptionFromID(buildDescriptionID: BuildDescriptionID, request: Request, session: Session, buildRequest: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, constructionDelegate: any BuildDescriptionConstructionDelegate) async -> ResultOrErrorMessage<BuildDescription> {
     let clientDelegate = ClientExchangeDelegate(request: request, session: session)
     do {
-        let descRequest = BuildDescriptionManager.BuildDescriptionRequest.cachedOnly(buildDescriptionID, request: buildRequest, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext)
+        let descRequest = BuildDescriptionManager.BuildDescriptionRequest.cachedOnly(buildDescriptionID, request: buildRequest, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext, retain: false)
         guard let retrievedBuildDescription = try await session.buildDescriptionManager.getNewOrCachedBuildDescription(descRequest, clientDelegate: clientDelegate, constructionDelegate: constructionDelegate) else {
             // If we don't receive a build description it means we were cancelled.
             return .failed(VoidResponse())
@@ -727,7 +727,7 @@ extension MessageHandler {
                     let clientDelegate = ClientExchangeDelegate(request: request, session: session)
                     let buildDescription: BuildDescription
                     do {
-                        if let retrievedBuildDescription = try await session.buildDescriptionManager.getBuildDescription(planRequest, clientDelegate: clientDelegate, constructionDelegate: operation) {
+                        if let retrievedBuildDescription = try await session.buildDescriptionManager.getBuildDescription(planRequest, retained: false, clientDelegate: clientDelegate, constructionDelegate: operation) {
                             buildDescription = retrievedBuildDescription
                         } else {
                             // If we don't receive a build description it means we were cancelled.
@@ -1626,6 +1626,7 @@ package struct ServiceMessageHandlers: ServiceExtension {
         service.registerMessageHandler(BuildDescriptionConfiguredTargetsMsg.self)
         service.registerMessageHandler(BuildDescriptionConfiguredTargetSourcesMsg.self)
         service.registerMessageHandler(IndexBuildSettingsMsg.self)
+        service.registerMessageHandler(ReleaseBuildDescriptionMsg.self)
 
         service.registerMessageHandler(MacroEvaluationMsg.self)
         service.registerMessageHandler(AllExportedMacrosAndValuesMsg.self)

--- a/Sources/SWBBuildService/PreviewInfo.swift
+++ b/Sources/SWBBuildService/PreviewInfo.swift
@@ -123,6 +123,7 @@ extension BuildDescriptionManager {
         do {
             if let retrievedBuildDescription = try await getBuildDescription(
                 planRequest,
+                retained: false,
                 clientDelegate: delegate.clientDelegate,
                 constructionDelegate: delegate
             ) {

--- a/Sources/SWBProtocol/BuildDescriptionMessages.swift
+++ b/Sources/SWBProtocol/BuildDescriptionMessages.swift
@@ -213,6 +213,24 @@ public struct IndexBuildSettingsResponse: Message, SerializableCodable, Equatabl
     }
 }
 
+public struct ReleaseBuildDescriptionRequest: SessionMessage, RequestMessage, SerializableCodable, Equatable {
+    public typealias ResponseMessage = VoidResponse
+
+    public static let name = "RELEASE_BUILD_DESCRIPTION"
+
+    public var sessionHandle: String
+
+    public let buildDescriptionID: BuildDescriptionID
+
+    public init(
+        sessionHandle: String,
+        buildDescriptionID: BuildDescriptionID
+    ) {
+        self.sessionHandle = sessionHandle
+        self.buildDescriptionID = buildDescriptionID
+    }
+}
+
 // MARK: Registering messages
 
 let buildDescriptionMessages: [any Message.Type] = [
@@ -222,4 +240,5 @@ let buildDescriptionMessages: [any Message.Type] = [
     BuildDescriptionConfiguredTargetSourcesResponse.self,
     IndexBuildSettingsRequest.self,
     IndexBuildSettingsResponse.self,
+    ReleaseBuildDescriptionRequest.self,
 ]

--- a/Sources/SWBProtocol/BuildOperationMessages.swift
+++ b/Sources/SWBProtocol/BuildOperationMessages.swift
@@ -263,19 +263,24 @@ public struct CreateBuildRequest: SessionChannelBuildMessage, RequestMessage, Se
     /// If true, the build operation will be completed after the build description is created and reported.
     public let onlyCreateBuildDescription: Bool
 
+    /// If true, the build description for this build wil be kept alive in memory, even if it would otherwise be evicted from caches.
+    public let retainBuildDescription: Bool?
+
+    @available(*, deprecated, renamed: "init(sessionHandle:responseChannel:request:onlyCreateBuildDescription:retainBuildDescription:)")
     public init(sessionHandle: String, responseChannel: UInt64, request: BuildRequestMessagePayload, onlyCreateBuildDescription: Bool) {
         self.sessionHandle = sessionHandle
         self.responseChannel = responseChannel
         self.request = request
         self.onlyCreateBuildDescription = onlyCreateBuildDescription
+        self.retainBuildDescription = nil
     }
 
-    public init(fromLegacy deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(4)
-        self.sessionHandle = try deserializer.deserialize()
-        self.responseChannel = try deserializer.deserialize()
-        self.request = try deserializer.deserialize()
-        self.onlyCreateBuildDescription = try deserializer.deserialize()
+    public init(sessionHandle: String, responseChannel: UInt64, request: BuildRequestMessagePayload, onlyCreateBuildDescription: Bool, retainBuildDescription: Bool) {
+        self.sessionHandle = sessionHandle
+        self.responseChannel = responseChannel
+        self.request = request
+        self.onlyCreateBuildDescription = onlyCreateBuildDescription
+        self.retainBuildDescription = retainBuildDescription
     }
 }
 

--- a/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
@@ -101,7 +101,7 @@ extension BuildDescription {
 
 extension BuildDescriptionManager {
     package func getNewOrCachedBuildDescription(_ request: BuildPlanRequest, bypassActualTasks: Bool = false, clientDelegate: any TaskPlanningClientDelegate, constructionDelegate: any BuildDescriptionConstructionDelegate) async throws -> BuildDescriptionRetrievalInfo? {
-        let descRequest = BuildDescriptionRequest.newOrCached(request, bypassActualTasks: bypassActualTasks, useSynchronousBuildDescriptionSerialization: true)
+        let descRequest = BuildDescriptionRequest.newOrCached(request, bypassActualTasks: bypassActualTasks, useSynchronousBuildDescriptionSerialization: true, retain: false)
         return try await getNewOrCachedBuildDescription(descRequest, clientDelegate: clientDelegate, constructionDelegate: constructionDelegate)
     }
 }

--- a/Sources/SWBUtil/Registry.swift
+++ b/Sources/SWBUtil/Registry.swift
@@ -52,6 +52,16 @@ public final class Registry<K: Hashable & Sendable, V: Sendable>: KeyValueStorag
         }
     }
 
+    public func update(_ key: K, update: (V) -> V?, default: () -> V?) {
+        dict.withLock {
+            if let value = $0[key] {
+                $0[key] = update(value)
+            } else if let value = `default`() {
+                $0[key] = update(value)
+            }
+        }
+    }
+
     public subscript(_ key: K) -> V? {
         get {
             return dict.withLock {

--- a/Sources/SwiftBuild/SWBBuildOperation.swift
+++ b/Sources/SwiftBuild/SWBBuildOperation.swift
@@ -73,7 +73,7 @@ public final class SWBBuildOperation: Sendable {
     private var activeTasks = Set<Int>()
 #endif
 
-    init(session: SWBBuildServiceSession, delegate: (any SWBPlanningOperationDelegate)?, request: SWBBuildRequest, onlyCreateBuildDescription: Bool) async throws {
+    init(session: SWBBuildServiceSession, delegate: (any SWBPlanningOperationDelegate)?, request: SWBBuildRequest, onlyCreateBuildDescription: Bool, retainBuildDescription: Bool) async throws {
         self.session = session
         self.delegate = delegate
         self.lockedState = .init(.requested)
@@ -91,7 +91,7 @@ public final class SWBBuildOperation: Sendable {
         }
 
         // Send an asynchronous message to add the build request.  This will cause it to start running at any point.
-        let msg = try await session.service.send(request: CreateBuildRequest(sessionHandle: session.uid, responseChannel: channel, request: request.messagePayloadRepresentation, onlyCreateBuildDescription: onlyCreateBuildDescription))
+        let msg = try await session.service.send(request: CreateBuildRequest(sessionHandle: session.uid, responseChannel: channel, request: request.messagePayloadRepresentation, onlyCreateBuildDescription: onlyCreateBuildDescription, retainBuildDescription: retainBuildDescription))
 
         // At the moment, by setting this here we guarantee the client can never cause any communication with the SWBBuildOperation before the ID is set.
         assert(state == .requested, "invalid state: \(state)")

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -818,7 +818,7 @@ private extension BuildDescription {
 
 private extension BuildDescriptionManager {
     func getNewOrCachedBuildDescription(_ request: BuildPlanRequest, bypassActualTasks: Bool = false, clientDelegate: any TaskPlanningClientDelegate) async throws -> BuildDescriptionRetrievalInfo? {
-        let descRequest = BuildDescriptionRequest.newOrCached(request, bypassActualTasks: bypassActualTasks, useSynchronousBuildDescriptionSerialization: true)
+        let descRequest = BuildDescriptionRequest.newOrCached(request, bypassActualTasks: bypassActualTasks, useSynchronousBuildDescriptionSerialization: true, retain: false)
         return try await getNewOrCachedBuildDescription(descRequest, clientDelegate: clientDelegate, constructionDelegate: MockTestBuildDescriptionConstructionDelegate())
     }
 }

--- a/Tests/SwiftBuildTests/BuildDescriptionLifecycleTests.swift
+++ b/Tests/SwiftBuildTests/BuildDescriptionLifecycleTests.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SwiftBuild
+import SwiftBuildTestSupport
+import SWBTestSupport
+@_spi(Testing) import SWBUtil
+import SWBProtocol
+import SWBCore
+
+@Suite
+fileprivate struct BuildDescriptionLifecycleTests {
+    @Test(.requireSDKs(.host))
+    func configuredTargets() async throws {
+        try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
+            try await withAsyncDeferrable { deferrable in
+                let tmpDir = temporaryDirectory.path
+                let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let target = TestStandardTarget(
+                    "Library",
+                    type: .dynamicLibrary,
+                    buildPhases: [TestSourcesBuildPhase([TestBuildFile("MyLibrary.swift")])],
+                )
+
+                let project = TestProject(
+                    "Test",
+                    groupTree: TestGroup("Test", children: [TestFile("MyLibrary.swift")]),
+                    targets: [target]
+                )
+
+                try await testSession.sendPIF(TestWorkspace("Test", sourceRoot: tmpDir, projects: [project]))
+
+                let activeRunDestination = SWBRunDestinationInfo.host
+                let buildParameters = SWBBuildParameters(configuration: "Debug", activeRunDestination: activeRunDestination)
+                var request = SWBBuildRequest()
+                request.add(target: SWBConfiguredTarget(guid: target.guid, parameters: buildParameters))
+
+                var buildDescriptionID: SWBBuildDescriptionID?
+                let buildDescriptionOperation = try await testSession.session.createBuildOperationForBuildDescriptionOnly(
+                    request: request,
+                    delegate: TestBuildOperationDelegate(),
+                    retainBuildDescription: true
+                )
+                for try await event in try await buildDescriptionOperation.start() {
+                    guard case .reportBuildDescription(let info) = event else {
+                        continue
+                    }
+                    guard buildDescriptionID == nil else {
+                        Issue.record("Received multiple build description IDs")
+                        continue
+                    }
+                    buildDescriptionID = SWBBuildDescriptionID(info.buildDescriptionID)
+                }
+                guard let buildDescriptionID else {
+                    throw StubError.error("Failed to get build description ID")
+                }
+
+                let targetInfos = try await testSession.session.configuredTargets(buildDescription: buildDescriptionID, buildRequest: request)
+                #expect(targetInfos.count == 1)
+
+                // Clear caches. The retained build description should remain available.
+                try await testSession.service.clearAllCaches()
+                let newTargetInfos = try await testSession.session.configuredTargets(buildDescription: buildDescriptionID, buildRequest: request)
+                #expect(newTargetInfos.count == 1)
+
+                await testSession.session.releaseBuildDescription(id: buildDescriptionID)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add basic optional refcounting for build descriptions so that clients making repeated requests can choose to manually manage their lifecycle.