### PR TITLE
Create a common static archive product-type for swiftPM to use

### DIFF
--- a/Sources/SWBApplePlatform/Specs/DarwinProductTypes.xcspec
+++ b/Sources/SWBApplePlatform/Specs/DarwinProductTypes.xcspec
@@ -474,15 +474,4 @@
             com.apple.package-type.mach-o-executable
         );
     },
-    {
-        _Domain = darwin;
-        Type = ProductType;
-        Identifier = org.swift.product-type.common.object;
-        BasedOn = com.apple.product-type.objfile;
-        Class = XCStandaloneExecutableProductType;
-        Description = "Object File";
-        IconNamePrefix = "TargetPlugin";
-        DefaultTargetName = "Object File";
-    },
-
 )

--- a/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
@@ -83,16 +83,6 @@
 
     {
         Domain = generic-unix;
-        Type = ProductType;
-        Identifier = org.swift.product-type.common.object;
-        BasedOn = com.apple.product-type.objfile;
-        Class = XCStandaloneExecutableProductType;
-        Description = "Object File";
-        IconNamePrefix = "TargetPlugin";
-        DefaultTargetName = "Object File";
-    },
-    {
-        Domain = generic-unix;
         Type = FileType;
         Identifier = compiled.mach-o.dylib;
         BasedOn = compiled.mach-o;

--- a/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
@@ -205,6 +205,23 @@
         );
     },
 
+    {
+        Type = ProductType;
+        Identifier = org.swift.product-type.common.object;
+        BasedOn = com.apple.product-type.objfile;
+        Name = "Mappable Common Object Type";
+        Description = "This type should be used as the top level product type for object files as it may map to different types on different platforms";
+    },
+
+    {
+        Type = ProductType;
+        Identifier = org.swift.product-type.library.static;
+        BasedOn = com.apple.product-type.objfile;
+        Name = "Mappable Common Static Library Type";
+        Description = "This type should be used as the top level product type for static libraries as it may map to different types on different platforms";
+    },
+
+
     //
     // Wrapper product types
     //

--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -116,6 +116,14 @@
 
     {
         Domain = windows;
+        Type = ProductType;
+        Identifier = org.swift.product-type.library.static;
+        BasedOn = com.apple.product-type.library.static;
+    },
+
+
+    {
+        Domain = windows;
         Type = FileType;
         Identifier = archive.ar;
         BasedOn = archive;

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -102,7 +102,7 @@
                 Name = __WINDOWS_STATIC_FLAG;
                 Type = Bool;
                 DefaultValue = YES;
-                Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.common.object'";
+                Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.common.object'";
                 CommandLineArgs = ("-static");
             }
         );

--- a/Sources/SwiftBuild/ProjectModel/Targets.swift
+++ b/Sources/SwiftBuild/ProjectModel/Targets.swift
@@ -310,6 +310,7 @@ extension ProjectModel {
         public enum ProductType: String, Sendable, Codable, CaseIterable {
             case application = "com.apple.product-type.application"
             case staticArchive = "com.apple.product-type.library.static"
+            case commonStaticArchive = "org.swift.product-type.library.static"
             case commonObject = "org.swift.product-type.common.object"
             case objectFile = "com.apple.product-type.objfile"
             case dynamicLibrary = "com.apple.product-type.library.dynamic"


### PR DESCRIPTION
The product-type that swiftPM uses for static archive and executable source modules are currently the same, which is set to the common object type, these need to be different on windows as we can't link test dlls with static archives currently, which is what the common object type maps to for windows. We need to create a new static archive type that can be mapped differently on windows vs other platforms. Then swiftPM can use the 2 different product types for a static archive and executable source module and these 2 types can be mapped them differently on each platform..
