### PR TITLE
[6.2] Only check `isTargetSuitableForPlatformForIndex` for workspace description

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -630,11 +630,13 @@ extension SpecializationParameters {
     ///
     /// Note there's an exception for this for host build tools, which are required for compilation
     /// and must therefore be configured (and registered as a dependency) regardless
-    nonisolated func isTargetSuitableForPlatformForIndex(_ target: Target, parameters: BuildParameters, imposedParameters: SpecializationParameters?, dependencies: OrderedSet<ConfiguredTarget>? = nil) -> Bool {
+    nonisolated func isTargetSuitableForPlatformForIndex(_ target: Target, parameters: BuildParameters, imposedParameters: SpecializationParameters?) -> Bool {
         guard buildRequest.buildsIndexWorkspaceDescription else { return true }
 
-        // Host tools case, always supported we'll override the parameters with that of the host regardless.
-        if target.isHostBuildTool || dependencies?.contains(where: { $0.target.isHostBuildTool }) == true {
+        // Host tools case, always supported since we'll override the parameters with that of the
+        // host regardless. Any dependencies will have the host platform imposed on them through
+        // `imposedParameters`.
+        if target.isHostBuildTool {
             return true
         }
 

--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -623,23 +623,15 @@ extension SpecializationParameters {
 
     /// Determines whether a target should be configured for the given platform in the index arena.
     ///
-    /// The arena is used for two purposes:
-    ///   1. To retrieve settings for a given target
-    ///   2. To produce products of source dependencies for compilation purposes (it does not produce binaries)
+    /// When building a workspace build description, we configure for all possible platforms. As such,
+    /// we want to avoid unnecessarily configuring targets for unsupported platforms. When building a
+    /// target or package description, we are only configuring for a single platform and can therefore
+    /// avoid this check since we assume any dependency will necessary.
     ///
-    /// Thus, in general if a target doesn't support a platform, we don't want to configure it for that platform. If a
-    /// dependency is not supported for the platform of the dependent, presumably the dependent will not be able
-    /// to use its products for compilation purposes, since the source products will be put in a different platform
-    /// directory and/or they will not be usable by the dependent (e.g. the module will not be importable from a
-    /// different platform). If the dependency was intended to be usable from that platform for compilation purposes,
-    /// it would be a supported platform.
-    ///
-    /// There's an exception for this for a dependent host tool, which are required for compilation and must therefore
-    /// be configured (and registered as a dependency) regardless.
+    /// Note there's an exception for this for host build tools, which are required for compilation
+    /// and must therefore be configured (and registered as a dependency) regardless
     nonisolated func isTargetSuitableForPlatformForIndex(_ target: Target, parameters: BuildParameters, imposedParameters: SpecializationParameters?, dependencies: OrderedSet<ConfiguredTarget>? = nil) -> Bool {
-        if !buildRequest.enableIndexBuildArena {
-            return true
-        }
+        guard buildRequest.buildsIndexWorkspaceDescription else { return true }
 
         // Host tools case, always supported we'll override the parameters with that of the host regardless.
         if target.isHostBuildTool || dependencies?.contains(where: { $0.target.isHostBuildTool }) == true {

--- a/Sources/SWBCore/TargetDependencyResolver.swift
+++ b/Sources/SWBCore/TargetDependencyResolver.swift
@@ -680,7 +680,7 @@ fileprivate extension TargetDependencyResolver {
         }
 
         // Add the discovered info.
-        let discoveredInfo = await computeDiscoveredTargetInfo(for: configuredTarget, imposedParameters: imposedParameters, dependencyPath: nil, resolver: resolver)
+        let discoveredInfo = await computeDiscoveredTargetInfo(for: configuredTarget, imposedParameters: imposedParameters, resolver: resolver)
         discoveredTargets[configuredTarget] = discoveredInfo
 
         // If we have no dependencies, we are done.
@@ -742,7 +742,7 @@ fileprivate extension TargetDependencyResolver {
             discoveredInfo = info
         } else {
             if resolver.makeAggregateTargetsTransparentForSpecialization {
-                discoveredInfo = await computeDiscoveredTargetInfo(for: configuredTarget, imposedParameters: imposedParameters, dependencyPath: dependencyPath, resolver: resolver)
+                discoveredInfo = await computeDiscoveredTargetInfo(for: configuredTarget, imposedParameters: imposedParameters, resolver: resolver)
             } else {
                 var immediateDependencies = [ResolvedTargetDependency]()
                 var packageProductDependencies = [PackageProductTarget]()
@@ -820,14 +820,14 @@ fileprivate extension TargetDependencyResolver {
     }
 
     /// Discover the info for a configured target with the given imposed parameters.
-    private func computeDiscoveredTargetInfo(for configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, dependencyPath: OrderedSet<ConfiguredTarget>?, resolver: isolated DependencyResolver) async -> DiscoveredTargetInfo {
+    private func computeDiscoveredTargetInfo(for configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, resolver: isolated DependencyResolver) async -> DiscoveredTargetInfo {
         var immediateDependencies = [ResolvedTargetDependency]()
         var packageProductDependencies = [PackageProductTarget]()
         for dependency in resolver.explicitDependencies(for: configuredTarget) {
             if let asPackageProduct = dependency as? PackageProductTarget {
                 packageProductDependencies.append(asPackageProduct)
             } else {
-                if !resolver.isTargetSuitableForPlatformForIndex(dependency, parameters: configuredTarget.parameters, imposedParameters: imposedParameters, dependencies: dependencyPath) {
+                if !resolver.isTargetSuitableForPlatformForIndex(dependency, parameters: configuredTarget.parameters, imposedParameters: imposedParameters) {
                     continue
                 }
 

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1650,6 +1650,7 @@ package final class BuildOperationTester {
     /// Construct 'prepare' index build operation, and test the result.
     package func checkIndexBuild<T>(
         prepareTargets: [String],
+        buildTargets: [any TestTarget]? = nil,
         workspaceOperation: Bool = true,
         runDestination: RunDestinationInfo? = nil,
         persistent: Bool = false,
@@ -1658,6 +1659,7 @@ package final class BuildOperationTester {
     ) async throws -> T {
         let buildRequest = try Self.buildRequestForIndexOperation(
             workspace: workspace,
+            buildTargets: buildTargets,
             prepareTargets: prepareTargets,
             workspaceOperation: workspaceOperation,
             runDestination: runDestination,

--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -176,16 +176,15 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGNING_ALLOWED": "NO",
+                        "SDKROOT": "auto",
+                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                     ]),
             ],
             targets: [
                 TestStandardTarget("TransitivePackageDep", type: .objectFile, buildConfigurations: [
                     TestBuildConfiguration(
                         "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                        ],
+                        buildSettings: [:],
                         impartedBuildProperties:
                             TestImpartedBuildProperties(
                                 buildSettings: [
@@ -195,14 +194,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                 ], buildPhases: [
                     TestSourcesBuildPhase(["transitivedep.swift"])
                 ]),
-                TestStandardTarget("PackageDep", type: .staticLibrary, buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                        ]),
-                ], buildPhases: [
+                TestStandardTarget("PackageDep", type: .staticLibrary, buildPhases: [
                     TestSourcesBuildPhase(["dep.swift"]),
                     TestFrameworksBuildPhase([
                         TestBuildFile(.target("TransitivePackageDep"))
@@ -214,14 +206,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                     TestFrameworksBuildPhase([
                         TestBuildFile(.target("PackageDep")),
                     ]
-                ), buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                        ]),
-                ], dependencies: [
+                ), dependencies: [
                     "PackageDep"
                 ]),
         ])
@@ -240,43 +225,25 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGNING_ALLOWED": "NO",
+                        "SDKROOT": "auto",
+                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                     ]),
             ],
             targets: [
-                TestStandardTarget("HostTool", type: .hostBuildTool, buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                        ])
-                ], buildPhases: [
+                TestStandardTarget("HostTool", type: .hostBuildTool, buildPhases: [
                     TestSourcesBuildPhase(["tool.swift"]),
                     TestFrameworksBuildPhase([TestBuildFile(.target("PackageDepProduct"))])
                 ], dependencies: [
                     "PackageDepProduct"
                 ]),
-                TestStandardTarget("HostToolClientLib", type: .objectFile, buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                        ]),
-                ], buildPhases: [
+                TestStandardTarget("HostToolClientLib", type: .objectFile, buildPhases: [
                     TestSourcesBuildPhase(["lib.swift"]),
                 ], dependencies: [
                     "HostTool"
                 ]),
                 TestPackageProductTarget("HostToolClientLibProduct", frameworksBuildPhase:
                     TestFrameworksBuildPhase([TestBuildFile(.target("HostToolClientLib"))]
-                ), buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SDKROOT": "auto",
-                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                        ]),
-                ], dependencies: [
+                ), dependencies: [
                     "HostToolClientLib"
                 ]),
         ])

--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -158,21 +158,6 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
-    func hostToolsAndDependenciesAreBuiltDuringIndexingPreparation_Mac() async throws {
-        try await testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: .anyMac)
-    }
-
-    @Test(.requireSDKs(.macOS, .iOS))
-    func hostToolsAndDependenciesAreBuiltDuringIndexingPreparation_MacCatalyst() async throws {
-        try await testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: .anyMacCatalyst)
-    }
-
-    @Test(.requireSDKs(.macOS, .iOS))
-    func hostToolsAndDependenciesAreBuiltDuringIndexingPreparation_iOS() async throws {
-        try await testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: .anyiOSDevice)
-    }
-
     private func withHostToolsPackages(
         clients: TestProject...,
         body: (BuildOperationTester, TestWorkspace) async throws -> Void
@@ -346,6 +331,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS, .iOS), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice])
     func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: RunDestinationInfo) async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -452,10 +438,10 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
-    func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparationForPackage() async throws {
+    @Test(.requireSDKs(.macOS, .iOS), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice])
+    func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparationForPackage(destination: RunDestinationInfo) async throws {
         try await withHostToolsPackages { tester, testWorkspace in
-            try await tester.checkIndexBuild(prepareTargets: testWorkspace.projects[1].targets.map(\.guid), workspaceOperation: false, runDestination: .anyMac, persistent: true) { results in
+            try await tester.checkIndexBuild(prepareTargets: testWorkspace.projects[1].targets.map(\.guid), workspaceOperation: false, runDestination: destination, persistent: true) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTaskExists(.matchTargetName("HostTool"), .matchRuleType("Ld"))

--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -173,183 +173,144 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         try await testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: .anyiOSDevice)
     }
 
-    func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: RunDestinationInfo) async throws {
-        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
-            let depPackage = try await TestPackageProject(
-                "DepPackage",
-                groupTree: TestGroup("Foo", children: [
-                    TestFile("transitivedep.swift"),
-                    TestFile("dep.swift"),
-                ]),
-                buildConfigurations: [
+    private func withHostToolsPackages(
+        clients: TestProject...,
+        body: (BuildOperationTester, TestWorkspace) async throws -> Void
+    ) async throws {
+        let depPackage = try await TestPackageProject(
+            "DepPackage",
+            groupTree: TestGroup("Foo", children: [
+                TestFile("transitivedep.swift"),
+                TestFile("dep.swift"),
+            ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "SWIFT_VERSION": swiftVersion,
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "CODE_SIGNING_ALLOWED": "NO",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget("TransitivePackageDep", type: .objectFile, buildConfigurations: [
                     TestBuildConfiguration(
                         "Debug",
                         buildSettings: [
-                            "SWIFT_VERSION": swiftVersion,
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "CODE_SIGNING_ALLOWED": "NO",
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
+                        ],
+                        impartedBuildProperties:
+                            TestImpartedBuildProperties(
+                                buildSettings: [
+                                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "IMPARTED_SETTINGS"
+                                ])
+                    ),
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["transitivedep.swift"])
+                ]),
+                TestStandardTarget("PackageDep", type: .staticLibrary, buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
                         ]),
-                ],
-                targets: [
-                    TestStandardTarget("TransitivePackageDep", type: .objectFile, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ],
-                            impartedBuildProperties:
-                                TestImpartedBuildProperties(
-                                    buildSettings: [
-                                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "IMPARTED_SETTINGS"
-                                    ])
-                        ),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["transitivedep.swift"])
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["dep.swift"]),
+                    TestFrameworksBuildPhase([
+                        TestBuildFile(.target("TransitivePackageDep"))
+                    ])
+                ], dependencies: [
+                    "TransitivePackageDep"
+                ]),
+                TestPackageProductTarget("PackageDepProduct", frameworksBuildPhase:
+                    TestFrameworksBuildPhase([
+                        TestBuildFile(.target("PackageDep")),
+                    ]
+                ), buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
+                        ]),
+                ], dependencies: [
+                    "PackageDep"
+                ]),
+        ])
+
+        let hostToolsPackage = try await TestPackageProject(
+            "HostToolsPackage",
+            groupTree: TestGroup("Foo", children: [
+                TestFile("tool.swift"),
+                TestFile("lib.swift"),
+            ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "SWIFT_VERSION": swiftVersion,
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "CODE_SIGNING_ALLOWED": "NO",
                     ]),
-                    TestStandardTarget("PackageDep", type: .staticLibrary, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["dep.swift"]),
-                        TestFrameworksBuildPhase([
-                            TestBuildFile(.target("TransitivePackageDep"))
+            ],
+            targets: [
+                TestStandardTarget("HostTool", type: .hostBuildTool, buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
                         ])
-                    ], dependencies: [
-                        "TransitivePackageDep"
-                    ]),
-                    TestPackageProductTarget("PackageDepProduct", frameworksBuildPhase:
-                        TestFrameworksBuildPhase([
-                            TestBuildFile(.target("PackageDep")),
-                        ]
-                    ), buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], dependencies: [
-                        "PackageDep"
-                    ]),
-            ])
-
-            let hostToolsPackage = try await TestPackageProject(
-                "HostToolsPackage",
-                groupTree: TestGroup("Foo", children: [
-                    TestFile("tool.swift"),
-                    TestFile("lib.swift"),
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["tool.swift"]),
+                    TestFrameworksBuildPhase([TestBuildFile(.target("PackageDepProduct"))])
+                ], dependencies: [
+                    "PackageDepProduct"
                 ]),
