### PR TITLE
Change how libraries are specified to the linker when using searched libs

### DIFF
--- a/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
@@ -89,11 +89,12 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
         /// The path to the privacy file, if one exists.
         public let privacyFile: Path?
 
-        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, swiftModulePaths: [String: Path], swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path], explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
+        public let libPrefix: String?
+
+        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, swiftModulePaths: [String: Path], swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path], prefix: String? = nil, explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
             self.kind = kind
             self.path = path
             self.mode = mode
-            self.useSearchPaths = useSearchPaths
             self.swiftModulePaths = swiftModulePaths
             self.swiftModuleAdditionalLinkerArgResponseFilePaths = swiftModuleAdditionalLinkerArgResponseFilePaths
             self.explicitDependencies = explicitDependencies
@@ -101,6 +102,10 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
             self.dsymPath = dsymPath
             self.xcframeworkSourcePath = xcframeworkSourcePath
             self.privacyFile = privacyFile
+            self.libPrefix = prefix
+            // Only use search paths when no prefix is required or when the prefix matches
+            let hasValidPrefix = libPrefix.map { path.basename.hasPrefix($0) } ?? true
+            self.useSearchPaths = hasValidPrefix && useSearchPaths
         }
     }
 

--- a/Sources/SWBCore/SpecImplementations/Specs.swift
+++ b/Sources/SWBCore/SpecImplementations/Specs.swift
@@ -301,6 +301,9 @@ public class FileTypeSpec : Spec, SpecType, @unchecked Sendable {
     /// Returns `true` if the `isWrapperFolder` value is set in the XCSpec for the file spec.
     public let isWrapper: Bool
 
+    /// Returns any common prefix this file may have (currently used when specifying searched libraries to linker)
+    public let prefix: String?
+
     required init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         let basedOnFileTypeSpec = basedOnSpec as? FileTypeSpec ?? nil
 
@@ -318,8 +321,8 @@ public class FileTypeSpec : Spec, SpecType, @unchecked Sendable {
         self.isEmbeddableInProduct = parser.parseBool("IsEmbeddable") ?? false
         self.validateOnCopy = parser.parseBool("ValidateOnCopy") ?? false
         self.codeSignOnCopy = parser.parseBool("CodeSignOnCopy") ?? false
-
         self.isWrapper = parser.parseBool("IsWrapperFolder") ?? false
+        self.prefix = parser.parseString("Prefix")
 
         // Parse and ignore keys we have no use for.
         //
@@ -358,7 +361,6 @@ public class FileTypeSpec : Spec, SpecType, @unchecked Sendable {
         parser.parseStringList("MIMETypes")
         parser.parseString("Permissions")
         parser.parseString("PlistStructureDefinition")
-        parser.parseStringList("Prefix")
         parser.parseBool("RemoveHeadersOnCopy")
         parser.parseBool("RequiresHardTabs")
         parser.parseString("UTI")

--- a/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
@@ -91,4 +91,14 @@
         IconNamePrefix = "TargetPlugin";
         DefaultTargetName = "Object File";
     },
+    {
+        Domain = generic-unix;
+        Type = FileType;
+        Identifier = compiled.mach-o.dylib;
+        BasedOn = compiled.mach-o;
+        Prefix = lib;
+        Extensions = (so);
+        IsLibrary = YES;
+        IsDynamicLibrary = YES;
+    }
 )

--- a/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
@@ -903,6 +903,7 @@
         Class = PBXMachOFileType;
         BasedOn = compiled.mach-o;
         Extensions = (dylib);
+        Prefix = lib;
         IsLibrary = YES;
         IsDynamicLibrary = YES;
         CodeSignOnCopy = YES;
@@ -939,6 +940,7 @@
         Identifier = sourcecode.text-based-dylib-definition;
         BasedOn = sourcecode;
         Extensions = (tbd);
+        Prefix = lib;
         IsLibrary = YES;
         IsDynamicLibrary = YES;
         CodeSignOnCopy = YES;
@@ -1471,7 +1473,7 @@
         Identifier = archive.ar;
         BasedOn = archive;
         Extensions = (a);
-        Prefix = (lib);
+        Prefix = lib;
         IsLibrary = YES;
         IsStaticLibrary = YES;
         ContainsNativeCode = YES;

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -170,7 +170,7 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
             "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
             "LIBRARY_SEARCH_PATHS": "$(inherited) $(SDKROOT)/usr/lib/swift/windows/$(CURRENT_ARCH)",
-            "TEST_LIBRARY_SEARCH_PATHS": .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH) \(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH)"),
+            "TEST_LIBRARY_SEARCH_PATHS": .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/ \(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH) \(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH) \(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows"),
             "OTHER_SWIFT_FLAGS": "$(inherited) -libc $(DEFAULT_USE_RUNTIME)",
 
             "DEFAULT_USE_RUNTIME": "MD",

--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -48,6 +48,7 @@
         Identifier = com.apple.product-type.bundle.unit-test;
         BasedOn = com.apple.product-type.library.dynamic;
         DefaultBuildProperties = {
+            ENABLE_TESTING_SEARCH_PATHS = YES;
             // Index store data is required to discover XCTest tests
             COMPILER_INDEX_STORE_ENABLE = YES;
             SWIFT_INDEX_STORE_ENABLE = YES;
@@ -87,6 +88,7 @@
         BasedOn = default:com.apple.product-type.library.dynamic;
         HasInfoPlist = NO;
         DefaultBuildProperties = {
+            EXECUTABLE_PREFIX = "";
             PUBLIC_HEADERS_FOLDER_PATH = "";
             PRIVATE_HEADERS_FOLDER_PATH = "";
         };
@@ -111,4 +113,25 @@
         Identifier = org.swift.product-type.common.object;
         BasedOn = com.apple.product-type.library.static;
     },
+
+    {
+        Domain = windows;
+        Type = FileType;
+        Identifier = archive.ar;
+        BasedOn = archive;
+        Extensions = (lib);
+        IsLibrary = YES;
+        IsStaticLibrary = YES;
+        ContainsNativeCode = YES;
+    },
+
+    {
+        Domain = windows;
+        Type = FileType;
+        Identifier = compiled.mach-o.dylib;
+        BasedOn = compiled.mach-o;
+        Extensions = (dll);
+        IsLibrary = YES;
+        IsDynamicLibrary = YES;
+    }
 )

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -29,7 +29,7 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
         try await withTemporaryDirectory { tmpDir in
             let destination: RunDestinationInfo = .host
             let core = try await getCore()
-            let environment = destination.hostRuntimeEnvironment(core)
+            let environment = try destination.hostRuntimeEnvironment(core)
 
             let testProject = TestProject(
                 "aProject",

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -223,7 +223,8 @@ fileprivate struct LinkerTests: CoreBasedTests {
                             TestSourcesBuildPhase([
                                 "library.swift"
                             ])
-                        ]
+                        ],
+                        productReferenceName: "$(EXECUTABLE_NAME)"
                     ),
                 ])
             let tester = try await BuildOperationTester(getCore(), testProject, simulated: false)

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1346,23 +1346,30 @@ import SWBMacro
             for useSearchPaths in [true, false] {
                 let searchPathString = useSearchPaths ? "search" : "abs"
                 for mode in LinkerSpec.LibrarySpecifier.Mode.allCases {
+                    let prefix: String?
                     let suffix = "_\(mode)_\(searchPathString)"
                     let filePath: Path
                     switch kind {
                     case .static:
                         filePath = Path.root.join("usr/lib/libfoo\(suffix).a")
+                        prefix = producer.lookupFileType(identifier: "archive.ar")?.prefix
                     case .dynamic:
                         filePath = Path.root.join("usr/lib/libbar\(suffix).dylib")
+                        prefix = producer.lookupFileType(identifier: "compiled.mach-o.dylib")?.prefix
                     case .textBased:
                         filePath = Path.root.join("usr/lib/libbaz\(suffix).tbd")
+                        prefix = producer.lookupFileType(identifier: "sourcecode.text-based-dylib-definition")?.prefix
                     case .framework:
                         filePath = Path.root.join("tmp/Foo\(suffix).framework")
+                        prefix = nil
                     case .object:
+                        prefix = nil
                         continue
                     case .objectLibrary:
+                        prefix = nil
                         continue
                     }
-                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]))
+                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:], prefix: prefix))
                 }
             }
             return result

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -328,9 +328,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     "UnitTestRunner",
                     type: .swiftpmTestRunner,
                     buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [:])
