### PR TITLE
Export settings defined in Settings.addTargetTaskOverrides() to shell script build phases.

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4044,7 +4044,8 @@ private class SettingsBuilder: ProjectMatchLookup {
     /// Add the target task overrides.  Most of these are *not* exported to scripts unless the settings have been marked to be exported elsewhere.
     private func addTargetTaskOverrides(_ target: Target, _ specLookupContext: any SpecLookupContext, _ sparseSDKs: [SDK], _ deploymentTarget: Version?, _ sdk: SDK?) {
         // Add the common overrides (which may effect the target specific ones).
-        push(getCommonTargetTaskOverrides(specLookupContext, deploymentTarget, sdk))
+        // This is the method which computes the list of architectures to build for, and so is a funnel point for a bunch of load-bearing logic.
+        push(getCommonTargetTaskOverrides(specLookupContext, deploymentTarget, sdk), .exported)
 
         do {
             // Also set each a build setting with the name of each architecture to `YES`.
@@ -4054,11 +4055,12 @@ private class SettingsBuilder: ProjectMatchLookup {
                 let decl = table.namespace.lookupOrDeclareMacro(StringMacroDeclaration.self, arch)
                 table.push(decl, table.namespace.parseForMacro(decl, value: "YES"))
             }
+            // We do not want to export this to script phases, because it can cause problems with inferior xcodebuild processes invoked by such scripts.
             push(table)
         }
 
         // Add the target-specific overrides.
-        push(getTargetTaskOverrides(target, specLookupContext, sparseSDKs, sdk))
+        push(getTargetTaskOverrides(target, specLookupContext, sparseSDKs, sdk), .exported)
 
         // Add the product specific task overrides.
         push(getProductSpecificTargetTaskOverrides(target, sdk))
@@ -4071,7 +4073,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         //
         // FIXME: We push this separately, because it re-modifies the search paths variables set up above in the overrides.
         if target is StandardTarget, let sdk {
-            push(getSDKSpecificPathOverrides(sdk, sparseSDKs))
+            push(getSDKSpecificPathOverrides(sdk, sparseSDKs), .exported)
         }
     }
 


### PR DESCRIPTION
The methods called by this can define settings which should be exported to shell script build phases.

rdar://167818073
