### PR TITLE
Move many Apple platforms build rules under the darwin domain

### DIFF
--- a/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataTaskProducer.swift
@@ -49,6 +49,9 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
 
     func generateTasks() async -> [any PlannedTask] {
         let tasks: [any PlannedTask] = []
+        guard let compilerSpec = self.context.appShortcutStringsMetadataCompilerSpec else {
+            return []
+        }
         guard !context.settings.globalScope.evaluate(BuiltinMacros.LM_SKIP_METADATA_EXTRACTION) else {
             return []
         }
@@ -151,7 +154,7 @@ final class AppIntentsMetadataTaskProducer: PhasedTaskProducer, TaskProducer {
                 let inputs = appShortcutStringsSources + assistantIntentsStringsSources
                 if inputs.count > 0, appShortcutStringsSources.count < 2, assistantIntentsStringsSources.count < 2 {
                     let appShortcutsMetadataCbc = CommandBuildContext(producer: self.context, scope: scope, inputs: inputs, resourcesDir: buildFilesProcessingContext.resourcesDir)
-                    await self.context.appShortcutStringsMetadataCompilerSpec.constructTasks(appShortcutsMetadataCbc, delegate)
+                    await compilerSpec.constructTasks(appShortcutsMetadataCbc, delegate)
                 }
 
                 // Only construct SSU task by default for public SDK clients. Internal default behavior should skip SSU task construction.

--- a/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.appintentsmetadata";
         Name = "App Intents Metadata Extractor";

--- a/Sources/SWBApplePlatform/Specs/AppIntentsNLTraining.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppIntentsNLTraining.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.appintents-ssu-training";
         Name = "App Intents SSU Training Processor";

--- a/Sources/SWBApplePlatform/Specs/AppShortcutStringsMetadata.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppShortcutStringsMetadata.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.appshortcutstringsmetadata";
         Name = "App Shortcut Strings Metadata Extractor";

--- a/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = com.apple.compilers.assetcatalog;
         Name = "Asset Catalog Compiler";

--- a/Sources/SWBApplePlatform/Specs/CompileSkybox.xcspec
+++ b/Sources/SWBApplePlatform/Specs/CompileSkybox.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = "com.apple.build-tasks.compile-skybox.xcplugin";
         Type = Compiler;
         Name = "Compile Skybox";

--- a/Sources/SWBApplePlatform/Specs/CopyPNGFile.xcspec
+++ b/Sources/SWBApplePlatform/Specs/CopyPNGFile.xcspec
@@ -12,7 +12,9 @@
 
 (
 
-    {   Type = Compiler;
+    {
+        _Domain = darwin;
+        Type = Compiler;
         Identifier = com.apple.build-tasks.copy-png-file;
         Name = "Compress PNG Files";
         Description = "Copies a .png file resource, optionally compressing it.";

--- a/Sources/SWBApplePlatform/Specs/CopyTiffFile.xcspec
+++ b/Sources/SWBApplePlatform/Specs/CopyTiffFile.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.build-tasks.copy-tiff-file;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.build-tasks.copy-tiff-file;
         Type = Compiler;
         Name = "Copy Tiff File";
         Description = "Copies a .tiff file resource with optional compression of the destination file";

--- a/Sources/SWBApplePlatform/Specs/CoreData.xcspec
+++ b/Sources/SWBApplePlatform/Specs/CoreData.xcspec
@@ -89,6 +89,7 @@
         UTI = "com.apple.xcode.model.class";
     },
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.model.coredata";
         Name = "Data Model Compiler (MOMC)";

--- a/Sources/SWBApplePlatform/Specs/CoreML.xcspec
+++ b/Sources/SWBApplePlatform/Specs/CoreML.xcspec
@@ -41,6 +41,7 @@
         UTI = "com.apple.coreml.mlpackage";
     },
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.coreml";
         Name = "CoreML Model Compiler";

--- a/Sources/SWBApplePlatform/Specs/EXUtil.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EXUtil.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.extract-appextensionpoints";
         Name = "ExtensionPoint Extractor";

--- a/Sources/SWBApplePlatform/Specs/EmbeddedBinaryValidationUtility.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EmbeddedBinaryValidationUtility.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Tool;
         Identifier = "com.apple.tools.validate-embedded-binary-utility";
         Name = "Embedded Binary Validation Utility";

--- a/Sources/SWBApplePlatform/Specs/GenerateAppPlaygroundAssetCatalog.xcspec
+++ b/Sources/SWBApplePlatform/Specs/GenerateAppPlaygroundAssetCatalog.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Tool;
         Identifier = "com.apple.tools.generate-app-playground-asset-catalog";
         Name = "App Playground Asset Catalog Generator";

--- a/Sources/SWBApplePlatform/Specs/GenerateTextureAtlas.xcspec
+++ b/Sources/SWBApplePlatform/Specs/GenerateTextureAtlas.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = "com.apple.build-tasks.generate-texture-atlas.xcplugin";
         Type = Compiler;
         Name = "Generate SpriteKit Texture Atlas";

--- a/Sources/SWBApplePlatform/Specs/IBCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBCompiler.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.xcode.tools.ibtool.compiler";
         Name = "Interface Builder XIB Compiler";

--- a/Sources/SWBApplePlatform/Specs/IBPostprocessor.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBPostprocessor.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.xcode.tools.ibtool.postprocessor";
         Name = "Interface Builder NIB Postprocessor";

--- a/Sources/SWBApplePlatform/Specs/IBStoryboardCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBStoryboardCompiler.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.xcode.tools.ibtool.storyboard.compiler";
         Name = "Interface Builder Storyboard Compiler";

--- a/Sources/SWBApplePlatform/Specs/IBStoryboardLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBStoryboardLinker.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.xcode.tools.ibtool.storyboard.linker";
         Name = "Interface Builder Storyboard Linker";

--- a/Sources/SWBApplePlatform/Specs/IBStoryboardPostprocessor.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBStoryboardPostprocessor.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.xcode.tools.ibtool.storyboard.postprocessor";
         Name = "Interface Builder Storyboard Postprocessor";

--- a/Sources/SWBApplePlatform/Specs/Iconutil.xcspec
+++ b/Sources/SWBApplePlatform/Specs/Iconutil.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.compilers.iconutil;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.compilers.iconutil;
         Type = Compiler;
         Name = "Iconutil";
         Description = "Icon conversion utility";

--- a/Sources/SWBApplePlatform/Specs/Iig.xcspec
+++ b/Sources/SWBApplePlatform/Specs/Iig.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.compilers.iig;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.compilers.iig;
         Type = Compiler;
         Name = "IOKit Interface Generator";
         Description = "Invoke the 'iig' command line utility to compile an IIG file.";

--- a/Sources/SWBApplePlatform/Specs/InstrumentsPackage.xcspec
+++ b/Sources/SWBApplePlatform/Specs/InstrumentsPackage.xcspec
@@ -75,6 +75,7 @@
     },
 
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.instruments-package-builder";
         Name = "Instruments Package Builder";

--- a/Sources/SWBApplePlatform/Specs/Intents.xcspec
+++ b/Sources/SWBApplePlatform/Specs/Intents.xcspec
@@ -27,6 +27,7 @@
     },
 
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.intents";
         Name = "Intent Definition Compiler";

--- a/Sources/SWBApplePlatform/Specs/LSRegisterURL.xcspec
+++ b/Sources/SWBApplePlatform/Specs/LSRegisterURL.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.build-tasks.ls-register-url;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.build-tasks.ls-register-url;
         Type = Compiler;
         Name = "LSRegisterURL";
         Description = "Registers the file at a URL with LaunchServices";

--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.metal";
         Name = "Metal Compiler";

--- a/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.metal-linker";
         Name = "Metal Linker";

--- a/Sources/SWBApplePlatform/Specs/MiG.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MiG.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Type = Compiler;
+    {
+        _Domain = darwin;
+        Type = Compiler;
         Identifier = com.apple.compilers.mig;
         Name = "MiG";
         Description = "Mach Interface Stub Generator";

--- a/Sources/SWBApplePlatform/Specs/OSACompile.xcspec
+++ b/Sources/SWBApplePlatform/Specs/OSACompile.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = "com.apple.compilers.osacompile";
         Type = Compiler;
         Name = "OSACompile";

--- a/Sources/SWBApplePlatform/Specs/RealityAssets.xcspec
+++ b/Sources/SWBApplePlatform/Specs/RealityAssets.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = "com.apple.build-tasks.compile-rk-assets.xcplugin";
         Type = Compiler;
         Name = "Compile Reality Assets";

--- a/Sources/SWBApplePlatform/Specs/ReferenceObject.xcspec
+++ b/Sources/SWBApplePlatform/Specs/ReferenceObject.xcspec
@@ -25,6 +25,7 @@
         UTI = "com.apple.arkit.referenceobject";
     },
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.referenceobject";
         Name = "Reference Object Compiler";

--- a/Sources/SWBApplePlatform/Specs/ResMerger.xcspec
+++ b/Sources/SWBApplePlatform/Specs/ResMerger.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Type = Linker;
+    {
+        _Domain = darwin;
+        Type = Linker;
         Identifier = com.apple.pbx.linkers.resmerger;
         Name = "ResMerger";
         Description = "Create a Carbon resource file using Apple's Carbon Resource Merger";

--- a/Sources/SWBApplePlatform/Specs/Rez.xcspec
+++ b/Sources/SWBApplePlatform/Specs/Rez.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.compilers.rez;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.compilers.rez;
         Type = Tool;
         Name = "Rez";
         Description = "Resource Manager Resource Compiler";

--- a/Sources/SWBApplePlatform/Specs/SceneKitTools.xcspec
+++ b/Sources/SWBApplePlatform/Specs/SceneKitTools.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = "com.apple.compilers.scntool";
         Type = Compiler;
         Name = "Process SceneKit Document";
@@ -73,6 +74,7 @@
         );
     },
     {
+        _Domain = darwin;
         Identifier = "com.apple.build-tasks.copy-scenekit-assets";
         Type = Compiler;
         Name = "Copy SceneKit Assets";
@@ -138,6 +140,7 @@
     },
 
     {
+        _Domain = darwin;
         Identifier = "com.apple.build-tasks.compile-scenekit-shadercache";
         Type = Compiler;
         Name = "Compile SceneKit Shaders";

--- a/Sources/SWBApplePlatform/Specs/TiffUtil.xcspec
+++ b/Sources/SWBApplePlatform/Specs/TiffUtil.xcspec
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 (
-    {   Identifier = com.apple.compilers.tiffutil;
+    {
+        _Domain = darwin;
+        Identifier = com.apple.compilers.tiffutil;
         Type = Compiler;
         Name = "TiffUtil";
         Description = "Combine a set of images at different resolutions into one HiDPI compliant file using TiffUtil";

--- a/Sources/SWBApplePlatform/Specs/XCAppExtensionPoints.xcspec
+++ b/Sources/SWBApplePlatform/Specs/XCAppExtensionPoints.xcspec
@@ -12,6 +12,7 @@
 
 (
     {
+        _Domain = darwin;
         Identifier = com.apple.compilers.process-xcappextensionpoints;
         Type = Compiler;
         Name = "Process XCAppExtensionPoints";

--- a/Sources/SWBApplePlatform/Specs/XCStrings.xcspec
+++ b/Sources/SWBApplePlatform/Specs/XCStrings.xcspec
@@ -26,6 +26,7 @@
     },
 
     {
+        _Domain = darwin;
         Type = Compiler;
         Identifier = "com.apple.compilers.xcstrings";
         Name = "XCStrings Compiler";

--- a/Sources/SWBApplePlatform/Specs/tvOSShared.xcspec
+++ b/Sources/SWBApplePlatform/Specs/tvOSShared.xcspec
@@ -36,7 +36,7 @@
         _Domain = appletvos-shared;
         Type = Compiler;
         Identifier = "com.apple.compilers.assetcatalog";
-        BasedOn = "default:com.apple.compilers.assetcatalog";
+        BasedOn = "darwin:com.apple.compilers.assetcatalog";
         Options = (
             {
                 Name = "ASSETCATALOG_COMPILER_LEADERBOARD_IDENTIFIER_PREFIX";

--- a/Sources/SWBApplePlatform/Specs/watchOSShared.xcspec
+++ b/Sources/SWBApplePlatform/Specs/watchOSShared.xcspec
@@ -122,7 +122,7 @@
         _Domain = watchos-shared;
         Type = Compiler;
         Identifier = "com.apple.compilers.assetcatalog";
-        BasedOn = "default:com.apple.compilers.assetcatalog";
+        BasedOn = "darwin:com.apple.compilers.assetcatalog";
         Options = (
             {
                 Name = "ASSETCATALOG_COMPILER_COMPLICATION_NAME";

--- a/Sources/SWBApplePlatform/Specs/xrOSShared.xcspec
+++ b/Sources/SWBApplePlatform/Specs/xrOSShared.xcspec
@@ -15,7 +15,7 @@
         _Domain = xros-shared;
         Type = Compiler;
         Identifier = "com.apple.compilers.assetcatalog";
-        BasedOn = "default:com.apple.compilers.assetcatalog";
+        BasedOn = "darwin:com.apple.compilers.assetcatalog";
         Options = (
             {
                 Name = "ASSETCATALOG_COMPILER_FLATTENED_APP_ICON_PATH";

--- a/Sources/SWBCore/BuildRuleSet.swift
+++ b/Sources/SWBCore/BuildRuleSet.swift
@@ -166,7 +166,7 @@ extension Core {
         switch inputSpecifier {
         case let .fileType(fileTypeIdentifier):
             let domain = platform?.name ?? ""
-            condition = BuildRuleFileTypeCondition(fileType: try specRegistry.getSpec(fileTypeIdentifier, domain: domain) as FileTypeSpec)
+            condition = BuildRuleFileTypeCondition(fileType: try specRegistry.getSpec(fileTypeIdentifier, domain: domain, ofType: FileTypeSpec.self))
         case let .patterns(filePatterns):
             condition = BuildRuleFileNameCondition(namePatterns: filePatterns)
         }
@@ -181,13 +181,13 @@ extension Core {
 
         switch inputSpecifier {
         case let .fileType(fileTypeIdentifier):
-            let spec = try specRegistry.getSpec(compilerSpecificationIdentifier, domain: domain) as CommandLineToolSpec
+            let spec = try specRegistry.getSpec(compilerSpecificationIdentifier, domain: domain, ofType: CommandLineToolSpec.self)
 
             // Capture the tool spec's supports file types, if any.  But we only need to do this if the condition is not a pattern identifier.
             var toolSpecSupportedFileTypes = [FileTypeSpec]()
             if let inputFileTypeDescriptors = spec.inputFileTypeDescriptors {
                 for inputFileType in inputFileTypeDescriptors {
-                    let fileType = try specRegistry.getSpec(inputFileType.identifier, domain: domain) as FileTypeSpec
+                    let fileType = try specRegistry.getSpec(inputFileType.identifier, domain: domain, ofType: FileTypeSpec.self)
                     toolSpecSupportedFileTypes.append(fileType)
                 }
             }
@@ -195,7 +195,7 @@ extension Core {
             let action = BuildRuleTaskAction(toolSpec: spec)
 
             let condition: any BuildRuleCondition
-            let fileType = try specRegistry.getSpec(fileTypeIdentifier, domain: domain) as FileTypeSpec
+            let fileType = try specRegistry.getSpec(fileTypeIdentifier, domain: domain, ofType: FileTypeSpec.self)
             let fileTypes = toolSpecSupportedFileTypes.compactMap({ $0.conformsTo(fileType) ? $0 : nil })
             if fileTypes.isEmpty {
                 // If the compiler spec defined any supported file types, then the file types for the condition are those from the compiler spec which conform to the one we looked up.
@@ -208,7 +208,7 @@ extension Core {
             // Return the build rule condition and action.
             return (condition, action)
         case let .patterns(filePatterns):
-            return (BuildRuleFileNameCondition(namePatterns: filePatterns), BuildRuleTaskAction(toolSpec: try specRegistry.getSpec(compilerSpecificationIdentifier, domain: domain) as CommandLineToolSpec))
+            return (BuildRuleFileNameCondition(namePatterns: filePatterns), BuildRuleTaskAction(toolSpec: try specRegistry.getSpec(compilerSpecificationIdentifier, domain: domain, ofType: CommandLineToolSpec.self)))
         }
     }
 }

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -618,7 +618,7 @@ public final class Core: Sendable {
 
     public func productTypeSupportsMacCatalyst(productTypeIdentifier: String) throws -> Bool {
         do {
-            let productTypeSpec = try specRegistry.getSpec(productTypeIdentifier, domain: "macosx") as ProductTypeSpec
+            let productTypeSpec = try specRegistry.getSpec(productTypeIdentifier, domain: "macosx", ofType: ProductTypeSpec.self)
             return productTypeSupportsPlatform(productType: productTypeSpec, platformName: "macosx")
         } catch SpecLoadingError.notFound {
             return false

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -741,7 +741,7 @@ public final class XCTestBundleProductTypeSpec : BundleProductTypeSpec, @uncheck
         table.push(BuiltinMacros._BUILDABLE_SERIALIZATION_KEY, literal: "test-bundle-with-host: \(testHost)")
 
         // Inject a runpath search path to the host app's Frameworks directory if it isn't already present to ensure the embedded libraries can be found
-        let applicationProductType: ProductTypeSpec? = try? platform?.specRegistryProvider.specRegistry.getSpec("com.apple.product-type.application", domain: platform?.name ?? "")
+        let applicationProductType = try? platform?.specRegistryProvider.specRegistry.getSpec("com.apple.product-type.application", domain: platform?.name ?? "", ofType: ProductTypeSpec.self)
         if let frameworksRunpath = applicationProductType?.frameworksRunpathSearchPath(in: scope)?.str {
             if !scope.evaluate(BuiltinMacros.LD_RUNPATH_SEARCH_PATHS).contains(frameworksRunpath) {
                 table.push(BuiltinMacros.LD_RUNPATH_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", frameworksRunpath]))

--- a/Sources/SWBCore/SpecImplementations/SpecRegistry.swift
+++ b/Sources/SWBCore/SpecImplementations/SpecRegistry.swift
@@ -886,7 +886,7 @@ public final class SpecRegistry: Sendable {
     }
 
     /// Get the loaded spec of a specific type for a given identifier and domain.  If no such spec exists or if it is not of the expected type, an error will be thrown.
-    public func getSpec<T: Spec>(_ identifier: String, domain: String = "") throws -> T {
+    public func getSpec<T: Spec>(_ identifier: String, domain: String = "", ofType _: T.Type) throws -> T {
         guard let spec = getSpec(identifier, domain: domain) else {
             throw SpecLoadingError.notFound(identifier: identifier, domain: domain)
         }
@@ -899,8 +899,8 @@ public final class SpecRegistry: Sendable {
     /// Get the loaded spec of a specific type for a given identifier and domain.  If no such spec exists or if it is not of the expected type, an error will be thrown.
     ///
     /// This is a convenience overload for identified spec types which removes the need to manually pass in the identifier.
-    public func getSpec<T: Spec & IdentifiedSpecType>(domain: String = "") throws -> T {
-        return try getSpec(T.identifier, domain: domain)
+    public func getSpec<T: Spec & IdentifiedSpecType>(domain: String = "", ofType type: T.Type) throws -> T {
+        return try getSpec(T.identifier, domain: domain, ofType: type)
     }
 
     /// Validate that there are no cases where a spec depends on one in a subdomain.  This is only used by `SpecLoadingTests.testSpecDomainInversion()`.
@@ -1094,15 +1094,15 @@ extension SpecLookupContext {
     }
 
     /// Get the loaded spec of a specific type for a given identifier and domain.  If no such spec exists or if it is not of the expected type, an error will be thrown.
-    public func getSpec<T: Spec>(_ identifier: String) throws -> T {
-        return try specRegistry.getSpec(identifier, domain: domain)
+    public func getSpec<T: Spec>(_ identifier: String, ofType type: T.Type) throws -> T {
+        return try specRegistry.getSpec(identifier, domain: domain, ofType: type)
     }
 
     /// Get the loaded spec of a specific type for a given identifier and domain.  If no such spec exists or if it is not of the expected type, an error will be thrown.
     ///
     /// This is a convenience overload for identified spec types which removes the need to manually pass in the identifier.
-    public func getSpec<T: Spec & IdentifiedSpecType>(domain: String = "") throws -> T {
-        return try getSpec(T.identifier)
+    public func getSpec<T: Spec & IdentifiedSpecType>(domain: String = "", ofType type: T.Type) throws -> T {
+        return try getSpec(T.identifier, ofType: type)
     }
 
     /// Looks up and returns the FileType (if any) that has the identifier `ident`.

--- a/Sources/SWBCore/SpecImplementations/Tools/ModulesVerifierTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/ModulesVerifierTool.swift
@@ -23,7 +23,7 @@ public final class ModulesVerifierToolSpec : GenericCommandLineToolSpec, SpecIde
     public func constructModuleVerifierTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, alwaysExecuteTask: Bool, fileNameMapPath: Path) async {
         let ruleInfo = defaultRuleInfo(cbc, delegate)
 
-        let clangSpec = try! cbc.producer.getSpec() as ClangCompilerSpec
+        let clangSpec = try! cbc.producer.getSpec(ofType: ClangCompilerSpec.self)
         let clangPath = await clangSpec.resolveExecutablePath(cbc, Path("clang"), delegate: delegate)
         let specialArguments = ["--clang", clangPath.str, "--diagnostic-filename-map", fileNameMapPath.str]
 

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -174,10 +174,10 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     var copySpec: CopyToolSpec { get }
 
     /// The copy-png spec to use.
-    var copyPngSpec: CommandLineToolSpec { get }
+    var copyPngSpec: CommandLineToolSpec? { get }
 
     /// The copy-tiff spec to use.
-    var copyTiffSpec: CommandLineToolSpec { get }
+    var copyTiffSpec: CommandLineToolSpec? { get }
 
     /// The unifdef spec to use.
     var unifdefSpec: UnifdefToolSpec { get }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -48,7 +48,7 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
 
         func lookupProductType(_ ident: String) -> ProductTypeSpec? {
             do {
-                return try context.getSpec(ident)
+                return try context.getSpec(ident, ofType: ProductTypeSpec.self)
             } catch {
                 context.error("Couldn't look up product type '\(ident)' in domain '\(context.domain)': \(error)")
                 return nil
@@ -498,7 +498,7 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                 }
 
                 if !scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc") {
-                    await context.validateEmbeddedBinarySpec.constructValidateEmbeddedBinaryTask(cbc, delegate, lookup: lookup)
+                    await context.validateEmbeddedBinarySpec?.constructValidateEmbeddedBinaryTask(cbc, delegate, lookup: lookup)
                 }
             }
         }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -689,7 +689,7 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
                 if !scope.evaluate(BuiltinMacros.SUPPORTS_TEXT_BASED_API) {
                     // If TAPI support errors are disabled or this task type doesn't actually require it, ignore the error.
                     if !scope.evaluate(BuiltinMacros.ALLOW_UNSUPPORTED_TEXT_BASED_API) && group.assignedBuildRuleAction?.requiresTextBasedAPI ?? false {
-                        let productType: ProductTypeSpec? = try? context.getSpec(scope.evaluate(BuiltinMacros.PRODUCT_TYPE))
+                        let productType = try? context.getSpec(scope.evaluate(BuiltinMacros.PRODUCT_TYPE), ofType: ProductTypeSpec.self)
                         if let productType = productType, productType.supportsInstallAPI && !generatedRequiresAPIError {
                             producer.context.error("\(productType.name) requested to generate API, but has not adopted SUPPORTS_TEXT_BASED_API", location: .buildSetting(BuiltinMacros.SUPPORTS_TEXT_BASED_API))
                             generatedRequiresAPIError = true

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SwiftPackageCopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SwiftPackageCopyFilesTaskProducer.swift
@@ -26,7 +26,7 @@ final class SwiftPackageCopyFilesTaskProducer: CopyFilesTaskProducer {
 
         func lookupProductType(_ ident: String) -> ProductTypeSpec? {
             do {
-                return try context.getSpec(ident)
+                return try context.getSpec(ident, ofType: ProductTypeSpec.self)
             } catch {
                 context.error("Couldn't look up product type '\(ident)' in domain '\(context.domain)': \(error)")
                 return nil

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CopySwiftPackageResourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CopySwiftPackageResourcesTaskProducer.swift
@@ -39,7 +39,7 @@ final class CopySwiftPackageResourcesTaskProducer: PhasedTaskProducer, TaskProdu
         let productTypeIdentifier = scope.evaluate(BuiltinMacros.PRODUCT_TYPE)
         func lookupProductType(_ ident: String) -> ProductTypeSpec? {
             do {
-                return try context.getSpec(ident)
+                return try context.getSpec(ident, ofType: ProductTypeSpec.self)
             } catch {
                 context.error("Couldn't look up product type '\(ident)' in domain '\(context.domain)': \(error)")
                 return nil

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -218,8 +218,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         }
     }
 
-    public let appShortcutStringsMetadataCompilerSpec: AppShortcutStringsMetadataCompilerSpec
-    let appleScriptCompilerSpec: CommandLineToolSpec
+    public let appShortcutStringsMetadataCompilerSpec: AppShortcutStringsMetadataCompilerSpec?
+    let appleScriptCompilerSpec: CommandLineToolSpec?
     let buildDependencyInfoSpec: BuildDependencyInfoSpec
     public let clangSpec: ClangCompilerSpec
     public let clangAssemblerSpec: ClangCompilerSpec
@@ -233,8 +233,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     var concatenateSpec: ConcatenateToolSpec? { return specForResult(_concatenateSpec) }
     public let copySpec: CopyToolSpec
     let copyPlistSpec: CommandLineToolSpec
-    public let copyPngSpec: CommandLineToolSpec
-    public let copyTiffSpec: CommandLineToolSpec
+    public let copyPngSpec: CommandLineToolSpec?
+    public let copyTiffSpec: CommandLineToolSpec?
     let cppSpec: CommandLineToolSpec
     let createAssetPackManifestSpec: CreateAssetPackManifestToolSpec
     public let createBuildDirectorySpec: CreateBuildDirectorySpec
@@ -242,7 +242,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     let dsymutilSpec: DsymutilToolSpec
     let infoPlistSpec: InfoPlistToolSpec
     let mergeInfoPlistSpec: MergeInfoPlistSpec
-    let launchServicesRegisterSpec: CommandLineToolSpec
+    let launchServicesRegisterSpec: CommandLineToolSpec?
     public let ldLinkerSpec: LdLinkerSpec
     public let libtoolLinkerSpec: LibtoolLinkerSpec
     public let lipoSpec: LipoToolSpec
@@ -270,8 +270,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     let tapiStubifySpec: CommandLineToolSpec
     let touchSpec: CommandLineToolSpec
     public let unifdefSpec: UnifdefToolSpec
-    let validateEmbeddedBinarySpec: ValidateEmbeddedBinaryToolSpec
-    let validateProductSpec: ValidateProductToolSpec
+    let validateEmbeddedBinarySpec: ValidateEmbeddedBinaryToolSpec?
+    let validateProductSpec: ValidateProductToolSpec?
     let processXCFrameworkLibrarySpec: ProcessXCFrameworkLibrarySpec
     public let processSDKImportsSpec: ProcessSDKImportsSpec
     public let validateDependenciesSpec: ValidateDependenciesSpec
@@ -343,65 +343,65 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         //
         // FIXME: These should really be bound even earlier, like in the spec cache. Or at least, we should throw here and just produce a dep graph error if any are missing.
         let domain = settings.platform?.name ?? ""
-        self.appShortcutStringsMetadataCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appshortcutstringsmetadata", domain: domain) as! AppShortcutStringsMetadataCompilerSpec
-        self.appleScriptCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.osacompile", domain: domain) as! CommandLineToolSpec
+        self.appShortcutStringsMetadataCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.appshortcutstringsmetadata", domain: domain) as? AppShortcutStringsMetadataCompilerSpec
+        self.appleScriptCompilerSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.osacompile", domain: domain) as? CommandLineToolSpec
         self.buildDependencyInfoSpec = workspaceContext.core.specRegistry.getSpec(BuildDependencyInfoSpec.identifier, domain: domain) as! BuildDependencyInfoSpec
-        self.clangSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangCompilerSpec
-        self.clangAssemblerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangAssemblerSpec
-        self.clangPreprocessorSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangPreprocessorSpec
-        self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangStaticAnalyzerSpec
-        self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ClangModuleVerifierSpec
-        self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache") as ClangStatCacheSpec }
-        self.codesignSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain) as! CodesignToolSpec
-        self._concatenateSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.concatenate") as ConcatenateToolSpec }
-        self.copySpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as CopyToolSpec
-        self.copyPlistSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-plist-file", domain: domain) as! CommandLineToolSpec
-        self.copyPngSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-png-file", domain: domain) as! CommandLineToolSpec
-        self.copyTiffSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-tiff-file", domain: domain) as! CommandLineToolSpec
-        self.cppSpec = workspaceContext.core.specRegistry.getSpec("com.apple.compilers.cpp", domain: domain) as! CommandLineToolSpec
-        self.createAssetPackManifestSpec = workspaceContext.core.specRegistry.getSpec(CreateAssetPackManifestToolSpec.identifier, domain: domain) as! CreateAssetPackManifestToolSpec
-        self.createBuildDirectorySpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.create-build-directory", domain: domain) as! CreateBuildDirectorySpec
-        self.diffSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.diff", domain: domain) as! CommandLineToolSpec
-        self.dsymutilSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.dsymutil", domain: domain) as! DsymutilToolSpec
-        self.infoPlistSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.info-plist-utility", domain: domain) as! InfoPlistToolSpec
-        self.mergeInfoPlistSpec = workspaceContext.core.specRegistry.getSpec(MergeInfoPlistSpec.identifier, domain: domain) as! MergeInfoPlistSpec
-        self.launchServicesRegisterSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.ls-register-url", domain: domain) as! CommandLineToolSpec
-        self.ldLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as LdLinkerSpec
-        self.libtoolLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as LibtoolLinkerSpec
-        self.lipoSpec = workspaceContext.core.specRegistry.getSpec("com.apple.xcode.linkers.lipo", domain: domain) as! LipoToolSpec
-        self.prelinkedObjectLinkSpec = workspaceContext.core.specRegistry.getSpec(PrelinkedObjectLinkSpec.identifier, domain: domain) as! CommandLineToolSpec
-        self.mkdirSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.mkdir", domain: domain) as! MkdirToolSpec
-        self.modulesVerifierSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.modules-verifier", domain: domain) as! ModulesVerifierToolSpec
-        self.clangModuleVerifierInputGeneratorSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.module-verifier-input-generator", domain: domain) as! ClangModuleVerifierInputGeneratorSpec
-        self.productPackagingSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as ProductPackagingToolSpec
+        self.clangSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangCompilerSpec.self)
+        self.clangAssemblerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangAssemblerSpec.self)
+        self.clangPreprocessorSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangPreprocessorSpec.self)
+        self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
+        self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
+        self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }
+        self.codesignSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain, ofType: CodesignToolSpec.self)
+        self._concatenateSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.concatenate", ofType: ConcatenateToolSpec.self) }
+        self.copySpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: CopyToolSpec.self)
+        self.copyPlistSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-plist-file", domain: domain, ofType: CommandLineToolSpec.self)
+        self.copyPngSpec = try? workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-png-file", domain: domain, ofType: CommandLineToolSpec.self)
+        self.copyTiffSpec = try? workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.copy-tiff-file", domain: domain, ofType: CommandLineToolSpec.self)
+        self.cppSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.compilers.cpp", domain: domain, ofType: CommandLineToolSpec.self)
+        self.createAssetPackManifestSpec = try! workspaceContext.core.specRegistry.getSpec(CreateAssetPackManifestToolSpec.identifier, domain: domain, ofType: CreateAssetPackManifestToolSpec.self)
+        self.createBuildDirectorySpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.create-build-directory", domain: domain, ofType: CreateBuildDirectorySpec.self)
+        self.diffSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.diff", domain: domain, ofType: CommandLineToolSpec.self)
+        self.dsymutilSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.dsymutil", domain: domain, ofType: DsymutilToolSpec.self)
+        self.infoPlistSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.info-plist-utility", domain: domain, ofType: InfoPlistToolSpec.self)
+        self.mergeInfoPlistSpec = try! workspaceContext.core.specRegistry.getSpec(MergeInfoPlistSpec.identifier, domain: domain, ofType: MergeInfoPlistSpec.self)
+        self.launchServicesRegisterSpec = try? workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.ls-register-url", domain: domain, ofType: CommandLineToolSpec.self)
+        self.ldLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: LdLinkerSpec.self)
+        self.libtoolLinkerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: LibtoolLinkerSpec.self)
+        self.lipoSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.xcode.linkers.lipo", domain: domain, ofType: LipoToolSpec.self)
+        self.prelinkedObjectLinkSpec = try! workspaceContext.core.specRegistry.getSpec(PrelinkedObjectLinkSpec.identifier, domain: domain, ofType: CommandLineToolSpec.self)
+        self.mkdirSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.mkdir", domain: domain, ofType: MkdirToolSpec.self)
+        self.modulesVerifierSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.modules-verifier", domain: domain, ofType: ModulesVerifierToolSpec.self)
+        self.clangModuleVerifierInputGeneratorSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.module-verifier-input-generator", domain: domain, ofType: ClangModuleVerifierInputGeneratorSpec.self)
+        self.productPackagingSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ProductPackagingToolSpec.self)
         self._registerExecutionPolicyExceptionSpec = .init(workspaceContext, settings)
-        self.setAttributesSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.set-attributes", domain: domain) as! SetAttributesSpec
-        self.shellScriptSpec = workspaceContext.core.specRegistry.getSpec("com.apple.commands.shell-script", domain: domain) as! ShellScriptToolSpec
-        self.signatureCollectionSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.signature-collection", domain: domain) as! SignatureCollectionSpec
+        self.setAttributesSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.set-attributes", domain: domain, ofType: SetAttributesSpec.self)
+        self.shellScriptSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.commands.shell-script", domain: domain, ofType: ShellScriptToolSpec.self)
+        self.signatureCollectionSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.signature-collection", domain: domain, ofType: SignatureCollectionSpec.self)
         self.stripSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.strip", domain: domain) as! StripToolSpec
-        self.swiftCompilerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain) as SwiftCompilerSpec
-        self.swiftHeaderToolSpec = workspaceContext.core.specRegistry.getSpec(SwiftHeaderToolSpec.identifier, domain: domain) as! SwiftHeaderToolSpec
-        self.swiftStdlibToolSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-stdlib-tool", domain: domain) as! SwiftStdLibToolSpec
-        self._swiftABICheckerToolSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-abi-checker", domain: domain) as SwiftABICheckerToolSpec }
-        self._swiftABIGenerationToolSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-abi-generation", domain: domain) as SwiftABIGenerationToolSpec }
-        self.symlinkSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.symlink", domain: domain) as! SymlinkToolSpec
-        self.tapiSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.installapi", domain: domain) as! TAPIToolSpec
-        self.tapiMergeSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.merge", domain: domain) as! CommandLineToolSpec
-        self.tapiStubifySpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.stubify", domain: domain) as! CommandLineToolSpec
-        self.touchSpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.touch", domain: domain) as! CommandLineToolSpec
-        self.unifdefSpec = workspaceContext.core.specRegistry.getSpec("public.build-task.unifdef", domain: domain) as! UnifdefToolSpec
-        self.validateEmbeddedBinarySpec = workspaceContext.core.specRegistry.getSpec("com.apple.tools.validate-embedded-binary-utility", domain: domain) as! ValidateEmbeddedBinaryToolSpec
-        self.validateProductSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.platform.validate", domain: domain) as! ValidateProductToolSpec
-        self.processXCFrameworkLibrarySpec = workspaceContext.core.specRegistry.getSpec(ProcessXCFrameworkLibrarySpec.identifier, domain: domain) as! ProcessXCFrameworkLibrarySpec
-        self.processSDKImportsSpec = workspaceContext.core.specRegistry.getSpec(ProcessSDKImportsSpec.identifier, domain: domain) as! ProcessSDKImportsSpec
-        self.validateDependenciesSpec = workspaceContext.core.specRegistry.getSpec(ValidateDependenciesSpec.identifier, domain: domain) as! ValidateDependenciesSpec
-        self.writeFileSpec = workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.write-file", domain: domain) as! WriteFileSpec
-        self._documentationCompilerSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation", domain: domain) as CommandLineToolSpec }
-        self._tapiSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.objc-symbol-extract", domain: domain) as TAPISymbolExtractor }
-        self._swiftSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.swift-symbol-extract", domain: domain) as CommandLineToolSpec }
-        self._developmentAssetsSpec = Result { try workspaceContext.core.specRegistry.getSpec(ValidateDevelopmentAssets.identifier, domain: domain) as CommandLineToolSpec }
-        self._generateAppPlaygroundAssetCatalogSpec = Result { try workspaceContext.core.specRegistry.getSpec(GenerateAppPlaygroundAssetCatalog.identifier, domain: domain) as CommandLineToolSpec }
-        self._realityAssetsCompilerSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.compile-rk-assets.xcplugin", domain: domain) as CommandLineToolSpec }
+        self.swiftCompilerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: SwiftCompilerSpec.self)
+        self.swiftHeaderToolSpec = try! workspaceContext.core.specRegistry.getSpec(SwiftHeaderToolSpec.identifier, domain: domain, ofType: SwiftHeaderToolSpec.self)
+        self.swiftStdlibToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-stdlib-tool", domain: domain, ofType: SwiftStdLibToolSpec.self)
+        self._swiftABICheckerToolSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-abi-checker", domain: domain, ofType: SwiftABICheckerToolSpec.self) }
+        self._swiftABIGenerationToolSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.swift-abi-generation", domain: domain, ofType: SwiftABIGenerationToolSpec.self) }
+        self.symlinkSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.symlink", domain: domain, ofType: SymlinkToolSpec.self)
+        self.tapiSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.installapi", domain: domain, ofType: TAPIToolSpec.self)
+        self.tapiMergeSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.merge", domain: domain, ofType: CommandLineToolSpec.self)
+        self.tapiStubifySpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.tapi.stubify", domain: domain, ofType: CommandLineToolSpec.self)
+        self.touchSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.tools.touch", domain: domain, ofType: CommandLineToolSpec.self)
+        self.unifdefSpec = try! workspaceContext.core.specRegistry.getSpec("public.build-task.unifdef", domain: domain, ofType: UnifdefToolSpec.self)
+        self.validateEmbeddedBinarySpec = try? workspaceContext.core.specRegistry.getSpec("com.apple.tools.validate-embedded-binary-utility", domain: domain, ofType: ValidateEmbeddedBinaryToolSpec.self)
+        self.validateProductSpec = try? workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.platform.validate", domain: domain, ofType: ValidateProductToolSpec.self)
+        self.processXCFrameworkLibrarySpec = try! workspaceContext.core.specRegistry.getSpec(ProcessXCFrameworkLibrarySpec.identifier, domain: domain, ofType: ProcessXCFrameworkLibrarySpec.self)
+        self.processSDKImportsSpec = try! workspaceContext.core.specRegistry.getSpec(ProcessSDKImportsSpec.identifier, domain: domain, ofType: ProcessSDKImportsSpec.self)
+        self.validateDependenciesSpec = try! workspaceContext.core.specRegistry.getSpec(ValidateDependenciesSpec.identifier, domain: domain, ofType: ValidateDependenciesSpec.self)
+        self.writeFileSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.write-file", domain: domain, ofType: WriteFileSpec.self)
+        self._documentationCompilerSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation", domain: domain, ofType: CommandLineToolSpec.self) }
+        self._tapiSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.objc-symbol-extract", domain: domain, ofType: TAPISymbolExtractor.self) }
+        self._swiftSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.swift-symbol-extract", domain: domain, ofType: CommandLineToolSpec.self) }
+        self._developmentAssetsSpec = Result { try workspaceContext.core.specRegistry.getSpec(ValidateDevelopmentAssets.identifier, domain: domain, ofType: CommandLineToolSpec.self) }
+        self._generateAppPlaygroundAssetCatalogSpec = Result { try workspaceContext.core.specRegistry.getSpec(GenerateAppPlaygroundAssetCatalog.identifier, domain: domain, ofType: CommandLineToolSpec.self) }
+        self._realityAssetsCompilerSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.build-tasks.compile-rk-assets.xcplugin", domain: domain, ofType: CommandLineToolSpec.self) }
 
         self.compilationRequirementOutputFileTypes = (SpecRegistry.headerFileTypeIdentifiers + [SpecRegistry.modulemapFileTypeIdentifier]).compactMap { workspaceContext.core.specRegistry.lookupFileType(identifier: $0, domain: domain) }
         self.emitFrontendCommandLines = settings.globalScope.evaluate(BuiltinMacros.EMIT_FRONTEND_COMMAND_LINES)
@@ -1333,7 +1333,7 @@ extension TaskProducerContext: CommandProducer {
             // arch is a VALID_ARCHS of the dependency but it's not building for that arch, we need to find a compatible one
             let dependencyArchs = dependencyScope.evaluate(BuiltinMacros.ARCHS)
             if false == dependencyArchs.contains(arch) {
-                guard let archSpec: ArchitectureSpec = try? workspaceContext.core.specRegistry.getSpec(arch) else {
+                guard let archSpec = try? workspaceContext.core.specRegistry.getSpec(arch, ofType: ArchitectureSpec.self) else {
                     return nil
                 }
                 // Currently there is no more than one compatibility arch; first might not be correct otherwise
@@ -1755,6 +1755,6 @@ class PhasedProducerBasedTaskGenerationDelegate: ProducerBasedTaskGenerationDele
 
 fileprivate extension Result where Success: Spec & IdentifiedSpecType, Failure == any Error {
     init(_ workspaceContext: WorkspaceContext, _ settings: Settings) {
-        self = Result { try workspaceContext.core.specRegistry.getSpec(domain: settings.platform?.name ?? "") }
+        self = Result { try workspaceContext.core.specRegistry.getSpec(domain: settings.platform?.name ?? "", ofType: Success.self) }
     }
 }

--- a/Sources/SWBTestSupport/CommandLineToolSpecDiscoveredInfo.swift
+++ b/Sources/SWBTestSupport/CommandLineToolSpecDiscoveredInfo.swift
@@ -23,7 +23,7 @@ extension CoreBasedTests {
 
     package func withSpec<T: DiscoveredCommandLineToolSpecInfo>(_ identifier: String, _ result: ExternalToolResult, platform: String? = nil, additionalTable: MacroValueAssignmentTable? = nil, _ block: (_ info: T) throws -> Void, sourceLocation: SourceLocation = #_sourceLocation) async throws {
         let core = try await getCore()
-        let spec = try core.specRegistry.getSpec(identifier) as CommandLineToolSpec
+        let spec = try core.specRegistry.getSpec(identifier, domain: platform ?? "", ofType: CommandLineToolSpec.self)
 
         // Create the context to use to discover the info.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -89,7 +89,7 @@ extension CoreBasedTests {
             // FIXME: We could probably collapse all of this logic into a single method inside the spec, with some refactoring in several places.
             let swiftSpecInfo = try await discoveredSwiftCompilerInfo(at: swiftc)
             let provisionalSwiftVersion = swiftSpecInfo.swiftVersion
-            let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
+            let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
             let swiftVersion: Version
             switch swiftSpec.validateSwiftVersion(provisionalSwiftVersion) {
             case .invalid:
@@ -409,7 +409,7 @@ extension CoreBasedTests {
 
     fileprivate func discoveredToolSpecInfo(specIdentifier: String, sourceLocation: SourceLocation = #_sourceLocation) async throws -> (any DiscoveredCommandLineToolSpecInfo)? {
         let core = try await getCore()
-        let spec = try core.specRegistry.getSpec(specIdentifier) as CommandLineToolSpec
+        let spec = try core.specRegistry.getSpec(specIdentifier, ofType: CommandLineToolSpec.self)
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: nil, useStandardExecutableSearchPaths: true, toolchain: nil, fs: localFS)
         let delegate = DiscoveredInfoDelegate()
         let info = await spec.discoveredCommandLineToolSpecInfo(producer, MacroEvaluationScope(table: MacroValueAssignmentTable(namespace: MacroNamespace())), delegate)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -42,7 +42,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.platform = platform
         self.sdk = (platform?.sdkCanonicalName).map(core.sdkRegistry.lookup) ?? nil
         self.sdkVariant = self.sdk?.defaultVariant
-        self.productType = try core.specRegistry.getSpec(productTypeIdentifier, domain: platform?.name ?? "") as ProductTypeSpec
+        self.productType = try core.specRegistry.getSpec(productTypeIdentifier, domain: platform?.name ?? "", ofType: ProductTypeSpec.self)
 
         // Construct some executable search paths if instructed, by mimicking part of what Settings.createExecutableSearchPaths() does, specifically:
         //  - Add from __XCODE_BUILT_PRODUCTS_DIR_PATHS, if present.
@@ -76,35 +76,35 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.toolchains = toolchain.map { [$0] } ?? []
 
         // Work around compiler (can't use self.getSpec before self initialization)
-        func getSpec<T: Spec>(_ identifier: String) throws -> T {
-            try core.specRegistry.getSpec(identifier, domain: platform?.name ?? "")
+        func getSpec<T: Spec>(_ identifier: String, ofType type: T.Type) throws -> T {
+            try core.specRegistry.getSpec(identifier, domain: platform?.name ?? "", ofType: type)
         }
 
-        func getSpec<T: Spec & IdentifiedSpecType>() throws -> T {
-            try getSpec(T.identifier)
+        func getSpec<T: Spec & IdentifiedSpecType>(ofType type: T.Type) throws -> T {
+            try getSpec(T.identifier, ofType: type)
         }
 
-        self.clangSpec = try getSpec() as ClangCompilerSpec
-        self.clangAssemblerSpec = try getSpec() as ClangAssemblerSpec
-        self.clangPreprocessorSpec = try getSpec() as ClangPreprocessorSpec
-        self.clangStaticAnalyzerSpec = try getSpec() as ClangStaticAnalyzerSpec
-        self.clangModuleVerifierSpec = try getSpec() as ClangModuleVerifierSpec
-        self.diffSpec = try getSpec("com.apple.build-tools.diff") as CommandLineToolSpec
-        self.stripSpec = try getSpec("com.apple.build-tools.strip") as StripToolSpec
-        self.ldLinkerSpec = try getSpec() as LdLinkerSpec
-        self.libtoolLinkerSpec = try getSpec() as LibtoolLinkerSpec
-        self.lipoSpec = try getSpec() as LipoToolSpec
-        self.codesignSpec = try getSpec("com.apple.build-tools.codesign") as CodesignToolSpec
-        self.copySpec = try getSpec() as CopyToolSpec
-        self.copyPngSpec = try getSpec("com.apple.build-tasks.copy-png-file") as CommandLineToolSpec
-        self.copyTiffSpec = try getSpec("com.apple.build-tasks.copy-tiff-file") as CommandLineToolSpec
-        self.writeFileSpec = try getSpec("com.apple.build-tools.write-file") as WriteFileSpec
-        self.createBuildDirectorySpec = try getSpec("com.apple.tools.create-build-directory") as CreateBuildDirectorySpec
-        self.unifdefSpec = try getSpec("public.build-task.unifdef") as UnifdefToolSpec
-        self.mkdirSpec = try getSpec("com.apple.tools.mkdir") as MkdirToolSpec
-        self.swiftCompilerSpec = try getSpec() as SwiftCompilerSpec
-        self.processSDKImportsSpec = try getSpec(ProcessSDKImportsSpec.identifier) as ProcessSDKImportsSpec
-        self.validateDependenciesSpec = try getSpec(ValidateDependenciesSpec.identifier) as ValidateDependenciesSpec
+        self.clangSpec = try getSpec(ofType: ClangCompilerSpec.self)
+        self.clangAssemblerSpec = try getSpec(ofType: ClangAssemblerSpec.self)
+        self.clangPreprocessorSpec = try getSpec(ofType: ClangPreprocessorSpec.self)
+        self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
+        self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
+        self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
+        self.stripSpec = try getSpec("com.apple.build-tools.strip", ofType: StripToolSpec.self)
+        self.ldLinkerSpec = try getSpec(ofType: LdLinkerSpec.self)
+        self.libtoolLinkerSpec = try getSpec(ofType: LibtoolLinkerSpec.self)
+        self.lipoSpec = try getSpec(ofType: LipoToolSpec.self)
+        self.codesignSpec = try getSpec("com.apple.build-tools.codesign", ofType: CodesignToolSpec.self)
+        self.copySpec = try getSpec(ofType: CopyToolSpec.self)
+        self.copyPngSpec = try? getSpec("com.apple.build-tasks.copy-png-file", ofType: CommandLineToolSpec.self)
+        self.copyTiffSpec = try? getSpec("com.apple.build-tasks.copy-tiff-file", ofType: CommandLineToolSpec.self)
+        self.writeFileSpec = try getSpec("com.apple.build-tools.write-file", ofType: WriteFileSpec.self)
+        self.createBuildDirectorySpec = try getSpec("com.apple.tools.create-build-directory", ofType: CreateBuildDirectorySpec.self)
+        self.unifdefSpec = try getSpec("public.build-task.unifdef", ofType: UnifdefToolSpec.self)
+        self.mkdirSpec = try getSpec("com.apple.tools.mkdir", ofType: MkdirToolSpec.self)
+        self.swiftCompilerSpec = try getSpec(ofType: SwiftCompilerSpec.self)
+        self.processSDKImportsSpec = try getSpec(ProcessSDKImportsSpec.identifier, ofType: ProcessSDKImportsSpec.self)
+        self.validateDependenciesSpec = try getSpec(ValidateDependenciesSpec.identifier, ofType: ValidateDependenciesSpec.self)
     }
 
     package let specDataCaches = Registry<Spec, any SpecDataCache>()
@@ -133,8 +133,8 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package let lipoSpec: LipoToolSpec
     package let codesignSpec: CodesignToolSpec
     package let copySpec: CopyToolSpec
-    package let copyPngSpec: CommandLineToolSpec
-    package let copyTiffSpec: CommandLineToolSpec
+    package let copyPngSpec: CommandLineToolSpec?
+    package let copyTiffSpec: CommandLineToolSpec?
     package let writeFileSpec: WriteFileSpec
     package let createBuildDirectorySpec: CreateBuildDirectorySpec
     package let unifdefSpec: UnifdefToolSpec

--- a/Tests/SWBApplePlatformTests/AppleCommandLineSpecTests.swift
+++ b/Tests/SWBApplePlatformTests/AppleCommandLineSpecTests.swift
@@ -148,7 +148,7 @@ fileprivate struct AppleCommandLineSpecTests: CoreBasedTests {
     @Test
     func resMergerLinkerTaskConstruction() async throws {
         let core = try await getCore()
-        let resMergerSpec: GenericLinkerSpec = try core.specRegistry.getSpec() as ResMergerLinkerSpec
+        let resMergerSpec: GenericLinkerSpec = try core.specRegistry.getSpec(domain: "macosx", ofType: ResMergerLinkerSpec.self)
 
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         table.push(BuiltinMacros.REZ_COLLECTOR_DIR, literal: Path.root.join("rezCollectorDir").str)

--- a/Tests/SWBApplePlatformTests/AppleCommandLineToolSpecDiscoveredInfoTests.swift
+++ b/Tests/SWBApplePlatformTests/AppleCommandLineToolSpecDiscoveredInfoTests.swift
@@ -21,7 +21,7 @@ import SWBProtocol
 @Suite
 fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     func _testDiscoveredIbSpecInfo(_ spec: CommandLineToolSpec) async throws {
-        try await withSpec(spec.identifier, .deferred) { (info: DiscoveredIbtoolToolSpecInfo) in
+        try await withSpec(spec.identifier, .deferred, platform: "macosx") { (info: DiscoveredIbtoolToolSpecInfo) in
             XCTAssertMatch(info.toolPath.basename, .or(.equal("actool"), .equal("ibtool")))
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion > Version(0, 0, 0))
@@ -35,7 +35,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     @Test(.requireHostOS(.macOS))
     func discoveredActoolSpecInfo() async throws {
         // Once with the real tool
-        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec() as ActoolCompilerSpec)
+        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec(domain: "macosx", ofType: ActoolCompilerSpec.self))
 
         let output = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -54,7 +54,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
             """
 
         // ...and with fake data
-        try await withSpec(ActoolCompilerSpec.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data())) { (info: DiscoveredIbtoolToolSpecInfo) in
+        try await withSpec(ActoolCompilerSpec.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredIbtoolToolSpecInfo) in
             #expect(info.toolPath.basename == "actool")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(87946))
@@ -68,7 +68,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     @Test(.requireHostOS(.macOS))
     func discoveredIbtoolSpecInfo() async throws {
         // Once with the real tool
-        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec() as IbtoolCompilerSpecStoryboard)
+        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec(domain: "darwin", ofType: IbtoolCompilerSpecStoryboard.self))
 
         let output = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -87,7 +87,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
             """
 
         // ...and with fake data
-        try await withSpec(IbtoolCompilerSpecStoryboard.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data())) { (info: DiscoveredIbtoolToolSpecInfo) in
+        try await withSpec(IbtoolCompilerSpecStoryboard.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredIbtoolToolSpecInfo) in
             #expect(info.toolPath.basename == "ibtool")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(87946))
@@ -101,7 +101,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     @Test(.requireHostOS(.macOS))
     func discoveredStoryboardLinkerSpecInfo() async throws {
         // Once with the real tool
-        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec() as IBStoryboardLinkerCompilerSpec)
+        try await _testDiscoveredIbSpecInfo(getCore().specRegistry.getSpec(domain: "macosx", ofType: IBStoryboardLinkerCompilerSpec.self))
 
         let output = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -120,7 +120,7 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
             """
 
         // ...and with fake data
-        try await withSpec(IBStoryboardLinkerCompilerSpec.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data())) { (info: DiscoveredIbtoolToolSpecInfo) in
+        try await withSpec(IBStoryboardLinkerCompilerSpec.self, .result(status: .exit(0), stdout: Data(output.utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredIbtoolToolSpecInfo) in
             #expect(info.toolPath.basename == "ibtool")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(87946))
@@ -134,20 +134,20 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     @Test(.requireHostOS(.macOS))
     func discoveredMigSpecInfo() async throws {
         // Once with the real tool
-        try await withSpec(MigCompilerSpec.self, .deferred) { (info: DiscoveredMiGToolSpecInfo) in
+        try await withSpec(MigCompilerSpec.self, .deferred, platform: "macosx") { (info: DiscoveredMiGToolSpecInfo) in
             #expect(info.toolPath.basename == "mig")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion > Version(0, 0, 0))
         }
 
         // ...and with fake data
-        try await withSpec(MigCompilerSpec.self, .result(status: .exit(0), stdout: Data("bootstrap_cmds-108\n".utf8), stderr: Data())) { (info: DiscoveredMiGToolSpecInfo) in
+        try await withSpec(MigCompilerSpec.self, .result(status: .exit(0), stdout: Data("bootstrap_cmds-108\n".utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredMiGToolSpecInfo) in
             #expect(info.toolPath.basename == "mig")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(108))
         }
 
-        try await withSpec(MigCompilerSpec.self, .result(status: .exit(0), stdout: Data("bootstrap_cmds-99.0.0.400.6\n".utf8), stderr: Data())) { (info: DiscoveredMiGToolSpecInfo) in
+        try await withSpec(MigCompilerSpec.self, .result(status: .exit(0), stdout: Data("bootstrap_cmds-99.0.0.400.6\n".utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredMiGToolSpecInfo) in
             #expect(info.toolPath.basename == "mig")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(99, 0, 0, 400, 6))
@@ -157,14 +157,14 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
     @Test(.requireHostOS(.macOS))
     func discoveredIigSpecInfo() async throws {
         // Once with the real tool
-        try await withSpec("com.apple.compilers.iig", .deferred) { (info: DiscoveredIiGToolSpecInfo) in
+        try await withSpec("com.apple.compilers.iig", .deferred, platform: "macosx") { (info: DiscoveredIiGToolSpecInfo) in
             #expect(info.toolPath.basename == "iig")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion > Version(0, 0, 0))
         }
 
         // ...and with fake data
-        try await withSpec("com.apple.compilers.iig", .result(status: .exit(0), stdout: Data("DriverKit-29\n".utf8), stderr: Data())) { (info: DiscoveredIiGToolSpecInfo) in
+        try await withSpec("com.apple.compilers.iig", .result(status: .exit(0), stdout: Data("DriverKit-29\n".utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredIiGToolSpecInfo) in
             #expect(info.toolPath.basename == "iig")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(29))
@@ -173,20 +173,20 @@ fileprivate struct AppleCommandLineToolSpecDiscoveredInfoTests: CoreBasedTests {
 
     @Test(.requireHostOS(.macOS))
     func discoveredCoreMLSpecInfo() async throws {
-        try await withSpec(CoreMLCompilerSpec.self, .deferred) { (info: DiscoveredCoreMLToolSpecInfo) in
+        try await withSpec(CoreMLCompilerSpec.self, .deferred, platform: "macosx") { (info: DiscoveredCoreMLToolSpecInfo) in
             #expect(info.toolPath.basename == "coremlc")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion > Version(0, 0, 0))
         }
 
         // ...and with fake data
-        try await withSpec(CoreMLCompilerSpec.self, .result(status: .exit(0), stdout: Data("PROGRAM:coremlcompiler  PROJECT:CoreML-1749.0.0.0.2\nPROGRAM:coremlcompiler  PROJECT:CoreML-1749.0.0.0.2\n".utf8), stderr: Data())) { (info: DiscoveredCoreMLToolSpecInfo) in
+        try await withSpec(CoreMLCompilerSpec.self, .result(status: .exit(0), stdout: Data("PROGRAM:coremlcompiler  PROJECT:CoreML-1749.0.0.0.2\nPROGRAM:coremlcompiler  PROJECT:CoreML-1749.0.0.0.2\n".utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredCoreMLToolSpecInfo) in
             #expect(info.toolPath.basename == "coremlc")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(1749, 0, 0, 0, 2))
         }
 
-        try await withSpec(CoreMLCompilerSpec.self, .result(status: .exit(0), stdout: Data("PROGRAM:coremlc  PROJECT:IDEMLKit-999999\n".utf8), stderr: Data())) { (info: DiscoveredCoreMLToolSpecInfo) in
+        try await withSpec(CoreMLCompilerSpec.self, .result(status: .exit(0), stdout: Data("PROGRAM:coremlc  PROJECT:IDEMLKit-999999\n".utf8), stderr: Data()), platform: "macosx") { (info: DiscoveredCoreMLToolSpecInfo) in
             #expect(info.toolPath.basename == "coremlc")
             let toolVersion = try #require(info.toolVersion)
             #expect(toolVersion == Version(999999))

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -3685,7 +3685,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                         results.checkWarnings([.contains("input unused"), .contains("input unused")], failIfNotFound: false)
 
                         func indexAndPreviewInfo(for task: any ExecutableTask) throws -> (index: SwiftSourceFileIndexingInfo?, preview: TaskGeneratePreviewInfoOutput?) {
-                            let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
+                            let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
                             let sourceFile = SRCROOT.join("Sources/file1.swift")
 
                             return (

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -270,7 +270,7 @@ fileprivate struct CommandLineSpecPerfTests: CoreBasedTests, PerfTests {
     func clangCompileTaskConstruction_X1000() async throws {
         let core = try await getCore()
 
-        let clangSpec: CommandLineToolSpec = try core.specRegistry.getSpec() as ClangCompilerSpec
+        let clangSpec: CommandLineToolSpec = try core.specRegistry.getSpec(ofType: ClangCompilerSpec.self)
 
         // Create the mock table.  We include all the defaults for the tool specification.
         var (table, namespace) = clangSpec.macroTableForBuildOptionDefaults(core)
@@ -308,7 +308,7 @@ fileprivate struct CommandLineSpecPerfTests: CoreBasedTests, PerfTests {
         // Create the delegate, scope, file type, etc.
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
 
         // Create the build context for the command.
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path("/tmp/input.c"), fileType: mockFileType)], output: nil)

--- a/Tests/SWBCoreTests/BuildRuleTests.swift
+++ b/Tests/SWBCoreTests/BuildRuleTests.swift
@@ -26,16 +26,16 @@ import SWBMacro
         // Create a set of rules.  We’ll use a couple of helper functions for creating the rules.
         var rules = Array<(any BuildRuleCondition,any BuildRuleAction)>()
         func MakeNamePatternConditionTaskActionRule(_ namePattern: String, _ compilerSpecIdent: String) throws -> (any BuildRuleCondition, any BuildRuleAction) {
-            return (BuildRuleFileNameCondition(namePatterns: [core.specRegistry.internalMacroNamespace.parseString(namePattern)]), BuildRuleTaskAction(toolSpec: try core.specRegistry.getSpec(compilerSpecIdent) as CommandLineToolSpec))
+            return (BuildRuleFileNameCondition(namePatterns: [core.specRegistry.internalMacroNamespace.parseString(namePattern)]), BuildRuleTaskAction(toolSpec: try core.specRegistry.getSpec(compilerSpecIdent, ofType: CommandLineToolSpec.self)))
         }
         func MakeNamePatternConditionScriptActionRule(_ namePattern: String, _ scriptSource: String) throws -> (any BuildRuleCondition, any BuildRuleAction) {
             return (BuildRuleFileNameCondition(namePatterns: [core.specRegistry.internalMacroNamespace.parseString(namePattern)]), BuildRuleScriptAction(guid: "BR\(scriptSource)", name: "BR\(scriptSource)", interpreterPath: "/bin/sh:", scriptSource: scriptSource, inputFiles: [], inputFileLists: [], outputFiles: [], outputFileLists: [], dependencyInfo: nil, runOncePerArchitecture: true, runDuringInstallAPI: false, runDuringInstallHeaders: false))
         }
         func MakeFileTypeConditionTaskActionRule(_ fileTypeIdent: String, _ compilerSpecIdent: String) throws -> (any BuildRuleCondition, any BuildRuleAction) {
-            return (BuildRuleFileTypeCondition(fileType: try core.specRegistry.getSpec(fileTypeIdent) as FileTypeSpec), BuildRuleTaskAction(toolSpec: try core.specRegistry.getSpec(compilerSpecIdent) as CommandLineToolSpec))
+            return (BuildRuleFileTypeCondition(fileType: try core.specRegistry.getSpec(fileTypeIdent, ofType: FileTypeSpec.self)), BuildRuleTaskAction(toolSpec: try core.specRegistry.getSpec(compilerSpecIdent, ofType: CommandLineToolSpec.self)))
         }
         func MakeFileTypeConditionScriptActionRule(_ fileTypeIdent: String, _ scriptSource: String) throws -> (any BuildRuleCondition, any BuildRuleAction) {
-            return (BuildRuleFileTypeCondition(fileType: try core.specRegistry.getSpec(fileTypeIdent) as FileTypeSpec), BuildRuleScriptAction(guid: "BR\(scriptSource)", name: "BR\(scriptSource)", interpreterPath: "/bin/sh:", scriptSource: scriptSource, inputFiles: [], inputFileLists: [], outputFiles: [], outputFileLists: [], dependencyInfo: nil, runOncePerArchitecture: true, runDuringInstallAPI: false, runDuringInstallHeaders: false))
+            return (BuildRuleFileTypeCondition(fileType: try core.specRegistry.getSpec(fileTypeIdent, ofType: FileTypeSpec.self)), BuildRuleScriptAction(guid: "BR\(scriptSource)", name: "BR\(scriptSource)", interpreterPath: "/bin/sh:", scriptSource: scriptSource, inputFiles: [], inputFileLists: [], outputFiles: [], outputFileLists: [], dependencyInfo: nil, runOncePerArchitecture: true, runDuringInstallAPI: false, runDuringInstallHeaders: false))
         }
         rules.append(try MakeNamePatternConditionTaskActionRule("*.c", "com.apple.compilers.llvm.clang.1_0"))
         rules.append(try MakeNamePatternConditionScriptActionRule("*.tiff", "pwd"))
@@ -45,9 +45,9 @@ import SWBMacro
         let ruleSet = BasicBuildRuleSet(rules: rules)
 
         // Create some matchable entities.
-        let hFile = FileToBuild(absolutePath: Path.root.join("foo.h"), fileType: try core.specRegistry.getSpec(SpecRegistry.headerFileTypeIdentifiers.first!) as FileTypeSpec)
-        let cFile = FileToBuild(absolutePath: Path.root.join("foo.c"), fileType: try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec)
-        let pngFile = FileToBuild(absolutePath: Path.root.join("bar.png"), fileType: try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec)
+        let hFile = FileToBuild(absolutePath: Path.root.join("foo.h"), fileType: try core.specRegistry.getSpec(SpecRegistry.headerFileTypeIdentifiers.first!, ofType: FileTypeSpec.self))
+        let cFile = FileToBuild(absolutePath: Path.root.join("foo.c"), fileType: try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self))
+        let pngFile = FileToBuild(absolutePath: Path.root.join("bar.png"), fileType: try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self))
 
         // Create a scope for evaluation.
         let table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -103,7 +103,7 @@ import SWBMacro
 
         func testDiagnostic(enableDebugActivityLogs: Bool) throws {
             let ruleSet = DisambiguatingBuildRuleSet(rules: rules, enableDebugActivityLogs: enableDebugActivityLogs)
-            let textSpec = try core.specRegistry.getSpec("text") as FileTypeSpec
+            let textSpec = try core.specRegistry.getSpec("text", ofType: FileTypeSpec.self)
             let textFilePath = Path.root.join("tmp/foo.out")
             let textFile = FileToBuild(absolutePath: textFilePath, fileType: textSpec)
 
@@ -139,7 +139,7 @@ import SWBMacro
             BasicBuildRuleSet(rules: [rule1]),
             BasicBuildRuleSet(rules: [rule2]),
         ])
-        let textSpec = try core.specRegistry.getSpec("text") as FileTypeSpec
+        let textSpec = try core.specRegistry.getSpec("text", ofType: FileTypeSpec.self)
         let textFile = FileToBuild(absolutePath: Path.root.join("tmp/foo.out"), fileType: textSpec)
 
         let result = ruleSet.match(textFile, scope)

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -166,8 +166,8 @@ import SWBMacro
     @Test(.requireHostOS(.macOS))
     func swiftTaskConstruction() async throws {
         let core = try await getCore()
-        let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
-        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool") as SwiftHeaderToolSpec
+        let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
+        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool", ofType: SwiftHeaderToolSpec.self)
 
         let swiftCompilerPath = try await self.swiftCompilerPath
 
@@ -212,9 +212,9 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/one.swift"), fileType: mockFileType), FileToBuild(absolutePath: Path.root.join("tmp/two.swift"), fileType: mockFileType)]
-        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
         await swiftSpec.constructTasks(cbc, delegate)
         headerSpec.constructSwiftHeaderToolTask(cbc, delegate, inputs: delegate.generatedSwiftObjectiveCHeaderFiles(), outputPath: Path("App1-Swift.h"))
@@ -307,9 +307,9 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/one.swift"), fileType: mockFileType), FileToBuild(absolutePath: Path.root.join("tmp/two.swift"), fileType: mockFileType)]
-            let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+            let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
             await swiftSpec.constructTasks(cbc, delegate)
             headerSpec.constructSwiftHeaderToolTask(cbc, delegate, inputs: delegate.generatedSwiftObjectiveCHeaderFiles(), outputPath: Path.root.join("tmp/output/obj/DerivedFiles/App1-Swift.h"))
@@ -323,8 +323,8 @@ import SWBMacro
     @Test(.requireHostOS(.macOS), .requireLLBuild(apiVersion: 12))
     func swiftTaskConstruction_integratedDriver() async throws {
         let core = try await getCore()
-        let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
-        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool") as SwiftHeaderToolSpec
+        let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
+        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool", ofType: SwiftHeaderToolSpec.self)
 
         let swiftCompilerPath = try await self.swiftCompilerPath
 
@@ -371,9 +371,9 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/one.swift"), fileType: mockFileType), FileToBuild(absolutePath: Path.root.join("tmp/two.swift"), fileType: mockFileType)]
-        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
         await swiftSpec.constructTasks(cbc, delegate)
         headerSpec.constructSwiftHeaderToolTask(cbc, delegate, inputs: delegate.generatedSwiftObjectiveCHeaderFiles(), outputPath: Path("App1-Swift.h"))
@@ -490,9 +490,9 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/one.swift"), fileType: mockFileType), FileToBuild(absolutePath: Path.root.join("tmp/two.swift"), fileType: mockFileType)]
-            let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+            let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
             await swiftSpec.constructTasks(cbc, delegate)
             headerSpec.constructSwiftHeaderToolTask(cbc, delegate, inputs: delegate.generatedSwiftObjectiveCHeaderFiles(), outputPath: Path.root.join("tmp/output/obj/DerivedFiles/App1-Swift.h"))
@@ -507,8 +507,8 @@ import SWBMacro
     @Test(.requireSDKs(.macOS))
     func swiftTaskConstructionWithoutResponseFile() async throws {
         let core = try await getCore()
-        let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
-        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool") as SwiftHeaderToolSpec
+        let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
+        let headerSpec = try core.specRegistry.getSpec("com.apple.build-tools.swift-header-tool", ofType: SwiftHeaderToolSpec.self)
 
         let swiftCompilerPath = try await self.swiftCompilerPath
 
@@ -549,9 +549,9 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/one.swift"), fileType: mockFileType), FileToBuild(absolutePath: Path.root.join("tmp/two.swift"), fileType: mockFileType)]
-        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
         await swiftSpec.constructTasks(cbc, delegate)
         headerSpec.constructSwiftHeaderToolTask(cbc, delegate, inputs: delegate.generatedSwiftObjectiveCHeaderFiles(), outputPath: Path("App1-Swift.h"))
@@ -600,7 +600,7 @@ import SWBMacro
     @Test(.skipHostOS(.windows, "tmp/not-mainone.swift not in command line"))
     func singleFileSwiftTaskConstruction() async throws {
         let core = try await getCore()
-        let swiftSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
+        let swiftSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
 
         // Create the mock table.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -620,9 +620,9 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let inputFiles = [FileToBuild(absolutePath: Path.root.join("tmp/not-mainone.swift"), fileType: mockFileType)]
-        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx") as ArchitectureSpec
+        let archSpec = try core.specRegistry.getSpec("x86_64", domain: "macosx", ofType: ArchitectureSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: inputFiles, currentArchSpec: archSpec, output: nil)
         await swiftSpec.constructTasks(cbc, delegate)
 
@@ -643,7 +643,7 @@ import SWBMacro
     @Test
     func stripTaskConstruction() async throws {
         let core = try await getCore()
-        let stripSpec = try core.specRegistry.getSpec("com.apple.build-tools.strip") as CommandLineToolSpec
+        let stripSpec = try core.specRegistry.getSpec("com.apple.build-tools.strip", ofType: CommandLineToolSpec.self)
 
         // Create the mock table.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -653,7 +653,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+                   let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input"), fileType: mockFileType)], output: Path.root.join("tmp/output"))
         await stripSpec.constructTasks(cbc, delegate)
 
@@ -669,7 +669,7 @@ import SWBMacro
     @Test(.requireSDKs(.macOS))
     func swiftStdlibTool() async throws {
         let core = try await getCore()
-        let stdlibTool = try core.specRegistry.getSpec("com.apple.build-tools.swift-stdlib-tool") as SwiftStdLibToolSpec
+        let stdlibTool = try core.specRegistry.getSpec("com.apple.build-tools.swift-stdlib-tool", ofType: SwiftStdLibToolSpec.self)
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         table.push(BuiltinMacros.CODESIGN_ALLOCATE, literal: "/path/to/codesign_allocate")
         table.push(BuiltinMacros.WRAPPER_NAME, literal: "wrapper")
@@ -677,7 +677,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.application", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input"), fileType: mockFileType)], output: nil)
 
         // Check that task construction sets the correct env bindings.
@@ -691,7 +691,7 @@ import SWBMacro
     @Test
     func dsymutilTaskConstruction() async throws {
         let core = try await getCore()
-        let dsymutilSpec = try core.specRegistry.getSpec("com.apple.tools.dsymutil") as DsymutilToolSpec
+        let dsymutilSpec = try core.specRegistry.getSpec("com.apple.tools.dsymutil", ofType: DsymutilToolSpec.self)
 
         do {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -702,7 +702,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+                       let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input"), fileType: mockFileType)], output: Path.root.join("tmp/output"))
             await dsymutilSpec.constructTasks(cbc, delegate, dsymBundle: Path.root.join("tmp/output.dSYM"))
 
@@ -725,7 +725,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input"), fileType: mockFileType)], output: Path.root.join("tmp/output"))
             await dsymutilSpec.constructTasks(cbc, delegate, dsymBundle: Path.root.join("tmp/output.dSYM"))
 
@@ -742,7 +742,7 @@ import SWBMacro
     @Test(.skipHostOS(.windows, "prefix.h header path is coming over as tmp\\tmp\\prefix.h"), .requireSDKs(.macOS))
     func clangCompileTaskConstruction() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
 
         // Create the mock table.  We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -804,7 +804,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self)
 
             // Create the build context for the command.
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input.c"), fileType: mockFileType)], output: nil)
@@ -861,7 +861,7 @@ import SWBMacro
     @Test
     func clangCompileWithPrefixHeaderTaskConstruction() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
 
         // Create the mock table.  We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -908,7 +908,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self)
 
         // We need to construct multiple tasks to ensure that they correctly share one precompiled header
         let numCompileTasks = 2
@@ -988,7 +988,7 @@ import SWBMacro
     @Test
     func clangCompileTaskConstructionWithCXXModulesDisabled() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
 
         // Create the dummy table.  We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1023,7 +1023,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let dummyScope = MacroEvaluationScope(table: table)
-            let dummyFileType = try core.specRegistry.getSpec(spec) as FileTypeSpec
+            let dummyFileType = try core.specRegistry.getSpec(spec, ofType: FileTypeSpec.self)
 
             let fileSuffix = spec.hasSuffix("objcpp") ? ".mm" : ".m"
             // Create the build context for the command.
@@ -1078,7 +1078,7 @@ import SWBMacro
     @Test
     func clangCompileTaskConstructionWithCXX20ModulesDisabled() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
 
         // Create the dummy table.  We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1115,7 +1115,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let dummyScope = MacroEvaluationScope(table: configTable)
-            let dummyFileType = try core.specRegistry.getSpec(spec) as FileTypeSpec
+            let dummyFileType = try core.specRegistry.getSpec(spec, ofType: FileTypeSpec.self)
 
             // Create the build context for the command.
             let cbc = CommandBuildContext(producer: producer, scope: dummyScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input.mm"), fileType: dummyFileType)], output: nil)
@@ -1186,7 +1186,7 @@ import SWBMacro
     @Test(.skipHostOS(.windows, "output file is coming out as tmp\\input.o (non-absolute)"))
     func cCompilerLauncher() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
 
         // Create the mock table.  We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1196,7 +1196,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("sourcecode.c") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("sourcecode.c", ofType: FileTypeSpec.self)
 
         // Create the build context for the command.
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input.c"), fileType: mockFileType)], output: nil)
@@ -1217,8 +1217,8 @@ import SWBMacro
     @Test
     func cppLanguageStandard() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
-        let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp") as FileTypeSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
+        let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp", ofType: FileTypeSpec.self)
         let langStandardMacro = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_CXX_LANGUAGE_STANDARD") as? StringMacroDeclaration)
 
         let macroFlagMapping = [
@@ -1254,12 +1254,12 @@ import SWBMacro
     @Test
     func compilerPathOverrides() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
         let fileTypes = [
-            ".c": try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec,
-            ".cpp": try core.specRegistry.getSpec("sourcecode.cpp.cpp") as FileTypeSpec,
-            ".m": try core.specRegistry.getSpec("sourcecode.c.objc") as FileTypeSpec,
-            ".mm": try core.specRegistry.getSpec("sourcecode.cpp.objcpp") as FileTypeSpec
+            ".c": try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self),
+            ".cpp": try core.specRegistry.getSpec("sourcecode.cpp.cpp", ofType: FileTypeSpec.self),
+            ".m": try core.specRegistry.getSpec("sourcecode.c.objc", ofType: FileTypeSpec.self),
+            ".mm": try core.specRegistry.getSpec("sourcecode.cpp.objcpp", ofType: FileTypeSpec.self)
         ]
 
         // Check with just CC.
@@ -1321,7 +1321,7 @@ import SWBMacro
     @Test
     func linkerTaskConstruction() async throws {
         let core = try await getCore()
-        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec() as LdLinkerSpec
+        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LdLinkerSpec.self)
 
         // Create the mock table.
         // Since these tests don't use any of the default settings, we need to push any defaults needed for the test here.
@@ -1337,7 +1337,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/obj/normal/x86_64/file1.o"), fileType: mockFileType)], output: Path.root.join("tmp/obj/normal/x86_64/output"))
 
         // Test all permutations of library kind, linkage mode and search path usage, except for object files and object libraries.
@@ -1439,7 +1439,7 @@ import SWBMacro
     @Test
     func linkerBuildSettings() async throws {
         let core = try await getCore()
-        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec() as LdLinkerSpec
+        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LdLinkerSpec.self)
         let variant = "normal"
         let arch = "arm64"
 
@@ -1449,7 +1449,7 @@ import SWBMacro
         baseTable.push(BuiltinMacros.variant, literal: variant)
 
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
 
         /// Utility method to add the setting to the table, create a task with the table, and call a checker block.
         func createAndCheckLinkerTask(_ name: String, type: MacroDeclaration.Type, value: String, check: (PlannedTaskBuilder) async throws -> Void) async throws {
@@ -1493,7 +1493,7 @@ import SWBMacro
     @Test
     func linkerAdHocSigningOptions() async throws {
         let core = try await getCore()
-        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec() as LdLinkerSpec
+        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LdLinkerSpec.self)
 
         // Create the mock table, which will get re-used across the tests.We include all the defaults for the tool specification.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1512,7 +1512,7 @@ import SWBMacro
 
         // Construct data we can re-use across the tests.
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
-        let mockFileType: FileTypeSpec = try core.specRegistry.getSpec("file")
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
 
         // Test linking for different macOS archs with a signing identity.
         // Presently we disable ad-hoc code signing always when we have a signing identity.
@@ -1574,7 +1574,7 @@ import SWBMacro
     @Test
     func libtoolTaskConstruction() async throws {
         let core = try await getCore()
-        let librarianSpec: LinkerSpec = try core.specRegistry.getSpec() as LibtoolLinkerSpec
+        let librarianSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LibtoolLinkerSpec.self)
 
         // Create the mock table.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1586,7 +1586,7 @@ import SWBMacro
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.library.static", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
         let mockScope = MacroEvaluationScope(table: table)
-        let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/obj/normal/x86_64/file1.o"), fileType: mockFileType)], output: Path.root.join("tmp/obj/normal/x86_64/output"))
         let libraries = [
             LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo1.a"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
@@ -1641,11 +1641,11 @@ import SWBMacro
     @Test
     func linkerPathOverrides() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
-        let spec: LinkerSpec = try core.specRegistry.getSpec() as LdLinkerSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
+        let spec: LinkerSpec = try core.specRegistry.getSpec(ofType: LdLinkerSpec.self)
         let fileTypes = [
-            ".c": try core.specRegistry.getSpec("sourcecode.c.c") as FileTypeSpec,
-            ".cpp": try core.specRegistry.getSpec("sourcecode.cpp.cpp") as FileTypeSpec,
+            ".c": try core.specRegistry.getSpec("sourcecode.c.c", ofType: FileTypeSpec.self),
+            ".cpp": try core.specRegistry.getSpec("sourcecode.cpp.cpp", ofType: FileTypeSpec.self),
         ]
 
         func check(name: String, expectedLinker: String, macros: [StringMacroDeclaration: String], sourceLocation: SourceLocation = #_sourceLocation) async throws {
@@ -1698,9 +1698,9 @@ import SWBMacro
     @Test
     func additionalLinkerArgs() async throws {
         let core = try await getCore()
-        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec() as LdLinkerSpec
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
-        let objcFileTypeSpec = try core.specRegistry.getSpec("sourcecode.c.objc") as FileTypeSpec
+        let linkerSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LdLinkerSpec.self)
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
+        let objcFileTypeSpec = try core.specRegistry.getSpec("sourcecode.c.objc", ofType: FileTypeSpec.self)
         let macroName = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("LLVM_LTO") as? StringMacroDeclaration)
 
         let macroValues = [
@@ -1739,7 +1739,7 @@ import SWBMacro
     @Test
     func copyTaskConstruction() async throws {
         let core = try await getCore()
-        let copySpec = try core.specRegistry.getSpec() as CopyToolSpec
+        let copySpec = try core.specRegistry.getSpec(ofType: CopyToolSpec.self)
 
         // Create the mock table. Note that the defaults from the spec are *not* added to this table.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1751,7 +1751,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/file-to-copy"), fileType: mockFileType)], output: Path.root.join("tmp/dst/file-to-copy"))
             await copySpec.constructCopyTasks(cbc, delegate)
 
@@ -1770,7 +1770,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/file-to-copy"), fileType: mockFileType)], output: Path.root.join("tmp/dst/file-to-copy"))
             await copySpec.constructCopyTasks(cbc, delegate, removeHeaderDirectories: true)
 
@@ -1789,7 +1789,7 @@ import SWBMacro
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
             let mockScope = MacroEvaluationScope(table: table)
-            let mockFileType = try core.specRegistry.getSpec("file") as FileTypeSpec
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/file-to-copy"), fileType: mockFileType)], output: Path.root.join("tmp/dst/file-to-copy"))
             await copySpec.constructCopyTasks(cbc, delegate, ignoreMissingInputs: true)
 
@@ -1808,14 +1808,14 @@ import SWBMacro
     @Test
     func touchTaskConstruction() async throws {
         let core = try await getCore()
-        let touchSpec = try #require(core.specRegistry.getSpec("com.apple.tools.touch") as? CommandLineToolSpec)
+        let touchSpec = try core.specRegistry.getSpec("com.apple.tools.touch", ofType: CommandLineToolSpec.self)
 
         let table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         let scope = MacroEvaluationScope(table: table)
 
         let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
         let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
-        let mockFileType = try #require(core.specRegistry.getSpec("file") as? FileTypeSpec)
+        let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: scope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/input"), fileType: mockFileType)])
         await touchSpec.constructTasks(cbc, delegate)
 
@@ -1836,7 +1836,7 @@ import SWBMacro
     @Test
     func symlinkTaskConstruction() async throws {
         let core = try await getCore()
-        let symlinkSpec = try #require(core.specRegistry.getSpec("com.apple.tools.symlink") as? SymlinkToolSpec)
+        let symlinkSpec = try core.specRegistry.getSpec("com.apple.tools.symlink", ofType: SymlinkToolSpec.self)
 
         let table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         let scope = MacroEvaluationScope(table: table)
@@ -1857,7 +1857,7 @@ import SWBMacro
     @Test
     func mkdirTaskConstruction() async throws {
         let core = try await getCore()
-        let mkdirSpec = try #require(core.specRegistry.getSpec("com.apple.tools.mkdir") as? MkdirToolSpec)
+        let mkdirSpec = try core.specRegistry.getSpec("com.apple.tools.mkdir", ofType: MkdirToolSpec.self)
 
         let table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         let scope = MacroEvaluationScope(table: table)
@@ -1882,7 +1882,7 @@ import SWBMacro
             // any spec is fine, we're testing the lookup function
             let delegate = TestingCoreDelegate()
             let core = try await Self.makeCore(simulatedInferiorProductsPath: nil, delegate)
-            let spec: CommandLineToolSpec = try core.specRegistry.getSpec("com.apple.tools.touch")
+            let spec = try core.specRegistry.getSpec("com.apple.tools.touch", ofType: CommandLineToolSpec.self)
 
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let namespace = BuiltinMacros.namespace
@@ -1891,7 +1891,7 @@ import SWBMacro
                 table.push(macro, namespace.parseLiteralString(Path.root.join("tmp").str))
             }
             let scope = MacroEvaluationScope(table: table)
-            let mockFileType = try #require(core.specRegistry.getSpec("file") as? FileTypeSpec)
+            let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
             let cbc = CommandBuildContext(producer: producer, scope: scope, inputs: (0..<numberOfInputs).map({ FileToBuild(absolutePath: Path.root.join("tmp/file\($0 + 1).c"), fileType: mockFileType) }), output: output ? Path.root.join("tmp/output.c") : nil)
             #expect(spec.lookup(macro, cbc, core.delegate)?.asLiteralString == expectation)
 
@@ -1953,8 +1953,8 @@ import SWBMacro
     @Test
     func clangDepscanPrefixMap() async throws {
         let core = try await getCore()
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CommandLineToolSpec
-        let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp") as FileTypeSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CommandLineToolSpec.self)
+        let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp", ofType: FileTypeSpec.self)
         let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
@@ -2006,9 +2006,9 @@ import SWBMacro
     @Test
     func swiftCachingPrefixMap() async throws {
         let core = try await getCore()
-        let swiftSpec = try core.specRegistry.getSpec("com.apple.xcode.tools.swift.compiler") as CompilerSpec
+        let swiftSpec = try core.specRegistry.getSpec("com.apple.xcode.tools.swift.compiler", ofType: CompilerSpec.self)
 
-        let mockFileType = try core.specRegistry.getSpec("sourcecode.swift") as FileTypeSpec
+        let mockFileType = try core.specRegistry.getSpec("sourcecode.swift", ofType: FileTypeSpec.self)
         let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
@@ -2227,7 +2227,7 @@ import SWBMacro
 
             do {
                 // Get the tool spec.
-                let thingSpec = try core.specRegistry.getSpec(ThingToolSpec.identifier) as ThingToolSpec
+                let thingSpec = try core.specRegistry.getSpec(ThingToolSpec.identifier, ofType: ThingToolSpec.self)
 
                 // Create a table with the unioned tool defaults, and any other values we want to add.
                 var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -2238,7 +2238,7 @@ import SWBMacro
                 let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
                 let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
                 let mockScope = MacroEvaluationScope(table: table)
-                let mockFileType = try core.specRegistry.getSpec("file.thing") as FileTypeSpec
+                let mockFileType = try core.specRegistry.getSpec("file.thing", ofType: FileTypeSpec.self)
                 let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/file.thing"), fileType: mockFileType)], output: Path.root.join("tmp/dst/file.something"), resourcesDir: Path.root.join("tmp/dst"), unlocalizedResourcesDir: Path.root.join("tmp/dst"))
                 await thingSpec.constructTasks(cbc, delegate)
 
@@ -2272,7 +2272,7 @@ import SWBMacro
 
             do {
                 // Get the tool spec.
-                let thingSpec = try core.specRegistry.getSpec(ThingToolSpec.identifier) as ThingToolSpec
+                let thingSpec = try core.specRegistry.getSpec(ThingToolSpec.identifier, ofType: ThingToolSpec.self)
 
                 // Create a table with the unioned tool defaults, and any other values we want to add.
                 var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -2283,7 +2283,7 @@ import SWBMacro
                 let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
                 let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
                 let mockScope = MacroEvaluationScope(table: table)
-                let mockFileType = try core.specRegistry.getSpec("file.thing") as FileTypeSpec
+                let mockFileType = try core.specRegistry.getSpec("file.thing", ofType: FileTypeSpec.self)
                 let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/file.thing"), fileType: mockFileType, regionVariantName: "en")], output: Path.root.join("tmp/dst/file.something"), resourcesDir: Path.root.join("tmp/dst/en.lproj"), unlocalizedResourcesDir: Path.root.join("tmp/dst"))
                 await thingSpec.constructTasks(cbc, delegate)
 

--- a/Tests/SWBCoreTests/FileToBuildTests.swift
+++ b/Tests/SWBCoreTests/FileToBuildTests.swift
@@ -20,7 +20,7 @@ import SWBCore
     /// Tests the basic FileToBuild functionality.
     @Test
     func basics() async throws {
-        let mockFileType = try await getCore().specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try await getCore().specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let f = FileToBuild(absolutePath: Path.root.join("tmp/foo"), fileType: mockFileType)
         #expect(f.absolutePath == Path.root.join("tmp/foo"))
     }
@@ -30,7 +30,7 @@ import SWBCore
     /// Tests the basic FileToBuildGroup functionality.
     @Test
     func basics() async throws {
-        let mockFileType = try await getCore().specRegistry.getSpec("file") as FileTypeSpec
+        let mockFileType = try await getCore().specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let f1 = FileToBuild(absolutePath: Path.root.join("tmp").join("foo"), fileType: mockFileType)
         #expect(f1.absolutePath == Path.root.join("tmp").join("foo"))
         let f2 = FileToBuild(absolutePath: Path.root.join("tmp").join("bar"), fileType: mockFileType)

--- a/Tests/SWBCoreTests/SDKRegistryTests.swift
+++ b/Tests/SWBCoreTests/SDKRegistryTests.swift
@@ -564,7 +564,7 @@ import SWBMacro
                 }
 
                 let toastVariant = try #require(toastSDK.variants["toastos"])
-                let toastAppSpec: ProductTypeSpec = try core.specRegistry.getSpec("com.apple.product-type.application", domain: "embedded")
+                let toastAppSpec: ProductTypeSpec = try core.specRegistry.getSpec("com.apple.product-type.application", domain: "embedded", ofType: ProductTypeSpec.self)
 
                 table.push(BuiltinMacros.TARGETED_DEVICE_FAMILY, literal: "1,2")
                 scope = MacroEvaluationScope(table: table)
@@ -596,7 +596,7 @@ import SWBMacro
                 #expect(effectiveIds == Set([7]))
 
                 let iosmacVariant = try #require(macosBorkSDK.variants["iosmac"])
-                let macAppSpec: ProductTypeSpec = try core.specRegistry.getSpec("com.apple.product-type.application", domain: "macosx")
+                let macAppSpec: ProductTypeSpec = try core.specRegistry.getSpec("com.apple.product-type.application", domain: "macosx", ofType: ProductTypeSpec.self)
 
                 table.remove(BuiltinMacros.TARGETED_DEVICE_FAMILY)
                 scope = MacroEvaluationScope(table: table)

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -126,7 +126,7 @@ import SWBMacro
     func archSpecLoading() async throws {
         let core = try await getCore()
         // Validate that we can load an arch spec properly.
-        let standardArchs = try core.specRegistry.getSpec("Standard", domain: "macosx") as ArchitectureSpec
+        let standardArchs = try core.specRegistry.getSpec("Standard", domain: "macosx", ofType: ArchitectureSpec.self)
         #expect(standardArchs.archSetting?.name == "ARCHS_STANDARD")
         #expect(standardArchs.realArchs?.stringRep == "arm64 x86_64")
     }
@@ -147,7 +147,7 @@ import SWBMacro
         for spec in core.specRegistry.findSpecs(ProductTypeSpec.self, domain: domain) {
             func check<T>(identifier: String, is: T.Type, sourceLocation: SourceLocation = #_sourceLocation) {
                 #expect(throws: Never.self) {
-                    try core.specRegistry.getSpec(identifier, domain: domain) as ProductTypeSpec
+                    try core.specRegistry.getSpec(identifier, domain: domain, ofType: ProductTypeSpec.self)
                 }
                 if spec.conformsTo(identifier: identifier) {
                     #expect(spec is T, "\(spec) is not an instance of \(T.self)", sourceLocation: sourceLocation)
@@ -854,7 +854,7 @@ import SWBMacro
     /// Validate that we can load a known command line spec properly.
     @Test
     func commandLineSpecLoading() async throws {
-        let infoPlistUtilSpec = try await getCore().specRegistry.getSpec("com.apple.tools.info-plist-utility") as CommandLineToolSpec
+        let infoPlistUtilSpec = try await getCore().specRegistry.getSpec("com.apple.tools.info-plist-utility", ofType: CommandLineToolSpec.self)
         #expect(infoPlistUtilSpec.execDescription!.stringRep.hasPrefix("Process"))
 
         // Check diagnostics using synthetic data.
@@ -896,7 +896,7 @@ import SWBMacro
     @Test
     func environmentVariableConsistentOrdering() async throws {
         let core = try await getCore()
-        let migSpec: CompilerSpec = try core.specRegistry.getSpec("com.apple.compilers.mig") as CompilerSpec
+        let migSpec: CompilerSpec = try core.specRegistry.getSpec("com.apple.compilers.mig", domain: "macosx", ofType: CompilerSpec.self)
         #expect(migSpec.environmentVariables?.map({ $0.0 }) == ["DEVELOPER_DIR", "SDKROOT", "TOOLCHAINS"])
     }
 
@@ -906,19 +906,19 @@ import SWBMacro
         let core = try await getCore()
 
         // Validate that we can load a compiler spec properly.
-        let clangCompilerSpec: CompilerSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0.compiler") as ClangCompilerSpec
+        let clangCompilerSpec: CompilerSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0.compiler", ofType: ClangCompilerSpec.self)
 
         // Validate that non-custom implementations get the custom subclass.
-        #expect(core.specRegistry.getSpec("com.apple.build-tasks.copy-png-file")! is GenericCompilerSpec)
+        #expect(core.specRegistry.getSpec("com.apple.build-tasks.copy-png-file", domain: "macosx")! is GenericCompilerSpec)
 
         // Validate that we properly fetch the Class field from the base spec.
-        let analyzerSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0.analyzer") as CompilerSpec
+        let analyzerSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0.analyzer", ofType: CompilerSpec.self)
         #expect(analyzerSpec is ClangCompilerSpec)
         let analyzerSpecIPhone = try #require(core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0.analyzer", domain: "iphoneos"))
         #expect(analyzerSpecIPhone is ClangCompilerSpec)
 
         // Validate that we parse other properties from the base spec.
-        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0") as CompilerSpec
+        let clangSpec = try core.specRegistry.getSpec("com.apple.compilers.llvm.clang.1_0", ofType: CompilerSpec.self)
         #expect(clangSpec.execDescription == clangCompilerSpec.execDescription)
 
         // Validate overridden class loading.
@@ -926,7 +926,7 @@ import SWBMacro
         #expect(codesignSpec is CodesignToolSpec)
 
         // Validate loading of supported language versions
-        let swiftCompilerSpec = try core.specRegistry.getSpec() as SwiftCompilerSpec
+        let swiftCompilerSpec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
         #expect(swiftCompilerSpec.supportedLanguageVersions == [ Version(4,0), Version(4,2), Version(5,0), Version(6, 0)])
     }
 
@@ -994,7 +994,7 @@ import SWBMacro
     /// Validate that we can load a linker spec properly.
     @Test
     func linkerSpecLoading() async throws {
-        try #require(try await (getCore().specRegistry.getSpec() as LdLinkerSpec).execDescription?.stringRep.hasPrefix("Link") == true)
+        try #require(try await (getCore().specRegistry.getSpec(ofType: LdLinkerSpec.self)).execDescription?.stringRep.hasPrefix("Link") == true)
     }
 
     /// Validate there are no cases of domain inversion.

--- a/Tests/SWBCoreTests/SwiftCompilerTests.swift
+++ b/Tests/SWBCoreTests/SwiftCompilerTests.swift
@@ -126,7 +126,7 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
             return localFS.exists(stdlibPath) ? [["-L\(stdlibPath.str)"], ["-L/usr/lib/swift"]] : [["-L/usr/lib/swift"]]
         }
 
-        let spec = try core.specRegistry.getSpec() as SwiftCompilerSpec
+        let spec = try core.specRegistry.getSpec(ofType: SwiftCompilerSpec.self)
 
         let defaultToolchain = try #require(core.toolchainRegistry.defaultToolchain)
         let swiftcPath = defaultToolchain.path.join("usr/bin/swiftc")

--- a/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
@@ -41,7 +41,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         // Look up the product type.
         var productType: ProductTypeSpec? = nil
         if let productTypeId {
-            productType = try core.specRegistry.getSpec(productTypeId, domain: platformName) as ProductTypeSpec
+            productType = try core.specRegistry.getSpec(productTypeId, domain: platformName, ofType: ProductTypeSpec.self)
         }
 
         // Create the task action.
@@ -1152,7 +1152,7 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
             }
             let productTypeSpec: ProductTypeSpec?
             do {
-                productTypeSpec = try productType.map { try core.specRegistry.getSpec($0, domain: platformName) as ProductTypeSpec }
+                productTypeSpec = try productType.map { try core.specRegistry.getSpec($0, domain: platformName, ofType: ProductTypeSpec.self) }
             } catch {
                 Issue.record("\(error)")
                 return


### PR DESCRIPTION
This ensures we don't attempt to apply them when targeting a non-Apple platform.

Closes https://github.com/swiftlang/swift-package-manager/issues/9423