### PR TITLE
Remove linux/windows guard from `DependencyValidationTests`

### DIFF
--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -494,12 +494,12 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "toolchain too old"), .skipHostOS(.linux, "toolchain too old"))
+    @Test(.requireSDKs(.macOS))
     func validateModuleDependenciesSwift() async throws {
         try await validateModuleDependenciesSwift(explicitModules: true)
     }
 
-    @Test(.requireSDKs(.host), .skipHostOS(.windows, "toolchain too old"), .skipHostOS(.linux, "toolchain too old"))
+    @Test(.requireSDKs(.macOS))
     func validateModuleDependenciesSwiftExplicitModulesOff() async throws {
         try await validateModuleDependenciesSwift(explicitModules: false)
     }
@@ -574,7 +574,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .requireClangFeatures(.printHeadersDirectPerFile), .skipHostOS(.windows, "toolchain too old"), .skipHostOS(.linux, "toolchain too old"), arguments: [false, true])
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.printHeadersDirectPerFile), arguments: [false, true])
     func validateModuleDependenciesMixedSource(downgradeErrors: Bool) async throws {
         try await withTemporaryDirectory { tmpDir async throws -> Void in
             let testWorkspace = try await TestWorkspace(
@@ -719,7 +719,7 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host), .requireClangFeatures(.printHeadersDirectPerFile), .skipHostOS(.windows, "toolchain too old"), .skipHostOS(.linux, "toolchain too old"))
+    @Test(.requireSDKs(.macOS), .requireClangFeatures(.printHeadersDirectPerFile))
     func validateUnusedModuleDependencies() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testWorkspace = try await TestWorkspace(


### PR DESCRIPTION
These tests are actually macOS-only at this point, so the requirements should reflect that.