### PR TITLE
[6.3] Do not pass index store options if indexing is disabled

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -239,7 +239,7 @@
                 Name = "METAL_INDEX_STORE_ONLY_PROJECT_FILES";
                 Type = Boolean;
                 DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
-                Condition = "$(MTL_ENABLE_INDEX_STORE)";
+                Condition = "$(MTL_ENABLE_INDEX_STORE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE) == YES || ( $(COMPILER_INDEX_STORE_ENABLE) == Default && $(MTL_ENABLE_DEBUG_INFO) != NO ) )";
                 CommandLineArgs = {
                     YES = (
                         // See corresponding definition in Clang.xcspec

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3189,7 +3189,7 @@
                 Name = "CLANG_INDEX_STORE_ONLY_PROJECT_FILES";
                 Type = Boolean;
                 DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
-                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(GCC_OPTIMIZATION_LEVEL) == 0 ) )";
                 CommandLineArgs = {
                     YES = (
                         "-index-ignore-system-symbols",
@@ -3203,7 +3203,7 @@
                 Name = "CLANG_INDEX_STORE_COMPRESS";
                 Type = Boolean;
                 DefaultValue = "$(INDEX_STORE_COMPRESS)";
-                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(GCC_OPTIMIZATION_LEVEL) == 0 ) )";
                 CommandLineArgs = {
                     YES = (
                         "-index-store-compress",
@@ -3215,7 +3215,7 @@
                 Name = "CLANG_INDEX_STORE_IGNORE_MACROS";
                 Type = Boolean;
                 DefaultValue = NO;
-                Condition = "$(CLANG_INDEX_STORE_ENABLE)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(GCC_OPTIMIZATION_LEVEL) == 0 ) )";
                 DisplayName = "Do not index C macros";
                 Description = "Do not emit entries for C macros into the Index Store.";
                 CommandLineArgs = {

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1343,7 +1343,7 @@
                 Name = "SWIFT_INDEX_STORE_ONLY_PROJECT_FILES";
                 Type = Boolean;
                 DefaultValue = "$(INDEX_STORE_ONLY_PROJECT_FILES)";
-                Condition = "$(SWIFT_INDEX_STORE_ENABLE)";
+                Condition = "$(SWIFT_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(SWIFT_OPTIMIZATION_LEVEL) == '-Onone' ) )";
                 CommandLineArgs = {
                     YES = (
                         // Assume that clang modules are getting indexed by a clang file within them. While this is technically not correct, since you could have a clang module that only consists of header files and is only included from Swift, such scenarios are rare.
@@ -1357,7 +1357,7 @@
                 Name = "SWIFT_INDEX_STORE_COMPRESS";
                 Type = Boolean;
                 DefaultValue = "$(INDEX_STORE_COMPRESS)";
-                Condition = "$(SWIFT_INDEX_STORE_ENABLE)";
+                Condition = "$(SWIFT_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(SWIFT_OPTIMIZATION_LEVEL) == '-Onone' ) )";
                 CommandLineArgs = {
                     YES = (
                         "-Xfrontend",

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4572,6 +4572,53 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.host))
+    func indexOptionsNotAddedIfIndexingIsDisabled() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.swift")
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "Test",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "COMPILER_INDEX_STORE_ENABLE": "NO",
+                                    "INDEX_DATA_STORE_DIR": tmpDir.join("index").str,
+                                    "INDEX_STORE_COMPRESS": "YES",
+                                    "INDEX_STORE_ONLY_PROJECT_FILES": "YES"
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["File1.swift"]),
+                        ]
+                    )
+                ])
+
+            let core = try await getCore()
+            let tester = try TaskConstructionTester(core, testProject)
+            await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: ["INDEX_ENABLE_DATA_STORE": "YES"]), runDestination: .host) { results in
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { compileTask in
+                    compileTask.checkCommandLineDoesNotContain("-index-store-path")
+                    compileTask.checkCommandLineDoesNotContain("-index-store-compress")
+                    compileTask.checkCommandLineDoesNotContain("-index-ignore-clang-modules")
+                    compileTask.checkCommandLineDoesNotContain("-index-ignore-system-modules")
+                }
+            }
+        }
+    }
 }
 
 private func XCTAssertEqual(_ lhs: EnvironmentBindings, _ rhs: [String: String], file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
- **Explanation**: We were passing `-index-store-compress` to the compiler even though we don’t pass `-index-store-path` if `INDEX_STORE_ENABLE = YES` but `COMPILER_INDEX_STORE_ENABLE = NO`. This is because `CLANG_INDEX_STORE_ENABLE` still evaluated to `YES` and thus the `Condition` of `CLANG_INDEX_STORE_COMPRESS` also evaluated to `YES` but we didn’t pass `-index-store-path` because the condition of `CLANG_INDEX_STORE_ENABLE` evaluated to `NO`.
This was a misconception on my side when I added these build settings because I assumed that the `Condition` would influence the value of the build setting instead of just influencing `ComandLineArgs`.
- **Scope**: Builds that set one of the index-related options introduced in https://github.com/swiftlang/swift-build/pull/815
- **Issue**: rdar://164248532
- **Original PR**: https://github.com/swiftlang/swift-build/pull/903
- **Risk**: Low, the options affected by this have not been released yet
- **Testing**: Added unit tests
- **Reviewer**: @jakepetroules @neonichu 
