### PR TITLE
Add new _LD_MACHINE_ARCH settings for windows dll linking

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -833,6 +833,7 @@ public final class BuiltinMacros {
     public static let LD_WARN_UNUSED_DYLIBS = BuiltinMacros.declareBooleanMacro("LD_WARN_UNUSED_DYLIBS")
     public static let _LD_MULTIARCH = BuiltinMacros.declareBooleanMacro("_LD_MULTIARCH")
     public static let _LD_MULTIARCH_PREFIX_MAP = BuiltinMacros.declareStringListMacro("_LD_MULTIARCH_PREFIX_MAP")
+    public static let _LD_ARCH = BuiltinMacros.declareStringMacro("_LD_ARCH")
     public static let LEX = BuiltinMacros.declarePathMacro("LEX")
     public static let LEXFLAGS = BuiltinMacros.declareStringListMacro("LEXFLAGS")
     public static let LIBRARIAN = BuiltinMacros.declareStringMacro("LIBRARIAN")
@@ -1949,6 +1950,7 @@ public final class BuiltinMacros {
         LD_WARN_UNUSED_DYLIBS,
         _LD_MULTIARCH,
         _LD_MULTIARCH_PREFIX_MAP,
+        _LD_ARCH,
         LEGACY_DEVELOPER_DIR,
         LEX,
         LEXFLAGS,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4206,6 +4206,18 @@ private class SettingsBuilder: ProjectMatchLookup {
         table.push(BuiltinMacros.__SWIFT_MODULE_ONLY_ARCHS__, literal: originalModuleOnlyArchs)
         table.push(BuiltinMacros.SWIFT_MODULE_ONLY_ARCHS, literal: moduleOnlyArchs)
 
+        let archMap = scope.evaluate(BuiltinMacros._LD_MULTIARCH_PREFIX_MAP)
+        let archMappings = archMap.reduce(into: [String?: String]()) { mappings, map in
+            let (arch, prefixDir) = map.split(":")
+            if !arch.isEmpty && !prefixDir.isEmpty {
+                return mappings[arch] = prefixDir
+            }
+        }
+
+        if let prefix = archMappings[self.preferredArch] {
+            table.push(BuiltinMacros._LD_ARCH, literal: prefix)
+        }
+
         // FIXME: There is a more random, but questionable stuff here. To be added in a test case driven fashion.
 
         // Resolve some of the key path settings to be absolute.

--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -111,7 +111,7 @@
         Domain = windows;
         Type = ProductType;
         Identifier = org.swift.product-type.common.object;
-        BasedOn = com.apple.product-type.library.static;
+        BasedOn = org.swift.product-type.library.object;
     },
 
     {

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -72,13 +72,21 @@
                 Name = _LD_MULTIARCH;
                 Type = Boolean;
                 DefaultValue = NO;
-                Condition = "$(ALTERNATE_LINKER) == link";
             },
             {
                 Name = _LD_MULTIARCH_PREFIX_MAP;
                 Type = StringList;
                 DefaultValue = "aarch64:arm64 armv7:arm arm64ec:arm64 x86_64:x64 i686:x86";
-                Condition = "$(ALTERNATE_LINKER) == link";
+            },
+            {
+                Name = _LD_MACHINE_ARCH;
+                Type = Boolean;
+                DefaultValue = YES;
+                Condition = "$(MACH_O_TYPE) == mh_dylib";
+                CommandLineArgs = {
+                    YES = ("-Xlinker", "/MACHINE:$(_LD_ARCH)");
+                    NO = ();
+                };
             },
             {
                 // No such concept
@@ -176,6 +184,18 @@
                 Name = "LD_DONT_RUN_DEDUPLICATION";
                 Type = Boolean;
                 DefaultValue = YES;
+                Condition = "NO";
+            },
+            {
+                Name = "SWIFTC_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                DefaultValue = "$(LD_EXPORT_GLOBAL_SYMBOLS)";
+                Condition = "NO";
+            },
+            {
+                Name = "CLANG_LD_EXPORT_GLOBAL_SYMBOLS";
+                Type = Boolean;
+                DefaultValue = "$(LD_EXPORT_GLOBAL_SYMBOLS)";
                 Condition = "NO";
             },
             {

--- a/Tests/SWBWindowsPlatformTests/SWBWindowsPlatformTests.swift
+++ b/Tests/SWBWindowsPlatformTests/SWBWindowsPlatformTests.swift
@@ -46,11 +46,10 @@ import SWBMacro
         // link.exe cannot be used for multipler architectures and requires a distinct link.exe for each target architecture
         table.push(BuiltinMacros.ALTERNATE_LINKER, literal: "link")
         table.push(BuiltinMacros._LD_MULTIARCH, literal: false)
-        table.push(BuiltinMacros._LD_MULTIARCH_PREFIX_MAP, literal: ["aarch64:arm64", "arm64ec:arm64", "armv7:arm", "x86_64:x64", "i686:x86"])
 
         // link x86_64
         if try await core.hasVisualStudioComponent(.visualCppBuildTools_x86_x64) {
-            table.push(BuiltinMacros.ARCHS, literal: ["x86_64"])
+            table.push(BuiltinMacros._LD_ARCH, literal: "x86")
             try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows", additionalTable: table) { (info: DiscoveredLdLinkerToolSpecInfo) in
                 #expect(!info.toolPath.isEmpty)
                 #expect(info.toolVersion != nil)
@@ -62,7 +61,7 @@ import SWBMacro
         }
         // link i686
         if try await core.hasVisualStudioComponent(.visualCppBuildTools_x86_x64) {
-            table.push(BuiltinMacros.ARCHS, literal: ["i686"])
+            table.push(BuiltinMacros._LD_ARCH, literal: "x86")
             try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows", additionalTable: table) { (info: DiscoveredLdLinkerToolSpecInfo) in
                 #expect(!info.toolPath.isEmpty)
                 #expect(info.toolVersion != nil)
@@ -74,7 +73,7 @@ import SWBMacro
         }
         // link aarch64
         if try await core.hasVisualStudioComponent(.visualCppBuildTools_arm64) {
-            table.push(BuiltinMacros.ARCHS, literal: ["aarch64"])
+            table.push(BuiltinMacros._LD_ARCH, literal: "arm64")
             try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows", additionalTable: table) { (info: DiscoveredLdLinkerToolSpecInfo) in
                 #expect(!info.toolPath.isEmpty)
                 #expect(info.toolVersion != nil)
@@ -86,7 +85,7 @@ import SWBMacro
         }
         // link armv7
         if try await core.hasVisualStudioComponent(.visualCppBuildTools_arm) {
-            table.push(BuiltinMacros.ARCHS, literal: ["armv7"])
+            table.push(BuiltinMacros._LD_ARCH, literal: "arm64")
             try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows", additionalTable: table) { (info: DiscoveredLdLinkerToolSpecInfo) in
                 #expect(!info.toolPath.isEmpty)
                 #expect(info.toolVersion != nil)
@@ -98,7 +97,7 @@ import SWBMacro
         }
         // link arm64ec
         if try await core.hasVisualStudioComponent(.visualCppBuildTools_arm64ec) {
-            table.push(BuiltinMacros.ARCHS, literal: ["arm64ec"])
+            table.push(BuiltinMacros._LD_ARCH, literal: "arm64")
             try await withSpec(LdLinkerSpec.self, .deferred, platform: "windows", additionalTable: table) { (info: DiscoveredLdLinkerToolSpecInfo) in
                 #expect(!info.toolPath.isEmpty)
                 #expect(info.toolVersion != nil)


### PR DESCRIPTION
- since the dlls link with .libs instead of .o we need to tell the linker the machine type as it can't auto discover with no .o files
- also don't pass -rdynamic on windows, it just produces a warning that its an unused argument
- update the common.object product type to map to object library so that when building tests with an executable dependency symbols can be properly resolved.