### PR TITLE
Add build settings to control the emission of the Index Store

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -236,6 +236,20 @@
                 };
             },
             {
+                Name = "METAL_INDEX_STORE_ONLY_PROJECT_FILES";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
+                Condition = "$(MTL_ENABLE_INDEX_STORE)";
+                CommandLineArgs = {
+                    YES = (
+                        // See corresponding definition in Clang.xcspec
+                        "-index-ignore-system-symbols",
+                        "-index-ignore-pcms",
+                    );
+                    NO = ();
+                };
+            },
+            {
                 Name = "MTL_LANGUAGE_REVISION";
                 Type = Enumeration;
                 DefaultValue = UseDeploymentTarget;

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3506,6 +3506,20 @@ For more information on mergeable libraries, see [Configuring your project to us
                 Description = "Control whether the compiler should emit index data while building.";
             },
             {
+                Name = "INDEX_STORE_ONLY_PROJECT_FILES";
+                Type = Boolean;
+                DefaultValue = NO;
+                DisplayName = "Index only project files";
+                Description = "Only index the source files that are being compiled within this project. Do not emit data into the index store for system modules.";
+            },
+            {
+                Name = "INDEX_STORE_COMPRESS";
+                Type = Boolean;
+                DefaultValue = NO;
+                DisplayName = "Compress Index Store";
+                Description = "Compress the index store, reducing its size on disk.";
+            },
+            {
                 Name = TOOLCHAINS;
                 Type = StringList;
                 DefaultValue = "";

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3116,6 +3116,46 @@
                     NO = ();
                 };
             },
+            {
+                Name = "CLANG_INDEX_STORE_ONLY_PROJECT_FILES";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                CommandLineArgs = {
+                    YES = (
+                        "-index-ignore-system-symbols",
+                        // If the PCM covers files generated within the project, we should have indexed them in the task that compiles them, otherwise it's a system module that we don't want to index.
+                        "-index-ignore-pcms",
+                    );
+                    NO = ();
+                };
+            },
+            {
+                Name = "CLANG_INDEX_STORE_COMPRESS";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_COMPRESS)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                CommandLineArgs = {
+                    YES = (
+                        "-index-store-compress",
+                    );
+                    NO = ();
+                };
+            },
+            {
+                Name = "CLANG_INDEX_STORE_IGNORE_MACROS";
+                Type = Boolean;
+                DefaultValue = NO;
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                DisplayName = "Do not index C macros";
+                Description = "Do not emit entries for C macros into the Index Store.";
+                CommandLineArgs = {
+                    YES = (
+                        "-index-ignore-macros",
+                    );
+                    NO = ();
+                };
+            },
 
             {
                 Name = "CLANG_ENABLE_COMPILE_CACHE";

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1319,6 +1319,33 @@
                     NO = ();
                 };
             },
+            {
+                Name = "SWIFT_INDEX_STORE_ONLY_PROJECT_FILES";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
+                Condition = "$(SWIFT_INDEX_STORE_ENABLE)";
+                CommandLineArgs = {
+                    YES = (
+                        // Assume that clang modules are getting indexed by a clang file within them. While this is technically not correct, since you could have a clang module that only consists of header files and is only included from Swift, such scenarios are rare.
+                        "-index-ignore-clang-modules",
+                        "-index-ignore-system-modules",
+                    );
+                    NO = ();
+                };
+            },
+            {
+                Name = "SWIFT_INDEX_STORE_COMPRESS";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_COMPRESS)";
+                Condition = "$(SWIFT_INDEX_STORE_ENABLE)";
+                CommandLineArgs = {
+                    YES = (
+                        "-Xfrontend",
+                        "-index-store-compress",
+                    );
+                    NO = ();
+                };
+            },
 
             // Swift caching options.
             {

--- a/Tests/SWBTaskConstructionTests/MetalTests.swift
+++ b/Tests/SWBTaskConstructionTests/MetalTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import SWBTestSupport
+import SWBCore
+import SWBUtil
+
+@Suite
+fileprivate struct MetalTests: CoreBasedTests {
+    @Test(.requireSDKs(.macOS), .skipInGitHubActions("Metal toolchain is not installed on GitHub runners"))
+    func indexOptions() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.metal")
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "Test",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "COMPILER_INDEX_STORE_ENABLE": "YES",
+                                    "INDEX_DATA_STORE_DIR": tmpDir.join("index").str,
+                                    "INDEX_STORE_COMPRESS": "YES",
+                                    "INDEX_STORE_ONLY_PROJECT_FILES": "YES",
+                                    "CLANG_INDEX_STORE_IGNORE_MACROS": "YES",
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["File1.metal"]),
+                        ]
+                    )
+                ])
+
+            let core = try await getCore()
+            let tester = try TaskConstructionTester(core, testProject)
+            await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: ["INDEX_ENABLE_DATA_STORE": "YES"]), runDestination: .macOS) { results in
+                results.checkTask(.matchRuleType("CompileMetalFile")) { compileTask in
+                    compileTask.checkCommandLineContains(["-index-store-path"])
+                    compileTask.checkCommandLineContains(["-index-ignore-system-symbols"])
+                    compileTask.checkCommandLineContains(["-index-ignore-pcms"])
+                    // metal doesn't support index store compression at the moment.
+                    compileTask.checkCommandLineDoesNotContain("-index-store-compress")
+                }
+            }
+            // Check that we don't emit any index-related options when INDEX_ENABLE_DATA_STORE is not enabled
+            await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: [:]), runDestination: .macOS) { results in
+                results.checkTask(.matchRuleType("CompileMetalFile")) { compileTask in
+                    compileTask.checkCommandLineDoesNotContain("-index-store-path")
+                    compileTask.checkCommandLineDoesNotContain("-index-store-compress")
+                    compileTask.checkCommandLineDoesNotContain("-index-ignore-system-symbols")
+                    compileTask.checkCommandLineDoesNotContain("-index-ignore-pcms")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add build settings that allow fine-tuning how the index store is being emitted during index-while-building.