-                buildConfigurations: [
+                TestStandardTarget("HostToolClientLib", type: .objectFile, buildConfigurations: [
                     TestBuildConfiguration(
                         "Debug",
                         buildSettings: [
-                            "SWIFT_VERSION": swiftVersion,
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "CODE_SIGNING_ALLOWED": "NO",
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
                         ]),
-                ],
-                targets: [
-                    TestStandardTarget("HostTool", type: .hostBuildTool, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                            ])
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["tool.swift"]),
-                        TestFrameworksBuildPhase([TestBuildFile(.target("PackageDepProduct"))])
-                    ], dependencies: [
-                        "PackageDepProduct"
-                    ]),
-                    TestStandardTarget("HostToolClientLib", type: .objectFile, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["lib.swift"]),
-                    ], dependencies: [
-                        "HostTool"
-                    ]),
-                    TestPackageProductTarget("HostToolClientLibProduct", frameworksBuildPhase:
-                        TestFrameworksBuildPhase([TestBuildFile(.target("HostToolClientLib"))]
-                    ), buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], dependencies: [
-                        "HostToolClientLib"
-                    ]),
-            ])
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["lib.swift"]),
+                ], dependencies: [
+                    "HostTool"
+                ]),
+                TestPackageProductTarget("HostToolClientLibProduct", frameworksBuildPhase:
+                    TestFrameworksBuildPhase([TestBuildFile(.target("HostToolClientLib"))]
+                ), buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
+                        ]),
+                ], dependencies: [
+                    "HostToolClientLib"
+                ]),
+        ])
 
