### PR TITLE
[Tests] NFC: Add iOS requirement to `selectConfiguredTargets` instead…

### DIFF
--- a/Tests/SwiftBuildTests/InspectBuildDescriptionTests.swift
+++ b/Tests/SwiftBuildTests/InspectBuildDescriptionTests.swift
@@ -74,7 +74,7 @@ fileprivate struct InspectBuildDescriptionTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS))
     func artifacts() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -307,7 +307,7 @@ fileprivate struct InspectBuildDescriptionTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS, .iOS))
     func selectConfiguredTargets() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in


### PR DESCRIPTION
… of `artifacts`

The test checks whether it's possible to select an appropriate target given a run destination and uses both macOS and iOS SDKs.

If there is no iOS SDK installed it won't be possible to configure a test target for that platform and the test is going to fail.

Resolves: rdar://162067445

_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
