### PR TITLE
Drop CI support for Xcode 16.3 and 16.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       enable_linux_static_sdk_build: true
       linux_static_sdk_build_command: SWIFTBUILD_STATIC_LINK=1 LLBUILD_STATIC_LINK=1 swift build
       enable_macos_checks: true
-      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.2\"}]"
+      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.3\"}, {\"xcode_version\": \"16.4\"}]"
       macos_build_command:
         swift test &&
         /usr/bin/xcrun xcodebuild -workspace . -scheme SwiftBuild-Package -destination generic/platform=iOS


### PR DESCRIPTION
They don't work, and main is targeting Swift 6.3 anyways, where we don't plan to support anything older than the latest shipping Xcode.