-            let testProject = try await TestProject(
-                "aProject",
-                groupTree: TestGroup("Foo", children: [
-                    TestFile("frame.swift"),
-                    TestFile("app.swift")
-                ]), buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SWIFT_VERSION": swiftVersion,
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "CODE_SIGNING_ALLOWED": "NO",
-                        ]),
-                ],
-                targets: [
-                    TestStandardTarget("Framework", type: .framework, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["frame.swift"]),
-                        TestFrameworksBuildPhase([
-                            TestBuildFile(.target("HostToolClientLibProduct"))
-                        ]),
-                    ], dependencies: [
-                        "HostToolClientLibProduct"
-                    ]),
-                    TestStandardTarget("App", type: .application, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["app.swift"]),
-                    ], dependencies: [
-                        "Framework"
-                    ]),
-                ]
-            )
-            let testWorkspace = TestWorkspace("aWorkspace", sourceRoot: tmpDirPath.join("Test"), projects: [depPackage, hostToolsPackage, testProject])
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = TestWorkspace("aWorkspace", sourceRoot: tmpDirPath.join("Test"), projects: [depPackage, hostToolsPackage] + clients)
             let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false, systemInfo: .init(operatingSystemVersion: Version(99, 98, 97), productBuildVersion: "99A98", nativeArchitecture: Architecture.host.stringValue ?? "undefined_arch"))
 
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("DepPackage/transitivedep.swift")) { stream in
+            let fs = tester.fs
+            let root = testWorkspace.sourceRoot
+
+            try await fs.writeFileContents(root.join("DepPackage/transitivedep.swift")) { stream in
                 stream <<<
                 """
                 public let transitiveDependencyMessage = "Hello from host tool transitive dependency!"
                 """
             }
 
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("DepPackage/dep.swift")) { stream in
+            try await fs.writeFileContents(root.join("DepPackage/dep.swift")) { stream in
                 stream <<<
                 """
                 import TransitivePackageDep
@@ -361,7 +322,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                 """
             }
 
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("HostToolsPackage/tool.swift")) { stream in
+            try await fs.writeFileContents(root.join("HostToolsPackage/tool.swift")) { stream in
                 stream <<<
                 """
                 import PackageDep
@@ -374,13 +335,65 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                 """
             }
 
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("HostToolsPackage/lib.swift")) { stream in
+            try await fs.writeFileContents(root.join("HostToolsPackage/lib.swift")) { stream in
                 stream <<<
                 """
                 public class MyClass {}
                 """
             }
 
+            try await body(tester, testWorkspace)
+        }
+    }
+
+    func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: RunDestinationInfo) async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup("Foo", children: [
+                TestFile("frame.swift"),
+                TestFile("app.swift")
+            ]), buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "SWIFT_VERSION": swiftVersion,
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "CODE_SIGNING_ALLOWED": "NO",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget("Framework", type: .framework, buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
+                        ]),
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["frame.swift"]),
+                    TestFrameworksBuildPhase([
+                        TestBuildFile(.target("HostToolClientLibProduct"))
+                    ]),
+                ], dependencies: [
+                    "HostToolClientLibProduct"
+                ]),
+                TestStandardTarget("App", type: .application, buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
+                        ]),
+                ], buildPhases: [
+                    TestSourcesBuildPhase(["app.swift"]),
+                ], dependencies: [
+                    "Framework"
+                ]),
+            ]
+        )
+
+        try await withHostToolsPackages(clients: testProject) { tester, testWorkspace in
             try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/frame.swift")) { stream in
                 stream <<<
                 """
@@ -441,169 +454,8 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
 
     @Test(.requireSDKs(.macOS))
     func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparationForPackage() async throws {
-        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
-            let depPackage = try await TestPackageProject(
-                "DepPackage",
-                groupTree: TestGroup("Foo", children: [
-                    TestFile("transitivedep.swift"),
-                    TestFile("dep.swift"),
-                ]),
-                buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SWIFT_VERSION": swiftVersion,
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "CODE_SIGNING_ALLOWED": "NO",
-                        ]),
-                ],
-                targets: [
-                    TestStandardTarget("TransitivePackageDep", type: .objectFile, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ],
-                            impartedBuildProperties:
-                                TestImpartedBuildProperties(
-                                    buildSettings: [
-                                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "IMPARTED_SETTINGS"
-                                    ])
-                        ),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["transitivedep.swift"])
-                    ]),
-                    TestStandardTarget("PackageDep", type: .staticLibrary, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["dep.swift"]),
-                        TestFrameworksBuildPhase([
-                            TestBuildFile(.target("TransitivePackageDep"))
-                        ])
-                    ], dependencies: [
-                        "TransitivePackageDep"
-                    ]),
-                    TestPackageProductTarget("PackageDepProduct", frameworksBuildPhase:
-                        TestFrameworksBuildPhase([
-                            TestBuildFile(.target("PackageDep")),
-                        ]
-                    ), buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], dependencies: [
-                        "PackageDep"
-                    ]),
-            ])
-
-            let hostToolsPackage = try await TestPackageProject(
-                "HostToolsPackage",
-                groupTree: TestGroup("Foo", children: [
-                    TestFile("tool.swift"),
-                    TestFile("lib.swift"),
-                ]),
-                buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "SWIFT_VERSION": swiftVersion,
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "CODE_SIGNING_ALLOWED": "NO",
-                        ]),
-                ],
-                targets: [
-                    TestStandardTarget("HostTool", type: .hostBuildTool, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                            ])
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["tool.swift"]),
-                        TestFrameworksBuildPhase([TestBuildFile(.target("PackageDepProduct"))])
-                    ], dependencies: [
-                        "PackageDepProduct"
-                    ]),
-                    TestStandardTarget("HostToolClientLib", type: .objectFile, buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], buildPhases: [
-                        TestSourcesBuildPhase(["lib.swift"]),
-                    ], dependencies: [
-                        "HostTool"
-                    ]),
-                    TestPackageProductTarget("HostToolClientLibProduct", frameworksBuildPhase:
-                        TestFrameworksBuildPhase([TestBuildFile(.target("HostToolClientLib"))]
-                    ), buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "macosx iphoneos iphonesimulator",
-                            ]),
-                    ], dependencies: [
-                        "HostToolClientLib"
-                    ]),
-            ])
-
-            let testWorkspace = TestWorkspace("aWorkspace", sourceRoot: tmpDirPath.join("Test"), projects: [depPackage, hostToolsPackage])
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false, systemInfo: .init(operatingSystemVersion: Version(99, 98, 97), productBuildVersion: "99A98", nativeArchitecture: Architecture.host.stringValue ?? "undefined_arch"))
-
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("DepPackage/transitivedep.swift")) { stream in
-                stream <<<
-                """
-                public let transitiveDependencyMessage = "Hello from host tool transitive dependency!"
-                """
-            }
-
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("DepPackage/dep.swift")) { stream in
-                stream <<<
-                """
-                import TransitivePackageDep
-
-                public let dependencyMessage = "Hello from host tool dependency! " + transitiveDependencyMessage
-                #if !IMPARTED_SETTINGS
-                #error("settings not imparted")
-                #endif
-                """
-            }
-
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("HostToolsPackage/tool.swift")) { stream in
-                stream <<<
-                """
-                import PackageDep
-
-                @main struct Foo {
-                    static func main() {
-                        print("Hello from host tool! " + dependencyMessage)
-                    }
-                }
-                """
-            }
-
-            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("HostToolsPackage/lib.swift")) { stream in
-                stream <<<
-                """
-                public class MyClass {}
-                """
-            }
-
-            try await tester.checkIndexBuild(prepareTargets: hostToolsPackage.targets.map(\.guid), workspaceOperation: false, runDestination: .anyMac, persistent: true) { results in
+        try await withHostToolsPackages { tester, testWorkspace in
+            try await tester.checkIndexBuild(prepareTargets: testWorkspace.projects[1].targets.map(\.guid), workspaceOperation: false, runDestination: .anyMac, persistent: true) { results in
                 results.checkNoDiagnostics()
 
                 results.checkTaskExists(.matchTargetName("HostTool"), .matchRuleType("Ld"))

--- a/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
@@ -949,8 +949,12 @@ import SWBUtil
             #expect(results.targets(packageProduct).map{ results.targetNameAndPlatform($0) } == ["PackageLibProduct-iphoneos"])
             #expect(results.targets(unreferencedPackageLib).map{ results.targetNameAndPlatform($0) } == ["UnreferencedPackageLib-iphoneos"])
 
-            try results.checkDependencies(of: .init(packageLib2, "iphoneos"), are: [])
-
+            switch results.graphType {
+            case .dependency:
+                try results.checkDependencies(of: packageLib2, are: [.init(packageTool, "macos")])
+            case .linkage:
+                try results.checkDependencies(of: packageLib2, are: [])
+            }
             results.delegate.checkNoDiagnostics()
         }
     }


### PR DESCRIPTION
*6.2 cherry-pick of #671*

- Explanation: Limits the platform filtering check we do for the index build to only apply to the workspace build description, ensuring that we don't incorrectly exclude host build tools for the target and package descriptions.
- Scope: Affects index build descriptions
- Issue: rdar://160798093
- Risk: Low, only affects index build descriptions, and relaxes the filtering logic such that it more closely matches what we do for a regular build
- Testing: Added tests to test suite
- Reviewer: Ben Barham, Owen Voorhees