### PR TITLE
Revert "Disable optimization to work around a compiler bug"

### DIFF
--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -175,11 +175,6 @@ package final class BuildDescriptionManager: Sendable {
     /// NOTE: This is primarily accessible for performance testing purposes, actual clients should prefer to access via the cached methods.
     ///
     /// - Returns: A build description, or nil if cancelled.
-    // TODO: Optimizations are disabled to work around a compiler bug. Remove this attribute when the bug is fixed.
-    // See https://github.com/swiftlang/llvm-project/issues/11377 for details.
-    #if os(Windows)
-    @_optimize(none)
-    #endif
     package static func constructBuildDescription(_ plan: BuildPlan, planRequest: BuildPlanRequest, signature: BuildDescriptionSignature, inDirectory path: Path, fs: any FSProxy, bypassActualTasks: Bool = false, planningDiagnostics: [ConfiguredTarget?: [Diagnostic]], delegate: any BuildDescriptionConstructionDelegate) async throws -> BuildDescription? {
         BuildDescriptionManager.descriptionsComputed.increment()
 


### PR DESCRIPTION
The compiler bug has been fixed so the workaround is no longer necessary.
Reverts #807.

Bug: swiftlang/llvm-project#11377