### PR TITLE
Move a build setting from swiftPM to swift-build

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
@@ -164,6 +164,10 @@
             GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
             KEEP_PRIVATE_EXTERNS = YES;
             DEAD_CODE_STRIPPING = NO;
+            // Disable code coverage linker flags since we're producing .o files.
+            // Otherwise, we will run into duplicated symbols when there are more than one targets that produce .o
+            // as their product.
+            CLANG_COVERAGE_MAPPING_LINKER_ARGS = NO;
         };
         PackageTypes = (
             com.apple.package-type.mach-o-objfile


### PR DESCRIPTION
There was some code in swiftPM that would set
CLANG_COVERAGE_MAPPING_LINKER_ARGS = NO if the mach_o_type was "mh_object" due to some duplicate symbol problems, this change moves it down to the objfile product type spec where it belongs.

