### PR TITLE
Provide LOCALIZED_STRING_CODE_COMMENTS build setting definition

### DIFF
--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3655,6 +3655,13 @@ When this setting is enabled:
                 Category = "Localization";
                 Description = "When enabled, literal strings in SwiftUI will be extracted during localization export. This will only extract string literals in `Text()` initializers, unless `SWIFT_EMIT_LOC_STRINGS` is also enabled.";
             },
+            {   Name = LOCALIZED_STRING_CODE_COMMENTS;
+                Type = Boolean;
+                DefaultValue = NO;
+                DisplayName = "Localized Strings in Code Comments";
+                Category = "Localization";
+                Description = "When enabled, localizable strings wrapped in NSLocalizedString and similar string macros will be extracted even if commented out or wrapped in `#if 0`.";
+            },
             {
                 Name = "STRINGSDATA_ROOT";
                 Type = Path;


### PR DESCRIPTION
Adding cousin setting to `LOCALIZED_STRING_MACRO_NAMES` and `LOCALIZED_STRING_SWIFTUI_SUPPORT` to specify whether extracting strings from code comments is desirable. By default it is not.

Like the similar settings, clients of SwiftBuild can use this to inform String Catalog sync and other localization behaviors.

The use case for setting this to YES is for projects that previously relied on this documented feature of `genstrings` in order to specify strings in a source file that would otherwise be dynamically constructed in code.