### PR TITLE
Fix realpath to do the right thing on all platforms

### DIFF
--- a/Sources/SWBUtil/Path.swift
+++ b/Sources/SWBUtil/Path.swift
@@ -927,6 +927,39 @@ extension Path {
     }
 }
 
+extension String {
+    @_spi(Testing) public var canonicalPathRepresentation: String {
+        get throws {
+            #if os(Windows)
+            return try withCString(encodedAs: UTF16.self) { platformPath in
+                return try platformPath.withCanonicalPathRepresentation { canonicalPath in
+                    return String(decodingCString: canonicalPath, as: UTF16.self)
+                }
+            }
+            #else
+            return self
+            #endif
+        }
+    }
+}
+
+extension Path {
+     @_spi(Testing) public var canonicalPathRepresentation: String {
+        get throws {
+            #if os(Windows)
+            return try withPlatformString { platformPath in
+                return try platformPath.withCanonicalPathRepresentation { canonicalPath in
+                    return String(decodingCString: canonicalPath, as: UTF16.self)
+                }
+            }
+            #else
+            return str
+            #endif
+        }
+    }
+}
+
+
 /// A wrapper for a string which is used to identify an absolute path on the file system.
 public struct AbsolutePath: Hashable, Equatable, Serializable, Sendable {
     public let path: Path

--- a/Tests/SWBUtilTests/PathWindowsTests.swift
+++ b/Tests/SWBUtilTests/PathWindowsTests.swift
@@ -12,7 +12,7 @@
 
 import Testing
 import SWBTestSupport
-import SWBUtil
+@_spi(Testing) import SWBUtil
 
 @Suite(.requireHostOS(.windows))
 fileprivate struct PathWindowsTests {
@@ -56,37 +56,5 @@ fileprivate struct PathWindowsTests {
 
         #expect(try Path(current.str.prefix(2) + String(repeating: "foo/bar/baz/", count: chunks)).canonicalPathRepresentation == current.join(String(repeating: "\\foo\\bar\\baz", count: chunks)).str)
         #expect(try Path(current.str.prefix(2) + String(repeating: "foo/bar/baz/", count: 22)).canonicalPathRepresentation == "\\\\?\\" + current.join(String(repeating: "\\foo\\bar\\baz", count: 22)).str)
-    }
-}
-
-fileprivate extension String {
-    var canonicalPathRepresentation: String {
-        get throws {
-            #if os(Windows)
-            return try withCString(encodedAs: UTF16.self) { platformPath in
-                return try platformPath.withCanonicalPathRepresentation { canonicalPath in
-                    return String(decodingCString: canonicalPath, as: UTF16.self)
-                }
-            }
-            #else
-            return self
-            #endif
-        }
-    }
-}
-
-fileprivate extension Path {
-    var canonicalPathRepresentation: String {
-        get throws {
-            #if os(Windows)
-            return try withPlatformString { platformPath in
-                return try platformPath.withCanonicalPathRepresentation { canonicalPath in
-                    return String(decodingCString: canonicalPath, as: UTF16.self)
-                }
-            }
-            #else
-            return str
-            #endif
-        }
     }
 }


### PR DESCRIPTION
This regressed as part of #427, which attempted to simplify API calls in FSProxy to use Foundation rather than bespoke implementations going directly to Win32/POSIX API.

However, `standardizingPath` on Windows doesn't actually handle 8.3 filenames correctly, and so Swift Build doesn't know (for example) that C:\Users\JAKEPE~1 and C:\Users\jakepetroules are the same path.

Use the canonicalPathKey from URLResourceValues to canonicalize the path appropriately on both platforms, which under the hood uses GetFinalPathNameByHandleW on Windows and realpath on POSIX, matching the previous behavior.

With this change, the androidCommandLineTool test now passes on Windows, which was previously failing due to differences between paths in 8.3 form vs long form.