### PR TITLE
Use SWIFT_MODULE_NAME (defaults to PRODUCT_MODULE_NAME) as argument for appintentsmetadataprocessor for correctness

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
@@ -17,7 +17,7 @@
         Identifier = "com.apple.compilers.appintentsmetadata";
         Name = "App Intents Metadata Extractor";
         Description = "Extracts app intents metadata";
-        CommandLine = "appintentsmetadataprocessor --toolchain-dir $(TOOLCHAIN_DIR) --module-name $(PRODUCT_MODULE_NAME) --sdk-root $(SDKROOT) --xcode-version $(XCODE_PRODUCT_BUILD_VERSION) --platform-family $(PLATFORM_FAMILY_NAME) --deployment-target $($(DEPLOYMENT_TARGET_SETTING_NAME)) [options]";
+        CommandLine = "appintentsmetadataprocessor --toolchain-dir $(TOOLCHAIN_DIR) --module-name $(SWIFT_MODULE_NAME) --sdk-root $(SDKROOT) --xcode-version $(XCODE_PRODUCT_BUILD_VERSION) --platform-family $(PLATFORM_FAMILY_NAME) --deployment-target $($(DEPLOYMENT_TARGET_SETTING_NAME)) [options]";
         RuleName = "ExtractAppIntentsMetadata";
         ExecDescription = "Extract app intents metadata";
         ProgressDescription = "Extracting app intents metadata";


### PR DESCRIPTION
We are currently passing PRODUCT_MODULE_NAME to appintentsmetadataprocessor, but SWIFT_MODULE_NAME is more correct since the latter can override the former for things like type names and protocol conformances if set as a user defined build configuration.