### PR TITLE
[Tests] NFC: Add `iOS` requirement to `selectConfiguredTargets` test

### DIFF
--- a/Tests/SwiftBuildTests/InspectBuildDescriptionTests.swift
+++ b/Tests/SwiftBuildTests/InspectBuildDescriptionTests.swift
@@ -74,7 +74,7 @@ fileprivate struct InspectBuildDescriptionTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS, .iOS))
     func artifacts() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in


### PR DESCRIPTION
The test checks whether it's possible to select an appropriate target given a run destination and uses both macOS and iOS SDKs.

If there is no `iOS` SDK installed it won't be possible to configure a test target for that platform and the test is going to fail.

Resolves: rdar://161676960