### PR TITLE
Enable iOS and Android CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,11 @@ jobs:
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'Invoke-Program swift test --no-parallel'
       enable_linux_static_sdk_build: true
+      enable_android_sdk_build: true
+      android_sdk_build_command: "swift build --build-tests"
+      android_ndk_versions: '["r27d", "r29"]'
       linux_static_sdk_build_command: SWIFTBUILD_STATIC_LINK=1 LLBUILD_STATIC_LINK=1 swift build
+      enable_ios_checks: true
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.3\"}, {\"xcode_version\": \"16.4\"}]"
       macos_pre_build_command: ./.github/scripts/prebuild.sh

--- a/Tests/SWBUtilTests/FSProxyTests.swift
+++ b/Tests/SWBUtilTests/FSProxyTests.swift
@@ -35,7 +35,7 @@ public import SystemPackage
             return
         }
         for mode in modes {
-            #expect(sbuf.st_mode & mode > 0, "mode \(mode) not found on \(path)", sourceLocation: sourceLocation)
+            #expect(mode_t(sbuf.st_mode) & mode > 0, "mode \(mode) not found on \(path)", sourceLocation: sourceLocation)
         }
     }
 #endif

--- a/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/ServiceConsoleTests.swift
@@ -25,6 +25,8 @@ import System
 import SystemPackage
 #endif
 
+import SWBLibc
+
 @Suite
 fileprivate struct ServiceConsoleTests {
     @Test


### PR DESCRIPTION
We should have iOS coverage for Swift Playground, and some folks are interested in building the Swift toolchain for Android itself.