### PR TITLE
Add file exclusion in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -262,7 +262,10 @@ let package = Package(
         .target(
             name: "SWBWindowsPlatform",
             dependencies: ["SWBCore", "SWBMacro", "SWBUtil"],
-            exclude: ["CMakeLists.txt"],
+            exclude: [
+                "CMakeLists.txt",
+                "README.md",
+            ],
             resources: [.process("Specs")],
             swiftSettings: swiftSettings(languageMode: .v6)),
 


### PR DESCRIPTION
A warning was being emitted as a result of the README.md. Add it to the exclusion list of the respctive target to remove the warning