### PR TITLE
Fix stack overflow in macro namespace lookups

### DIFF
--- a/Tests/SWBMacroTests/MacroBasicTests.swift
+++ b/Tests/SWBMacroTests/MacroBasicTests.swift
@@ -183,5 +183,32 @@ import SWBMacro
         let middleLookedupCondParam = middleNamespace.lookupConditionParameter("upper")
         #expect(middleLookedupCondParam == nil)
     }
+
+    @Test
+    func deepNamespaceHierarchy() throws {
+        let depth = 600
+        var namespaces: [MacroNamespace] = []
+
+        let root = MacroNamespace(debugDescription: "root")
+        let rootMacro = try root.declareStringMacro("ROOT_MACRO")
+        namespaces.append(root)
+
+        for i in 1..<depth {
+            let parent = namespaces[i - 1]
+            let child = MacroNamespace(parent: parent, debugDescription: "namespace_\(i)")
+            namespaces.append(child)
+        }
+
+        let deepest = namespaces[depth - 1]
+        let lookedUp = deepest.lookupMacroDeclaration("ROOT_MACRO")
+        #expect(lookedUp === rootMacro)
+
+        let nonExistent = deepest.lookupMacroDeclaration("NON_EXISTENT_MACRO")
+        #expect(nonExistent == nil)
+
+        let rootCondParam = root.declareConditionParameter("rootCond")
+        let lookedUpCondParam = deepest.lookupConditionParameter("rootCond")
+        #expect(lookedUpCondParam === rootCondParam)
+    }
 }
 


### PR DESCRIPTION
When building projects with many targets using the swiftbuild backend, the process crashes with a stack overflow. The teco project, which has 522 targets, is an example of this.

The `lookupMacroDeclaration` and `lookupConditionParameter` methods traverse parent namespaces recursively. With hundreds of nested namespaces, this blows the call stack.

This PR converts those recursive lookups to iterative ones using a while loop, which can handle any depth.

Fixes swiftlang/swift-package-manager#9270