### PR TITLE
Adjust SDK import test criteria

### DIFF
--- a/Tests/SWBBuildSystemTests/SDKImportsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SDKImportsBuildOperationTests.swift
@@ -118,7 +118,7 @@ fileprivate struct SDKImportsBuildOperationTests: CoreBasedTests {
                 }
 
                 let sdkImports = try JSONDecoder().decode(SDKImports.self, from: sdkImportsData)
-                #expect(sdkImports.inputs.map { $0.path }.sorted() == ["libstaticlib.a", "main.o", "objc-file", "stubs-got-file"])
+                #expect(sdkImports.inputs.map { $0.path }.sorted().contains(["libstaticlib.a", "main.o"]))
             }
         }
     }


### PR DESCRIPTION
Narrow the scope of the expected linked libraries to only the ones explicitly specified by the user's configuration.

rdar://164982001