### PR TITLE
Add support for artifact bundles with static libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -192,7 +192,11 @@ let package = Package(
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBTaskConstruction",
-            dependencies: ["SWBCore", "SWBUtil"],
+            dependencies: [
+                "SWBCore",
+                "SWBUtil",
+                .product(name: "SwiftDriver", package: "swift-driver")
+            ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: swiftSettings(languageMode: .v5)),
         .target(
@@ -206,6 +210,7 @@ let package = Package(
                 "SWBCSupport",
                 "SWBLibc",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SwiftDriver", package: "swift-driver"),
                 .product(name: "SystemPackage", package: "swift-system", condition: .when(platforms: [.linux, .openbsd, .android, .windows, .custom("freebsd")])),
             ],
             exclude: ["CMakeLists.txt"],

--- a/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
@@ -122,7 +122,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
         for variant in buildVariants {
             let scope = cbc.scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
             for arch in archs {
-                let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                let scope = scope.subscopeBindingArchAndTriple(arch: arch)
                 let dependencyInfoFile = scope.evaluate(BuiltinMacros.LD_DEPENDENCY_INFO_FILE)
                 let libtoolDependencyInfo = scope.evaluate(BuiltinMacros.LIBTOOL_DEPENDENCY_INFO_FILE)
                 if !isStaticLibrary && !dependencyInfoFile.isEmpty {

--- a/Sources/SWBCore/ArtifactBundleMetadata.swift
+++ b/Sources/SWBCore/ArtifactBundleMetadata.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import SWBUtil
+import Foundation
+
+package struct ArtifactBundleInfo: Hashable {
+    package let bundlePath: Path
+    package let metadata: ArtifactBundleMetadata
+
+    package init(bundlePath: Path, metadata: ArtifactBundleMetadata) {
+        self.bundlePath = bundlePath
+        self.metadata = metadata
+    }
+}
+
+package struct ArtifactBundleMetadata: Sendable, Hashable, Decodable {
+    package let schemaVersion: String
+    package let artifacts: [String: ArtifactMetadata]
+
+    package struct ArtifactMetadata: Sendable, Hashable, Decodable {
+        package let type: ArtifactType
+        package let version: String
+        package let variants: [VariantMetadata]
+    }
+
+    package enum ArtifactType: String, Sendable, Decodable {
+        case executable
+        case staticLibrary
+        case swiftSDK
+        case crossCompilationDestination
+    }
+
+    package struct VariantMetadata: Sendable, Hashable, Decodable {
+        package let path: Path
+        package let supportedTriples: [String]?
+        package let staticLibraryMetadata: StaticLibraryMetadata?
+    }
+
+    package struct StaticLibraryMetadata: Sendable, Hashable, Decodable {
+        package let headerPaths: [Path]
+        package let moduleMapPath: Path?
+    }
+
+    package static func parse(
+        at bundlePath: Path,
+        fileSystem: any FSProxy
+    ) throws -> ArtifactBundleMetadata {
+        let infoPath = bundlePath.join("info.json")
+
+        guard fileSystem.exists(infoPath) else {
+            throw StubError.error("artifact bundle info.json not found at '\(infoPath.str)'")
+        }
+
+        do {
+            let bytes = try fileSystem.read(infoPath)
+            let data = Data(bytes.bytes)
+            let decoder = JSONDecoder()
+            let metadata = try decoder.decode(ArtifactBundleMetadata.self, from: data)
+
+            guard let version = try? Version(metadata.schemaVersion) else {
+                throw StubError.error("invalid schema version '\(metadata.schemaVersion)' in '\(infoPath.str)'")
+            }
+
+            switch version {
+            case Version(1, 2), Version(1, 1), Version(1, 0):
+                break
+            default:
+                throw StubError.error("invalid `schemaVersion` of bundle manifest at '\(infoPath)': \(version)")
+            }
+
+            return metadata
+        } catch {
+            throw StubError.error("failed to parse ArtifactBundle info.json at '\(infoPath.str)': \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/SWBCore/BuildRequestContext.swift
+++ b/Sources/SWBCore/BuildRequestContext.swift
@@ -44,25 +44,25 @@ public final class BuildRequestContext: Sendable {
     }
 
     /// Get the cached settings for the given parameters, without considering the context of any project/target.
-    public func getCachedSettings(_ parameters: BuildParameters) -> Settings {
+    package func getCachedSettings(_ parameters: BuildParameters) -> Settings {
         workspaceContext.workspaceSettingsCache.getCachedSettings(parameters, buildRequestContext: self, purpose: .build, filesSignature: filesSignature(for:))
     }
 
     /// Get the cached settings for the given parameters and project.
-    public func getCachedSettings(_ parameters: BuildParameters, project: Project, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs? = nil, impartedBuildProperties: [ImpartedBuildProperties]? = nil) -> Settings {
-        getCachedSettings(parameters, project: project, target: nil, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: impartedBuildProperties)
+    package func getCachedSettings(_ parameters: BuildParameters, project: Project, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs? = nil) -> Settings {
+        getCachedSettings(parameters, project: project, target: nil, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: nil, artifactBundleInfo: nil)
     }
 
     /// Get the cached settings for the given parameters and target.
-    public func getCachedSettings(_ parameters: BuildParameters, target: Target, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs? = nil, impartedBuildProperties: [ImpartedBuildProperties]? = nil) -> Settings {
-        getCachedSettings(parameters, project: workspaceContext.workspace.project(for: target), target: target, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: impartedBuildProperties)
+    package func getCachedSettings(_ parameters: BuildParameters, target: Target, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs? = nil, impartedBuildProperties: [ImpartedBuildProperties]? = nil, artifactBundleInfo: [ArtifactBundleInfo]? = nil) -> Settings {
+        getCachedSettings(parameters, project: workspaceContext.workspace.project(for: target), target: target, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: impartedBuildProperties, artifactBundleInfo: artifactBundleInfo)
     }
 
     /// Private method to get the cached settings for the given parameters, project, and target.
     ///
     /// - remark: This is private so that clients don't somehow call this with a project which doesn't match the target.  There are public methods covering this one.
-    private func getCachedSettings(_ parameters: BuildParameters, project: Project, target: Target?, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs?, impartedBuildProperties: [ImpartedBuildProperties]?) -> Settings {
-        workspaceContext.workspaceSettingsCache.getCachedSettings(parameters, project: project, target: target, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: impartedBuildProperties, buildRequestContext: self, filesSignature: filesSignature(for:))
+    private func getCachedSettings(_ parameters: BuildParameters, project: Project, target: Target?, purpose: SettingsPurpose = .build, provisioningTaskInputs: ProvisioningTaskInputs?, impartedBuildProperties: [ImpartedBuildProperties]?, artifactBundleInfo: [ArtifactBundleInfo]?) -> Settings {
+        workspaceContext.workspaceSettingsCache.getCachedSettings(parameters, project: project, target: target, purpose: purpose, provisioningTaskInputs: provisioningTaskInputs, impartedBuildProperties: impartedBuildProperties, artifactBundleInfo: artifactBundleInfo, buildRequestContext: self, filesSignature: filesSignature(for:))
     }
 
     @_spi(Testing) public func getCachedMacroConfigFile(_ path: Path, project: Project? = nil, context: MacroConfigLoadContext) -> MacroConfigInfo {

--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SWBCore
   ActivityReporting.swift
   Apple/DeviceFamily.swift
   Apple/InterfaceBuilderShared.swift
+  ArtifactBundleMetadata.swift
   BuildDependencyInfo.swift
   BuildFileFilteringContext.swift
   BuildFileResolution.swift

--- a/Sources/SWBCore/MacroEvaluationExtensions.swift
+++ b/Sources/SWBCore/MacroEvaluationExtensions.swift
@@ -126,4 +126,10 @@ extension MacroEvaluationScope {
             return ($0 == BuiltinMacros.TARGET_BUILD_SUBPATH) ? self.table.namespace.parseLiteralString("") : nil
         })
     }
+
+    public func subscopeBindingArchAndTriple(arch: String) -> MacroEvaluationScope {
+        let archScope = subscope(binding: BuiltinMacros.archCondition, to: arch)
+        let swiftTargetTriple = archScope.evaluate(BuiltinMacros.SWIFT_TARGET_TRIPLE)
+        return archScope.subscope(binding: BuiltinMacros.normalizedUnversionedTripleCondition, to: swiftTargetTriple)
+    }
 }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -25,8 +25,9 @@ public final class BuiltinMacros {
     public static let platformCondition = BuiltinMacros.declareConditionParameter("__platform_filter")
     public static let sdkBuildVersionCondition = BuiltinMacros.declareConditionParameter("_sdk_build_version")
     public static let targetNameCondition = BuiltinMacros.declareConditionParameter("target")
+    public static let normalizedUnversionedTripleCondition = BuiltinMacros.declareConditionParameter("__normalized_unversioned_triple")
 
-    private static let allBuiltinConditionParameters = [archCondition, sdkCondition, variantCondition, configurationCondition, platformCondition, sdkBuildVersionCondition, targetNameCondition]
+    private static let allBuiltinConditionParameters = [archCondition, sdkCondition, variantCondition, configurationCondition, platformCondition, sdkBuildVersionCondition, targetNameCondition, normalizedUnversionedTripleCondition]
 
     // MARK: Built-in Macro Definitions
 

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
@@ -451,7 +451,7 @@ final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompil
         var paths: [Path] = []
 
         let archSpecificSubScopes = cbc.scope.evaluate(BuiltinMacros.ARCHS).map { arch in
-            return cbc.scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+            cbc.scope.subscopeBindingArchAndTriple(arch: arch)
         }
 
         for subScope in archSpecificSubScopes {

--- a/Sources/SWBProjectModel/IDE/IDESwiftPackageExtensions.swift
+++ b/Sources/SWBProjectModel/IDE/IDESwiftPackageExtensions.swift
@@ -108,6 +108,8 @@ extension PIF.FileReference : PIFRepresentable {
 
         case "xcframework":
             return "wrapper.xcframework"
+        case "artifactbundle":
+            return "wrapper.artifactbundle"
 
         case "docc":
             return "folder.documentationcatalog"

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/InfoPlistTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/InfoPlistTaskProducer.swift
@@ -195,7 +195,7 @@ private extension BundleProductTypeSpec
                 for variant in scope.evaluate(BuiltinMacros.BUILD_VARIANTS) {
                     let scope = scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
                     for arch in scope.evaluate(BuiltinMacros.ARCHS) {
-                        let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                        let scope = scope.subscopeBindingArchAndTriple(arch: arch)
 
                         // Preprocess the file, if requested.
                         if let preprocessedPlistPath = await self.addInfoPlistPreprocessTaskIfNeeded(rawPlistPath, basename: infoplistPath.basename, producer, scope, &tasks) {
@@ -255,7 +255,7 @@ private extension ToolProductTypeSpec
                     let scope = scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
                     for arch in scope.evaluate(BuiltinMacros.ARCHS)
                     {
-                        let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                        let scope = scope.subscopeBindingArchAndTriple(arch: arch)
 
                         // Preprocess the file, if requested.
                         let preprocessedPlistPath = await addInfoPlistPreprocessTaskIfNeeded(rawPlistPath, basename: infoplistPath.basename, producer, scope, &tasks) ?? rawPlistPath

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -735,7 +735,9 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         assert((scope.values(for: BuiltinMacros.archCondition) != nil) == forArch)
 
         if !forArch {
-            return scope.evaluate(BuiltinMacros.ARCHS).contains(where: { arch in willProduceBinary(scope.subscope(binding: BuiltinMacros.archCondition, to: arch), forArch: true) })
+            return scope.evaluate(BuiltinMacros.ARCHS).contains(where: { arch in
+                willProduceBinary(scope.subscopeBindingArchAndTriple(arch: arch), forArch: true)
+            })
         }
 
         // If we're copying a stub binary for this target, then we have a binary.
@@ -1340,7 +1342,7 @@ extension TaskProducerContext: CommandProducer {
 
             return dependencyScope
                 .subscope(binding: BuiltinMacros.variantCondition, to: variant)
-                .subscope(binding: BuiltinMacros.archCondition, to: arch)
+                .subscopeBindingArchAndTriple(arch: arch)
         }
     }
 
@@ -1432,7 +1434,9 @@ extension TaskProducerContext {
         guard let swiftFileType = lookupFileType(identifier: "sourcecode.swift") else { return false }
         guard let applescriptFileType = lookupFileType(identifier: "sourcecode.applescript") else { return false }
         guard let doccFileType = lookupFileType(identifier: "folder.documentationcatalog") else { return false }
-        for archSpecificSubscope in scope.evaluate(BuiltinMacros.ARCHS).map({ arch in scope.subscope(binding: BuiltinMacros.archCondition, to: arch) }) {
+        for archSpecificSubscope in scope.evaluate(BuiltinMacros.ARCHS).map({ arch in
+            scope.subscopeBindingArchAndTriple(arch: arch)
+        }) {
             let context = BuildFilesProcessingContext(archSpecificSubscope)
             guard !sourcesBuildPhase.buildFiles.contains(where: { buildFile in
                 guard let resolvedBuildFileInfo = try? resolveBuildFileReference(buildFile),

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -301,6 +301,8 @@ package final class TestFile: TestInternalStructureItem, CustomStringConvertible
             return "text.plist.xcappextensionpoints"
         case ".xcframework":
             return "wrapper.xcframework"
+        case ".artifactbundle":
+            return "wrapper.artifactbundle"
         case ".xcspec":
             return "text.plist.xcspec"
         case ".xib":

--- a/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
@@ -1213,6 +1213,13 @@
     },
     {
         Type = FileType;
+        Identifier = wrapper.artifactbundle;
+        BasedOn = wrapper;
+        Extensions = (artifactbundle);
+        UTI = "org.swift.artifactbundle";
+    },
+    {
+        Type = FileType;
         Identifier = wrapper.plug-in;
         Class = PBXCFBundleWrapperFileType;
         BasedOn = wrapper.cfbundle;

--- a/Sources/SWBUniversalPlatform/TestEntryPointTaskProducer.swift
+++ b/Sources/SWBUniversalPlatform/TestEntryPointTaskProducer.swift
@@ -54,7 +54,7 @@ class TestEntryPointTaskProducer: PhasedTaskProducer, TaskProducer {
                     for arch in settings.globalScope.evaluate(BuiltinMacros.ARCHS) {
                         for variant in settings.globalScope.evaluate(BuiltinMacros.BUILD_VARIANTS) {
                             let innerScope = settings.globalScope
-                                .subscope(binding: BuiltinMacros.archCondition, to: arch)
+                                .subscopeBindingArchAndTriple(arch: arch)
                                 .subscope(binding: BuiltinMacros.variantCondition, to: variant)
                             let linkerFileListPath = innerScope.evaluate(BuiltinMacros.__INPUT_FILE_LIST_PATH__)
                             if !linkerFileListPath.isEmpty {

--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(SWBUtil
   Statistics.swift
   String.swift
   SWBDispatch.swift
+  SwiftDriverTripleExtensions.swift
   TAPIFileList.swift
   UniqueSerialization.swift
   UnsafeSendableDelayedInitializationWrapper.swift
@@ -115,6 +116,7 @@ target_link_libraries(SWBUtil PUBLIC
   SWBCSupport
   SWBLibc
   ArgumentParser
+  SwiftDriver
   $<$<NOT:$<PLATFORM_ID:Darwin>>:SwiftSystem::SystemPackage>)
 
 set_target_properties(SWBUtil PROPERTIES

--- a/Sources/SWBUtil/SwiftDriverTripleExtensions.swift
+++ b/Sources/SWBUtil/SwiftDriverTripleExtensions.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDriver
+
+/// Compares two triples for equality after normalization, ignoring OS versions.
+package func normalizedTriplesCompareDisregardingOSVersions(_ firstTripleString: String, _ secondTripleString: String) -> Bool {
+    // Normalize both triples
+    let firstTriple = Triple(firstTripleString, normalizing: true)
+    let secondTriple = Triple(secondTripleString, normalizing: true)
+
+    // Ignore OS versions in the comparison
+    return firstTriple.arch == secondTriple.arch &&
+    firstTriple.subArch == secondTriple.subArch &&
+    firstTriple.vendor == secondTriple.vendor &&
+    firstTriple.os == secondTriple.os &&
+    firstTriple.environment == secondTriple.environment &&
+    firstTriple.objectFormat == secondTriple.objectFormat
+}

--- a/Sources/SwiftBuild/ProjectModel/References.swift
+++ b/Sources/SwiftBuild/ProjectModel/References.swift
@@ -227,6 +227,8 @@ extension ProjectModel.FileReference: Codable {
 
         case "xcframework":
             return "wrapper.xcframework"
+        case "artifactbundle":
+            return "wrapper.artifactbundle"
 
         case "docc":
             return "folder.documentationcatalog"

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -5630,5 +5630,27 @@ import SWBMacro
             let otherCflagsValues = BuiltinMacros.ifSet(BuiltinMacros.OTHER_CFLAGS, in: scope) { ["blah", $0] }
             #expect(otherCflagsValues == ["blah", "-Wall", "blah", "-O3"])
         }
+
+        @Test
+        func tripleCondition() async throws {
+            let namespace = try await getCore().specRegistry.internalMacroNamespace
+            var table = MacroValueAssignmentTable(namespace: namespace)
+
+            table.push(
+                BuiltinMacros.OTHER_CFLAGS,
+                literal: ["-DARM64_APPLE_IOS"],
+                conditions: .init(conditions: [MacroCondition(parameter: BuiltinMacros.normalizedUnversionedTripleCondition, valuePattern: "arm64-apple-ios")])
+            )
+
+            do {
+                let scope = MacroEvaluationScope(table: table).subscope(binding: BuiltinMacros.normalizedUnversionedTripleCondition, to: "arm64-apple-ios26.0")
+                #expect(scope.evaluate(BuiltinMacros.OTHER_CFLAGS) == ["-DARM64_APPLE_IOS"])
+            }
+
+            do {
+                let scope = MacroEvaluationScope(table: table).subscope(binding: BuiltinMacros.normalizedUnversionedTripleCondition, to: "arm64-apple-macos")
+                #expect(scope.evaluate(BuiltinMacros.OTHER_CFLAGS) == [])
+            }
+        }
     }
 }

--- a/Tests/SWBMacroTests/MacroConditionTripleTests.swift
+++ b/Tests/SWBMacroTests/MacroConditionTripleTests.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBMacro
+import SwiftDriver
+
+@Suite fileprivate struct MacroConditionTripleTests {
+    @Test
+    func normalizedUnversionedTripleConditionBasicMatching() throws {
+        let namespace = MacroNamespace(debugDescription: "test")
+        let tripleParam = namespace.declareConditionParameter("__normalized_unversioned_triple")
+
+        // Basics
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "arm64-apple-macos"
+            )
+
+            #expect(condition.evaluate("arm64-apple-macos"))
+            #expect(!condition.evaluate("x86_64-apple-ios"))
+            #expect(!condition.evaluate("arm64-apple-ios"))
+            #expect(!condition.evaluate("x86_64-unknown-linux-gnu"))
+        }
+
+        // Versioning is ignored
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "arm64-apple-tvos26.0"
+            )
+
+            #expect(condition.evaluate("arm64-apple-tvos"))
+            #expect(condition.evaluate("arm64-apple-tvos15.0"))
+            #expect(!condition.evaluate("arm64-apple-ios26.0"))
+        }
+
+        // Versioning is ignored (Android)
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "aarch64-unknown-linux-android"
+            )
+
+            #expect(condition.evaluate("aarch64-unknown-linux-android28"))
+            #expect(condition.evaluate("aarch64-unknown-linux-android"))
+            #expect(!condition.evaluate("aarch64-unknown-linux-foo"))
+        }
+
+        // macosx/macos normalization
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "arm64-apple-macosx"
+            )
+
+            #expect(condition.evaluate("arm64-apple-macosx"))
+            #expect(condition.evaluate("arm64-apple-macos"))
+        }
+
+        // aarch64/arm64 normalization
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "aarch64-unknown-linux-gnu"
+            )
+
+            #expect(condition.evaluate("aarch64-unknown-linux-gnu"))
+            #expect(condition.evaluate("arm64-unknown-linux-gnu"))
+        }
+
+        do {
+            let condition = MacroCondition(
+                parameter: tripleParam,
+                valuePattern: "arm64-apple-ios"
+            )
+
+            #expect(condition.evaluate([tripleParam: ["x86_64-apple-macos", "arm64-apple-ios", "x86_64-unknown-linux-gnu"]]))
+            #expect(!condition.evaluate([tripleParam: ["x86_64-apple-macos", "arm64-apple-watchos", "x86_64-unknown-linux-gnu"]]))
+        }
+    }
+}

--- a/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+
+import SWBCore
+import SWBProtocol
+import SWBTestSupport
+import SWBUtil
+import SWBTaskConstruction
+
+@Suite
+fileprivate struct ArtifactBundleTaskConstructionTests: CoreBasedTests {
+    @Test(.requireSDKs(.macOS))
+    func buildSettingsTripleCondition() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = try await TestProject(
+                "aProject",
+                sourceRoot: tmpDir.join("srcroot"),
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("SourceFile.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "CODE_SIGN_IDENTITY": "",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": swiftVersion,
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "LIBTOOL": libtoolPath.str,
+                            "SWIFT_ACTIVE_COMPILATION_CONDITIONS[__normalized_unversioned_triple=arm64-apple-macos]": "CONDITION_ACTIVE",
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "target",
+                        type: .staticLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["SourceFile.swift"]),
+                        ]
+                    )
+                ])
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+
+            await tester.checkBuild(runDestination: .macOSAppleSilicon) { results -> Void in
+                results.checkNoDiagnostics()
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContains(["-DCONDITION_ACTIVE"])
+                }
+            }
+
+            await tester.checkBuild(runDestination: .macOSIntel) { results -> Void in
+                results.checkNoDiagnostics()
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineDoesNotContain("-DCONDITION_ACTIVE")
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func artifactBundleWithStaticLibrary() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "aProject",
+                sourceRoot: tmpDir.join("srcroot"),
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("s.swift"),
+                        TestFile("c.c"),
+                        TestFile("MyLibrary.artifactbundle"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "CODE_SIGN_IDENTITY": "",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": swiftVersion,
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Framework",
+                        type: .framework,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["s.swift", "c.c"]),
+                            TestFrameworksBuildPhase(["MyLibrary.artifactbundle"]),
+                        ]
+                    )
+                ])
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            let fs = PseudoFS()
+            try fs.createDirectory(Path(SRCROOT).join("Sources"), recursive: true)
+            try fs.write(Path(SRCROOT).join("Sources/s.swift"), contents: "print(\"Hello\")")
+            try fs.write(Path(SRCROOT).join("Sources/c.c"), contents: "void f(void) {}")
+
+            let artifactBundlePath = Path(SRCROOT).join("Sources/MyLibrary.artifactbundle")
+            try fs.createDirectory(artifactBundlePath, recursive: true)
+            let arm64VariantPath = artifactBundlePath.join("macos-arm64")
+            try fs.createDirectory(arm64VariantPath.join("include"), recursive: true)
+            try fs.write(arm64VariantPath.join("libMyLibrary.a"), contents: "")
+            try fs.write(arm64VariantPath.join("include/MyLibrary.h"), contents: "void bar(void);")
+            try fs.write(arm64VariantPath.join("include/module.modulemap"), contents: "module MyLibrary { header \"MyLibrary.h\" }")
+            let x86VariantPath = artifactBundlePath.join("macos-x86_64")
+            try fs.createDirectory(x86VariantPath.join("include"), recursive: true)
+            try fs.write(x86VariantPath.join("libMyLibrary.a"), contents: "")
+            try fs.write(x86VariantPath.join("include/MyLibrary.h"), contents: "void bar(void);")
+            try fs.write(x86VariantPath.join("include/module.modulemap"), contents: "module MyLibrary { header \"MyLibrary.h\" }")
+            let infoJSONContent = """
+            {
+              "schemaVersion": "1.2",
+              "artifacts": {
+                "MyLibrary": {
+                  "type": "staticLibrary",
+                  "version": "1.0.0",
+                  "variants": [
+                    {
+                      "path": "macos-arm64/libMyLibrary.a",
+                      "supportedTriples": ["arm64-apple-macos"],
+                      "staticLibraryMetadata": {
+                        "headerPaths": ["macos-arm64/include"],
+                        "moduleMapPath": "macos-arm64/include/module.modulemap"
+                      }
+                    },
+                    {
+                      "path": "macos-x86_64/libMyLibrary.a",
+                      "supportedTriples": ["x86_64-apple-macos"],
+                      "staticLibraryMetadata": {
+                        "headerPaths": ["macos-x86_64/include"],
+                        "moduleMapPath": "macos-x86_64/include/module.modulemap"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            """
+            try fs.write(artifactBundlePath.join("info.json"), contents: ByteString(encodingAsUTF8: infoJSONContent))
+
+            await tester.checkBuild(runDestination: .macOSAppleSilicon, fs: fs) { results in
+                results.checkNoDiagnostics()
+
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContains([
+                        "-Xcc", "-fmodule-map-file=\(SRCROOT)/Sources/MyLibrary.artifactbundle/macos-arm64/include/module.modulemap"
+                    ])
+                    task.checkCommandLineContains([
+                        "-Xcc", "-I\(SRCROOT)/Sources/MyLibrary.artifactbundle/macos-arm64/include"
+                    ])
+                }
+
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineContains([
+                        "-fmodule-map-file=\(SRCROOT)/Sources/MyLibrary.artifactbundle/macos-arm64/include/module.modulemap"
+                    ])
+                    task.checkCommandLineContains([
+                        "-I\(SRCROOT)/Sources/MyLibrary.artifactbundle/macos-arm64/include"
+                    ])
+                }
+
+                results.checkTask(.matchRuleType("Ld")) { task in
+                    task.checkCommandLineContains(["\(SRCROOT)/Sources/MyLibrary.artifactbundle/macos-arm64/libMyLibrary.a"])
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- parsing for artifact bundle info.json metadata
- Propagation of search paths for libraries in artifact bundles via the global product plan. To support per-triple artifact bundle variants, this relies on a new __normalized_unversioned_triple macro condition
- linker library selection