### PR TITLE
Fix some new issues with linking DLL

### DIFF
--- a/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/Windows.xcspec
@@ -118,7 +118,7 @@
         Domain = windows;
         Type = ProductType;
         Identifier = org.swift.product-type.library.static;
-        BasedOn = com.apple.product-type.library.static;
+        BasedOn = org.swift.product-type.library.object;
     },
 
 

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -81,7 +81,7 @@
             {
                 Name = _LD_MACHINE_ARCH;
                 Type = Boolean;
-                DefaultValue = YES;
+                DefaultValue = NO;
                 Condition = "$(MACH_O_TYPE) == mh_dylib";
                 CommandLineArgs = {
                     YES = ("-Xlinker", "/MACHINE:$(_LD_ARCH)");
@@ -93,7 +93,7 @@
                 // this for the immediate targets for the .dynamic product
                 Name = _LD_WHOLEARCHIVE;
                 Type = Boolean;
-                DefaultValue = YES;
+                DefaultValue = NO;
                 Condition = "$(MACH_O_TYPE) == mh_dylib";
                 CommandLineArgs = {
                     YES = ("-Xlinker", "/WHOLEARCHIVE");


### PR DESCRIPTION
Seems using WHOLEARCHIVE to make DLLs does not work in most cases switch to using object library type for swift modules which seems to work better

