### PR TITLE
Configure Clang Importer search paths when running the API digester

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABICheckerTool.swift
@@ -101,10 +101,7 @@ public final class SwiftABICheckerToolSpec : GenericCommandLineToolSpec, SpecIde
             commandLine += ["-disable-fail-on-error"]
         }
         let allInputs = cbc.inputs.map { delegate.createNode($0.absolutePath) } + [baselinePath, allowlistPath].compactMap { $0 }.map { delegate.createNode($0.normalize()) }
-        // Add import search paths
-        for searchPath in SwiftCompilerSpec.collectInputSearchPaths(cbc, toolInfo: toolSpecInfo) {
-            commandLine += ["-I", searchPath]
-        }
+        commandLine.append(contentsOf: computeSharedAPIDigesterFlags(cbc: cbc, toolSpecInfo: toolSpecInfo))
         delegate.createTask(type: self,
                             payload: ABICheckerPayload(
                                 serializedDiagnosticsPath: serializedDiagsPath,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1093,6 +1093,7 @@ public struct DiscoveredSwiftCompilerToolSpecInfo: DiscoveredCommandLineToolSpec
         case emitPackageModuleInterfacePath = "emit-package-module-interface-path"
         case compilationCaching = "compilation-caching"
         case Isystem = "Isystem"
+        case apiDigesterXcc = "api-digester-Xcc"
     }
     public var toolFeatures: ToolFeatures<FeatureFlag>
     public func hasFeature(_ flag: String) -> Bool {


### PR DESCRIPTION
When using a version of the digester which supports -Xcc, pass it search paths, preprocessor definitions, module maps, etc. This ensures that it can correctly load clang module dependencies of the module being processed.