### PR TITLE
Ensure TARGET_TEMP_DIR values do not collide when package PIF targets differ only in case

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -220,6 +220,7 @@ public final class BuiltinMacros {
     public static let TARGET_BUILD_DIR = BuiltinMacros.declarePathMacro("TARGET_BUILD_DIR")
     public static let TARGET_BUILD_SUBPATH = BuiltinMacros.declarePathMacro("TARGET_BUILD_SUBPATH")
     public static let TARGET_NAME = BuiltinMacros.declareStringMacro("TARGET_NAME")
+    public static let TARGET_NAME_CASE_SENSITIVITY_DISCRIMINATOR = BuiltinMacros.declareStringMacro("TARGET_NAME_CASE_SENSITIVITY_DISCRIMINATOR")
     public static let TARGET_TEMP_DIR = BuiltinMacros.declarePathMacro("TARGET_TEMP_DIR")
     // FIXME: This macro should be deprecated.
     public static let TARGETNAME = BuiltinMacros.declareStringMacro("TARGETNAME")
@@ -2376,6 +2377,7 @@ public final class BuiltinMacros {
         TARGET_DEVICE_OS_VERSION,
         TARGET_DEVICE_PLATFORM_NAME,
         TARGET_NAME,
+        TARGET_NAME_CASE_SENSITIVITY_DISCRIMINATOR,
         TARGET_TEMP_DIR,
         TEMP_DIR,
         TEMP_FILES_DIR,

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -2987,7 +2987,7 @@ For more information on mergeable libraries, see [Configuring your project to us
             {
                 Name = "TARGET_TEMP_DIR";
                 Type = Path;
-                DefaultValue = "$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME).build";
+                DefaultValue = "$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME)$(TARGET_NAME_CASE_SENSITIVITY_DISCRIMINATOR).build";
                 Description = "Identifies the directory containing the target’s intermediate build files. Run Script build phases should place intermediate files at the location indicated by `DERIVED_FILE_DIR`, not the directory identified by this build setting.";
             },
             {


### PR DESCRIPTION
It turns out that SwiftPM will allow a package to have targets/products whose names only differ in case (and this is somewhat common in real packages), which could cause TARGET_TEMP_DIR collisions and build failures on case-insensitive filesystems like APFS on macOS. Introduce a TARGET_NAME_DISCRIMINANT which is used to differentiate these only when the collision exists.

Notably this isn't enough to solve the issue of colliding products in every case, but it's a necessary prerequisite.

Closes https://github.com/MobileNativeFoundation/XCLogParser.git