### PR TITLE
Move project identity matching to a plugin

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -262,13 +262,4 @@ struct AppleSettingsBuilderExtension: SettingsBuilderExtension {
         let constValueProtocols = [appIntentsProtocols, extensionKitProtocols].joined(separator: " ")
         return ["SWIFT_EMIT_CONST_VALUE_PROTOCOLS" : constValueProtocols]
     }
-    func addOverrides(fromEnvironment: [String : String], parameters: BuildParameters) throws -> [String : String] { [:] }
-    func addProductTypeDefaults(productType: ProductTypeSpec) -> [String : String] { [:] }
-    func addSDKOverridingSettings(_ sdk: SDK, _ variant: SDKVariant?, _ sparseSDKs: [SDK], specLookupContext: any SWBCore.SpecLookupContext, environment: [String: String]) throws -> [String : String] { [:] }
-    func addPlatformSDKSettings(_ platform: SWBCore.Platform?, _ sdk: SDK, _ sdkVariant: SDKVariant?) -> [String : String] { [:] }
-    func xcconfigOverrideData(fromParameters: BuildParameters) -> ByteString { ByteString() }
-    func getTargetTestingSwiftPluginFlags(_ scope: MacroEvaluationScope, toolchainRegistry: ToolchainRegistry, sdkRegistry: SDKRegistry, activeRunDestination: RunDestinationInfo?, project: SWBCore.Project?) -> [String] { [] }
-    func shouldSkipPopulatingValidArchs(platform: SWBCore.Platform, sdk: SDK?) -> Bool { false }
-    func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool { false }
-    func overridingBuildSettings(_: MacroEvaluationScope, platform: SWBCore.Platform?, productType: ProductTypeSpec) -> [String : String] { [:] }
 }

