### PR TITLE
Expose SWIFT_LIBRARIES_ONLY setting for SwiftPM

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -103,6 +103,7 @@ extension ProjectModel {
             case SWIFT_ENABLE_BARE_SLASH_REGEX
             case SWIFT_INDEX_STORE_ENABLE
             case SWIFT_INSTALL_MODULE
+            case SWIFT_LIBRARIES_ONLY
             case SWIFT_PACKAGE_NAME
             case SWIFT_USER_MODULE_VERSION
             case TAPI_DYLIB_INSTALL_NAME


### PR DESCRIPTION
This will allow the PIF to explicitly set for every target whether we should pass -parse-as-library to swiftc