### PR TITLE
[TEST-ONLY] Disable explicitModulesEnvironment() test

### DIFF
--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -19,7 +19,7 @@ import SWBTestSupport
 import SWBUtil
 
 @Suite(.skipHostOS(.windows, "Windows platform has no CAS support yet"),
-       .requireDependencyScannerPlusCaching, .skipInXcodeCloud("flaky tests"), .requireXcode26())
+       .requireDependencyScannerPlusCaching, .requireXcode26())
 fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
     let canUseCASPlugin: Bool
     let canUseCASPruning: Bool

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -373,7 +373,8 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .disabled("setting global environment interferes concurrent tests"),
+          .bug("https://github.com/swiftlang/swift-build/issues/835"))
     func explicitModulesEnvironment() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = TestWorkspace(

--- a/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangModuleVerifierTests.swift
@@ -191,8 +191,7 @@ fileprivate struct ClangModuleVerifierTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching,
-          .skipInXcodeCloud("flaky tests"), .requireXcode26())
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule), .requireDependencyScannerPlusCaching, .requireXcode26())
     func cachedBuild() async throws {
         try await withTemporaryDirectory { (tmpDirPath: Path) in
             let archs = ["arm64", "x86_64"]

--- a/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftCompilationCachingTests.swift
@@ -19,8 +19,7 @@ import SWBUtil
 import SWBTaskExecution
 import SWBProtocol
 
-@Suite(.requireSwiftFeatures(.compilationCaching),
-       .skipInXcodeCloud("flaky tests"), .requireXcode26())
+@Suite(.requireSwiftFeatures(.compilationCaching), .requireXcode26())
 fileprivate struct SwiftCompilationCachingTests: CoreBasedTests {
     @Test(.requireSDKs(.iOS))
     func swiftCachingSimple() async throws {


### PR DESCRIPTION
Test sets global environment that interferes other tests that are running at the same time. Bug tracked: https://github.com/swiftlang/swift-build/issues/835

Also drop the flaky tests label in Xcode cloud for compilation caching tests that are likely all related the change of the environment.