### PR TITLE
fix required SDKs for validateModuleDependenciesClang

### DIFF
--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -499,7 +499,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
         try await validateModuleDependenciesSwift(explicitModules: false)
     }
 
-    @Test(.requireSDKs(.host), .requireClangFeatures(.printHeadersDirectPerFile))
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.printHeadersDirectPerFile))
     func validateModuleDependenciesClang() async throws {
         try await withTemporaryDirectory { tmpDir async throws -> Void in
             let testWorkspace = TestWorkspace(


### PR DESCRIPTION
This test has sources which require a macOS SDK