### PR TITLE
[BoundsSafety] Add build settings to control the bounds check mode for `-fbounds-safety`

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -544,6 +544,44 @@
                 // Hidden.
             },
             {
+                Name = "CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS";
+                Type = Enumeration;
+                FileTypes = (
+                    "sourcecode.c.c",
+                );
+                Values = (
+                    "none",
+                    "default",
+                );
+                DefaultValue = "default";
+                CommandLineArgs = {
+                    "none" = ( "-fno-bounds-safety-bringup-missing-checks" );
+                    // Use the compiler default
+                    "default" = ();
+                    // E.g. `batch_0` or `all` or comma separated lists of checks to enable
+                    "<<otherwise>>" = ( "-fbounds-safety-bringup-missing-checks=$(value)" );
+                };
+
+                Condition = "$(CLANG_ENABLE_BOUNDS_ATTRIBUTES) || $(CLANG_ENABLE_BOUNDS_SAFETY)";
+                // Hidden
+            },
+            {
+              Name = "CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS_OPT_OUTS";
+              Type = String;
+              FileTypes = (
+                    "sourcecode.c.c",
+                );
+              DefaultValue = "";
+              CommandLineArgs = {
+                "" = ();
+                // Comma separated list of checks to disable
+                "<<otherwise>>" = ( "-fno-bounds-safety-bringup-missing-checks=$(value)" );
+              };
+              Condition = "$(CLANG_ENABLE_BOUNDS_ATTRIBUTES) || $(CLANG_ENABLE_BOUNDS_SAFETY)";
+              AppearsAfter = "CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS";
+              // Hidden
+            },
+            {
                 Name = "CLANG_ENABLE_APP_EXTENSION";
                 Type = Boolean;
                 DefaultValue = "$(APPLICATION_EXTENSION_API_ONLY)";


### PR DESCRIPTION
This patch introduces two new build settings

The first is `CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS`. This setting can be used to control which new bounds checks are enabled. It takes two special values:

1. `none` - This disables all the new bounds checks. This corresponds to `-fno-bounds-safety-bringup-missing-checks`.
2. `default` - This will use the compiler default (i.e. the build system won't pass the `-fbounds-safety-bringup-missing-checks=` flag).

If the build setting value is not any of the special values it is passed directly as an argument to `-fbounds-safety-bringup-missing-checks=`. This allows enabling a specific set of checks. E.g.:

```
CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS=access_size,return_size
```

would pass `-fbounds-safety-bringup-missing-checks=access_size,return-size`.

The second build setting is
`CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS_OPT_OUTS`. This setting is intended to complement the previous build setting by providing a way to opt out of specific bounds checks. E.g.:

```
CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS=batch_0
CLANG_BOUNDS_SAFETY_BRINGUP_MISSING_CHECKS_OPT_OUTS=access_size
```

This is equivalent to

```
-fbound-safety-bringup-missing-checks=batch_0 -fno-bounds-safety-bringup-missing-checks=access_size
```

This opts the compilation unit into all checks in the `batch_0` group except the `access_size` bounds check.

These new build settings only apply when all of the following are true:

* `CLANG_ENABLE_BOUNDS_SAFETY` or `CLANG_ENABLE_BOUNDS_ATTRIBUTES` is enabled.
* For C source files

The existing `boundsSafetyCLanguageExtension` test case has been modified to test the behavior of these new flags.

rdar://161599307