### PR TITLE
Fix static linking on windows

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
@@ -39,7 +39,7 @@ public final class ObjectLibraryAssemblerTaskAction: TaskAction {
             _ = try await options.inputs.concurrentMap(maximumParallelism: 10) { input in
                 try executionDelegate.fs.copy(input, to: options.output.join(input.basename))
             }
-            let args = options.inputs.map { $0.strWithPosixSlashes }
+            let args = options.inputs.map { options.output.join($0.basename).strWithPosixSlashes }
             try executionDelegate.fs.write(options.output.join("args.resp"), contents: ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: args, format: options.linkerResponseFileFormat)))
             return .succeeded
         } catch {

--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -109,11 +109,6 @@
         Domain = windows;
         Type = ProductType;
         Identifier = org.swift.product-type.common.object;
-        BasedOn = org.swift.product-type.library.object;
-        Class = XCStandaloneExecutableProductType;
-        Name = "Object Library";
-        Description = "Object library";
-        IconNamePrefix = "TargetLibrary";
-        DefaultTargetName = "Object Library";
+        BasedOn = com.apple.product-type.library.static;
     },
 )

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -102,7 +102,7 @@
                 Name = __WINDOWS_STATIC_FLAG;
                 Type = Bool;
                 DefaultValue = YES;
-                Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static'";
+                Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.common.object'";
                 CommandLineArgs = ("-static");
             }
         );


### PR DESCRIPTION
- xcspec condition needs to test for toplevel product type.
- update objlib response file to use .o file in the Products dir instead of the Intermediates dir.

