### PR TITLE
Add dependency graph analysis to apply -static more correctly to swift compilations targeting Windows

### DIFF
--- a/Sources/SWBCore/LinkageDependencyResolver.swift
+++ b/Sources/SWBCore/LinkageDependencyResolver.swift
@@ -126,13 +126,9 @@ actor LinkageDependencyResolver {
             }
         }
 
-        var allTargets = OrderedSet<ConfiguredTarget>()
-        for (target, dependencies) in dependenciesPerTarget {
-            allTargets.insert(target, at: 0)
-            for dependency in dependencies {
-                allTargets.insert(dependency.target, at: 0)
-            }
-        }
+        let allTargets = OrderedSet(topologicalSort(Array(dependenciesPerTarget.keys), successors: { vertex in
+            return dependenciesPerTarget[vertex]?.map { dependency in dependency.target } ?? []
+        }))
 
         return (allTargets, dependenciesPerTarget)
     }

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1883,6 +1883,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // Instruct the compiler to serialize diagnostics.
             args.append("-serialize-diagnostics")
 
+            if cbc.producer.swiftModuleShouldCompileForStaticLinking {
+                args.append("-static")
+            }
+
             if await shouldEmitMakeStyleDependencies(cbc.producer, cbc.scope, delegate: delegate) {
                 // Instruct the compiler to emit dependencies information.
                 args.append("-emit-dependencies")

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -251,6 +251,8 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     /// Swift macro implementation descriptors to be applied to this target.
     var swiftMacroImplementationDescriptors: Set<SwiftMacroImplementationDescriptor>? { get }
 
+    var swiftModuleShouldCompileForStaticLinking: Bool { get }
+
     func supportsEagerLinking(scope: MacroEvaluationScope) -> Bool
 
     /// Returns information on the headers referenced by an individual project, identified by one of the targets in that project.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1356,6 +1356,11 @@ extension TaskProducerContext: CommandProducer {
         configuredTarget.flatMap { globalProductPlan.swiftMacroImplementationDescriptorsByTarget[$0] }
     }
 
+    public var swiftModuleShouldCompileForStaticLinking: Bool {
+        guard let configuredTarget else { return false }
+        return globalProductPlan.targetsWhichShouldCompileSwiftModulesForStaticLinking.contains(configuredTarget)
+    }
+
     /// Returns true if eager linking is supported in this context and scope. The eager linking optimization is only permitted if certain criteria are met.
     public func supportsEagerLinking(scope: MacroEvaluationScope) -> Bool {
         let buildComponents = scope.evaluate(BuiltinMacros.BUILD_COMPONENTS)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -259,4 +259,8 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package func matchesAnyProjectIdentities(scope: SWBMacro.MacroEvaluationScope, projectIdentities: Set<String>) -> Bool {
         false
     }
+
+    package var swiftModuleShouldCompileForStaticLinking: Bool {
+        false
+    }
 }

--- a/Sources/SWBUtil/GraphAlgorithms.swift
+++ b/Sources/SWBUtil/GraphAlgorithms.swift
@@ -101,3 +101,36 @@ public func transitiveClosure<T>(
 
     return (result, dupes)
 }
+
+public func topologicalSort<T: Hashable>(_ vertices: [T], successors: (T) throws -> [T]) rethrows -> [T] {
+    var degreeByVertex: [T: UInt] = Dictionary(uniqueKeysWithValues: vertices.map { ($0, 0) })
+    for vertex in vertices {
+        for successor in try successors(vertex) {
+            degreeByVertex[successor, default: 0] += 1
+        }
+    }
+
+    var queue: [T] = []
+    for (vertex, degree) in degreeByVertex {
+        if degree == 0 {
+            queue.append(vertex)
+        }
+    }
+
+    var result: [T] = []
+    while !queue.isEmpty {
+        let currentVertex = queue.removeFirst()
+        result.append(currentVertex)
+        for successor in try successors(currentVertex) {
+            guard let currentDegree = degreeByVertex[successor] else {
+                fatalError("programmer error: encountered inconsistent state during topological sort")
+            }
+            if currentDegree == 1 {
+                queue.append(successor)
+            }
+            degreeByVertex[successor] = currentDegree - 1
+        }
+    }
+
+    return result
+}

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -98,13 +98,7 @@
             "PATH" = "$(TOOLCHAIN_DIR)/usr/bin;$(DEVELOPER_DIR)/Runtimes/$(TOOLCHAIN_VERSION)/usr/bin;$(PATH)";
         };
         Options = (
-            {
-                Name = __WINDOWS_STATIC_FLAG;
-                Type = Bool;
-                DefaultValue = YES;
-                Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.common.object'";
-                CommandLineArgs = ("-static");
-            }
+
         );
     },
 )

