### PR TITLE
Correctly locate chown on all platforms

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -133,8 +133,6 @@ struct AndroidPlatformExtension: PlatformInfoExtension {
             "GENERATE_TEXT_BASED_STUBS": "NO",
             "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
-            "CHOWN": "/usr/bin/chown",
-
             "LIBTOOL": .plString(host.imageFormat.executableName(basename: "llvm-lib")),
             "AR": .plString(host.imageFormat.executableName(basename: "llvm-ar")),
         ]

--- a/Sources/SWBCore/SpecImplementations/Tools/SetAttributes.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SetAttributes.swift
@@ -57,7 +57,7 @@ public final class SetAttributesSpec: CommandLineToolSpec, SpecImplementationTyp
                 execDescription = "Set Group"
             }
 
-            let args = [cbc.scope.evaluate(BuiltinMacros.CHOWN).str, "-RH", attrs, input.absolutePath.str]
+            let args = [resolveExecutablePath(cbc.producer, cbc.scope.evaluate(BuiltinMacros.CHOWN)).str, "-RH", attrs, input.absolutePath.str]
 
             let commandOutput = delegate.createVirtualNode("SetOwner \(input.absolutePath.str)")
             let outputs: [any PlannedNode] = [delegate.createNode(input.absolutePath), commandOutput]

--- a/Sources/SWBCore/Specs/NativeBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/NativeBuildSystem.xcspec
@@ -831,7 +831,7 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleExecut
             },
             {   Name = CHOWN;
                 Type = Path;
-                DefaultValue = "/usr/sbin/chown";
+                DefaultValue = "chown";
             },
             {   Name = CHMOD;
                 Type = Path;

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -119,7 +119,6 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
                     "GENERATE_TEXT_BASED_STUBS": "NO",
                     "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
-                    "CHOWN": "/usr/bin/chown",
                     "AR": "llvm-ar",
                 ]
             default:

--- a/Sources/SWBWebAssemblyPlatform/Plugin.swift
+++ b/Sources/SWBWebAssemblyPlatform/Plugin.swift
@@ -65,8 +65,6 @@ struct WebAssemblySDKRegistryExtension: SDKRegistryExtension {
             "GENERATE_TEXT_BASED_STUBS": "NO",
             "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
-            "CHOWN": "/usr/bin/chown",
-
             "LIBTOOL": .plString(host.imageFormat.executableName(basename: "llvm-lib")),
             "AR": .plString(host.imageFormat.executableName(basename: "llvm-ar")),
         ]

--- a/Tests/SWBTaskConstructionTests/PostprocessingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PostprocessingTaskConstructionTests.swift
@@ -65,8 +65,12 @@ fileprivate struct PostprocessingTaskConstructionTests: CoreBasedTests {
 
         let tester = try await TaskConstructionTester(getCore(), testProject)
 
+        let fs = PseudoFS()
+        try fs.createDirectory(.root.join("usr").join("sbin"), recursive: true)
+        try fs.write(.root.join("usr").join("sbin").join("chown"), contents: "")
+
         let installParameters = BuildParameters(action: .install, configuration: "Debug")
-        await tester.checkBuild(installParameters, runDestination: .macOS) { results in
+        await tester.checkBuild(installParameters, runDestination: .macOS, processEnvironment: ["PATH": "/usr/bin:/usr/sbin"], fs: fs) { results in
             results.checkNoDiagnostics()
 
             results.checkTarget("Library") { target in

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -204,8 +204,11 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
             try await fs.writePlist(Path(SRCROOT).join("Entitlements.plist"), .plDict([:]))
 
+            try fs.createDirectory(.root.join("usr").join("sbin"), recursive: true)
+            try fs.write(.root.join("usr").join("sbin").join("chown"), contents: "")
+
             // Check the debug build.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INFOPLIST_PREPROCESS": "YES", "COMBINE_HIDPI_IMAGES": "YES"]), runDestination: .macOS, fs: fs) { results -> Void in
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["INFOPLIST_PREPROCESS": "YES", "COMBINE_HIDPI_IMAGES": "YES"]), runDestination: .macOS, processEnvironment: ["PATH": "/usr/bin:/usr/sbin"], fs: fs) { results -> Void in
                 // There should be two warnings about our custom output files, since we won't reprocess the custom file it generates with the same name.
                 results.checkWarning(.prefix("no rule to process file '\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources-normal/\(results.runDestinationTargetArchitecture)/Custom.fake-lang'"))
                 results.checkWarning(.prefix("no rule to process file '\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/DerivedSources-normal/\(results.runDestinationTargetArchitecture)/en.lproj/Standard.fake-lang'"))
@@ -836,7 +839,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             try await localFS.writePlist(Path(SRCROOT).join("Entitlements.plist"), .plDict([:]))
 
             // Check an install release build.
-            try await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS, fs: localFS) { results -> Void in
+            try await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .macOS, processEnvironment: ["PATH": "/usr/bin:/usr/sbin"], fs: localFS) { results -> Void in
                 try results.checkTarget("AppTarget") { target -> Void in
                     // There should be a symlink task.
                     try results.checkTask(.matchTarget(target), .matchRuleType("SymLink")) { task in


### PR DESCRIPTION
On Linux, chown is at /usr/bin/chown, while on BSDs it's at /usr/sbin/chown

It was also being incorrectly located based on the target platform, which is incorrect. Only the host platform matters for this lookup. This meant macOS to Android or WebAssembly cross compilation, FreeBSD to Linux cross compilation, or FreeBSD native compilation could have failed if the build graph contained any chown commands. Also use a search path so we don't have to hardcode knowledge of any specific platform for this.