### PR TITLE
Add support for enabling MemTagSanitizer in builds

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -1102,7 +1102,8 @@ private extension PreviewInfoOutput {
                     enableDebugDylib: info.enableDebugDylib,
                     enableAddressSanitizer: info.enableAddressSanitizer,
                     enableThreadSanitizer: info.enableThreadSanitizer,
-                    enableUndefinedBehaviorSanitizer: info.enableUndefinedBehaviorSanitizer
+                    enableUndefinedBehaviorSanitizer: info.enableUndefinedBehaviorSanitizer,
+                    enableMemoryTaggingAddressSanitizer: info.enableMemoryTaggingAddressSanitizer
                 )
             )
         }

--- a/Sources/SWBBuildService/PreviewInfo.swift
+++ b/Sources/SWBBuildService/PreviewInfo.swift
@@ -62,6 +62,7 @@ package struct PreviewInfoOutput: Sendable {
         package let enableAddressSanitizer: Bool
         package let enableThreadSanitizer: Bool
         package let enableUndefinedBehaviorSanitizer: Bool
+        package let enableMemoryTaggingAddressSanitizer: Bool
     }
 
     package enum Kind: Sendable {
@@ -276,7 +277,8 @@ extension BuildDescription {
                             enableDebugDylib: settings.globalScope.evaluate(BuiltinMacros.ENABLE_DEBUG_DYLIB),
                             enableAddressSanitizer: settings.globalScope.evaluate(BuiltinMacros.ENABLE_ADDRESS_SANITIZER),
                             enableThreadSanitizer: settings.globalScope.evaluate(BuiltinMacros.ENABLE_THREAD_SANITIZER),
-                            enableUndefinedBehaviorSanitizer: settings.globalScope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+                            enableUndefinedBehaviorSanitizer: settings.globalScope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER),
+                            enableMemoryTaggingAddressSanitizer: settings.globalScope.evaluate(BuiltinMacros.ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER)
                         )
                         info = .targetDependencyInfo(targetInfo)
                     }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -405,6 +405,7 @@ public final class BuiltinMacros {
     public static let ENABLE_ADDRESS_SANITIZER = BuiltinMacros.declareBooleanMacro("ENABLE_ADDRESS_SANITIZER")
     public static let ENABLE_THREAD_SANITIZER = BuiltinMacros.declareBooleanMacro("ENABLE_THREAD_SANITIZER")
     public static let ENABLE_UNDEFINED_BEHAVIOR_SANITIZER = BuiltinMacros.declareBooleanMacro("ENABLE_UNDEFINED_BEHAVIOR_SANITIZER")
+    public static let ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER = BuiltinMacros.declareBooleanMacro("ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER")
     public static let ENABLE_SYSTEM_SANITIZERS = BuiltinMacros.declareBooleanMacro("ENABLE_SYSTEM_SANITIZERS")
 
     // MARK: Unit testing macros
@@ -1759,6 +1760,7 @@ public final class BuiltinMacros {
         ENABLE_PRIVATE_TESTING_SEARCH_PATHS,
         ENABLE_THREAD_SANITIZER,
         ENABLE_UNDEFINED_BEHAVIOR_SANITIZER,
+        ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER,
         DISABLE_TASK_SANDBOXING,
         ENABLE_USER_SCRIPT_SANDBOXING,
         ENTITLEMENTS_ALLOWED,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1626,6 +1626,18 @@ private class SettingsBuilder: ProjectMatchLookup {
             }
         }
 
+        // Memory-Tagging Address Sanitizer architecture validation
+        if scope.evaluate(BuiltinMacros.ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER) {
+            let unsupportedArchs = Set(["arm64_32", "armv7k", "i386", "x86_64", "x86_64h"])
+            let buildArchs = Set(scope.evaluate(BuiltinMacros.ARCHS))
+            let presentUnsupportedArchs = buildArchs.intersection(unsupportedArchs)
+
+            if !presentUnsupportedArchs.isEmpty {
+                let archList = presentUnsupportedArchs.sorted().joined(separator: ", ")
+                self.errors.append("Memory-Tagging Address Sanitizer is enabled (ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER = YES), but is not supported for architecture(s): \(archList).")
+            }
+        }
+
         if scope.evaluate(BuiltinMacros.ENABLE_PLAYGROUND_RESULTS) {
             addPlaygroundSettings(specLookupContext.platform)
         }
@@ -4530,6 +4542,9 @@ private class SettingsBuilder: ProjectMatchLookup {
                 if scope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER) {
                     variantObjectFileDir += "-ubsan"
                 }
+                if scope.evaluate(BuiltinMacros.ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER) {
+                    variantObjectFileDir += "-mtasan"
+                }
 
                 // We push the value here with an embedded literal, since this can be referenced in places when the variant condition itself may not be active (e.g., shell scripts).
                 let macro = userNamespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, "OBJECT_FILE_DIR_\(variant)")
