### PR TITLE
Don't fail when QNX 7 SDP is present on the system and Rosetta is not installed

### DIFF
--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -45,7 +45,7 @@ struct QNXEnvironmentExtension: EnvironmentExtension {
     let plugin: QNXPlugin
 
     func additionalEnvironmentVariables(context: any EnvironmentExtensionAdditionalEnvironmentVariablesContext) async throws -> [String : String] {
-        if let latest = try await plugin.cachedQNXSDPInstallations(host: context.hostOperatingSystem).first {
+        if let latest = try? await plugin.cachedQNXSDPInstallations(host: context.hostOperatingSystem).first {
             return .init(latest.environment)
         }
         return [:]


### PR DESCRIPTION
Auxiliary platform lookup is intended to be failable; one of the three calls to cachedQNXSDPInstallations was missing a `try?`

Closes #836