### PR TITLE
Mock out time itself in the elapsed timer and rate limiter tests

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -683,7 +683,7 @@ private struct GetIndexingHeaderInfoMsg: MessageHandler {
 }
 
 extension MessageHandler {
-    fileprivate func handleIndexingInfoRequest<T: IndexingInfoRequest>(serializationQueue: ActorLock, request: Request, message: T, _ transformResponse: @escaping @Sendable (T, WorkspaceContext, BuildRequest, BuildRequestContext, BuildDescription, ConfiguredTarget, ElapsedTimer) -> any SWBProtocol.Message) async throws -> VoidResponse {
+    fileprivate func handleIndexingInfoRequest<T: IndexingInfoRequest>(serializationQueue: ActorLock, request: Request, message: T, _ transformResponse: @escaping @Sendable (T, WorkspaceContext, BuildRequest, BuildRequestContext, BuildDescription, ConfiguredTarget, ElapsedTimer<ContinuousClock>) -> any SWBProtocol.Message) async throws -> VoidResponse {
         let elapsedTimer = ElapsedTimer()
 
         // FIXME: Move this to use ActiveBuild.

--- a/Sources/SWBTestSupport/MockClock.swift
+++ b/Sources/SWBTestSupport/MockClock.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SWBUtil
+import Synchronization
+
+/// A mock clock whose current time is controllable.
+public struct MockClock: Clock {
+    public typealias Instant = ContinuousClock.Instant
+
+    private final class State: Sendable {
+        let now: SWBMutex<Instant>
+
+        init(now: Instant) {
+            self.now = .init(now)
+        }
+    }
+
+    private let state: State
+
+    public init(now: Instant = .now) {
+        self.state = .init(now: now)
+    }
+
+    public var now: Instant {
+        state.now.withLock({ $0 })
+    }
+
+    public var minimumResolution: Duration {
+        ContinuousClock.continuous.minimumResolution
+    }
+
+    public func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        state.now.withLock { now in
+            if now < deadline {
+                now = deadline
+            }
+        }
+    }
+}

--- a/Tests/SWBUtilTests/ElapsedTimerTests.swift
+++ b/Tests/SWBUtilTests/ElapsedTimerTests.swift
@@ -19,16 +19,18 @@ import SWBTestSupport
     @Test(.skipHostOS(.freebsd, "Currently hangs on FreeBSD"))
     func time() async throws {
         do {
-            let delta = try await ElapsedTimer.measure {
-                try await Task.sleep(for: .microseconds(1000))
+            let clock = MockClock()
+            let delta = try await ElapsedTimer.measure(clock: clock) {
+                try await clock.sleep(for: .microseconds(1001))
                 return ()
             }
             #expect(delta.seconds > 1.0 / 1000.0)
         }
 
         do {
-            let (delta, result) = try await ElapsedTimer.measure { () -> Int in
-                try await Task.sleep(for: .microseconds(1000))
+            let clock = MockClock()
+            let (delta, result) = try await ElapsedTimer.measure(clock: clock) { () -> Int in
+                try await clock.sleep(for: .microseconds(1001))
                 return 22
             }
             #expect(delta.seconds > 1.0 / 1000.0)

--- a/Tests/SWBUtilTests/RateLimiterTests.swift
+++ b/Tests/SWBUtilTests/RateLimiterTests.swift
@@ -19,8 +19,9 @@ import SWBTestSupport
 fileprivate struct RateLimiterTests {
     @Test
     func rateLimiterSeconds() async throws {
-        let timer = ElapsedTimer()
-        var limiter = RateLimiter(interval: .seconds(1))
+        let clock = MockClock()
+        let timer = ElapsedTimer(clock: clock)
+        var limiter = RateLimiter(interval: .seconds(1), clock: clock)
         #expect(limiter.interval == .nanoseconds(1_000_000_000))
 
         var count = 0
@@ -28,7 +29,7 @@ fileprivate struct RateLimiterTests {
             if limiter.hasNextIntervalPassed() {
                 count += 1
             }
-            try await Task.sleep(for: .seconds(1))
+            try await clock.sleep(for: .seconds(1))
         }
 
         #expect(count > 1)
@@ -37,8 +38,9 @@ fileprivate struct RateLimiterTests {
 
     @Test
     func rateLimiterTwoSeconds() async throws {
-        let timer = ElapsedTimer()
-        var limiter = RateLimiter(interval: .seconds(2))
+        let clock = MockClock()
+        let timer = ElapsedTimer(clock: clock)
+        var limiter = RateLimiter(interval: .seconds(2), clock: clock)
         #expect(limiter.interval == .nanoseconds(2_000_000_000))
 
         var count = 0
@@ -46,7 +48,7 @@ fileprivate struct RateLimiterTests {
             if limiter.hasNextIntervalPassed() {
                 count += 1
             }
-            try await Task.sleep(for: .seconds(1))
+            try await clock.sleep(for: .seconds(1))
         }
 
         #expect(count > 0)
@@ -55,16 +57,17 @@ fileprivate struct RateLimiterTests {
 
     @Test
     func rateLimiterMilliseconds() async throws {
-        let timer = ElapsedTimer()
-        var limiter = RateLimiter(interval: .milliseconds(100))
+        let clock = MockClock()
+        let timer = ElapsedTimer(clock: clock)
+        var limiter = RateLimiter(interval: .milliseconds(100), clock: clock)
         #expect(limiter.interval == .nanoseconds(100_000_000))
 
         var count = 0
-        for _ in 0..<100 {
+        for _ in 0..<101 {
             if limiter.hasNextIntervalPassed() {
                 count += 1
             }
-            try await Task.sleep(for: .microseconds(2001))
+            try await clock.sleep(for: .microseconds(2001))
         }
 
         #expect(count > 1)
@@ -73,16 +76,17 @@ fileprivate struct RateLimiterTests {
 
     @Test
     func rateLimiterMicroseconds() async throws {
-        let timer = ElapsedTimer()
-        var limiter = RateLimiter(interval: .microseconds(100000))
+        let clock = MockClock()
+        let timer = ElapsedTimer(clock: clock)
+        var limiter = RateLimiter(interval: .microseconds(100000), clock: clock)
         #expect(limiter.interval == .nanoseconds(100_000_000))
 
         var count = 0
-        for _ in 0..<100 {
+        for _ in 0..<101 {
             if limiter.hasNextIntervalPassed() {
                 count += 1
             }
-            try await Task.sleep(for: .microseconds(1001))
+            try await clock.sleep(for: .microseconds(1001))
         }
 
         #expect(count > 0)
@@ -91,16 +95,17 @@ fileprivate struct RateLimiterTests {
 
     @Test
     func rateLimiterNanoseconds() async throws {
-        let timer = ElapsedTimer()
-        var limiter = RateLimiter(interval: .nanoseconds(100_000_000))
+        let clock = MockClock()
+        let timer = ElapsedTimer(clock: clock)
+        var limiter = RateLimiter(interval: .nanoseconds(100_000_000), clock: clock)
         #expect(limiter.interval == .nanoseconds(100_000_000))
 
         var count = 0
-        for _ in 0..<100 {
+        for _ in 0..<101 {
             if limiter.hasNextIntervalPassed() {
                 count += 1
             }
-            try await Task.sleep(for: .microseconds(1001))
+            try await clock.sleep(for: .microseconds(1001))
         }
 
         #expect(count > 0)
@@ -109,12 +114,13 @@ fileprivate struct RateLimiterTests {
 
     @Test
     func rateLimiterNoCrashNever() async throws {
-        var limiter = RateLimiter(interval: .nanoseconds(UInt64.max))
+        let clock = MockClock()
+        var limiter = RateLimiter(interval: .nanoseconds(UInt64.max), clock: clock)
 
         for _ in 0..<2 {
             let nextIntervalPassed = limiter.hasNextIntervalPassed()
             #expect(!nextIntervalPassed)
-            try await Task.sleep(for: .seconds(1))
+            try await clock.sleep(for: .seconds(1))
         }
     }
 }


### PR DESCRIPTION
These occasionally fail nondeterministically; remove the property which allows them to do so (timing).

This also fixes some "off by one" errors that relying on a mock clock revealed -- there was an implicit assumption that sleep() would take a bit more time than requested, and environments with extreme timing sensitivity sometimes failed to do so.