### PR TITLE
Disable SWIFT_MODULE_ONLY_ARCHS if we detect a SWIFT_PLATFORM_TARGET_PREFIX

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -142,6 +142,7 @@ public final class BuiltinMacros {
     public static let HOST_TARGETED_PLATFORM_NAME = BuiltinMacros.declareStringMacro("HOST_TARGETED_PLATFORM_NAME")
     public static let SUPPORTS_MACCATALYST = BuiltinMacros.declareBooleanMacro("SUPPORTS_MACCATALYST")
     public static let SUPPORTS_ON_DEMAND_RESOURCES = BuiltinMacros.declareBooleanMacro("SUPPORTS_ON_DEMAND_RESOURCES")
+    public static let __ORIGINAL_SDK_DEFINED_LLVM_TARGET_TRIPLE_SYS = BuiltinMacros.declareStringMacro("__ORIGINAL_SDK_DEFINED_LLVM_TARGET_TRIPLE_SYS")
     public static let SWIFT_PLATFORM_TARGET_PREFIX = BuiltinMacros.declareStringMacro("SWIFT_PLATFORM_TARGET_PREFIX")
     public static let TVOS_DEPLOYMENT_TARGET = BuiltinMacros.declareStringMacro("TVOS_DEPLOYMENT_TARGET")
     public static let VALID_ARCHS = BuiltinMacros.declareStringListMacro("VALID_ARCHS")
@@ -2279,6 +2280,7 @@ public final class BuiltinMacros {
         SWIFT_SYSTEM_INCLUDE_PATHS,
         PACKAGE_RESOURCE_BUNDLE_NAME,
         PACKAGE_RESOURCE_TARGET_KIND,
+        __ORIGINAL_SDK_DEFINED_LLVM_TARGET_TRIPLE_SYS,
         SWIFT_PLATFORM_TARGET_PREFIX,
         USE_SWIFT_RESPONSE_FILE, // remove in rdar://53000820
         SWIFT_INSTALL_MODULE,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2524,6 +2524,7 @@ private class SettingsBuilder {
             }
 
             if let llvmTargetTripleSys = variant.llvmTargetTripleSys {
+                sdkTable.push(BuiltinMacros.__ORIGINAL_SDK_DEFINED_LLVM_TARGET_TRIPLE_SYS, literal: llvmTargetTripleSys)
                 sdkTable.push(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX, literal: llvmTargetTripleSys)
             }
 
@@ -4101,7 +4102,10 @@ private class SettingsBuilder {
         // setting will primarily be used to support building Swift modules for deprecated (or at least unsupported)
         // architectures.
         let originalModuleOnlyArchs = scope.evaluate(BuiltinMacros.SWIFT_MODULE_ONLY_ARCHS)
-        let moduleOnlyArchs = onlyActiveArchApplied ? [] : originalModuleOnlyArchs
+        // Detect discouraged overrides of SWIFT_PLATFORM_TARGET_PREFIX and use this as a signal to suppress
+        // module only architectures
+        let tripleOverridesApplied = scope.evaluate(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX) != scope.evaluate(BuiltinMacros.__ORIGINAL_SDK_DEFINED_LLVM_TARGET_TRIPLE_SYS)
+        let moduleOnlyArchs = (onlyActiveArchApplied || tripleOverridesApplied) ? [] : originalModuleOnlyArchs
             .filter { validArchs.contains($0) }
             .filter { !excludedArchs.contains($0) }
             .filter { !effectiveArchs.contains($0) }


### PR DESCRIPTION
In these situations, we can't accurately predict what platform the user is actually targeting, so we shouldn't try to generate modules for extra archs

rdar://160601005
