### PR TITLE
Disable LD_DEBUG_VARIANT when using non-Darwin linkers

### DIFF
--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -155,6 +155,11 @@
                 Condition = "NO";
             },
             {
+                Name = "LD_DEBUG_VARIANT";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;

--- a/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
@@ -144,6 +144,11 @@
                 Condition = "NO";
             },
             {
+                Name = "LD_DEBUG_VARIANT";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;

--- a/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WasmLd.xcspec
@@ -132,6 +132,11 @@
                 Condition = "NO";
             },
             {
+                Name = "LD_DEBUG_VARIANT";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // wasm-ld doesn't support dependency info
                 Name = "LD_DEPENDENCY_INFO_FILE";
                 Type = Path;

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -172,6 +172,11 @@
                 Condition = "NO";
             },
             {
+                Name = "LD_DEBUG_VARIANT";
+                Type = Boolean;
+                Condition = "NO";
+            },
+            {
                 // Don't deduplicate is broken in gold
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;


### PR DESCRIPTION
Other linkers may incorrectly interpret this as an entry point symbol override.