### PR TITLE
Add `createBuildDescription` command to the service console

### DIFF
--- a/Tests/SwiftBuildTests/ConsoleCommands/GeneralCommandsTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/GeneralCommandsTests.swift
@@ -69,6 +69,7 @@ fileprivate struct GeneralCommandsTests {
                     build\r
                     clang-scan\r
                     clearAllCaches\r
+                    createBuildDescription\r
                     createSession\r
                     createXCFramework\r
                     deleteSession\r
@@ -131,6 +132,7 @@ fileprivate struct GeneralCommandsTests {
             "build",
             "clang-scan",
             "clearAllCaches",
+            "createBuildDescription",
             "createSession",
             "createXCFramework",
             "deleteSession",


### PR DESCRIPTION
This is equivalent to the existing `build` command except that it creates the underlying build operation using `createBuildOperationForBuildDescriptionOnly`.
