### PR TITLE
Introduce formal build setting for skipping the bundle hook in mergeable libraries

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -430,6 +430,8 @@ public final class BuiltinMacros {
     public static let MERGE_LINKED_LIBRARIES = BuiltinMacros.declareBooleanMacro("MERGE_LINKED_LIBRARIES")
     public static let MERGED_BINARY_TYPE = BuiltinMacros.declareEnumMacro("MERGED_BINARY_TYPE") as EnumMacroDeclaration<MergedBinaryType>
     public static let MAKE_MERGEABLE = BuiltinMacros.declareBooleanMacro("MAKE_MERGEABLE")
+    public static let SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK = BuiltinMacros.declareBooleanMacro("SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK") // user-set
+    public static let LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK = BuiltinMacros.declareBooleanMacro("LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK") // synthesized based on above + MERGEABLE_LIBRARY
 
     // MARK: Task Planning Macros
 
@@ -1950,6 +1952,7 @@ public final class BuiltinMacros {
         LD_NO_PIE,
         LD_RUNPATH_SEARCH_PATHS,
         LD_SDK_IMPORTS_FILE,
+        LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK,
         LD_WARN_UNUSED_DYLIBS,
         _LD_MULTIARCH,
         _LD_MULTIARCH_PREFIX_MAP,
@@ -2206,6 +2209,7 @@ public final class BuiltinMacros {
         SKIP_INSTALL,
         SKIP_CLANG_STATIC_ANALYZER,
         SKIP_EMBEDDED_FRAMEWORKS_VALIDATION,
+        SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK,
         SOURCE_ROOT,
         SPECIALIZATION_SDK_OPTIONS,
         SRCROOT,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2319,9 +2319,17 @@ private class SettingsBuilder: ProjectMatchLookup {
 
             // Even if not being merged in this build, a mergeable library still uses a generated bundle lookup helper to power #bundle support.
             if scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) {
+                let skipBundleHook = scope.evaluate(BuiltinMacros.SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK)
                 let pathResolver = FilePathResolver(scope: scope)
                 if (target as? StandardTarget)?.sourcesBuildPhase?.containsSwiftSources(workspaceContext.workspace, specLookupContext, scope, pathResolver) ?? false {
-                    table.push(BuiltinMacros.SWIFT_ACTIVE_COMPILATION_CONDITIONS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE"]))
+                    if skipBundleHook {
+                        table.push(BuiltinMacros.SWIFT_ACTIVE_COMPILATION_CONDITIONS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"]))
+                    } else {
+                        table.push(BuiltinMacros.SWIFT_ACTIVE_COMPILATION_CONDITIONS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "SWIFT_BUNDLE_LOOKUP_HELPER_AVAILABLE"]))
+                    }
+                }
+                if skipBundleHook {
+                    table.push(BuiltinMacros.LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK, literal: true)
                 }
             }
 

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -949,6 +949,11 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleIdenti
                 DefaultValue = NO;
             },
             {
+                Name = "SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK";
+                Type = Boolean;
+                DefaultValue = NO;
+            },
+            {
                 Name = "LD_SHARED_CACHE_ELIGIBLE";
                 Type = Enumeration;
                 Values = (
@@ -1770,6 +1775,16 @@ For more information on mergeable libraries, see [Configuring your project to us
                 Name = "MAKE_MERGEABLE";
                 Type = Boolean;
                 DefaultValue = NO;
+            },
+            {
+                Name = "SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK";
+                Type = Boolean;
+                DefaultValue = NO;
+                Category = "Linking - Mergeable Libraries";
+                DisplayName = "Skip Mergeable Library Bundle Hook";
+                Description = "For mergeable libraries, skips adding a hook into the library's resource bundle. This will prevent `Bundle(for:)` from returning this library's resource bundle.
+
+For more information on mergeable libraries, see [Configuring your project to use mergeable libraries](https://developer.apple.com/documentation/xcode/configuring-your-project-to-use-mergeable-libraries).";
             },
 
             {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1857,7 +1857,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         // Package targets do something similar but they generate the Bundle.module extensions and #bundle calls that.
 
         // We need to do this for all mergeable libraries, even if it will just be re-exported in this build.
-        guard scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) else {
+        guard scope.evaluate(BuiltinMacros.MERGEABLE_LIBRARY) && !scope.evaluate(BuiltinMacros.SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK) else {
             return nil
         }
 

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -781,6 +781,18 @@
                 SupportedVersionRanges = ( "1217" );
             },
 
+            {   Name = LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK;
+                Type = Boolean;
+                DefaultValue = NO;
+                CommandLineArgs = {
+                    YES = (
+                        "-Xlinker",
+                        "-no_merged_libraries_hook",
+                    );
+                    NO = ();
+                };
+            },
+
             {
                 Name = "LD_SHARED_CACHE_ELIGIBLE";
                 Type = Enumeration;


### PR DESCRIPTION
Introducing a new linker build setting for mergeable libraries: `SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK`.

This setting translates to the `-no_merged_libraries_hook` linker flag.

It also prevents code generation of the `__BundleLookupHelper` Swift class and explicitly sets `SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE` in Swift so that `#bundle` would return an error when used within the library.
