### PR TITLE
Retain old-syle response file escaping on macOS for compatibility

### DIFF
--- a/Sources/SWBApplePlatform/MetalCompiler.swift
+++ b/Sources/SWBApplePlatform/MetalCompiler.swift
@@ -33,7 +33,7 @@ struct MetalSourceFileIndexingInfo: SourceFileIndexingInfo {
 
     fileprivate init(task: any ExecutableTask, payload: MetalIndexingPayload) {
         self.outputFile = Path(task.commandLine[payload.outputFileIndex].asString)
-        self.commandLine = ClangSourceFileIndexingInfo.indexingCommandLine(from: task.commandLine.map(\.asByteString), workingDir: payload.workingDir, responseFileMapping: [:])
+        self.commandLine = ClangSourceFileIndexingInfo.indexingCommandLine(from: task.commandLine.map(\.asByteString), workingDir: payload.workingDir, responseFileMapping: [:], responseFileFormat: nil)
         self.builtProductsDir = payload.builtProductsDir
         self.toolchains = payload.toolchains
     }

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -983,6 +983,10 @@ extension BuildOperation: TaskExecutionDelegate {
         return core
     }
 
+    package var hostOperatingSystem: OperatingSystem {
+        core.hostOperatingSystem
+    }
+
     package var sdkRegistry: SDKRegistry {
         return core.sdkRegistry
     }

--- a/Sources/SWBTaskExecution/Task.swift
+++ b/Sources/SWBTaskExecution/Task.swift
@@ -569,6 +569,8 @@ public protocol TaskExecutionDelegate
     /// User preferences
     var userPreferences: UserPreferences { get }
 
+    var hostOperatingSystem: OperatingSystem { get }
+
     var emitFrontendCommandLines: Bool { get }
 
     var infoLookup: any PlatformInfoLookup { get }

--- a/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
@@ -74,7 +74,7 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
             self.scanningOutput = parsedOutput
             if expandResponseFiles {
                 do {
-                    self.commandLine = try ResponseFiles.expandResponseFiles(cliArguments, fileSystem: executionDelegate.fs, relativeTo: workingDirectory, format: .llvmStyleEscaping)
+                    self.commandLine = try ResponseFiles.expandResponseFiles(cliArguments, fileSystem: executionDelegate.fs, relativeTo: workingDirectory, format: ClangCompilerSpec.responseFileFormat(hostOS: executionDelegate.hostOperatingSystem))
                 } catch {
                     outputDelegate.error(error.localizedDescription)
                     return nil

--- a/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
@@ -36,6 +36,7 @@ struct MockExecutionDelegate: TaskExecutionDelegate {
     let environment: [String: String]?
     let userPreferences: UserPreferences
     let infoLookup: any PlatformInfoLookup
+    var hostOperatingSystem: OperatingSystem { core!.hostOperatingSystem }
     var sdkRegistry: SDKRegistry { core!.sdkRegistry }
     var specRegistry: SpecRegistry { core!.specRegistry }
     var platformRegistry: PlatformRegistry { core!.platformRegistry }


### PR DESCRIPTION
Some projects on macOS currently manually shell escape the values of build settings which are translated to compiler args, which breaks the escaping change here, as they end up double escaped. Restore the old behavior on macOS for compatibility.

rdar://162035972