### PR TITLE
Sanitizers: Address and thread sanitizers config changes

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -2896,7 +2896,7 @@
                 };
                 AdditionalLinkerArgs = {
                     YES = (
-                        "-fsanitize=address",
+                        "$(LD_ADDRESS_SANITIZER)",
                     );
                     NO = ();
                 };

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -582,20 +582,59 @@
                 DefaultValue = YES;
             },
 
+            // Address Sanitizer options
+            {
+                Name = LD_ADDRESS_SANITIZER;
+                DefaultValue = "$(LD_ADDRESS_SANITIZER_$(LINKER_DRIVER))";
+            },
+            {
+                Name = LD_ADDRESS_SANITIZER_clang;
+                DefaultValue = "-fsanitize=address";
+            },
+            {
+                Name = LD_ADDRESS_SANITIZER_swiftc;
+                DefaultValue = "-sanitize=address";
+            },
+
             // Thread Sanitizer options
             {
                 Name = "LD_THREAD_SANITIZER";
                 Type = Boolean;
                 DefaultValue = "$(ENABLE_THREAD_SANITIZER)";
+            },
+            {
+                Name = "CLANG_LD_THREAD_SANITIZER";
+                Type = Boolean;
+                DefaultValue = "$(LD_THREAD_SANITIZER)";
                 Architectures = (
                     x86_64,
                     x86_64h,
                     arm64,
                     arm64e,
                 );
+                Condition = "$(LINKER_DRIVER) == clang";
                 CommandLineArgs = {
                     YES = (
                         "-fsanitize=thread",
+                    );
+                    NO = ();
+                };
+                // Not visible in the build settings editor
+            },
+            {
+                Name = "SWIFTC_LD_THREAD_SANITIZER";
+                Type = Boolean;
+                DefaultValue = "$(LD_THREAD_SANITIZER)";
+                Architectures = (
+                    x86_64,
+                    x86_64h,
+                    arm64,
+                    arm64e,
+                );
+                Condition = "$(LINKER_DRIVER) == swiftc";
+                CommandLineArgs = {
+                    YES = (
+                        "-sanitize=thread",
                     );
                     NO = ();
                 };

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1225,7 +1225,7 @@
                 };
                 AdditionalLinkerArgs = {
                     YES = (
-                        "-fsanitize=address",
+                        "$(LD_ADDRESS_SANITIZER)",
                     );
                     NO = ();
                 };

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -4061,8 +4061,17 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Test that we properly generate commands for the compiler sanitizer features.
-    @Test(.requireSDKs(.macOS))
-    func sanitizers() async throws {
+    @Test(
+        .requireSDKs(.macOS),
+        arguments:[
+            (linkerDriver: "clang", expectedArgument: "-fsanitize=address"),
+            (linkerDriver: "swiftc", expectedArgument: "-sanitize=address"),
+        ],
+    )
+    func sanitizers(
+        linkerDriver: String,
+        expectedArgument: String,
+    ) async throws {
         try await withTemporaryDirectory { tmpDir in
             let targetName = "AppTarget"
             let testProject = try await TestProject(
@@ -4115,7 +4124,18 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             }
 
             // Check the LibSystem address sanitizer.
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_ADDRESS_SANITIZER": "YES","ENABLE_SYSTEM_SANITIZERS": "YES" ]), runDestination: .macOS, fs: fs) { results in
+            await tester.checkBuild(
+                BuildParameters(
+                    configuration: "Debug",
+                    overrides: [
+                        "LINKER_DRIVER": linkerDriver,
+                        "ENABLE_ADDRESS_SANITIZER": "YES",
+                        "ENABLE_SYSTEM_SANITIZERS": "YES",
+                    ],
+                ),
+                runDestination: .macOS,
+                fs: fs,
+            ) { results in
                 results.checkTarget(targetName) { target in
                     // There should be one CompileC task, which includes the ASan option, and which puts its output in a -asan directory.
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
@@ -4129,8 +4149,12 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     }
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                         task.checkCommandLineContains(
-                            ["-fsanitize=address", "-fsanitize-stable-abi", "\(SRCROOT)/build/Debug/\(targetName).app/Contents/MacOS/\(targetName)"
-                            ])
+                            [
+                                expectedArgument,
+                                "-fsanitize-stable-abi",
+                                "\(SRCROOT)/build/Debug/\(targetName).app/Contents/MacOS/\(targetName)",
+                            ]
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Update the Address and Thread sanitizers xcspec properties to support using `clang` and `swiftc` as a linker.


relates to: 
 - https://github.com/swiftlang/swift-package-manager/issues/9322
 - https://github.com/swiftlang/swift-package-manager/issues/8869