### PR TITLE
Add Windows 6.2 GitHub action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       linux_build_command: 'swift test --no-parallel'
       linux_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
-      windows_swift_versions: '["nightly-main"]'
+      windows_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_build_command: 'Invoke-Program swift test --no-parallel'
       enable_linux_static_sdk_build: true
       enable_android_sdk_build: true


### PR DESCRIPTION
SwiftPM has a branch dependency on SwiftBUild. Ensure the SwiftBuild project is able to build against the Swift 6.2 as the SwiftPM self-hosted builds run using this toolchain version.
