### PR TITLE
Fill out platformName extension point for other platforms

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -109,6 +109,14 @@ struct AndroidPlatformExtension: PlatformInfoExtension {
             ])
         ]
     }
+
+    func platformName(triple: LLVMTriple) -> String? {
+        if triple.system == "linux" && triple.environment?.hasPrefix("android") == true {
+            return "android"
+        }
+
+        return nil
+    }
 }
 
 @_spi(Testing) public struct AndroidSDKRegistryExtension: SDKRegistryExtension {

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -92,6 +92,17 @@ struct GenericUnixPlatformInfoExtension: PlatformInfoExtension {
             ])
         }
     }
+
+    func platformName(triple: LLVMTriple) -> String? {
+        switch triple.system {
+        case "linux" where triple.environment?.hasPrefix("gnu") == true || triple.environment == "musl",
+            "freebsd",
+            "openbsd":
+            return triple.system
+        default:
+            return nil
+        }
+    }
 }
 
 struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {

--- a/Sources/SWBQNXPlatform/Plugin.swift
+++ b/Sources/SWBQNXPlatform/Plugin.swift
@@ -66,6 +66,14 @@ struct QNXPlatformExtension: PlatformInfoExtension {
             ])
         ]
     }
+
+    func platformName(triple: LLVMTriple) -> String? {
+        if triple.system == "nto" {
+            return "qnx"
+        }
+
+        return nil
+    }
 }
 
 struct QNXSDKRegistryExtension: SDKRegistryExtension {

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -148,6 +148,14 @@ struct WindowsPlatformExtension: PlatformInfoExtension {
             return []
         }
     }
+
+    public func platformName(triple: LLVMTriple) -> String? {
+        if triple.system == "windows" {
+            return triple.system
+        }
+
+        return nil
+    }
 }
 
 struct WindowsSDKRegistryExtension: SDKRegistryExtension {


### PR DESCRIPTION
Inert until used, but gets it into place. Android, Linux, and FreeBSD in particular are relevant to begin testing with since all of those are Swift SDK based or have Swift SDK variations.

Based on my comments in https://github.com/swiftlang/swift-build/pull/966#discussion_r2615924274.