### PR TITLE
Don't expect module deps if Swift explicit modules are turned off

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2311,7 +2311,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             }
 
             let dependencyValidationPayload: SwiftDependencyValidationPayload?
-            if let context = cbc.producer.moduleDependenciesContext, let outputPath = objectOutputPaths.first, context.validate != .no {
+            if explicitModuleBuildEnabled, let context = cbc.producer.moduleDependenciesContext, let outputPath = objectOutputPaths.first, context.validate != .no {
                 let primarySwiftBaseName = cbc.scope.evaluate(BuiltinMacros.TARGET_NAME) + compilationMode.moduleBaseNameSuffix + "-primary"
                 let dependencyValidationOutputPath = outputPath.dirname.join(primarySwiftBaseName + ".dependencies")
                 extraOutputPaths.append(dependencyValidationOutputPath)


### PR DESCRIPTION
We can't compute module deps if Swift explicit modules are turned off for a target, but we were still setting up the `ValidateDependencies` task to expect them.

rdar://161603360