+                        TestBuildConfiguration("Debug")
                     ],
                     buildPhases: [
                         TestSourcesBuildPhase(),
@@ -346,7 +344,11 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     buildConfigurations: [
                         TestBuildConfiguration(
                             "Debug",
-                            buildSettings: [:])
+                            buildSettings: [
+                                // FIXME: Find a way to make these default
+                                "EXECUTABLE_PREFIX": "lib",
+                                "EXECUTABLE_PREFIX[sdk=windows*]": "",
+                            ])
                     ],
                     buildPhases: [
                         TestSourcesBuildPhase([
@@ -355,7 +357,6 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                         ])
                     ],
                     dependencies: [],
-                    productReferenceName: "$(EXCTABLE_NAME)"
                 ),
             ])
         let core = try await getCore()
@@ -384,7 +385,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     ])
                     task.checkInputs([
                         .pathPattern(.suffix("UnitTestTarget.LinkFileList")),
-                        .pathPattern(.or(.suffix("UnitTestTarget.so"), .suffix("UnitTestTarget.dll"))),
+                        .pathPattern(.or(.suffix("/libUnitTestTarget.so"), .suffix("\\UnitTestTarget.dll"))),
                         .namePattern(.any),
                         .namePattern(.any),
                     ])


### PR DESCRIPTION
- remove the platform specifics from computeLibraryArgs (we cannot assume
  that all libraries have a lib prefix and what there suffix is.) So we
  now use the FileType prefix and remove any suffix when using
  searchPathFlagsForLD, moving this into the LinkerSpec.LibrarySpecifier
  extension, this allows for proper searching of libraries, and linking
  of dynamic libraries (especially on Windows).

closes #879 