### PR TITLE
Fix parameter name passed to actool

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AssetCatalogCompiler.xcspec
@@ -211,7 +211,7 @@
                 Name = ASSETCATALOG_COMPILER_INCLUDED_LANGUAGES;
                 Type = StringList;
                 DefaultValue = "";
-                CommandLineFlag = "--include-languages";
+                CommandLineFlag = "--include-language";
             },
 
             {

--- a/Tests/SWBTaskConstructionTests/AssetCatalogTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AssetCatalogTaskConstructionTests.swift
@@ -476,8 +476,8 @@ fileprivate struct AssetCatalogTaskConstructionTests: CoreBasedTests {
                     .matchRuleType("CompileAssetCatalogVariant"),
                     .matchRuleItem("thinned")
                 ) { task in
-                    task.checkCommandLineContains(["--include-languages", "en"])
-                    task.checkCommandLineContains(["--include-languages", "de"])
+                    task.checkCommandLineContains(["--include-language", "en"])
+                    task.checkCommandLineContains(["--include-language", "de"])
                     task.checkCommandLineDoesNotContain("Base")
                 }
                 results.checkNoDiagnostics()
@@ -521,8 +521,8 @@ fileprivate struct AssetCatalogTaskConstructionTests: CoreBasedTests {
                     .matchRuleType("CompileAssetCatalogVariant"),
                     .matchRuleItem("thinned")
                 ) { task in
-                    // When knownLocalizations is empty, no --include-languages should appear
-                    task.checkCommandLineDoesNotContain("--include-languages")
+                    // When knownLocalizations is empty, no --include-language should appear
+                    task.checkCommandLineDoesNotContain("--include-language")
                 }
                 results.checkNoDiagnostics()
             }


### PR DESCRIPTION
`actool` expects `--include-language`, not `--include-languages`.

I used the wrong name in https://github.com/swiftlang/swift-build/pull/1015, and this PR fixes that.