### PR TITLE
Remove the system prefix fallbacks

### DIFF
--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -407,16 +407,7 @@ public final class SDKVariant: PlatformInfoProvider, Sendable {
         self.minimumOSForSwiftConcurrency = try (supportedTargetDict["SwiftConcurrencyMinimumDeploymentTarget"]?.stringValue ?? concurrency).map { try Version($0) }
         self.minimumOSForSwiftSpan = try (supportedTargetDict["SwiftSpanMinimumDeploymentTarget"]?.stringValue ?? span).map { try Version($0) }
 
-        self.systemPrefix = supportedTargetDict["SystemPrefix"]?.stringValue ?? {
-            switch name {
-            case MacCatalystInfo.sdkVariantName:
-                return "/System/iOSSupport"
-            case "driverkit":
-                return "/System/DriverKit"
-            default:
-                return ""
-            }
-        }()
+        self.systemPrefix = supportedTargetDict["SystemPrefix"]?.stringValue ?? ""
     }
 
     private static func fallbackDeviceFamiliesData(variantName name: String) throws -> PropertyListItem {


### PR DESCRIPTION
SystemPrefix is present at least as far back as macOS 14.0/DriverKit 23.0, so it should be ok to remove the hard coded fallbacks now.

rdar://165715061