### PR TITLE
libtool version regex should be more lenient on Apple platforms

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -1661,7 +1661,7 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
             let outputString = String(decoding: executionResult.stdout, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
             let regexes: [Regex<(Substring, libtool: Substring)>]
             if producer.isApplePlatform {
-                regexes = [#/^Apple Inc\. version cctools(?:_[A-Za-z0-9_]+)?-(?<libtool>[0-9\.]+)$/#]
+                regexes = [#/^Apple Inc\. version .*-(?<libtool>[0-9\.]+)$/#]
             } else {
                 regexes = [
                     #/^libtool \(GNU libtool\) (?<libtool>[0-9\.]+).*/#,


### PR DESCRIPTION
Make this check a bit more permissive to we don't fallback to an error if the format doesn't exactly match our expectations