### PR TITLE
Add an `--allTargets` option to the console build command

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -465,7 +465,7 @@ private struct WorkspaceInfoMsg: MessageHandler {
 
         return WorkspaceInfoResponse(sessionHandle: session.UID, workspaceInfo: .init(targetInfos: workspaceContext.workspace.projects.flatMap { project in
             return project.targets.map { target in
-                return .init(guid: target.guid, targetName: target.name, projectName: project.name)
+                return .init(guid: target.guid, targetName: target.name, projectName: project.name, dynamicTargetVariantGuid: target.dynamicTargetVariantGuid)
             }
         }))
     }

--- a/Sources/SWBProtocol/Message.swift
+++ b/Sources/SWBProtocol/Message.swift
@@ -1049,11 +1049,13 @@ public struct WorkspaceInfoResponse: Message, Equatable {
             public let guid: String
             public let targetName: String
             public let projectName: String
+            public let dynamicTargetVariantGuid: String?
 
-            public init(guid: String, targetName: String, projectName: String) {
+            public init(guid: String, targetName: String, projectName: String, dynamicTargetVariantGuid: String?) {
                 self.guid = guid
                 self.targetName = targetName
                 self.projectName = projectName
+                self.dynamicTargetVariantGuid = dynamicTargetVariantGuid
             }
         }
 

--- a/Sources/SwiftBuild/SWBWorkspaceInfo.swift
+++ b/Sources/SwiftBuild/SWBWorkspaceInfo.swift
@@ -22,10 +22,11 @@ public struct SWBTargetInfo: Sendable {
     public let guid: String
     public let targetName: String
     public let projectName: String
+    public let dynamicTargetVariantGuid: String?
 }
 
 extension SWBWorkspaceInfo {
     init(_ workspaceInfo: WorkspaceInfoResponse.WorkspaceInfo) {
-        self = .init(targetInfos: workspaceInfo.targetInfos.map { .init(guid: $0.guid, targetName: $0.targetName, projectName: $0.projectName) })
+        self = .init(targetInfos: workspaceInfo.targetInfos.map { .init(guid: $0.guid, targetName: $0.targetName, projectName: $0.projectName, dynamicTargetVariantGuid: $0.dynamicTargetVariantGuid) })
     }
 }

--- a/Tests/SWBProtocolTests/MessageSerializationTests.swift
+++ b/Tests/SWBProtocolTests/MessageSerializationTests.swift
@@ -94,7 +94,7 @@ import Testing
         assertMsgPackMessageRoundTrip(AuditSessionPIFRequest(sessionHandle: "theSession", pifContents: [4, 7, 9, 13]))
         assertMsgPackMessageRoundTrip(IncrementalPIFLookupFailureRequest(sessionHandle: "theSession", diagnostic: "everything went wrong"))
         assertMsgPackMessageRoundTrip(WorkspaceInfoRequest(sessionHandle: "theSession"))
-        assertMsgPackMessageRoundTrip(WorkspaceInfoResponse(sessionHandle: "theSession", workspaceInfo: .init(targetInfos: [.init(guid: "theGuid", targetName: "aTarget", projectName: "aProject")])))
+        assertMsgPackMessageRoundTrip(WorkspaceInfoResponse(sessionHandle: "theSession", workspaceInfo: .init(targetInfos: [.init(guid: "theGuid", targetName: "aTarget", projectName: "aProject", dynamicTargetVariantGuid: nil)])))
 
         assertMsgPackMessageRoundTrip(ErrorResponse("everything went wrong"))
         assertMsgPackMessageRoundTrip(BoolResponse(true))


### PR DESCRIPTION
Since the console command doesn't allow a fine grained selection of targets but relies on names only, it is currently sometimes not possible to build certain targets at all using that. As a simple mitigation, add an option that will simply build all targets (minus dynamic variants).
