### PR TITLE
Set linker settings for non-Apple platform when use static swift stdlib

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -2778,7 +2778,7 @@ public enum ModuleVerifierKind: String, Equatable, Hashable, EnumerationMacroTyp
     case both
 }
 
-public enum LinkerDriverChoice: String, Equatable, Hashable, EnumerationMacroType {
+public enum LinkerDriverChoice: String, Equatable, Hashable, EnumerationMacroType, CaseIterable {
     public static let defaultValue: LinkerDriverChoice = .clang
 
     case clang


### PR DESCRIPTION
Update the linker settings on non-Apple platforms when use static Swift. stdlib is set.

Fixes: https://github.com/swiftlang/swift-package-manager/issues/9320
Issue: rdar://163948614
~Depends on #890~