### PR TITLE
Correct cross-platform formatting of clang response files

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -235,7 +235,7 @@ public struct ClangSourceFileIndexingInfo: SourceFileIndexingInfo {
                 // Skip
             } else if arg.starts(with: ByteString(unicodeScalarLiteral: "@")),
                       let attachmentPath = responseFileMapping[Path(arg.asString.dropFirst())],
-                      let responseFileArgs = try? ResponseFiles.expandResponseFiles(["@\(attachmentPath.str)"], fileSystem: localFS, relativeTo: workingDir, format: .unixShellQuotedSpaceSeparated) {
+                      let responseFileArgs = try? ResponseFiles.expandResponseFiles(["@\(attachmentPath.str)"], fileSystem: localFS, relativeTo: workingDir, format: .llvmStyleEscaping) {
                 result.append(contentsOf: responseFileArgs.map { ByteString(encodingAsUTF8: $0) })
             } else {
                 result.append(arg)
@@ -719,7 +719,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             ctx.add(string: self.identifier)
 
             let responseFilePath = scope.evaluate(BuiltinMacros.PER_ARCH_OBJECT_FILE_DIR).join("\(ctx.signature.asString)-common-args.resp")
-            let attachmentPath = producer.writeFileSpec.constructFileTasks(CommandBuildContext(producer: producer, scope: scope, inputs: [], output: responseFilePath), delegate, contents: ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: responseFileCommandLine, format: .unixShellQuotedSpaceSeparated)), permissions: nil, logContents: true, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
+            let attachmentPath = producer.writeFileSpec.constructFileTasks(CommandBuildContext(producer: producer, scope: scope, inputs: [], output: responseFilePath), delegate, contents: ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: responseFileCommandLine, format: .llvmStyleEscaping)), permissions: nil, logContents: true, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
 
             return ConstantFlags(flags: regularCommandLine + ["@\(responseFilePath.str)"], headerSearchPaths: headerSearchPaths, inputs: [responseFilePath], responseFileMapping: [responseFilePath: attachmentPath])
         } else {

--- a/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
@@ -74,7 +74,7 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
             self.scanningOutput = parsedOutput
             if expandResponseFiles {
                 do {
-                    self.commandLine = try ResponseFiles.expandResponseFiles(cliArguments, fileSystem: executionDelegate.fs, relativeTo: workingDirectory, format: .unixShellQuotedSpaceSeparated)
+                    self.commandLine = try ResponseFiles.expandResponseFiles(cliArguments, fileSystem: executionDelegate.fs, relativeTo: workingDirectory, format: .llvmStyleEscaping)
                 } catch {
                     outputDelegate.error(error.localizedDescription)
                     return nil

--- a/Sources/SWBUtil/ResponseFiles.swift
+++ b/Sources/SWBUtil/ResponseFiles.swift
@@ -15,6 +15,7 @@ public enum ResponseFileFormat: String, Equatable, Hashable, CaseIterable, Senda
     case unixShellQuotedNewlineSeparated
     case unixShellQuotedSpaceSeparated
     case windowsShellQuotedNewlineSeparated
+    case llvmStyleEscaping
 }
 
 public enum ResponseFiles: Sendable {
@@ -30,6 +31,8 @@ public enum ResponseFiles: Sendable {
         case .windowsShellQuotedNewlineSeparated:
             let escaper = WindowsProcessArgumentsCodec()
             return args.map { escaper.encode([$0]) + "\r\n" }.joined()
+        case .llvmStyleEscaping:
+            return LLVMStyleCommandCodec().encode(args)
         }
     }
 
@@ -73,6 +76,8 @@ public enum ResponseFiles: Sendable {
         case .windowsShellQuotedNewlineSeparated:
             return content.split { $0 == "\n" || $0 == "\r\n" }
                 .map { tokenizeWindowsShellQuotedResponseFileArg($0) }
+        case .llvmStyleEscaping:
+            return (try? LLVMStyleCommandCodec().decode(content)) ?? []
         }
     }
 


### PR DESCRIPTION
This is a more correct alternative to https://github.com/swiftlang/swift-build/pull/810

clang doesn't use Windows style response files unless you invoke it as clang-cl. Instead, use the existing LLVMStyleCommandCodec which should give correct behavior on any platform