### PR TITLE
Drop '-sdk /' from swiftc args when using the fallback sdk on generic unix platforms

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1014,6 +1014,7 @@ public final class BuiltinMacros {
     public static let PLATFORM_REQUIRES_SWIFT_MODULEWRAP = BuiltinMacros.declareBooleanMacro("PLATFORM_REQUIRES_SWIFT_MODULEWRAP")
     public static let RPATH_ORIGIN = BuiltinMacros.declareStringMacro("RPATH_ORIGIN")
     public static let PLATFORM_USES_DSYMS = BuiltinMacros.declareBooleanMacro("PLATFORM_USES_DSYMS")
+    public static let SWIFTC_PASS_SDKROOT = BuiltinMacros.declareBooleanMacro("SWIFTC_PASS_SDKROOT")
     public static let SWIFT_ABI_CHECKER_BASELINE_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_BASELINE_DIR")
     public static let SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS = BuiltinMacros.declareBooleanMacro("SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS")
     public static let SWIFT_ABI_CHECKER_EXCEPTIONS_FILE = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_EXCEPTIONS_FILE")
@@ -2230,6 +2231,7 @@ public final class BuiltinMacros {
         PLATFORM_REQUIRES_SWIFT_MODULEWRAP,
         RPATH_ORIGIN,
         PLATFORM_USES_DSYMS,
+        SWIFTC_PASS_SDKROOT,
         SWIFT_ABI_CHECKER_BASELINE_DIR,
         SWIFT_ABI_CHECKER_DOWNGRADE_ERRORS,
         SWIFT_ABI_CHECKER_EXCEPTIONS_FILE,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2240,7 +2240,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             var environment: [(String, String)] = environmentFromSpec(cbc, delegate)
             environment.append(("DEVELOPER_DIR", cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR).str))
             let sdkroot = cbc.scope.evaluate(BuiltinMacros.SDKROOT)
-            if !sdkroot.isEmpty {
+            if !sdkroot.isEmpty && cbc.scope.evaluate(BuiltinMacros.SWIFTC_PASS_SDKROOT) {
                 environment.append(("SDKROOT", sdkroot.str))
             }
             let toolchains = cbc.scope.evaluateAsString(BuiltinMacros.TOOLCHAINS)

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -164,7 +164,9 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
                 sysroot = .root
                 architectures = [Architecture.hostStringValue ?? "unknown"]
                 tripleVersion = nil
-                customProperties = [:]
+                customProperties = [
+                    "SWIFTC_PASS_SDKROOT": "NO",
+                ]
             } else {
                 do {
                     let swiftSDKs = try SwiftSDK.findSDKs(

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -918,11 +918,16 @@
                     NO  = ();
                 };
             },
-
+            {
+                Name = SWIFTC_PASS_SDKROOT;
+                Type = Boolean;
+                DefaultValue = YES;
+            },
             {
                 Name = SDKROOT;
                 Type = Path;
                 CommandLineFlag = "-sdk";
+                Condition = "$(SWIFTC_PASS_SDKROOT)";
             },
             {
                 Name = "SWIFT_DEPLOYMENT_TARGET";

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -23,6 +23,8 @@ import SWBCore
 import SWBMacro
 import SWBTaskExecution
 
+import Foundation
+
 @Suite
 fileprivate struct SwiftDriverTests: CoreBasedTests {
     @Test(.requireSDKs(.host))
@@ -146,14 +148,16 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                         compileTask.checkCommandLineMatches([.anySequence, "-primary-file", .anySequence, .equal(SRCROOT.join("Sources/\(fileName).swift").str), .anySequence, "-o", .suffix("\(fileName).o")])
                         let env = compileTask.environment.bindingsDictionary
                         #expect(env["DEVELOPER_DIR"] != nil)
-                        #expect(env["SDKROOT"] != nil)
+                        if ![.linux, .freebsd, .openbsd].contains(try ProcessInfo.processInfo.hostOperatingSystem()) {
+                            #expect(env["SDKROOT"] != nil)
+                        }
 
                         try results.checkTaskFollows(linkTask, compileTask)
                     }
                 }
 
                 // Swift Driver changed default behavior from merging modules after compilation to eagerly emitting the module, both are valid here.
-                results.checkTask(.matchTargetName("TargetA"), .matchRulePattern([.or("SwiftMergeModule", "SwiftEmitModule"), "normal", .any, .or("Merging module TargetA", "Emitting module for TargetA")])) { task in
+                try results.checkTask(.matchTargetName("TargetA"), .matchRulePattern([.or("SwiftMergeModule", "SwiftEmitModule"), "normal", .any, .or("Merging module TargetA", "Emitting module for TargetA")])) { task in
                     if task.ruleIdentifier == "SwiftMergeModule" {
                         task.checkCommandLineMatches([.anySequence, "-merge-modules", .anySequence, .suffix("file1~partial.swiftmodule"), .suffix("file2~partial.swiftmodule"), .anySequence, "-o", .suffix("TargetA.swiftmodule")])
                     } else {
@@ -161,7 +165,9 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                     }
                     let env = task.environment.bindingsDictionary
                     #expect(env["DEVELOPER_DIR"] != nil)
-                    #expect(env["SDKROOT"] != nil)
+                    if ![.linux, .freebsd, .openbsd].contains(try ProcessInfo.processInfo.hostOperatingSystem()) {
+                        #expect(env["SDKROOT"] != nil)
+                    }
                 }
 
                 for fileName in ["file3", "file4"] {


### PR DESCRIPTION
This fixes a couple miscellaneous issues:
- All headers/modules under / are no longer treated as system content, which is especially important because this usually includes the build directory itself
- Fixes issues with duplicate includes when C++ interop is enabled