### PR TITLE
A couple incremental entitlements processing / signing fixes

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -331,7 +331,7 @@ public protocol TaskActionCreationDelegate
     func createLinkAssetCatalogTaskAction() -> any PlannedTaskAction
     func createLSRegisterURLTaskAction() -> any PlannedTaskAction
     func createODRAssetPackManifestTaskAction() -> any PlannedTaskAction
-    func createProcessProductEntitlementsTaskAction(scope: MacroEvaluationScope, mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction
+    func createProcessProductEntitlementsTaskAction(mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, allowEntitlementsModification: Bool, entitlementsDestination: EntitlementsDestination, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction
     func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction
     func createRegisterExecutionPolicyExceptionTaskAction() -> any PlannedTaskAction
     func createSwiftHeaderToolTaskAction() -> any PlannedTaskAction

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2876,7 +2876,7 @@ public enum StickerSharingLevel: String, Equatable, Hashable, EnumerationMacroTy
 }
 
 /// Enumeration macro type for the value of the `ENTITLEMENTS_DESTINATION` build setting.
-public enum EntitlementsDestination: String, Equatable, Hashable, EnumerationMacroType {
+public enum EntitlementsDestination: String, Equatable, Hashable, EnumerationMacroType, Serializable {
     public static let defaultValue = EntitlementsDestination.none
 
     case codeSignature = "Signature"

--- a/Sources/SWBCore/SpecImplementations/Tools/ProductPackaging.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ProductPackaging.swift
@@ -169,7 +169,7 @@ public final class ProductPackagingToolSpec : GenericCommandLineToolSpec, SpecId
         }
 
         // Create the task action, and then the task.
-        let action = delegate.taskActionCreationDelegate.createProcessProductEntitlementsTaskAction(scope: cbc.scope, mergedEntitlements: entitlements, entitlementsVariant: entitlementsVariant, destinationPlatformName: platform.name, entitlementsFilePath: codeSignEntitlementsInput?.absolutePath, fs: fs)
+        let action = delegate.taskActionCreationDelegate.createProcessProductEntitlementsTaskAction(mergedEntitlements: entitlements, entitlementsVariant: entitlementsVariant, allowEntitlementsModification: cbc.scope.evaluate(BuiltinMacros.CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION), entitlementsDestination: cbc.scope.evaluate(BuiltinMacros.ENTITLEMENTS_DESTINATION), destinationPlatformName: platform.name, entitlementsFilePath: codeSignEntitlementsInput?.absolutePath, fs: fs)
         // The action records a timestamp representing the last modification date of the entitlements file, so changes to the input must invalidate the build description.
         if let path = codeSignEntitlementsInput?.absolutePath {
             delegate.access(path: path)

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -857,8 +857,8 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return LSRegisterURLTaskAction()
     }
 
-    func createProcessProductEntitlementsTaskAction(scope: MacroEvaluationScope, mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
-        return ProcessProductEntitlementsTaskAction(scope: scope, fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
+    func createProcessProductEntitlementsTaskAction(mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, allowEntitlementsModification: Bool, entitlementsDestination: EntitlementsDestination, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
+        return ProcessProductEntitlementsTaskAction(fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, allowEntitlementsModification: allowEntitlementsModification, entitlementsDestination: entitlementsDestination, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
     }
 
     func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction {

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -180,8 +180,8 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return LSRegisterURLTaskAction()
     }
 
-    package func createProcessProductEntitlementsTaskAction(scope: MacroEvaluationScope, mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
-        return ProcessProductEntitlementsTaskAction(scope: scope, fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
+    package func createProcessProductEntitlementsTaskAction(mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, allowEntitlementsModification: Bool, entitlementsDestination: EntitlementsDestination, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
+        return ProcessProductEntitlementsTaskAction(fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, allowEntitlementsModification: allowEntitlementsModification, entitlementsDestination: entitlementsDestination, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
     }
 
     package func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction {

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -408,8 +408,8 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return LSRegisterURLTaskAction()
     }
 
-    package func createProcessProductEntitlementsTaskAction(scope: MacroEvaluationScope, mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
-        return ProcessProductEntitlementsTaskAction(scope: scope, fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
+    package func createProcessProductEntitlementsTaskAction(mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, allowEntitlementsModification: Bool, entitlementsDestination: EntitlementsDestination, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
+        return ProcessProductEntitlementsTaskAction(fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, allowEntitlementsModification: allowEntitlementsModification, entitlementsDestination: entitlementsDestination, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
     }
 
     package func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction {

--- a/Tests/SWBBuildSystemTests/CodeSigningBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CodeSigningBuildOperationTests.swift
@@ -75,5 +75,69 @@ fileprivate struct CodeSigningBuildOperationTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.macOS))
+    func entitlementsProcessingNotInvalidatedByUnrelatedSettingsChange() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testProject = TestProject(
+                "aProject",
+                sourceRoot: tmpDirPath,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("AppSource.m"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration( "Debug", buildSettings: [
+                        "COPY_PHASE_STRIP": "NO",
+                        "DEBUG_INFORMATION_FORMAT": "dwarf",
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "CODE_SIGN_IDENTITY": "-",
+                        "CODE_SIGN_ENTITLEMENTS": "Entitlements.entitlements",
+                        "SDKROOT": "macosx",
+                        "SUPPORTED_PLATFORMS": "macosx",
+                    ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "AppTarget",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                "AppSource.m",
+                            ]),
+                        ],
+                    ),
+                ]
+            )
+
+            let tester = try await BuildOperationTester(getCore(), testProject, simulated: false)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            try tester.fs.createDirectory(Path(SRCROOT).join("Sources"), recursive: true)
+            try tester.fs.write(Path(SRCROOT).join("Sources/AppSource.m"), contents: "int main() { return 0; }")
+            try await tester.fs.writePlist(Path(SRCROOT).join("Entitlements.entitlements"), .plDict([:]))
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .macOS, persistent: true, signableTargets: ["AppTarget"]) { results in
+                results.checkNoDiagnostics()
+            }
+
+            // After changing irrelevant settings, we should not see CodeSign/ProcessProductPackaging tasks.
+            // We may still see a task to process Info.plist since that supports build settings interpolation.
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: ["Foo": "Bar"]), runDestination: .macOS, persistent: true, signableTargets: ["AppTarget"]) { results in
+                results.checkNoTask(.matchRuleType("CodeSign"))
+                results.checkNoTask(.matchRuleType("ProcessProductPackaging"))
+                results.checkNoDiagnostics()
+            }
+
+            // Changing CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION should force them to re-run.
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", overrides: ["CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION": "YES"]), runDestination: .macOS, persistent: true, signableTargets: ["AppTarget"]) { results in
+                results.checkTaskExists(.matchRuleType("CodeSign"))
+                results.checkTasks(.matchRuleType("ProcessProductPackaging")) { #expect(!$0.isEmpty) }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
 }
 

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -175,8 +175,8 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return LSRegisterURLTaskAction()
     }
 
-    public func createProcessProductEntitlementsTaskAction(scope: MacroEvaluationScope, mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
-        return ProcessProductEntitlementsTaskAction(scope: scope, fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
+    public func createProcessProductEntitlementsTaskAction(mergedEntitlements: PropertyListItem, entitlementsVariant: EntitlementsVariant, allowEntitlementsModification: Bool, entitlementsDestination: EntitlementsDestination, destinationPlatformName: String, entitlementsFilePath: Path?, fs: any FSProxy) -> any PlannedTaskAction {
+        return ProcessProductEntitlementsTaskAction(fs: fs, entitlements: mergedEntitlements, entitlementsVariant: entitlementsVariant, allowEntitlementsModification: allowEntitlementsModification, entitlementsDestination: entitlementsDestination, destinationPlatformName: destinationPlatformName, entitlementsFilePath: entitlementsFilePath)
     }
 
     public func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction {


### PR DESCRIPTION
1. Ensure we regenerate the build description on every entitlements change, because it records a timestamp of the file to diagnose modifications during the build
2. Ensure irrelevant settings changes do not invalidate entitlements processing