### PR TITLE
Don't rely on SystemPrefix to set IOS_UNZIPPERED_TWIN_PREFIX_PATH

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -120,6 +120,7 @@ public final class BuiltinMacros {
     public static let HOST_PLATFORM = BuiltinMacros.declareStringMacro("HOST_PLATFORM")
     public static let IOS_UNZIPPERED_TWIN_PREFIX_PATH = BuiltinMacros.declareStringMacro("IOS_UNZIPPERED_TWIN_PREFIX_PATH")
     public static let IPHONEOS_DEPLOYMENT_TARGET = BuiltinMacros.declareStringMacro("IPHONEOS_DEPLOYMENT_TARGET")
+    public static let MACOS_UNZIPPERED_TWIN_PREFIX_PATH = BuiltinMacros.declareStringMacro("MACOS_UNZIPPERED_TWIN_PREFIX_PATH")
     public static let MACOSX_DEPLOYMENT_TARGET = BuiltinMacros.declareStringMacro("MACOSX_DEPLOYMENT_TARGET")
     public static let NATIVE_ARCH = BuiltinMacros.declareStringMacro("NATIVE_ARCH")
     public static let NATIVE_ARCH_32_BIT = BuiltinMacros.declareStringMacro("NATIVE_ARCH_32_BIT")
@@ -1993,6 +1994,7 @@ public final class BuiltinMacros {
         MACOS_CREATOR_ARG,
         MACOS_TYPE,
         MACOS_TYPE_ARG,
+        MACOS_UNZIPPERED_TWIN_PREFIX_PATH,
         MAC_OS_X_PRODUCT_BUILD_VERSION,
         MAC_OS_X_VERSION_ACTUAL,
         MAC_OS_X_VERSION_MAJOR,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2524,6 +2524,11 @@ private class SettingsBuilder: ProjectMatchLookup {
                 platformTable.push(BuiltinMacros.PLATFORM_DEVELOPER_USR_DIR, Static { BuiltinMacros.namespace.parseString("$(DEVELOPER_USR_DIR)") })
                 platformTable.push(BuiltinMacros.PLATFORM_DEVELOPER_BIN_DIR, Static { BuiltinMacros.namespace.parseString("$(DEVELOPER_BIN_DIR)") })
                 platformTable.push(BuiltinMacros.PLATFORM_DEVELOPER_SDK_DIR, Static { BuiltinMacros.namespace.parseString("$(DEVELOPER_SDK_DIR)") })
+
+                // Set twin prefix paths in macOS for Mac Catalyst.
+                platformTable.push(BuiltinMacros.MACOS_UNZIPPERED_TWIN_PREFIX_PATH, literal: "")
+                platformTable.push(BuiltinMacros.IOS_UNZIPPERED_TWIN_PREFIX_PATH, literal: "/System/iOSSupport")
+
             } else {
                 platformTable.push(BuiltinMacros.PLATFORM_DEVELOPER_APPLICATIONS_DIR, literal: "\(platform.path.str)/Developer/Applications")
                 platformTable.push(BuiltinMacros.PLATFORM_DEVELOPER_TOOLS_DIR, literal: "\(platform.path.str)/Developer/Tools")
@@ -2583,11 +2588,6 @@ private class SettingsBuilder: ProjectMatchLookup {
         var sdkTable = MacroValueAssignmentTable(namespace: userNamespace)
         if let defaultSettingsTable = sdk.defaultSettingsTable {
             sdkTable.pushContentsOf(defaultSettingsTable)
-        }
-
-        // Set IOS_UNZIPPERED_TWIN_PREFIX_PATH to the Mac Catalyst variant's prefix path, even for the macOS variant.
-        if let macCatalystVariant = sdk.variant(for: MacCatalystInfo.sdkVariantName) {
-            sdkTable.push(BuiltinMacros.IOS_UNZIPPERED_TWIN_PREFIX_PATH, literal: macCatalystVariant.systemPrefix)
         }
 
         // Add the settings provided by the SDK variant, if there is one.


### PR DESCRIPTION
Mac Catalyst shouldn't have a SystemPrefix set in its SDK variant, so don't rely on that to set IOS_UNZIPPERED_TWIN_PREFIX_PATH, hard code it instead. Set MACOS_UNZIPPERED_TWIN_PREFIX_PATH too for completeness.

rdar://165798693