### PR TITLE
[Caching] Make sure .cas-config is deterministic

### DIFF
--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -248,9 +248,11 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
 
             let CASConfigPath = tmpDirPath.join("Test/aProject/build/aProject.build/Debug\(runDestination == .macOS ? "": "-" + runDestination.platform)/Library.build/.cas-config")
 
-            #expect(try tester.fs.read(CASConfigPath).asString.contains("\"CASPath\":"))
             if usePlugin {
-                #expect(try tester.fs.read(CASConfigPath).asString.contains("\"PluginPath\":"))
+                let content = try Regex("\"CASPath\":.*\"PluginPath\"")
+                #expect(try tester.fs.read(CASConfigPath).asString.contains(content))
+            } else {
+                #expect(try tester.fs.read(CASConfigPath).asString.contains("\"CASPath\":"))
             }
 
             // Touch the source file to trigger a new scan.


### PR DESCRIPTION
Use sortedKey when generating JSON .cas-config file. This ensures the file generated is deterministic. This fixes a non-determinsitic failure when building using a CAS that requires a JSON configuration that has more than 1 key.

rdar://168957458