--- a/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
+++ b/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
@@ -53,4 +53,21 @@ public protocol SettingsBuilderExtension: Sendable {
     func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool
 
     func overridingBuildSettings(_: MacroEvaluationScope, platform: Platform?, productType: ProductTypeSpec) -> [String: String]
+
+    func matchesAnyProjectIdentities(scope: MacroEvaluationScope, projectIdentities: Set<String>) -> Bool
+}
+
+extension SettingsBuilderExtension {
+    public func addOverrides(fromEnvironment: [String: String], parameters: BuildParameters) throws -> [String: String] { [:] }
+    public func addBuiltinDefaults(fromEnvironment environment: [String: String], parameters: BuildParameters) throws -> [String: String] { [:] }
+    public func addProductTypeDefaults(productType: ProductTypeSpec) -> [String: String] { [:] }
+    public func addSDKSettings(_ sdk: SDK, _ variant: SDKVariant?, _ sparseSDKs: [SDK]) throws -> [String: String] { [:] }
+    public func addSDKOverridingSettings(_ sdk: SDK, _ variant: SDKVariant?, _ sparseSDKs: [SDK], specLookupContext: any SWBCore.SpecLookupContext, environment: [String: String]) throws -> [String: String] { [:] }
+    public func addPlatformSDKSettings(_ platform: SWBCore.Platform?, _ sdk: SDK, _ sdkVariant: SDKVariant?) -> [String: String] { [:] }
+    public func xcconfigOverrideData(fromParameters: BuildParameters) -> ByteString { ByteString() }
+    public func getTargetTestingSwiftPluginFlags(_ scope: MacroEvaluationScope, toolchainRegistry: ToolchainRegistry, sdkRegistry: SDKRegistry, activeRunDestination: RunDestinationInfo?, project: SWBCore.Project?) -> [String] { [] }
+    public func shouldSkipPopulatingValidArchs(platform: SWBCore.Platform, sdk: SDK?) -> Bool { false }
+    public func shouldDisableXOJITPreviews(platformName: String, sdk: SDK?) -> Bool { false }
+    public func overridingBuildSettings(_: MacroEvaluationScope, platform: SWBCore.Platform?, productType: ProductTypeSpec) -> [String: String] { [:] }
+    public func matchesAnyProjectIdentities(scope: MacroEvaluationScope, projectIdentities: Set<String>) -> Bool { false }
 }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1210,8 +1210,6 @@ public final class BuiltinMacros {
     public static let TARGET_DEVICE_PLATFORM_NAME = BuiltinMacros.declareStringMacro("TARGET_DEVICE_PLATFORM_NAME")
 
     public static let RC_ARCHS = BuiltinMacros.declareStringListMacro("RC_ARCHS")
-    public static let RC_BASE_PROJECT_NAME = BuiltinMacros.declareStringMacro("RC_BASE_PROJECT_NAME")
-    public static let RC_ProjectName = BuiltinMacros.declareStringMacro("RC_ProjectName")
 
     // LLVM Target
     public static let LLVM_TARGET_TRIPLE_OS_VERSION = BuiltinMacros.declareStringMacro("LLVM_TARGET_TRIPLE_OS_VERSION")
@@ -2140,8 +2138,6 @@ public final class BuiltinMacros {
         PUBLIC_HEADERS_FOLDER_PATH,
         ProductResourcesDir,
         RC_ARCHS,
-        RC_BASE_PROJECT_NAME,
-        RC_ProjectName,
         RECORD_SYSTEM_HEADER_DEPENDENCIES_OUTSIDE_SYSROOT,
         RECURSIVE_SEARCH_PATHS_FOLLOW_SYMLINKS,
         MAKE_MERGEABLE,

--- a/Sources/SWBCore/SpecImplementations/CompilerSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CompilerSpec.swift
@@ -108,18 +108,9 @@ protocol ProjectFailuresBlockList {
 }
 
 extension ProjectFailuresBlockList {
-    func isProjectListed(_ scope: MacroEvaluationScope) -> Bool {
+    func isProjectListed(_ producer: any CommandProducer, _ scope: MacroEvaluationScope) -> Bool {
         // Check if this project is on the blocklist.
-        let RC_ProjectName = scope.evaluate(BuiltinMacros.RC_ProjectName)
-        if !RC_ProjectName.isEmpty, KnownFailures.contains(RC_ProjectName) {
-            return true
-        }
-        let RC_BaseProjectName = scope.evaluate(BuiltinMacros.RC_BASE_PROJECT_NAME)
-        if !RC_BaseProjectName.isEmpty, KnownFailures.contains(RC_BaseProjectName) {
-            return true
-        }
-        let projectName = scope.evaluate(BuiltinMacros.PROJECT_NAME)
-        return KnownFailures.contains(projectName)
+        producer.matchesAnyProjectIdentities(scope: scope, projectIdentities: Set(KnownFailures))
     }
 }
 

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -904,7 +904,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         let buildSettingEnabled = cbc.scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE)
 
         // If this project is on the blocklist, override the blocklist default enable for it.
-        return clangInfo?.isCachingBlocked(cbc.scope) == true ? false : buildSettingEnabled
+        return clangInfo?.isCachingBlocked(cbc.producer, cbc.scope) == true ? false : buildSettingEnabled
     }
 
     private func createExplicitModulesActionAndPayload(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, _ compilerLauncher: Path?, _ input: FileToBuild, _ language: GCCCompatibleLanguageDialect?, commandLine: [String], scanningOutputPath: Path, isForPCHTask: Bool, clangInfo: DiscoveredClangToolSpecInfo?) -> (action: (any PlannedTaskAction)?, usesExecutionInputs: Bool, payload: ClangExplicitModulesPayload?, signatureData: String?) {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1408,7 +1408,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                                   scope.evaluate(BuiltinMacros._EXPERIMENTAL_SWIFT_EXPLICIT_MODULES) == .enabled
 
         // If this project is on the blocklist, override the blocklist default enable for it
-        if let explicitModuleBlocklist = await getExplicitModuleBlocklist(producer, scope, delegate), explicitModuleBlocklist.isProjectListed(scope) {
+        if let explicitModuleBlocklist = await getExplicitModuleBlocklist(producer, scope, delegate), explicitModuleBlocklist.isProjectListed(producer, scope) {
             return false
         }
 
@@ -1463,7 +1463,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 if blocklist.Modules.contains(moduleName) {
                     return false
                 }
-                if blocklist.isProjectListed(cbc.scope) {
+                if blocklist.isProjectListed(cbc.producer, cbc.scope) {
                     return false
                 }
             }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -97,8 +97,12 @@ extension PlatformBuildContext {
     }
 }
 
+public protocol ProjectMatchLookup {
+    func matchesAnyProjectIdentities(scope: MacroEvaluationScope, projectIdentities: Set<String>) -> Bool
+}
+
 /// Protocol describing the interface producers use to communicate information to the command build context.
-public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, ReferenceLookupContext, PlatformInfoLookup {
+public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, ReferenceLookupContext, PlatformInfoLookup, ProjectMatchLookup {
     /// The configured target the command is being produced for, if any.
     var configuredTarget: ConfiguredTarget? { get }
 

--- a/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
+++ b/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
@@ -38,9 +38,9 @@ public struct ClangBlocklists : Sendable {
     var builtinModuleVerify: BuiltinModuleVerifierInfo? = nil
 
     /// Helper method for determining if a given functionality is blocklisted for the active scope.
-    func isBlocked<BlockListT: ProjectFailuresBlockList>(_ scope: MacroEvaluationScope, info: BlockListT?) -> Bool {
+    func isBlocked<BlockListT: ProjectFailuresBlockList>(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, info: BlockListT?) -> Bool {
         guard let blocklistInfo = info else { return false }
-        return blocklistInfo.isProjectListed(scope)
+        return blocklistInfo.isProjectListed(producer, scope)
     }
 }
 
@@ -98,12 +98,12 @@ public struct DiscoveredClangToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
         Set(toolFeatures.value(.deploymentTargetEnvironmentVariables)?.stringArrayValue ?? [])
     }
 
-    public func isCachingBlocked(_ scope: MacroEvaluationScope) -> Bool {
-        return blocklists.isBlocked(scope, info: blocklists.caching)
+    public func isCachingBlocked(_ producer: any CommandProducer, _ scope: MacroEvaluationScope) -> Bool {
+        return blocklists.isBlocked(producer, scope, info: blocklists.caching)
      }
 
-    public func isBuiltinModuleVerifyBlocked(_ scope: MacroEvaluationScope) -> Bool {
-        return blocklists.isBlocked(scope, info: blocklists.builtinModuleVerify)
+    public func isBuiltinModuleVerifyBlocked(_ producer: any CommandProducer, _ scope: MacroEvaluationScope) -> Bool {
+        return blocklists.isBlocked(producer, scope, info: blocklists.builtinModuleVerify)
     }
 }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
@@ -150,7 +150,7 @@ final class ModuleVerifierTaskProducer: PhasedTaskProducer, TaskProducer {
                     return
                 }
                 // Fallback to external verifier if current scope is blocklisted.
-                if clangInfo?.isBuiltinModuleVerifyBlocked(scope) == true {
+                if clangInfo?.isBuiltinModuleVerifyBlocked(context, scope) == true {
                     fallbackToExternal = true
                     return
                 }

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1428,6 +1428,10 @@ extension TaskProducerContext: CommandProducer {
     public func lookupLibclang(path: SWBUtil.Path) -> (libclang: SWBCore.Libclang?, version: Version?) {
         workspaceContext.core.lookupLibclang(path: path)
     }
+
+    public func matchesAnyProjectIdentities(scope: SWBMacro.MacroEvaluationScope, projectIdentities: Set<String>) -> Bool {
+        workspaceContext.core.pluginManager.extensions(of: SettingsBuilderExtensionPoint.self).contains(where: { ext in ext.matchesAnyProjectIdentities(scope: scope, projectIdentities: projectIdentities) })
+    }
 }
 
 extension TaskProducerContext {

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -252,4 +252,8 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package var headerDependenciesContext: SWBCore.HeaderDependenciesContext? {
         nil
     }
+
+    package func matchesAnyProjectIdentities(scope: SWBMacro.MacroEvaluationScope, projectIdentities: Set<String>) -> Bool {
+        false
+    }
 }


### PR DESCRIPTION
These are behaviors specific to certain environments that don't belong in the core logic.