### PR TITLE
[GH:#9202] [Parity] error: unable to spawn process 'metal' (No such file or directory)

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -16,7 +16,7 @@
         Identifier = "com.apple.compilers.metal";
         Name = "Metal Compiler";
         Description = "Compiles Metal files";
-        CommandLine = "metal -c [options] [inputs]";
+        CommandLine = "$(MTL_COMPILER_PATH) -c [options] [inputs]";
         RuleName = "CompileMetalFile [input]";
         ExecDescription = "Compile $(InputFileName)";
         ProgressDescription = "Compiling $(CommandProgressByType) Metal files";
@@ -36,6 +36,13 @@
             "com.apple.compilers.metal-linker",
         );
         Options = (
+            {
+                Name = "MTL_COMPILER_PATH";
+                Type = Path;
+                DefaultValue = "metal";
+                SetValueInEnvironmentVariable = "MTL_COMPILER_PATH";
+                Description = "Path to the Metal compiler executable.";
+            },
             {
                 Name = "MTL_TARGET_TRIPLE";
                 Type = String;

--- a/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
@@ -16,7 +16,7 @@
         Identifier = "com.apple.compilers.metal-linker";
         Name = "Metal Linker";
         Description = "Links Metal AIR files";
-        CommandLine = "metal [options] [inputs]";
+        CommandLine = "$(MTL_COMPILER_PATH) [options] [inputs]";
         RuleName = "MetalLink [output]";
         ExecDescription = "Linking Metal AIR $(OutputFile:file)";
         ProgressDescription = "Linking Metal AIR $(CommandProgressByType)";

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -113,6 +113,7 @@ extension ProjectModel {
 
             // @available(*, deprecated, renamed: "GENERATE_PRELINK_OBJECT_FILE") // can't add @available because it breaks CaseIterable
             case GENERATE_MASTER_OBJECT_FILE // ignore-unacceptable-language
+            case MTL_COMPILER_PATH
         }
 
         public enum MultipleValueSetting: String, CaseIterable, Sendable, Hashable, Codable {


### PR DESCRIPTION
[GH:#9202] [Parity] error: unable to spawn process 'metal' (No such file or directory)

Adds support for passing MTL_COMPILER_PATH.  MTL_COMPILER_PATH may contain the location of the metal compiler returned by xcrun.