### PR TITLE
Add a request to find a most appropriate configured target for indexi…

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -1624,6 +1624,7 @@ package struct ServiceMessageHandlers: ServiceExtension {
         service.registerMessageHandler(DumpBuildDependencyInfoMsg.self)
         
         service.registerMessageHandler(BuildDescriptionConfiguredTargetsMsg.self)
+        service.registerMessageHandler(BuildDescriptionSelectConfiguredTargetsForIndexMsg.self)
         service.registerMessageHandler(BuildDescriptionConfiguredTargetSourcesMsg.self)
         service.registerMessageHandler(IndexBuildSettingsMsg.self)
         service.registerMessageHandler(ReleaseBuildDescriptionMsg.self)

--- a/Sources/SWBProtocol/BuildDescriptionMessages.swift
+++ b/Sources/SWBProtocol/BuildDescriptionMessages.swift
@@ -168,6 +168,41 @@ public struct BuildDescriptionConfiguredTargetSourcesResponse: Message, Serializ
     }
 }
 
+/// Select a configured target for each provided target GUID in the pre-generated build description to be used by the index.
+public struct BuildDescriptionSelectConfiguredTargetsForIndexRequest: SessionMessage, RequestMessage, SerializableCodable, Equatable {
+    public typealias ResponseMessage = BuildDescriptionSelectConfiguredTargetsForIndexResponse
+
+    public static let name = "BUILD_DESCRIPTION_SELECT_CONFIGURED_TARGETS_FOR_INDEX_REQUEST"
+
+    public let sessionHandle: String
+
+    /// The ID of the build description from which to load the configured targets
+    public let buildDescriptionID: BuildDescriptionID
+
+    /// The build request that was used to generate the build description with the given ID.
+    public let request: BuildRequestMessagePayload
+
+    /// The targets for which to select configured targets.
+    public let targets: [TargetGUID]
+
+    public init(sessionHandle: String, buildDescriptionID: BuildDescriptionID, request: BuildRequestMessagePayload, targets: [TargetGUID]) {
+        self.sessionHandle = sessionHandle
+        self.buildDescriptionID = buildDescriptionID
+        self.request = request
+        self.targets = targets
+    }
+}
+
+public struct BuildDescriptionSelectConfiguredTargetsForIndexResponse: Message, SerializableCodable, Equatable {
+    public static let name = "BUILD_DESCRIPTION_SELECT_CONFIGURED_TARGETS_FOR_INDEX_RESPONSE"
+
+    public let configuredTargets: [ConfiguredTargetIdentifier]
+
+    public init(configuredTargets: [ConfiguredTargetIdentifier]) {
+        self.configuredTargets = configuredTargets
+    }
+}
+
 /// Load the build settings that should be used to index a source file in a given configured target
 public struct IndexBuildSettingsRequest: SessionMessage, RequestMessage, SerializableCodable, Equatable {
     public typealias ResponseMessage = IndexBuildSettingsResponse
@@ -241,6 +276,8 @@ let buildDescriptionMessages: [any Message.Type] = [
     BuildDescriptionConfiguredTargetsResponse.self,
     BuildDescriptionConfiguredTargetSourcesRequest.self,
     BuildDescriptionConfiguredTargetSourcesResponse.self,
+    BuildDescriptionSelectConfiguredTargetsForIndexRequest.self,
+    BuildDescriptionSelectConfiguredTargetsForIndexResponse.self,
     IndexBuildSettingsRequest.self,
     IndexBuildSettingsResponse.self,
     ReleaseBuildDescriptionRequest.self,

--- a/Sources/SwiftBuild/SWBBuildServiceSession.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceSession.swift
@@ -433,6 +433,24 @@ public final class SWBBuildServiceSession: Sendable {
         return buildSettings.compilerArguments
     }
 
+    public func selectConfiguredTargetsForIndex(targets: [SWBTargetGUID], buildDescription: SWBBuildDescriptionID, buildRequest: SWBBuildRequest) async throws -> [SWBConfiguredTargetIdentifier] {
+        let response = try await service.send(
+            request: BuildDescriptionSelectConfiguredTargetsForIndexRequest(
+                sessionHandle: uid,
+                buildDescriptionID: BuildDescriptionID(buildDescription),
+                request: buildRequest.messagePayloadRepresentation,
+                targets: targets.map { TargetGUID(rawValue: $0.rawValue) }
+            )
+         )
+
+        return response.configuredTargets.map {
+            SWBConfiguredTargetIdentifier(
+                rawGUID: $0.rawGUID,
+                targetGUID: .init($0.targetGUID)
+            )
+        }
+    }
+
     // MARK: Macro evaluation
 
 


### PR DESCRIPTION
…ng purposes

It's prompted by the fact that LSP has to operate on targets instead of configured targets at the moment because there is (currently) no way (or enough information) on LSP side to select a canonical target for a given document.

This change creates an API endpoint for `selectConfiguredTargetForIndex`. It makes it possible to select a single configured target given a target GUID and a run destination (+ other parameters).