### PR TITLE
Remove some workarounds used to support very old SDKs

### DIFF
--- a/Sources/SWBCore/PlatformRegistry.swift
+++ b/Sources/SWBCore/PlatformRegistry.swift
@@ -546,13 +546,6 @@ public final class PlatformRegistry {
         var defaultSettings: [String: PropertyListItem] = [:]
         if case .plDict(let defaultSettingsItems)? = items["DefaultProperties"] {
             defaultSettings = defaultSettingsItems
-
-            // Rev-lock: rdar://85769354 (Remove DEPLOYMENT_TARGET_CLANG_* properties from SDK)
-            for macroName in [
-                "DEPLOYMENT_TARGET_CLANG_ENV_NAME",
-                "DEPLOYMENT_TARGET_CLANG_FLAG_NAME",
-                "DEPLOYMENT_TARGET_CLANG_FLAG_PREFIX",
-            ] { defaultSettings.removeValue(forKey: macroName) }
         }
 
         // Parse whether this is a deployment platform.

--- a/Tests/SWBBuildSystemTests/UnitTestBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/UnitTestBuildOperationTests.swift
@@ -1045,7 +1045,7 @@ fileprivate struct UnitTestBuildOperationTests: CoreBasedTests {
 
     /// Test building an application and a UI test target for iOS for both the device and the simulator.
     @Test(.requireSDKs(.iOS))
-    func uITestTarget_iOS() async throws {
+    func uiTestTarget_iOS() async throws {
         // Creates and returns a tester for a given test.
         func makeTester(_ tmpDir: Path) async throws -> BuildOperationTester {
             let testWorkspace = try await TestWorkspace(

--- a/Tests/SWBCoreTests/SDKRegistryTests.swift
+++ b/Tests/SWBCoreTests/SDKRegistryTests.swift
@@ -538,7 +538,12 @@ import SWBMacro
                     "CanonicalName": "macosbork",
                     "IsBaseSDK": "YES",
                     "SupportedTargets": [
-                        "iosmac": [] as PropertyListItem
+                        "iosmac": [
+                            "DeviceFamilies": [
+                                ["DisplayName": "iPad", "Identifier": "2", "Name": "pad"],
+                                ["DisplayName": "Mac", "Identifier": "6", "Name": "mac"],
+                            ]
+                        ] as PropertyListItem
                     ]
                 ])
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -69,12 +69,12 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftAppBasics_preSwiftOS() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "10.14.0", shouldEmitSwiftRPath: true, shouldFilterSwiftLibs: false, shouldBackDeploySwiftConcurrency: true, shouldBackDeploySwiftSpan: true)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftAppBasics_postSwiftOS() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "12.0", shouldEmitSwiftRPath: true, shouldFilterSwiftLibs: true, shouldBackDeploySwiftConcurrency: false, shouldBackDeploySwiftSpan: true, missingSpanCompatibilitySuppressesRPath: true)
     }
@@ -84,22 +84,22 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         try await _testSwiftAppBasics(deploymentTargetVersion: "26.0", shouldEmitSwiftRPath: false, shouldFilterSwiftLibs: true, shouldBackDeploySwiftConcurrency: false, shouldBackDeploySwiftSpan: false)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftAppBasics_preSwiftOSDeploymentTarget_postSwiftOSTargetDevice() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "10.14.0", targetDeviceOSVersion: "11.0", targetDevicePlatformName: "macosx", shouldEmitSwiftRPath: true, shouldFilterSwiftLibs: true, shouldBackDeploySwiftConcurrency: true, shouldBackDeploySwiftSpan: true)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftAppBasics_preSwiftOSDeploymentTarget_postSwiftOSTargetDevice_mixedPlatform() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "10.14.0", targetDeviceOSVersion: "14.0", targetDevicePlatformName: "iphoneos", shouldEmitSwiftRPath: true, shouldFilterSwiftLibs: false, shouldBackDeploySwiftConcurrency: true, shouldBackDeploySwiftSpan: true)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftAppBasics_postSwiftOSDeploymentTarget_preSwiftConcurrencySupportedNatively() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "11.0", shouldEmitSwiftRPath: true, shouldFilterSwiftLibs: true, shouldBackDeploySwiftConcurrency: true, shouldBackDeploySwiftSpan: true)
     }
 
-    @Test(.requireSDKs(.macOS), .userDefaults(["AllowRuntimeSearchPathAdditionForSwiftConcurrency": "0"]))
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .userDefaults(["AllowRuntimeSearchPathAdditionForSwiftConcurrency": "0"]))
     func swiftAppBasics_postSwiftOSDeploymentTarget_preSwiftConcurrencySupportedNatively_DisallowRpathInjection() async throws {
         try await _testSwiftAppBasics(deploymentTargetVersion: "11.0", shouldEmitSwiftRPath:true, shouldFilterSwiftLibs: true, shouldBackDeploySwiftConcurrency: true, shouldBackDeploySwiftSpan: true,
         missingSpanCompatibilitySuppressesRPath: true)

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -2800,8 +2800,8 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
     /// Test task construction for a UI test target for iOS.  Both debug and install builds are tested for the device, and a debug build is tested for the simulator.
     ///
     /// This test is primarily intended to validate that building for iOS works, to check that the different bundle packaging for iOS is being handled, and to check some ways in which building for iOS differs from building for macOS.  The corresponding macOS test dives deeper into checking details of the tasks.
-    @Test(.requireSDKs(.macOS, .iOS))
-    func uITestTarget_iOS() async throws {
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
+    func uiTestTarget_iOS() async throws {
         let testProject = try await TestProject(
             "aProject",
             groupTree: TestGroup(


### PR DESCRIPTION
Only OS version 26 and above SDKs (and DriverKit version 25) are supported now.