### PR TITLE
Expose DEPLOYMENT_POSTPROCESSING in ProjectModel.BuildSettings

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -29,6 +29,7 @@ extension ProjectModel {
             case COPY_PHASE_STRIP
             case DEBUG_INFORMATION_FORMAT
             case DEFINES_MODULE
+            case DEPLOYMENT_POSTPROCESSING
             case DRIVERKIT_DEPLOYMENT_TARGET
             case DYLIB_INSTALL_NAME_BASE
             case EMBEDDED_CONTENT_CONTAINS_SWIFT


### PR DESCRIPTION
When implementing setting get-task-allow entitlement in SwiftPM it was suggested to set `DEPLOYMENT_POSTPROCESSING` to `YES` for release builds.
Currently `ProjectModel.BuildSettings.SingleValueSetting` does have this case, so this PR is to add it.
See https://github.com/swiftlang/swift-package-manager/pull/9380/changes#r2531790083

swiftlang/swift-package-manager#9380


