### PR TITLE
Log instead of ignoring failures in preview info requests (rdar://165722419)

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -21,6 +21,11 @@ public import enum SWBProtocol.BuildAction
 import Foundation
 public import SWBMacro
 
+#if canImport(Darwin) && canImport(os.log)
+// For Previews logging
+import os.log
+#endif
+
 /// The minimal data we need to serialize to reconstruct `SwiftSourceFileIndexingInfo` from `generateIndexingInfoForTask`
 public struct SwiftIndexingPayload: Serializable, Sendable {
     // If `USE_SWIFT_RESPONSE_FILE` is enabled, we use `filePaths`, otherwise `range`.
@@ -3548,6 +3553,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     let overlay = try vfs.toVFSOverlay().propertyListItem.asJSONFragment().asString
                     try fs.write(newVFSOverlayPath!, contents: ByteString(encodingAsUTF8: overlay))
                 } catch {
+                    logErrorForPreviews("Failed to generate vfsoverlay for \(inputPath.basename), error: \(error)")
                     return []
                 }
             } else {
@@ -3628,11 +3634,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
             // The driver may have emitted an error even if it returned us a command line. In this case, don't return the command line since it likely won't work.
             if commandLine.isEmpty || outputDelegate.engine.hasErrors {
-                #if canImport(os)
+                logErrorForPreviews("Swift driver failed to compute command line for preview info.")
                 for diagnostic in outputDelegate.engine.diagnostics.filter({ $0.behavior == .error }) {
-                    OSLog.log("Swift driver preview info error: \(diagnostic.data.description)")
+                    logErrorForPreviews("Swift driver preview info error: \(diagnostic.data.description)")
                 }
-                #endif
                 return []
             }
         }
@@ -3958,4 +3963,15 @@ extension SwiftDiscoveredCommandLineToolSpecInfo {
         // Get the info from the global cache.
         return try await discoveredSwiftCompilerInfo(producer, delegate, at: toolPath, blocklistsPathOverride: userSpecifiedBlocklists)
     }
+}
+
+#if canImport(Darwin) && canImport(os.log)
+let previewsLogger = Logger(subsystem: "com.apple.dt.Previews", category: "swift-build")
+#endif
+
+private func logErrorForPreviews(_ message: @autoclosure () -> String) {
+#if canImport(Darwin) && canImport(os.log)
+    let resolved = message()
+    previewsLogger.error("\(resolved, privacy: .private)")
+#endif
 }


### PR DESCRIPTION
We'd like to rethink the preview info request types and payloads over time. But in the short term we need to get information about failed preview info requests in previews diagnostics we gather.
