### PR TITLE
SWBCore: Resolve miscellaneous Swift 6 adoption issues

### DIFF
--- a/Sources/SWBCore/Apple/DeviceFamily.swift
+++ b/Sources/SWBCore/Apple/DeviceFamily.swift
@@ -82,7 +82,7 @@ public struct DeviceFamily: Decodable, Hashable, Sendable {
     }
 }
 
-public struct DeviceFamilies: Hashable {
+public struct DeviceFamilies: Hashable, Sendable {
     @_spi(Testing) public let list: [DeviceFamily]
 
     /// Used for platforms where a numeric `UIDeviceFamily` value is not used, but a device family name must still be passed to asset processing tools via the `--target-device` flag. Mutually exclusive with `deviceFamiliesByIdentifier`.

--- a/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
+++ b/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
@@ -23,7 +23,7 @@ public struct SettingsBuilderExtensionPoint: ExtensionPoint {
     public init() {}
 }
 
-public protocol SettingsBuilderExtension {
+public protocol SettingsBuilderExtension: Sendable {
     /// Provides a table of additional build properties overrides
     func addOverrides(fromEnvironment: [String:String], parameters: BuildParameters) throws -> [String:String]
 

--- a/Sources/SWBCore/FileToBuild.swift
+++ b/Sources/SWBCore/FileToBuild.swift
@@ -15,7 +15,7 @@ public import SWBProtocol
 public import SWBMacro
 
 /// Represents a file to be passed as input to some part of the build machinery.  May be a source file originally sent down with the PIF, or might be a temporary file.  Once a build rule action has been determined, it is assigned to the FileToBuild so it doesn’t have to be looked up again.  Note that the term “file” here is used in the loosest sense — the path can refer to any file system entity.
-public struct FileToBuild : Hashable {
+public struct FileToBuild : Hashable, Sendable {
     /// Absolute path of the referenced file.
     public let absolutePath: Path
 

--- a/Sources/SWBCore/SWBFeatureFlag.swift
+++ b/Sources/SWBCore/SWBFeatureFlag.swift
@@ -29,7 +29,7 @@ import SWBUtil
 /// "on" or "off" by default. For features whose configurability should be
 /// toggleable indefinitely, do not use a feature flag, and consider an
 /// alternative such as a build setting.
-public struct SWBFeatureFlagProperty {
+public struct SWBFeatureFlagProperty: Sendable {
     private let key: String
     private let defaultValue: Bool
 
@@ -52,7 +52,7 @@ public struct SWBFeatureFlagProperty {
     }
 }
 
-public struct SWBOptionalFeatureFlagProperty {
+public struct SWBOptionalFeatureFlagProperty: Sendable {
     private let key: String
 
     /// Indicates whether the feature flag is currently active in the calling environment.

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -20,7 +20,7 @@ fileprivate struct PreOverridesSettings {
 }
 
 /// This class stores settings tables which are cached or shared across all clients of the Core.
-@_spi(Testing) public final class CoreSettings {
+@_spi(Testing) public final class CoreSettings: Sendable {
     /// The core this object is associated with.
     unowned let core: Core
 
@@ -69,7 +69,7 @@ fileprivate struct PreOverridesSettings {
         self.nativeBuildSystemSpec = getRequiredBuildSystemSpec("com.apple.build-system.native")
     }
 
-    private var unionedToolDefaultsCache = Registry<String, (MacroValueAssignmentTable, errors: [String])>()
+    private let unionedToolDefaultsCache = Registry<String, (MacroValueAssignmentTable, errors: [String])>()
     @_spi(Testing) public func unionedToolDefaults(domain: String) -> (table: MacroValueAssignmentTable, errors: [String]) {
         return unionedToolDefaultsCache.getOrInsert(domain) {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -106,7 +106,7 @@ fileprivate struct PreOverridesSettings {
     }
 
     fileprivate var universalDefaults: MacroValueAssignmentTable { return universalDefaultsCache.getValue(self) }
-    private var universalDefaultsCache = LazyCache{ (settings: CoreSettings) -> MacroValueAssignmentTable in settings.computeUniversalDefaults() }
+    private let universalDefaultsCache = LazyCache{ (settings: CoreSettings) -> MacroValueAssignmentTable in settings.computeUniversalDefaults() }
     private func computeUniversalDefaults() -> MacroValueAssignmentTable {
         var table = MacroValueAssignmentTable(namespace: BuiltinMacros.namespace)
 

--- a/Sources/SWBCore/Settings/StackedSearchPaths.swift
+++ b/Sources/SWBCore/Settings/StackedSearchPaths.swift
@@ -81,7 +81,7 @@ extension StackedSearchPath {
     }
 }
 
-public enum StackedSearchPathLookupSubject {
+public enum StackedSearchPathLookupSubject: Sendable {
     case executable(basename: String)
     case library(basename: String)
 

--- a/Sources/SWBCore/SigningSupport.swift
+++ b/Sources/SWBCore/SigningSupport.swift
@@ -21,7 +21,7 @@ public enum EntitlementsVariant: Int, Serializable, Sendable {
 }
 
 /// Provides contextual behavior for code signing based on the type of platform being targeted.
-public protocol PlatformSigningContext
+public protocol PlatformSigningContext: Sendable
 {
     func adHocSigningAllowed(_ scope: MacroEvaluationScope) -> Bool
 

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -101,7 +101,7 @@ protocol DependencyInfoEditableTaskPayload: TaskPayload {
 
 
 /// A class that adopts this protocol can be used to collect information for creating tasks for a given command line tool spec, e.g. information from elsewhere in the build phase or target which is not local to the input files of the task being created.
-public protocol BuildPhaseInfoForToolSpec: AnyObject {
+public protocol BuildPhaseInfoForToolSpec: AnyObject, Sendable {
     // Certainly other parameters can be added here, or ways to collect broader information than just on individual files, but the initial implementation only covers what it was needed for.
     //
     /// Have the info object collect information from the file-to-build.
@@ -234,7 +234,7 @@ public struct AppleGenericVersionInfo: Sendable {
 
 extension DiscoveredCommandLineToolSpecInfo {
     /// Parses a standard version number from a command line invocation.
-    public static func parseProjectNameAndSourceVersionStyleVersionInfo<T: DiscoveredCommandLineToolSpecInfo>(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, commandLine: [String], construct: (ProjectVersionInfo) -> T) async throws -> T {
+    public static func parseProjectNameAndSourceVersionStyleVersionInfo<T: DiscoveredCommandLineToolSpecInfo>(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, commandLine: [String], construct: @Sendable (ProjectVersionInfo) -> T) async throws -> T {
         try await producer.discoveredCommandLineToolSpecInfo(delegate, nil, commandLine) { executionResult in
             let outputString = String(decoding: executionResult.stdout, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
             return try construct(ProjectVersionInfo(string: outputString))
@@ -242,7 +242,7 @@ extension DiscoveredCommandLineToolSpecInfo {
     }
 
     /// Parses a standard Apple Generic Versioning style version number from the output of invoking `what -q` on a binary.
-    public static func parseWhatStyleVersionInfo<T: DiscoveredCommandLineToolSpecInfo>(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, toolPath: Path, construct: (AppleGenericVersionInfo) -> T) async throws -> T {
+    public static func parseWhatStyleVersionInfo<T: DiscoveredCommandLineToolSpecInfo>(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, toolPath: Path, construct: @Sendable (AppleGenericVersionInfo) -> T) async throws -> T {
         if !toolPath.isAbsolute {
             throw StubError.error("\(toolPath.str) is not absolute")
         }

--- a/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
+++ b/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
@@ -108,7 +108,7 @@ public struct DiscoveredClangToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
 }
 
 private let clangVersionRe = RegEx(patternLiteral: #""(?<llvm>[0-9]+(?:\.[0-9]+){0,}) \(clang-(?<clang>[0-9]+(?:\.[0-9]+){0,})\)(?: ((\[.+\])|(\(.+\)))+)?""#)
-private let swiftOSSToolchainClangVersionRe = #/"(?<llvm>[0-9]+(?:\.[0-9]+){0,}) \(.* \b([a-f0-9]{40})\b\)(?: ((\[.+\])|(\(.+\)))+)?"/#
+private let swiftOSSToolchainClangVersionRe = UnsafeSendableRegex(regex: #/"(?<llvm>[0-9]+(?:\.[0-9]+){0,}) \(.* \b([a-f0-9]{40})\b\)(?: ((\[.+\])|(\(.+\)))+)?"/#)
 
 /// Creates and returns a discovered info object for the clang compiler for the given path to clang, architecture, SDK, and language.
 public func discoveredClangToolInfo(
@@ -163,7 +163,7 @@ public func discoveredClangToolInfo(
                     if let match: RegEx.MatchResult = clangVersionRe.firstMatch(in: macroValue) {
                         llvmVersion = match["llvm"].map { try? Version($0) } ?? nil
                         clangVersion = match["clang"].map { try? Version($0) } ?? nil
-                    } else if let match = try? swiftOSSToolchainClangVersionRe.firstMatch(in: macroValue) {
+                    } else if let match = try? swiftOSSToolchainClangVersionRe.regex.firstMatch(in: macroValue) {
                         llvmVersion = try? Version(String(match.llvm))
                     }
                 }

--- a/Sources/SWBUtil/LazyCache.swift
+++ b/Sources/SWBUtil/LazyCache.swift
@@ -65,7 +65,7 @@ public final class Lazy<T: Sendable>: Sendable {
 }
 
 /// Wrapper for thread-safe lazily computed values.
-public final class LazyCache<Class, T: Sendable> {
+public final class LazyCache<Class, T: Sendable>: Sendable {
     private let body: @Sendable (Class) -> T
     private let cachedValue = LockedValue<T?>(nil)
 
@@ -85,8 +85,6 @@ public final class LazyCache<Class, T: Sendable> {
         }
     }
 }
-
-extension LazyCache: Sendable where T: Sendable {}
 
 /// Wrapper for thread-safe lazily computed key-value pairs.
 public final class LazyKeyValueCache<Class, Key: Hashable & Sendable, Value: Sendable> {

--- a/Sources/SWBUtil/RegEx.swift
+++ b/Sources/SWBUtil/RegEx.swift
@@ -100,3 +100,12 @@ public struct RegEx: Sendable {
 
 @available(*, unavailable)
 extension RegEx.MatchResult: Sendable { }
+
+// Unsafe Sendable wrapper for Swift Regexs known to be thread safe because they don't include custom components or non-sendable transform closures.
+public struct UnsafeSendableRegex<Output: Sendable>: @unchecked Sendable {
+    public let regex: _StringProcessing.Regex<Output>
+
+    public init(regex: _StringProcessing.Regex<Output>) {
+        self.regex = regex
+    }
+}

--- a/Sources/SWBUtil/Registry.swift
+++ b/Sources/SWBUtil/Registry.swift
@@ -15,7 +15,7 @@ import Synchronization
 
 /// A threadsafe mapping of hashable keys to values.  Unlike a Dictionary, which has independent lookup and insertion operations, a registry has an atomic lookup-or-insert operation that takes a constructor block, which is called only if the key isn't already in the registry.  The block is guaranteed to be called only once, even if multiple threads lookup-or-insert the same key at the same time (this allows it to have side effects without needing additional checking).  Unlike a Cache, a Registry never discards entries based on memory pressure.  Unlike a LazyCache, the value creation block is provided for each call and not just once per instance.
 // FIXME: We should consider whether we should combine Cache, LazyCache, and Registry, possibly with per-instance options for things like whether background deletion is allowed, whether a value creator block is guaranteed to run only once, etc.  At the moment, the various clients in Swift Build depend on the semantics of the various utility types they use.
-public final class Registry<K: Hashable & Sendable, V: Sendable>: KeyValueStorage {
+public final class Registry<K: Hashable & Sendable, V: Sendable>: KeyValueStorage, Sendable {
     public typealias Key = K
     public typealias Value = V
 
@@ -105,5 +105,3 @@ public final class Registry<K: Hashable & Sendable, V: Sendable>: KeyValueStorag
         }
     }
 }
-
-extension Registry: Sendable where K: Sendable, V: Sendable { }

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -20,7 +20,7 @@ import SWBMacro
 @Suite fileprivate struct SpecLoadingTests: CoreBasedTests {
     var specDataCaches = Registry<Spec, any SpecDataCache>()
 
-    class TestDataDelegate : SpecParserDelegate {
+    final class TestDataDelegate : SpecParserDelegate {
         final class MockSpecRegistryDelegate: SpecRegistryDelegate, Sendable {
             private let _diagnosticsEngine: DiagnosticsEngine
 
@@ -35,7 +35,7 @@ import SWBMacro
 
         let specRegistry: SpecRegistry
 
-        var internalMacroNamespace: MacroNamespace
+        let internalMacroNamespace: MacroNamespace
 
         private let _diagnosticsEngine = DiagnosticsEngine()
 

--- a/Tests/SWBCoreTests/SpecParserTests.swift
+++ b/Tests/SWBCoreTests/SpecParserTests.swift
@@ -42,7 +42,7 @@ fileprivate final class MockSpecType: SpecType {
         }
         let specRegistry: SpecRegistry
 
-        var internalMacroNamespace = MacroNamespace(debugDescription: "internal")
+        let internalMacroNamespace = MacroNamespace(debugDescription: "internal")
 
         private let _diagnosticsEngine = DiagnosticsEngine()
 


### PR DESCRIPTION
This patch allows most of SWBCore to build with the Swift 6 language mode. Areas which still need work after this are:

- Dependency resolver delegates
- Code which integrates with LibSwiftDriver
- libClang wrappers
- provisional tasks
- SpecProxy
