### PR TITLE
Revert to using OBJROOT as the tmpdir for Windows compiles

### DIFF
--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -17,8 +17,8 @@
         Type = Compiler;
         BasedOn = "default:com.apple.compilers.llvm.clang.1_0";
         EnvironmentVariables = {
-            "TEMP" = "$(CACHE_ROOT:default=$(OBJROOT))";
-            "TMP" = "$(CACHE_ROOT:default=$(OBJROOT))";
+            "TEMP" = "$(OBJROOT)";
+            "TMP" = "$(OBJROOT)";
         };
         Name = "Apple LLVM Windows";
         Description = "Apple LLVM Windows compiler";

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -1397,6 +1397,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                         buildConfigurations: [TestBuildConfiguration(
                             "Debug",
                             buildSettings: [
+                                "OBJROOT": tmpDir.join("objroot").str,
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
@@ -1419,6 +1420,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                             buildConfigurations: [TestBuildConfiguration(
                                 "Debug",
                                 buildSettings: [
+                                    "OBJROOT": tmpDir.join("objroot").str,
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "CLANG_ENABLE_MODULES": "YES",
                                     "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",


### PR DESCRIPTION
The CACHE_ROOT doesn't always exist. Fixup one test to ensure it uses a consistent OBJROOT