### PR TITLE
Introduce INSTALLLOC_DIRECTORY_CONTENTS to allow installloc to support installing ad-hoc bundle sub-contents

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -780,6 +780,7 @@ public final class BuiltinMacros {
     public static let INPUT_FILE_SUFFIX = BuiltinMacros.declareStringMacro("INPUT_FILE_SUFFIX")
     public static let INSTALLHDRS_COPY_PHASE = BuiltinMacros.declareBooleanMacro("INSTALLHDRS_COPY_PHASE")
     public static let INSTALLHDRS_SCRIPT_PHASE = BuiltinMacros.declareBooleanMacro("INSTALLHDRS_SCRIPT_PHASE")
+    public static let INSTALLLOC_DIRECTORY_CONTENTS = BuiltinMacros.declareBooleanMacro("INSTALLLOC_DIRECTORY_CONTENTS")
     public static let INSTALLLOC_LANGUAGE = BuiltinMacros.declareStringListMacro("INSTALLLOC_LANGUAGE")
     public static let INSTALLLOC_SCRIPT_PHASE = BuiltinMacros.declareBooleanMacro("INSTALLLOC_SCRIPT_PHASE")
     public static let INSTALL_DIR = BuiltinMacros.declarePathMacro("INSTALL_DIR")
@@ -1877,6 +1878,7 @@ public final class BuiltinMacros {
         INSTALLED_PRODUCT_ASIDES,
         INSTALLHDRS_COPY_PHASE,
         INSTALLHDRS_SCRIPT_PHASE,
+        INSTALLLOC_DIRECTORY_CONTENTS,
         INSTALLLOC_LANGUAGE,
         INSTALLLOC_SCRIPT_PHASE,
         INSTALL_DIR,

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -226,6 +226,10 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                         return
                     }
                 }
+            } else if scope.evaluate(BuiltinMacros.INSTALLLOC_DIRECTORY_CONTENTS), !ftb.isValidLocalizedContent(scope), context.workspaceContext.fs.isDirectory(ftb.absolutePath) {
+                // Treat any package or directory the same as a copied bundle and copy over the relevant lproj directories.
+                await addTasksForEmbeddedLocalizedBundle(ftb, buildFilesContext, scope, &tasks)
+                return
             }
             guard ftb.isValidLocalizedContent(scope) || targetBundleProduct else { return }
         }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
@@ -163,6 +163,10 @@ final class ResourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBa
                     await addTasksForEmbeddedLocalizedBundle(ftb, buildFilesContext, scope, &tasks)
                     return
                 }
+            } else if scope.evaluate(BuiltinMacros.INSTALLLOC_DIRECTORY_CONTENTS), !ftb.isValidLocalizedContent(scope), context.workspaceContext.fs.isDirectory(ftb.absolutePath) {
+                // Treat any package or directory the same as a copied bundle and copy over the relevant lproj directories.
+                await addTasksForEmbeddedLocalizedBundle(ftb, buildFilesContext, scope, &tasks)
+                return
             }
             guard ftb.isValidLocalizedContent(scope) || targetBundleProduct else { return }
         }

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -315,6 +315,10 @@ package final class TestFile: TestInternalStructureItem, CustomStringConvertible
             return "folder.documentationcatalog"
         case ".tightbeam":
             return "sourcecode.tightbeam"
+        case ".myPackage":
+            return "com.apple.package"
+        case "":
+            return "public.directory"
         case let ext where ext.hasPrefix(".fake-"):
             // If this is a fake extension, just return "file".
             return "file"


### PR DESCRIPTION
This change allows `installloc` to treat directories and package files in Resources and Copy Files build phases the same as if they were actual sub-bundles.

In practice, these usually can be thought of as sub-bundles and could contain their own lproj directories that should be installed into a localization root.

Putting behind a user-defined build setting for now until we can evaluate how this impacts a variety of project configurations.