### PR TITLE
SWBBuildServer: send target change notification when build description regenerates

### DIFF
--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -255,6 +255,7 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
                         throw ResponseError.unknown("Failed to get build description ID")
                     }
                     self.buildDescriptionID = SWBBuildDescriptionID(buildDescriptionID)
+                    self.connectionToClient.send(OnBuildTargetDidChangeNotification(changes: nil))
                 }
             } catch {
                 self.logToClient(.error, "Error generating build description: \(error)")

--- a/Tests/SwiftBuildTests/BuildServerTests.swift
+++ b/Tests/SwiftBuildTests/BuildServerTests.swift
@@ -177,7 +177,12 @@ fileprivate struct BuildServerTests: CoreBasedTests {
             }
 
             return (testWorkspace, request)
-        }) { connection, _, _ in
+        }) { connection, handler, _ in
+            #expect(handler.notifications.withLock { notifications in
+                notifications.contains { notification in
+                    notification is OnBuildTargetDidChangeNotification
+                }
+            })
             let targetsResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             let firstLibrary = try #require(targetsResponse.targets.filter { $0.displayName == "Target" }.only)
             let secondLibrary = try #require(targetsResponse.targets.filter { $0.displayName == "Target2" }.only)


### PR DESCRIPTION
This ensures clients can re-request the target list, since it will have been empty before the build description is computed