### PR TITLE
Keep -target and -isysroot options on the clang command lines, rather than in response files

### DIFF
--- a/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangResponseFileTaskConstructionTests.swift
@@ -63,7 +63,6 @@ fileprivate struct ClangResponseFileTaskConstructionTests: CoreBasedTests {
 
                     // The command arguments in the response file vary vastly between different platforms, so just check for some basics present in the content.
                     let contentAsString = contents.asString
-                    #expect(contentAsString.contains("-target "))
                     #expect(contentAsString.contains("Test-generated-files.hmap"))
                     #expect(contentAsString.contains("Test-own-target-headers.hmap"))
                     #expect(contentAsString.contains("Test-all-target-headers.hmap"))


### PR DESCRIPTION
rdar://161776508
