### PR TITLE
Fix coverage mapping linker args when using swiftc linker driver

### DIFF
--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1311,9 +1311,9 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
     }
 
     /// Compute the list of additional linker arguments to use when this tool is used for building with the given scope.
-    public func computeAdditionalLinkerArgs(_ producer: any CommandProducer, scope: MacroEvaluationScope, inputFileTypes: [FileTypeSpec], optionContext: (any BuildOptionGenerationContext)?, delegate: any TaskGenerationDelegate) async -> (args: [[String]], inputPaths: [Path]) {
+    public func computeAdditionalLinkerArgs(_ producer: any CommandProducer, scope: MacroEvaluationScope, lookup: @escaping ((MacroDeclaration) -> MacroStringExpression?), inputFileTypes: [FileTypeSpec], optionContext: (any BuildOptionGenerationContext)?, delegate: any TaskGenerationDelegate) async -> (args: [[String]], inputPaths: [Path]) {
         // FIXME: Optimize the list to search here.
-        return (args: producer.effectiveFlattenedOrderedBuildOptions(self).map { $0.getAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: inputFileTypes) }, inputPaths: [])
+        return (args: producer.effectiveFlattenedOrderedBuildOptions(self).map { $0.getAdditionalLinkerArgs(producer, scope: scope, lookup: lookup, inputFileTypes: inputFileTypes) }, inputPaths: [])
     }
 
     // Creates and returns the environment from the specification.  This includes both the 'EnvironmentVariables' property for this tool spec, and any build options which define that their value should be exported via their 'SetValueInEnvironmentVariable' property.

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -510,7 +510,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
             let spec = info.key
             let inputFileTypes = info.value
-            let (args, inputs) = await spec.computeAdditionalLinkerArgs(cbc.producer, scope: cbc.scope, inputFileTypes: [FileTypeSpec](inputFileTypes), optionContext: spec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate), delegate: delegate)
+            let (args, inputs) = await spec.computeAdditionalLinkerArgs(cbc.producer, scope: cbc.scope, lookup: linkerDriverLookup, inputFileTypes: [FileTypeSpec](inputFileTypes), optionContext: spec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate), delegate: delegate)
             additionalLinkerArgsArray.append(contentsOf: args)
             inputPaths.append(contentsOf: inputs)
         }
@@ -531,7 +531,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
                 for scope in depScopes {
                     if scope.evaluate(BuiltinMacros.SWIFT_OBJC_INTEROP_MODE) == "objcxx" {
                         let optionContext = await cbc.producer.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, scope, delegate)
-                        additionalLinkerArgsArray.append(contentsOf: await cbc.producer.swiftCompilerSpec.computeAdditionalLinkerArgs(cbc.producer, scope: cbc.scope, inputFileTypes: [FileTypeSpec](), optionContext: optionContext, delegate: delegate).args)
+                        additionalLinkerArgsArray.append(contentsOf: await cbc.producer.swiftCompilerSpec.computeAdditionalLinkerArgs(cbc.producer, scope: cbc.scope, lookup: linkerDriverLookup, inputFileTypes: [FileTypeSpec](), optionContext: optionContext, delegate: delegate).args)
                         additionalLinkerArgsArray.append(["-l\(cbc.scope.evaluate(BuiltinMacros.SWIFT_STDLIB))"])
                         break
                     }

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
@@ -120,7 +120,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
             let producer = cbc.producer
             let swiftCompilerSpec = producer.swiftCompilerSpec
             let optionContext = await swiftCompilerSpec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            commandLine += await swiftCompilerSpec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, forTAPI: true, delegate: delegate).args.flatMap({ $0 })
