### PR TITLE
Improve error output when a process fails to launch

### DIFF
--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -175,7 +175,13 @@ extension Process {
 
         async let outputTask = await collect(streams)
 
-        try await process.run(interruptible: interruptible)
+        do {
+            try await process.run(interruptible: interruptible)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw try RunProcessLaunchError(process, context: error.localizedDescription)
+        }
 
         let output = try await outputTask
 


### PR DESCRIPTION
This relates to #836 where failing to spawn a process says nothing about _which_ process failed to spawn.