### PR TITLE
Allow `QueueBasedMessageHandler.handle` to return `any Error` instead of `ResponseError`

### DIFF
--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -163,7 +163,7 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
     public func handle<Request: RequestType>(
         request: Request,
         id: RequestID,
-        reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+        reply: @Sendable @escaping (Result<Request.Response, any Error>) -> Void
     ) async {
         let request = RequestAndReply(request, reply: reply)
         if !(request.params is InitializeBuildRequest) {


### PR DESCRIPTION
Linked PR: swiftlang/swift-tools-protocols#33

Update for the API changed in https://github.com/swiftlang/swift-tools-protocols/pull/33.