+            commandLine += await swiftCompilerSpec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, forTAPI: true, delegate: delegate).args.flatMap({ $0 })
 
             if !scope.evaluate(BuiltinMacros.SWIFT_OBJC_INTERFACE_HEADER_NAME).isEmpty && scope.evaluate(BuiltinMacros.SWIFT_INSTALL_OBJC_HEADER) {
                 let generatedHeaderPath = SwiftCompilerSpec.generatedObjectiveCHeaderOutputPath(scope).str

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -2850,6 +2850,26 @@
                 Name = "CLANG_COVERAGE_MAPPING_LINKER_ARGS";
                 Type = Boolean;
                 DefaultValue = "$(CLANG_COVERAGE_MAPPING)";
+            },
+
+            {
+                Name = "SWIFTC_CLANG_COVERAGE_MAPPING_LINKER_ARGS";
+                Type = Boolean;
+                DefaultValue = "$(CLANG_COVERAGE_MAPPING_LINKER_ARGS)";
+                Condition = "$(LINKER_DRIVER) == swiftc";
+                AdditionalLinkerArgs = {
+                    NO = ();
+                    YES = (
+                        "-Xclang-linker", "-fprofile-instr-generate",
+                    );
+                };
+            },
+
+            {
+                Name = "CLANG_CLANG_COVERAGE_MAPPING_LINKER_ARGS";
+                Type = Boolean;
+                DefaultValue = "$(CLANG_COVERAGE_MAPPING_LINKER_ARGS)";
+                Condition = "$(LINKER_DRIVER) == clang";
                 AdditionalLinkerArgs = {
                     NO = ();
                     YES = (

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1138,6 +1138,26 @@
                 Name = "CLANG_COVERAGE_MAPPING_LINKER_ARGS";
                 Type = Boolean;
                 DefaultValue = "$(CLANG_COVERAGE_MAPPING)";
+            },
+
+            {
+                Name = "SWIFTC_CLANG_COVERAGE_MAPPING_LINKER_ARGS";
+                Type = Boolean;
+                DefaultValue = "$(CLANG_COVERAGE_MAPPING_LINKER_ARGS)";
+                Condition = "$(LINKER_DRIVER) == swiftc";
+                AdditionalLinkerArgs = {
+                    NO = ();
+                    YES = (
+                        "-Xclang-linker", "-fprofile-instr-generate",
+                    );
+                };
+            },
+
+            {
+                Name = "CLANG_CLANG_COVERAGE_MAPPING_LINKER_ARGS";
+                Type = Boolean;
+                DefaultValue = "$(CLANG_COVERAGE_MAPPING_LINKER_ARGS)";
+                Condition = "$(LINKER_DRIVER) == clang";
                 AdditionalLinkerArgs = {
                     NO = ();
                     YES = (

--- a/Tests/SWBCoreTests/SwiftCompilerTests.swift
+++ b/Tests/SWBCoreTests/SwiftCompilerTests.swift
@@ -142,7 +142,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             let scope = MacroEvaluationScope(table: table)
             let delegate = TestTaskPlanningDelegate(clientDelegate: MockTestTaskPlanningClientDelegate(), fs: localFS)
             let optionContext = await spec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
+            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
         }
 
         // Check force static stdlib.
@@ -157,7 +157,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             let scope = MacroEvaluationScope(table: table)
             let delegate = TestTaskPlanningDelegate(clientDelegate: MockTestTaskPlanningClientDelegate(), fs: localFS)
             let optionContext = await spec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == (additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath)) + [["-Xlinker", "-force_load_swift_libs"], ["-lc++", "-framework", "Foundation"]])
+            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == (additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath)) + [["-Xlinker", "-force_load_swift_libs"], ["-lc++", "-framework", "Foundation"]])
         }
 
         // Check tool product type.
@@ -171,7 +171,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             let scope = MacroEvaluationScope(table: table)
             let delegate = TestTaskPlanningDelegate(clientDelegate: MockTestTaskPlanningClientDelegate(), fs: localFS)
             let optionContext = await spec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
+            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
         }
 
         // Check tool product type forced to dynamic link.
@@ -186,7 +186,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             let scope = MacroEvaluationScope(table: table)
             let delegate = TestTaskPlanningDelegate(clientDelegate: MockTestTaskPlanningClientDelegate(), fs: localFS)
             let optionContext = await spec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
+            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath))
         }
 
         // Check system stdlib option.
@@ -201,7 +201,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             let scope = MacroEvaluationScope(table: table)
             let delegate = TestTaskPlanningDelegate(clientDelegate: MockTestTaskPlanningClientDelegate(), fs: localFS)
             let optionContext = await spec.discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == ([["-L/usr/lib/swift"]] + additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath)))
+            try await #expect(spec.computeAdditionalLinkerArgs(producer, scope: scope, lookup: { _ in nil }, inputFileTypes: [], optionContext: optionContext, delegate: CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)).args == ([["-L/usr/lib/swift"]] + additionalSwiftLinkerArgs(spec, producer, scope, stdlibPath)))
         }
     }
 }

--- a/Tests/SWBTaskConstructionTests/CodeCoverageTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CodeCoverageTaskConstructionTests.swift
@@ -113,5 +113,26 @@ fileprivate struct CodeCoverageTaskConstructionTests: CoreBasedTests {
 
             results.checkNoDiagnostics()
         }
-    }
+
+        for linkerDriver in ["auto", "swiftc"] {
+            // Repeat the linker argument checks using alternate drivers
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["CLANG_COVERAGE_MAPPING": "YES", "LINKER_DRIVER": linkerDriver]), runDestination: .host) { results in
+                results.checkTarget("Target") { target in
+                    // There should be one Ld task, which includes coverage options
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-Xclang-linker", "-fprofile-instr-generate"])
+                    }
+                }
+
+                results.checkTarget("NoCoverageTarget") { target in
+                    // There should be one Ld task, which includes coverage options
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-Xclang-linker", "-fprofile-instr-generate"])
+                    }
+                }
+
+                results.checkNoDiagnostics()
+            }
+        }
+        }
 }


### PR DESCRIPTION
Plumb the linker driver selection through to AdditionalLinkerArgs selection in specs, and adopt it for the coverage args