@@ -4669,7 +4684,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         }
 
         // If any sanitizer is enabled, and this product type has a runpath to its Frameworks directory defined, then we want to add that path to the runpath search path if it's not already present.
-        if scope.evaluate(BuiltinMacros.ENABLE_ADDRESS_SANITIZER) || scope.evaluate(BuiltinMacros.ENABLE_THREAD_SANITIZER) || scope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER)
+        if scope.evaluate(BuiltinMacros.ENABLE_ADDRESS_SANITIZER) || scope.evaluate(BuiltinMacros.ENABLE_THREAD_SANITIZER) || scope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER) || scope.evaluate(BuiltinMacros.ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER)
         {
             if let frameworksRunpath = productType?.frameworksRunpathSearchPath(in: scope)?.str {
                 if !scope.evaluate(BuiltinMacros.LD_RUNPATH_SEARCH_PATHS).contains(frameworksRunpath) {

--- a/Sources/SWBProtocol/MessageSupport.swift
+++ b/Sources/SWBProtocol/MessageSupport.swift
@@ -506,6 +506,7 @@ public struct PreviewInfoTargetDependencyInfo: Codable, Equatable, Sendable {
     public let enableAddressSanitizer: Bool
     public let enableThreadSanitizer: Bool
     public let enableUndefinedBehaviorSanitizer: Bool
+    public let enableMemoryTaggingAddressSanitizer: Bool
 
     public init(
         productModuleName: String,
@@ -518,7 +519,8 @@ public struct PreviewInfoTargetDependencyInfo: Codable, Equatable, Sendable {
         enableDebugDylib: Bool,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
-        enableUndefinedBehaviorSanitizer: Bool
+        enableUndefinedBehaviorSanitizer: Bool,
+        enableMemoryTaggingAddressSanitizer: Bool,
     ) {
         self.productModuleName = productModuleName
         self.objectFileInputMap = objectFileInputMap
@@ -531,6 +533,7 @@ public struct PreviewInfoTargetDependencyInfo: Codable, Equatable, Sendable {
         self.enableAddressSanitizer = enableAddressSanitizer
         self.enableThreadSanitizer = enableThreadSanitizer
         self.enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer
+        self.enableMemoryTaggingAddressSanitizer = enableMemoryTaggingAddressSanitizer
     }
 }
 

--- a/Sources/SWBTaskConstruction/StaleFileRemovalContext.swift
+++ b/Sources/SWBTaskConstruction/StaleFileRemovalContext.swift
@@ -82,6 +82,9 @@ extension StaleFileRemovalContext {
         if scope.evaluate(BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER) {
             staleFileRemovalIdentifier += "-ubsan"
         }
+        if scope.evaluate(BuiltinMacros.ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER) {
+            staleFileRemovalIdentifier += "-mtasan"
+        }
 
         // Add the build components to ensure the various styles of builds do not stomp on one another.
         staleFileRemovalIdentifier += scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).sorted().map({ "-\($0)" }).joined()

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SanitizerTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SanitizerTaskProducer.swift
@@ -47,6 +47,7 @@ final class SanitizerTaskProducer: PhasedTaskProducer, TaskProducer {
             Sanitizer(name: "Address", macro: BuiltinMacros.ENABLE_ADDRESS_SANITIZER, libraryNameInfix: "asan"),
             Sanitizer(name: "Thread", macro: BuiltinMacros.ENABLE_THREAD_SANITIZER, libraryNameInfix: "tsan"),
             Sanitizer(name: "Undefined Behavior", macro: BuiltinMacros.ENABLE_UNDEFINED_BEHAVIOR_SANITIZER, libraryNameInfix: "ubsan"),
+            // Note: Memory-Tagging Address Sanitizer is not included here because it doesn't have a runtime library to copy
         ]
     }
 

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3270,6 +3270,24 @@
                 // Not visible in the build settings editor
             },
 
+            // Memory-Tagging Address Sanitizer options.
+            {
+                Name = "CLANG_MEMORY_TAGGING_ADDRESS_SANITIZER";
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER)";
+                CommandLineArgs = {
+                    YES = (
+                        "-Xclang",
+                        "-target-feature",
+                        "-Xclang",
+                        "+mte",
+                        "-fsanitize=memtag-stack",
+                    );
+                    NO = ();
+                };
+                // Not visible in the build settings editor
+            },
+
             {
                 Name = "CLANG_ENABLE_PREFIX_MAPPING";
                 Type = Boolean;

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -690,7 +690,7 @@
                 Name = "LD_DEBUG_VARIANT";
                 Type = Boolean;
                 DefaultValue = YES;
-                Condition = "$(ENABLE_ADDRESS_SANITIZER) || $(ENABLE_THREAD_SANITIZER) || $(ENABLE_SANITIZER_COVERAGE) || $(ENABLE_UNDEFINED_BEHAVIOR_SANITIZER) || $(CLANG_COVERAGE_MAPPING)";
+                Condition = "$(ENABLE_ADDRESS_SANITIZER) || $(ENABLE_THREAD_SANITIZER) || $(ENABLE_SANITIZER_COVERAGE) || $(ENABLE_UNDEFINED_BEHAVIOR_SANITIZER) || $(ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER) || $(CLANG_COVERAGE_MAPPING)";
                 CommandLineArgs = {
                     YES = (
                         "-Xlinker",

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1270,6 +1270,19 @@
                 };
                 // Not visible in the build settings editor
             },
+            // Memory-Tagging Address Sanitizer options.
+            {
+                Name = "SWIFT_MEMORY_TAGGING_ADDRESS_SANITIZER";
+                Type = Boolean;
+                DefaultValue = "$(ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER)";
+                CommandLineArgs = {
+                    YES = (
+                        "-sanitize=memtag-stack",
+                    );
+                    NO = ();
+                };
+                // Not visible in the build settings editor
+            },
             {
                 Name = "ENABLE_SYSTEM_SANITIZERS";
                 Type = Boolean;

--- a/Sources/SwiftBuild/SWBBuildServiceSession.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceSession.swift
@@ -1006,6 +1006,7 @@ fileprivate extension SWBPreviewTargetDependencyInfo {
             self.enableAddressSanitizer = targetDependencyInfo.enableAddressSanitizer
             self.enableThreadSanitizer = targetDependencyInfo.enableThreadSanitizer
             self.enableUndefinedBehaviorSanitizer = targetDependencyInfo.enableUndefinedBehaviorSanitizer
+            self.enableMemoryTaggingAddressSanitizer = targetDependencyInfo.enableMemoryTaggingAddressSanitizer
         }
     }
 }

--- a/Sources/SwiftBuild/SWBPreviewSupport.swift
+++ b/Sources/SwiftBuild/SWBPreviewSupport.swift
@@ -106,6 +106,10 @@ public struct SWBPreviewTargetDependencyInfo: SWBPreviewInfoContext, Hashable, S
     /// user to disable the sanitizer in some cases where it is known to fail.
     public let enableUndefinedBehaviorSanitizer: Bool
 
+    /// Reads from `ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER`. Previews currently uses this to ask the
+    /// user to disable the sanitizer in some cases where it is known to fail.
+    public let enableMemoryTaggingAddressSanitizer: Bool
+
     @_spi(Testing) public init(
         sdkRoot: String,
         sdkVariant: String? = nil,
@@ -122,7 +126,8 @@ public struct SWBPreviewTargetDependencyInfo: SWBPreviewInfoContext, Hashable, S
         enableDebugDylib: Bool,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
-        enableUndefinedBehaviorSanitizer: Bool
+        enableUndefinedBehaviorSanitizer: Bool,
+        enableMemoryTaggingAddressSanitizer: Bool
     ) {
         self.sdkRoot = sdkRoot
         self.sdkVariant = sdkVariant
@@ -140,5 +145,6 @@ public struct SWBPreviewTargetDependencyInfo: SWBPreviewInfoContext, Hashable, S
         self.enableAddressSanitizer = enableAddressSanitizer
         self.enableThreadSanitizer = enableThreadSanitizer
         self.enableUndefinedBehaviorSanitizer = enableUndefinedBehaviorSanitizer
+        self.enableMemoryTaggingAddressSanitizer = enableMemoryTaggingAddressSanitizer
     }
 }

--- a/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
+++ b/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
@@ -281,6 +281,94 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.macOS), .disabled("Awaiting clang support for -Xclang -target-feature -Xclang +mte"))
+    func switchingBetweenSanitizerModesNew() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources", path: "Sources", children: [
+                                TestFile("shared.m"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                            ]
+                        )],
+                        targets: [
+                            TestStandardTarget(
+                                "shared", type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["shared.m"]),
+                                ]),
+                        ])
+                ])
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/shared.m")) { contents in
+                contents <<< "int number = 1;\n"
+            }
+
+            let excludingTypes = Set([
+                "Copy", "Touch", "Gate", "MkDir", "WriteAuxiliaryFile", "SymLink", "CreateBuildDirectory",
+                "ProcessInfoPlistFile", "RegisterExecutionPolicyException", "ClangStatCache"
+            ])
+
+            let sanitizerCombinations = [
+                "ENABLE_ADDRESS_SANITIZER",
+                "ENABLE_THREAD_SANITIZER",
+                "ENABLE_UNDEFINED_BEHAVIOR_SANITIZER",
+                "ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER"
+            ].combinationsWithoutRepetition
+
+            var previousBuildParameters = [BuildParameters]()
+
+            for combination in sanitizerCombinations {
+                // Skip combinations with (asan + tsan) or (asan + mtsan), since they're invalid to the compiler.
+                if (combination.contains("ENABLE_ADDRESS_SANITIZER") && combination.contains("ENABLE_THREAD_SANITIZER")) ||
+                   (combination.contains("ENABLE_ADDRESS_SANITIZER") && combination.contains("ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER"))
+                {
+                    continue
+                }
+
+                var overrides = combination.reduce(into: [String:String]()) { $0[$1] = "YES" }
+                // Only build for the active architecture (arm64) to avoid trying to enable
+                // memory-tagging address sanitizer on x86_64, which doesn't support it.
+                overrides["ONLY_ACTIVE_ARCH"] = "YES"
+                let parameters = BuildParameters(configuration: "Debug", overrides: overrides)
+
+                // Try build with new combination of sanitizers. Note that memory-tagging address sanitizer is only
+                // available on Apple Silicon, so this is hardcoded.
+                try await tester.checkBuild(parameters: parameters, runDestination: .macOSAppleSilicon, persistent: true) { results in
+                    results.checkTask(.matchRuleType("CompileC")) { _ in }
+                    results.checkTask(.matchRuleType("Libtool")) { _ in }
+                    results.consumeTasksMatchingRuleTypes(excludingTypes)
+                    results.checkNoTask()
+                }
+
+                // Check that we get a null build when using same parameters
+                try await tester.checkNullBuild(parameters: parameters, runDestination: .macOSAppleSilicon, persistent: true)
+
+                for previousParameters in previousBuildParameters {
+                    // Try build with all previous parameters to ensure that compilation doesn't happen again for them
+                    try await tester.checkBuild(parameters: previousParameters, runDestination: .macOSAppleSilicon, persistent: true) { results in
+                        results.checkTask(.matchRuleType("Libtool")) { _ in }
+                        results.consumeTasksMatchingRuleTypes(excludingTypes)
+                        results.checkNoTask()
+                    }
+                }
+
+                previousBuildParameters.append(parameters)
+            }
+        }
+    }
 }
 
 fileprivate extension Array {

--- a/Tests/SWBTaskExecutionTests/StaleFileRemovalTests.swift
+++ b/Tests/SWBTaskExecutionTests/StaleFileRemovalTests.swift
@@ -26,6 +26,7 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
         case address
         case thread
         case undefinedBehavior
+        case memoryTaggingAddress
 
         var settingName: String {
             switch self {
@@ -35,6 +36,8 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
                 return "ENABLE_THREAD_SANITIZER"
             case .undefinedBehavior:
                 return "ENABLE_UNDEFINED_BEHAVIOR_SANITIZER"
+            case .memoryTaggingAddress:
+                return "ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER"
             }
         }
 
@@ -46,6 +49,8 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
                 return "tsan"
             case .undefinedBehavior:
                 return "ubsan"
+            case .memoryTaggingAddress:
+                return "mtasan"
             }
         }
     }

