### PR TITLE
Pseudo-namespace runner struct in test entrypoints

### DIFF
--- a/Sources/SWBUniversalPlatform/TestEntryPointGenerationTaskAction.swift
+++ b/Sources/SWBUniversalPlatform/TestEntryPointGenerationTaskAction.swift
@@ -63,7 +63,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
             @main
             @available(macOS 10.15, iOS 11, watchOS 4, tvOS 11, visionOS 1, *)
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-            struct Runner {
+            struct __SwiftPMGeneratedTestRunner {
                 private static func testingLibrary() -> String {
                     var iterator = CommandLine.arguments.makeIterator()
                     while let argument = iterator.next() {


### PR DESCRIPTION
Otherwise it may collide with user code.

Closes https://github.com/swiftlang/swift-package-manager/issues/9467