--- a/Tests/SWBTaskConstructionTests/CustomTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CustomTaskConstructionTests.swift
@@ -33,6 +33,7 @@ fileprivate struct CustomTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                     ]),
             ],
@@ -86,6 +87,7 @@ fileprivate struct CustomTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                     ]),
             ],
@@ -146,6 +148,7 @@ fileprivate struct CustomTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                     ]),
             ],
@@ -196,6 +199,7 @@ fileprivate struct CustomTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                         "MY_SETTING": "FOO",
                     ]),
@@ -246,6 +250,7 @@ fileprivate struct CustomTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                     ]),
             ],

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4660,6 +4660,175 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.windows))
+    func swiftStaticLinkingOnWindows() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("file.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "Executable",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                            TestFrameworksBuildPhase(["libDynamic1.dll", "libStatic1.a"]),
+                        ],
+                        dependencies: ["Dynamic1", "Static1"]
+                    ),
+                    TestStandardTarget(
+                        "Dynamic1",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                            TestFrameworksBuildPhase(["libStatic2.a"]),
+                        ],
+                        dependencies: ["Static2"]
+                    ),
+                    TestStandardTarget(
+                        "Static1",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "LIBTOOL": libtoolPath.str,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                            TestFrameworksBuildPhase(["libStatic4.a"]),
+                        ],
+                        dependencies: ["Static4"]
+                    ),
+
+                    TestStandardTarget(
+                        "Static2",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "LIBTOOL": libtoolPath.str,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                            TestFrameworksBuildPhase(["libStatic3.a"]),
+                        ],
+                        dependencies: ["Static3"]
+                    ),
+
+                    TestStandardTarget(
+                        "Static3",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "LIBTOOL": libtoolPath.str,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                        ]
+                    ),
+
+                    TestStandardTarget(
+                        "Static4",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "LIBTOOL": libtoolPath.str,
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                        ]
+                    ),
+                ])
+
+            let core = try await getCore()
+            let tester = try TaskConstructionTester(core, testProject)
+            await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .host) { results in
+                results.checkTarget("Executable") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineContains(["-static"])
+                    }
+                }
+
+                results.checkTarget("Dynamic1") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineDoesNotContain("-static")
+                    }
+                }
+
+                results.checkTarget("Static1") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineContains(["-static"])
+                    }
+                }
+
+                results.checkTarget("Static2") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineDoesNotContain("-static")
+                    }
+                }
+
+                results.checkTarget("Static3") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineDoesNotContain("-static")
+                    }
+                }
+
+                results.checkTarget("Static4") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { compileTask in
+                        compileTask.checkCommandLineContains(["-static"])
+                    }
+                }
+            }
+        }
+    }
 }
 
 private func XCTAssertEqual(_ lhs: EnvironmentBindings, _ rhs: [String: String], file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -317,6 +317,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     buildSettings: [
                         "CODE_SIGN_IDENTITY": "",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
                         "SDKROOT": "auto",
                         "SWIFT_VERSION": swiftVersion,
                         "INDEX_DATA_STORE_DIR": "/index",

--- a/Tests/SWBUtilTests/GraphAlgorithmsTests.swift
+++ b/Tests/SWBUtilTests/GraphAlgorithmsTests.swift
@@ -77,6 +77,76 @@ import SWBUtil
         #expect([4] == dupes)
     }
 
+    @Test
+    func topologicalSort() throws {
+        let linear: [Int: [Int]] = [
+            1: [2],
+            2: [3],
+            3: []
+        ]
+        let linearResult = SWBUtilTests.topologicalSort([1, 2, 3], linear)
+        #expect(linearResult == [1, 2, 3])
+
+        let diamond: [Int: [Int]] = [
+            1: [2, 3],
+            2: [4],
+            3: [4],
+            4: []
+        ]
+        let diamondResult = SWBUtilTests.topologicalSort([1, 2, 3, 4], diamond)
+        #expect(diamondResult.first == 1)
+        #expect(diamondResult.last == 4)
+        let diamondIndex1 = try #require(diamondResult.firstIndex(of: 1))
+        let diamondIndex2 = try #require(diamondResult.firstIndex(of: 2))
+        let diamondIndex3 = try #require(diamondResult.firstIndex(of: 3))
+        let diamondIndex4 = try #require(diamondResult.firstIndex(of: 4))
+        #expect(diamondIndex1 < diamondIndex2)
+        #expect(diamondIndex1 < diamondIndex3)
+        #expect(diamondIndex2 < diamondIndex4)
+        #expect(diamondIndex3 < diamondIndex4)
+
+        let empty: [Int: [Int]] = [:]
+        #expect(SWBUtilTests.topologicalSort([], empty) == [])
+
+        let single: [Int: [Int]] = [1: []]
+        #expect(SWBUtilTests.topologicalSort([1], single) == [1])
+
+        let independent: [Int: [Int]] = [
+            1: [2],
+            2: [],
+            3: [4],
+            4: []
+        ]
+        let indepResult = SWBUtilTests.topologicalSort([1, 2, 3, 4], independent)
+        #expect(indepResult.count == 4)
+        let indepIndex1 = try #require(indepResult.firstIndex(of: 1))
+        let indepIndex2 = try #require(indepResult.firstIndex(of: 2))
+        let indepIndex3 = try #require(indepResult.firstIndex(of: 3))
+        let indepIndex4 = try #require(indepResult.firstIndex(of: 4))
+        #expect(indepIndex1 < indepIndex2)
+        #expect(indepIndex3 < indepIndex4)
+
+        let complex: [Int: [Int]] = [
+            1: [3],
+            2: [3, 4],
+            3: [5],
+            4: [5],
+            5: []
+        ]
+        let complexResult = SWBUtilTests.topologicalSort([1, 2, 3, 4, 5], complex)
+        #expect(complexResult.last == 5)
+        let complexIndex1 = try #require(complexResult.firstIndex(of: 1))
+        let complexIndex2 = try #require(complexResult.firstIndex(of: 2))
+        let complexIndex3 = try #require(complexResult.firstIndex(of: 3))
+        let complexIndex4 = try #require(complexResult.firstIndex(of: 4))
+        let complexIndex5 = try #require(complexResult.firstIndex(of: 5))
+        #expect(complexIndex1 < complexIndex3)
+        #expect(complexIndex2 < complexIndex3)
+        #expect(complexIndex2 < complexIndex4)
+        #expect(complexIndex3 < complexIndex5)
+        #expect(complexIndex4 < complexIndex5)
+    }
+
 }
 
 private func minimumDistance<T>(
@@ -96,4 +166,8 @@ private func transitiveClosure(_ nodes: [Int], _ successors: [Int: [Int]]) -> [I
 }
 private func transitiveClosure(_ node: Int, _ successors: [Int: [Int]]) -> [Int] {
     return transitiveClosure([node], successors)
+}
+
+private func topologicalSort<T: Hashable>(_ vertices: [T], _ graph: [T: [T]]) -> [T] {
+    return topologicalSort(vertices, successors: { graph[$0] ?? [] })
 }


### PR DESCRIPTION
Walk the dependency graph to determine whether the code corresponding to a module will be linked into a dll, and apply -static (or don't) to the compilation accordingly.

Not addressed here: If e.g. an object gets linked statically and included in a dll, we're not duplicating its compilation yet, it just doesn't get -static.