### PR TITLE
Further reduce lock contention around `macroConfigPaths`

### DIFF
--- a/Sources/SWBCore/MacroConfigFileLoader.swift
+++ b/Sources/SWBCore/MacroConfigFileLoader.swift
@@ -248,7 +248,7 @@ final class MacroConfigFileLoader: Sendable {
                 return MacroConfigFileParser(byteString: data, path: path, delegate: delegate)
             }
 
-            mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
+            mutating func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, pathRef: OrderedSet<Path>.Index, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
                 // Look up the macro name, creating it as a user-defined macro if it isn’t already known.
                 let macro = table.namespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, macroName)
 
@@ -259,8 +259,8 @@ final class MacroConfigFileLoader: Sendable {
                 }
 
                 // Parse the value in a manner consistent with the macro definition.
-                let location = MacroValueAssignmentLocation(path: path, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
-                table.push(macro, table.namespace.parseForMacro(macro, value: value), conditions: conditionSet, location: location)
+                let locationRef = InternedMacroValueAssignmentLocation(pathRef: pathRef, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
+                table.push(macro, table.namespace.parseForMacro(macro, value: value), conditions: conditionSet, locationRef: locationRef)
             }
 
             func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser) {
@@ -308,8 +308,8 @@ fileprivate final class MacroValueAssignmentTableRef {
         table.namespace
     }
 
-    func push(_ macro: MacroDeclaration, _ value: MacroExpression, conditions: MacroConditionSet? = nil, location: MacroValueAssignmentLocation? = nil) {
-        table.push(macro, value, conditions: conditions, location: location)
+    func push(_ macro: MacroDeclaration, _ value: MacroExpression, conditions: MacroConditionSet? = nil, locationRef: InternedMacroValueAssignmentLocation? = nil) {
+        table.push(macro, value, conditions: conditions, locationRef: locationRef)
     }
 }
 

--- a/Sources/SWBMacro/MacroEvaluationScope.swift
+++ b/Sources/SWBMacro/MacroEvaluationScope.swift
@@ -17,7 +17,7 @@ private extension MacroValueAssignmentTable {
     func lookupMacro(_ macro: MacroDeclaration, overrideLookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> MacroValueAssignment? {
         // See if we have an overriding binding.
         if let override = overrideLookup?(macro) {
-            return MacroValueAssignment(expression: override, conditions: nil, next: lookupMacro(macro), location: nil)
+            return MacroValueAssignment(expression: override, conditions: nil, next: lookupMacro(macro), locationRef: nil)
         }
 
         // Otherwise, return the normal lookup.

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -17,7 +17,7 @@ import Testing
 import SWBProtocol
 import SWBTestSupport
 @_spi(Testing) import SWBUtil
-import SWBMacro
+@_spi(Testing) import SWBMacro
 @_spi(Testing) import SWBCore
 
 @Suite fileprivate struct SettingsTests: CoreBasedTests {

--- a/Tests/SWBMacroTests/MacroParsingTests.swift
+++ b/Tests/SWBMacroTests/MacroParsingTests.swift
@@ -790,7 +790,7 @@ fileprivate let testFileData = [
         }
         func endPreprocessorInclusion() {
         }
-        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
+        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, pathRef: OrderedSet<Path>.Index, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
         }
 
         func handleDiagnostic(_ diagnostic: MacroConfigFileDiagnostic, parser: MacroConfigFileParser) {
@@ -895,7 +895,7 @@ private func TestMacroConfigFileParser(_ string: String, expectedAssignments: [A
         func endPreprocessorInclusion() {
             self.includeDirectivesCount += 1
         }
-        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
+        func foundMacroValueAssignment(_ macroName: String, conditions: [(param: String, pattern: String)], value: String, path: Path, pathRef: OrderedSet<Path>.Index, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int, parser: MacroConfigFileParser) {
             // print("\(parser.lineNumber): \(macroName)\(conditions.map({ "[\($0.param)=\($0.pattern)]" }).joinWithSeparator(""))=\(value)")
             assignments.append((macro: macroName, conditions: conditions, value: value))
             locations.append((macro: macroName, path: path, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn))


### PR DESCRIPTION
We were still going through the lock once for every `MacroValueAssignment` which was causing performance issues during config file parsing. This didn't really make sense since we can instead do the insert in `MacroConfigFileParser` and otherwise only deal in index references. Real locations only need to be materialized for code that deals with them.

rdar://164650188