--- a/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
+++ b/Tests/SwiftBuildTests/GeneratePreviewInfoTests.swift
@@ -263,7 +263,8 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                             enableDebugDylib: true,
                             enableAddressSanitizer: false,
                             enableThreadSanitizer: false,
-                            enableUndefinedBehaviorSanitizer: false
+                            enableUndefinedBehaviorSanitizer: false,
+                            enableMemoryTaggingAddressSanitizer: false
                         )
                     ])
 
@@ -409,7 +410,8 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                             enableDebugDylib: false,
                             enableAddressSanitizer: false,
                             enableThreadSanitizer: false,
-                            enableUndefinedBehaviorSanitizer: false
+                            enableUndefinedBehaviorSanitizer: false,
+                            enableMemoryTaggingAddressSanitizer: false
                         )
                     ]
                 )
@@ -537,7 +539,8 @@ fileprivate struct GeneratePreviewInfoTests: CoreBasedTests {
                             enableDebugDylib: false,
                             enableAddressSanitizer: false,
                             enableThreadSanitizer: false,
-                            enableUndefinedBehaviorSanitizer: false
+                            enableUndefinedBehaviorSanitizer: false,
+                            enableMemoryTaggingAddressSanitizer: false
                         )
                     ]
                 )


### PR DESCRIPTION
This is a previously unsupported sanitizer.

rdar://161720969