### PR TITLE
Add new clang build setting EMIT_SARIF_DIAGNOSTICS_FILE

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -639,7 +639,7 @@ public final class BuiltinMacros {
     public static let EMBEDDED_CONTENT_CONTAINS_SWIFT = BuiltinMacros.declareBooleanMacro("EMBEDDED_CONTENT_CONTAINS_SWIFT")
     public static let EMBEDDED_PROFILE_NAME = BuiltinMacros.declareStringMacro("EMBEDDED_PROFILE_NAME")
     public static let EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES = BuiltinMacros.declareStringListMacro("EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES")
-    public static let EMIT_COMPILER_SOURCE_METADATA = BuiltinMacros.declareBooleanMacro("EMIT_COMPILER_SOURCE_METADATA")
+    public static let EMIT_SARIF_DIAGNOSTICS_FILE = BuiltinMacros.declareBooleanMacro("EMIT_SARIF_DIAGNOSTICS_FILE")
     public static let EMIT_FRONTEND_COMMAND_LINES = BuiltinMacros.declareBooleanMacro("EMIT_FRONTEND_COMMAND_LINES")
     public static let ENABLE_APPINTENTS_DEPLOYMENT_AWARE_PROCESSING = BuiltinMacros.declareBooleanMacro("ENABLE_APPINTENTS_DEPLOYMENT_AWARE_PROCESSING")
     public static let ENABLE_ADDITIONAL_CODESIGN_INPUT_TRACKING = BuiltinMacros.declareBooleanMacro("ENABLE_ADDITIONAL_CODESIGN_INPUT_TRACKING")
@@ -1718,7 +1718,7 @@ public final class BuiltinMacros {
         EMBEDDED_CONTENT_CONTAINS_SWIFT,
         EMBEDDED_PROFILE_NAME,
         EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES,
-        EMIT_COMPILER_SOURCE_METADATA,
+        EMIT_SARIF_DIAGNOSTICS_FILE,
         EMIT_FRONTEND_COMMAND_LINES,
         ENABLE_APPINTENTS_DEPLOYMENT_AWARE_PROCESSING,
         ENABLE_ADDRESS_SANITIZER,

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1337,7 +1337,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             }
         }
 
-        commandLine += addCompilerMetadataFlags(cbc, outputFileDir.join(outputNode.path.str + ".source-metadata.json"),  delegate, &extraOutputs)
+        commandLine += addCompilerSarifFlags(cbc, outputFileDir.join(outputNode.path.str + ".compiled.sarif"),  delegate, &extraOutputs)
 
         // Handle explicit modules build.
         let scanningOutput = delegate.createNode(outputNode.path.dirname.join(outputNode.path.basename + ".scan"))
@@ -1651,12 +1651,12 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         }
     }
 
-    func addCompilerMetadataFlags(_ cbc: CommandBuildContext, _ outputPath: Path, _ delegate: any TaskGenerationDelegate, _ taskOutputs: inout [any PlannedNode]) -> [String] {
-        guard cbc.scope.evaluate(BuiltinMacros.EMIT_COMPILER_SOURCE_METADATA) else  {
+    func addCompilerSarifFlags(_ cbc: CommandBuildContext, _ outputPath: Path, _ delegate: any TaskGenerationDelegate, _ taskOutputs: inout [any PlannedNode]) -> [String] {
+        guard cbc.scope.evaluate(BuiltinMacros.EMIT_SARIF_DIAGNOSTICS_FILE) else  {
             return []
         }
 
-        guard let metadatatype = cbc.producer.lookupFileType(identifier: "text.json.compiler-metadata.source") else {
+        guard let metadatatype = cbc.producer.lookupFileType(identifier: "text.json.sarif") else {
             return []
         }
 

--- a/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/StandardFileTypes.xcspec
@@ -1721,10 +1721,10 @@
         UTI = "public.protobuf-source";
     },
     {
-        Identifier = text.json.compiler-metadata.source;
+        Identifier = text.json.sarif;
         Type = FileType;
-        Name = "Source metadata emitted from compiler";
-        UTI = "com.apple.compiler-metadata.source";
+        Name = "Diagnostics log in SARIF format";
+        UTI = "com.apple.sarif";
         BasedOn = text.json;
     },
 )

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -9514,7 +9514,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
-    func testSourceMetadata() async throws {
+    func testEmitSarif() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) async throws -> Void in
             let sources = [
                 "SourceFile0.c",
@@ -9543,7 +9543,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                 "GENERATE_INFOPLIST_FILE": "YES",
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "ARCHS": "x86_64 arm64",
-                                "EMIT_COMPILER_SOURCE_METADATA": "YES"
+                                "EMIT_SARIF_DIAGNOSTICS_FILE": "YES"
                             ])
                         ],
                         buildPhases: [
@@ -9563,7 +9563,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     let buildPath = tmpDir.join("build/aProject.build/Debug/AppTarget.build/Objects-normal/")
                     for arch in ["x86_64", "arm64"] {
                         let metadataPath = buildPath.join(arch)
-                        let inputs = sources.map{metadataPath.join(Path($0).basenameWithoutSuffix + ".o.source-metadata.json").str}
+                        let inputs = sources.map{metadataPath.join(Path($0).basenameWithoutSuffix + ".o.compiled.sarif").str}
 
                         for (source, input) in zip(sources, inputs) {
                             results.checkTask(.matchTarget(target), .matchRuleType("CompileC"), .matchRuleItemBasename(source), .matchRuleItem(arch), body: { task in
@@ -9578,7 +9578,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                 ])
                                 task.checkOutputs([
                                     .path(buildPath.join(arch).join(Path(source).basenameWithoutSuffix + ".o").str),
-                                    .path(metadataPath.join(Path(source).basenameWithoutSuffix + ".o.source-metadata.json").str)
+                                    .path(metadataPath.join(Path(source).basenameWithoutSuffix + ".o.compiled.sarif").str)
                                 ])
                             })
 


### PR DESCRIPTION
Add new clang build setting EMIT_SARIF_DIAGNOSTICS_FILE that passes
-fdiagnostic-add-output=sarif:file=<path>. The flag emits a SARIF log during the compilation which contains diagnostic information. The path is currently fixed to <object_file_path>.compiled.sarif