### PR TITLE
Exclude C/C++-only targets from resource bundle accessor generation

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3855,6 +3855,20 @@ public extension BuildPhaseWithBuildFiles {
         }
         return containsFiles(ofType: swiftFileType, referenceLookupContext, specLookupContext, scope, filePathResolver)
     }
+
+    /// Checks if the build phase contains any ObjC/ObjC++ source files.
+    func containsObjCSources(_ referenceLookupContext: any ReferenceLookupContext, _ specLookupContext: any SpecLookupContext, _ scope: MacroEvaluationScope, _ filePathResolver: FilePathResolver) -> Bool {
+        let objCFileType = specLookupContext.lookupFileType(identifier: "sourcecode.c.objc")
+        let objCPlusPlusFileType = specLookupContext.lookupFileType(identifier: "sourcecode.cpp.objcpp")
+
+        for fileType in [objCFileType, objCPlusPlusFileType] {
+            guard let fileType else { continue }
+            if containsFiles(ofType: fileType, referenceLookupContext, specLookupContext, scope, filePathResolver) {
+                return true
+            }
+        }
+        return false
+    }
 }
 
 struct SwiftOutputFileMap: Codable {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1852,8 +1852,10 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         // we don't need to worry about targets with mixed languages.
         if buildPhase.containsSwiftSources(workspace, context, scope, context.filePathResolver) {
             return await generatePackageTargetBundleAccessorForSwift(scope, bundleName: bundleName)
-        } else {
+        } else if buildPhase.containsObjCSources(workspace, context, scope, context.filePathResolver) {
             return await generatePackageTargetBundleAccessorForObjC(scope, bundleName: bundleName)
+        } else {
+            return nil
         }
     }
 


### PR DESCRIPTION
Match the behavior of SwiftPM's build system, since only ObjC/ObjC++ compiles can parse the resource accessor header, and C/C++ targets may be compiling on a platform without an ObjC compiler/ObjC-compatible Foundation (Linux, Windows, etc.)