### PR TITLE
Disable modular builds when compiling for >= c++20 modes

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -365,7 +365,18 @@
                     "sourcecode.cpp.cpp",
                     "sourcecode.cpp.objcpp"
                 );
-                Condition = "$(CLANG_ENABLE_MODULES)";
+                // Disable c++ modules if it was set by CLANG_ENABLE_MODULES or
+                // when using a c++ language mode that implicitly enables it.
+                Condition = "$(CLANG_ENABLE_MODULES) || 
+                    !($(CLANG_CXX_LANGUAGE_STANDARD) == 'c++98' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'gnu++98' || 
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'c++0x' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'gnu++0x' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'c++14' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'gnu++14' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'c++17' ||
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'gnu++17'|| 
+                      $(CLANG_CXX_LANGUAGE_STANDARD) == 'compiler-default')";
                 // Intentionally hidden.
             },
             {


### PR DESCRIPTION
The clang compiler will implicitly enable the modules feature when in language mode c++20 or greater. This is for c++20 modules, which strictly differ from clang modules, but are conflated at times like when the compiler evaluates `__has_feature(modules)`.
Since the sdks cannot cleanly build in this mode, disable it by default but allow explicit overrides.

rdar://156935289