### PR TITLE
Make build jobs dependent on soundness checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,7 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    needs: [soundness, space-format-check]
     with:
       linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_pre_build_command: ./.github/scripts/prebuild.sh
@@ -38,6 +39,7 @@ jobs:
   cmake-smoke-test:
     name: cmake-smoke-test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    needs: [soundness, space-format-check]
     with:
       linux_os_versions: '["noble"]'
       linux_pre_build_command: SKIP_ANDROID=1 INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh


### PR DESCRIPTION
This helps avoid wasting resources and user frustration due to re-running the CI when soundness checks fail.