### PR TITLE
[CI] Update the github-workflows tag to 0.0.6 to support macOS Tahoe

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.3
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.6
     with:
       head_branch: main
       base_branch: release/6.3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.4
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     needs: [soundness, space-format-check]
     with:
       linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
@@ -39,7 +39,7 @@ jobs:
         /usr/bin/xcrun xcodebuild -workspace . -scheme SwiftBuild-Package -destination generic/platform=iOS
   tests_without_docker:
     name: Test without Docker
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.4
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     needs: [soundness, space-format-check]
     with:
       enable_linux_checks: false
@@ -50,7 +50,7 @@ jobs:
       windows_os_versions: '["windows-2022", "windows-11-arm"]'
   cmake-smoke-test:
     name: cmake-smoke-test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.4
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     needs: [soundness, space-format-check]
     with:
       linux_os_versions: '["noble"]'
@@ -68,7 +68,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.4
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.6
     with:
       license_header_check_project_name: "Swift"
       api_breakage_check_enabled: false


### PR DESCRIPTION
swiftlang’s self-hosted runners are now running on Tahoe