### PR TITLE
Add an option to make the bridging header internal

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1057,6 +1057,7 @@ public final class BuiltinMacros {
     public static let SWIFT_WARNINGS_AS_WARNINGS_GROUPS = BuiltinMacros.declareStringListMacro("SWIFT_WARNINGS_AS_WARNINGS_GROUPS")
     public static let SWIFT_WARNINGS_AS_ERRORS_GROUPS = BuiltinMacros.declareStringListMacro("SWIFT_WARNINGS_AS_ERRORS_GROUPS")
     public static let SWIFT_OBJC_BRIDGING_HEADER = BuiltinMacros.declareStringMacro("SWIFT_OBJC_BRIDGING_HEADER")
+    public static let SWIFT_BRIDGING_HEADER_IS_INTERNAL = BuiltinMacros.declareBooleanMacro("SWIFT_BRIDGING_HEADER_IS_INTERNAL")
     public static let SWIFT_OBJC_INTERFACE_HEADER_NAME = BuiltinMacros.declareStringMacro("SWIFT_OBJC_INTERFACE_HEADER_NAME")
     public static let SWIFT_OBJC_INTERFACE_HEADER_DIR = BuiltinMacros.declareStringMacro("SWIFT_OBJC_INTERFACE_HEADER_DIR")
     public static let SWIFT_OBJC_INTEROP_MODE = BuiltinMacros.declareStringMacro("SWIFT_OBJC_INTEROP_MODE")
@@ -2271,6 +2272,7 @@ public final class BuiltinMacros {
         SWIFT_MODULE_ONLY_TVOS_DEPLOYMENT_TARGET,
         SWIFT_MODULE_ONLY_WATCHOS_DEPLOYMENT_TARGET,
         SWIFT_OBJC_BRIDGING_HEADER,
+        SWIFT_BRIDGING_HEADER_IS_INTERNAL,
         SWIFT_OBJC_INTERFACE_HEADER_NAME,
         SWIFT_OBJC_INTERFACE_HEADER_DIR,
         SWIFT_OBJC_INTEROP_MODE,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2097,7 +2097,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             let objcBridgingHeaderPath = Path(cbc.scope.evaluate(BuiltinMacros.SWIFT_OBJC_BRIDGING_HEADER))
             if !objcBridgingHeaderPath.isEmpty {
                 let objcBridgingHeaderNode = delegate.createNode(objcBridgingHeaderPath)
-                args += ["-import-objc-header", objcBridgingHeaderNode.path.normalize().str]
+                let flag = cbc.scope.evaluate(BuiltinMacros.SWIFT_BRIDGING_HEADER_IS_INTERNAL)
+                    ? "-internal-import-bridging-header"
+                    : "-import-objc-header"
+                args += [flag, objcBridgingHeaderNode.path.normalize().str]
                 extraInputPaths.append(objcBridgingHeaderPath)
                 let precompsPath = cbc.scope.evaluate(BuiltinMacros.SHARED_PRECOMPS_DIR)
                 if !precompsPath.isEmpty,
@@ -3476,6 +3479,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             for arg in [
                 // We want the objc header in XOJIT mode so ignore in dynamic replacement mode
                 "-import-objc-header",
+
+                "-internal-import-bridging-header",
 
                 // Old setting only stripped in dynamic replacement mode for backward compatibility
                 "-clang-build-session-file",

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -225,8 +225,16 @@
                 Type = String;
                 DefaultValue = "";
                 Category = "General";
-                DisplayName = "Objective-C Bridging Header";
-                Description = "Path to the header defining the Objective-C interfaces to be exposed in Swift.";
+                DisplayName = "Bridging Header";
+                Description = "Path to the header defining the C interfaces to be exposed in Swift.";
+            },
+            {
+                Name = "SWIFT_BRIDGING_HEADER_IS_INTERNAL";
+                Type = Boolean;
+                DefaultValue = "NO";
+                Category = "General";
+                DisplayName = "Bridging Header is Internal to the Module";
+                Description = "When there is a bridging header, this setting indicates whether the contents of that bridging header should be imported as-if they came from an internal import. This is necessary when using bridging headers with Swift modules that are imported into other modules.";
             },
             {
                 Name = "SWIFT_OBJC_INTERFACE_HEADER_NAME";


### PR DESCRIPTION
Add `SWIFT_BRIDGING_HEADER_IS_INTERNAL` option, which defaults to NO. When it is YES, use the new `-internal-import-bridging-header` instead of `-import-objc-header`. The new version treats the contents of the bridging header as if they came in through an internal import.

Tracked by rdar://161172254.
