### PR TITLE
Pass `-Xcc -std=c++2b` to Swift when `CLANG_CXX_LANGUAGE_STANDARD` is set to `c++2b`

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1420,6 +1420,8 @@
                     "objcxx-gnu++20" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "objcxx-c++23" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "objcxx-gnu++23" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
+                    "objcxx-c++2b" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
+                    "objcxx-gnu++2b" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "<<otherwise>>" = ();
                 };
             },

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4052,6 +4052,15 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             }
         }
 
+        try await withTemporaryDirectory { tmpDir in
+            let tester = try await setupInteropTest(tmpDir, enableInterop: true, cxxLangStandard: "c++2b")
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContainsUninterrupted(["-Xcc", "-std=c++2b"])
+                }
+            }
+        }
+
         // Verify that we don't pass C++ settings to Swift compilations when C++
         // interoperability is disabled.
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
If pbxproj contains this line:
```
CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
```
then we should pass the corresponding flag to Swift compiler invocations that enable Swift/C++ interop.

Prior to this change, this worked fine for `c++23`, but not `c++2b`.

rdar://149474443