### PR TITLE
Emit some missing newlines when emitting output from the linker to the build transcript.

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -211,13 +211,17 @@ public struct DiscoveredLdLinkerToolSpecInfo: DiscoveredCommandLineToolSpecInfo 
             }
             
             // Forward the bytes
-            let processedBytes = ByteString(processedLines.joined(separator: ByteString("\n")))
-            delegate.emitOutput(processedBytes)
+            processedLines.forEach {
+                delegate.emitOutput($0)
+                delegate.emitOutput("\n")
+            }
         }
         else {
             // Forward the bytes
-            let processedBytes = ByteString(linesToParse.joined(separator: ByteString("\n")))
-            delegate.emitOutput(processedBytes)
+            linesToParse.forEach {
+                delegate.emitOutput(ByteString($0))
+                delegate.emitOutput("\n")
+            }
         }
         
         // Parse any complete lines of output.


### PR DESCRIPTION
This issue was introduced in https://github.com/swiftlang/swift-build/pull/774

rdar://162789686
