### PR TITLE
Copy Files phase should automatically use the correct lproj directory even if applying build rules

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -169,9 +169,15 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
     override func constructTasksForRule(_ rule: any BuildRuleAction, _ group: FileToBuildGroup, _ buildFilesContext: BuildFilesProcessingContext, _ scope: MacroEvaluationScope, _ delegate: any TaskGenerationDelegate) async {
         let dstFolder = computeOutputDirectory(scope)
 
-        // FIXME: Merge the region variant.
+        // Merge the region variant.
+        // Since this behavior was not always here, some people have hardcoded lproj directories in their destination folder path.
+        // Only add an additional component if there isn't one already.
+        var locDST = dstFolder
+        if !locDST.containsRegionVariantPathComponent {
+            locDST = dstFolder.join(group.regionVariantPathComponent)
+        }
 
-        let cbc = CommandBuildContext(producer: context, scope: scope, inputs: group.files, isPreferredArch: buildFilesContext.belongsToPreferredArch, buildPhaseInfo: buildFilesContext.buildPhaseInfo(for: rule), resourcesDir: dstFolder, unlocalizedResourcesDir: dstFolder)
+        let cbc = CommandBuildContext(producer: context, scope: scope, inputs: group.files, isPreferredArch: buildFilesContext.belongsToPreferredArch, buildPhaseInfo: buildFilesContext.buildPhaseInfo(for: rule), resourcesDir: locDST, unlocalizedResourcesDir: dstFolder)
         await constructTasksForRule(rule, cbc, delegate)
     }
 

--- a/Sources/SWBUtil/Path.swift
+++ b/Sources/SWBUtil/Path.swift
@@ -404,6 +404,24 @@ public struct Path: Serializable, Sendable {
         return nil
     }
 
+    /// `true` if the path contains any .lproj directories as path components.
+    public var containsRegionVariantPathComponent: Bool {
+        var path = self.join("File.strings") // since regionVariantName looks at parent dir
+        while !path.isRoot && !path.isEmpty {
+            if path.regionVariantName != nil {
+                return true
+            } else {
+                let parent = path.dirname
+                if parent == path {
+                    break
+                } else {
+                    path = parent
+                }
+            }
+        }
+        return false
+    }
+
     /// Return true if the pathname is conformant to path restrictions on the platform.
     ///
     /// Check the Unicode string representation of the path for reserved characters that cannot be represented as a path.


### PR DESCRIPTION
`CopyFilesTaskProducer` now adds the lproj directory automatically when copying a file from a variant group.

It already did this in the normal case, but not when `APPLY_RULES_IN_COPY_FILES` was set.