### PR TITLE
Verbosity fix

### DIFF
--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -400,7 +400,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
     }
 
     public func commandLineForSignature(for task: any ExecutableTask) -> [ByteString]? {
-        nil
+        return nil
     }
 
     static func parseCommandLineTemplate(_ parser: SpecParser, _ components: [String]) -> [CommandLineTemplateArg] {

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -818,7 +818,6 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         "-fdiagnostics-parseable-fixits",
         "-fno-elide-type",
         "-fdiagnostics-show-template-tree",
-        
 
         // https://clang.llvm.org/docs/ClangCommandLineReference.html
         "-fdiagnostics-show-note-include-stack",
@@ -845,7 +844,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
     func isOutputAgnosticCommandLineArgument(_ argument: ByteString, prevArgument: ByteString?) -> Bool {
         if ClangCompilerSpec.outputAgnosticCompilerArguments.contains(argument) ||
-            ClangCompilerSpec.outputAgnosticCompilerArgumentsWithValues.contains(argument) {
+           ClangCompilerSpec.outputAgnosticCompilerArgumentsWithValues.contains(argument) {
             return true
         }
 


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift-package-manager/issues/9299

Solving --very-verbose flag causing rebuilds. Just filtered the "-v" flag when computing hashes and encoding to avoid rebuilding project.