### PR TITLE
Disable autolink extract and other linker arguments for Wasm SDK

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2702,6 +2702,8 @@ private class SettingsBuilder: ProjectMatchLookup {
                 imageFormat = .macho
             } else if variant.llvmTargetTripleSys == "windows" {
                 imageFormat = .pe
+            } else if variant.llvmTargetTripleSys?.hasPrefix("wasi") == true {
+                imageFormat = .wasm
             } else {
                 imageFormat = .elf
             }

--- a/Sources/SWBCore/SwiftSDK.swift
+++ b/Sources/SWBCore/SwiftSDK.swift
@@ -70,8 +70,10 @@ public struct SwiftSDK: Sendable {
             public let extraCLIOptions: [String]?
         }
 
-        public let rootPath: String
+        public let rootPath: String?
+        public let cCompiler: Tool?
         public let swiftCompiler: Tool?
+        public let linker: Tool?
     }
 
     /// The identifier of the artifact bundle containing this SDK.

--- a/Sources/SWBGenericUnixPlatform/Specs/UnixCompile.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixCompile.xcspec
@@ -138,6 +138,7 @@
                 Name = "__SWIFT_OPTIMIZATION_LEVEL_LINKER_ARGS";
                 Type = String;
                 DefaultValue = "$(SWIFT_OPTIMIZATION_LEVEL)";
+                Condition = "$(MACH_O_TYPE) != mh_object";
                 AdditionalLinkerArgs = {
                     "-Onone" = ("-lswiftCore", "-lswiftSwiftOnoneSupport");
                     "<<otherwise>>" = "-lswiftCore";

--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -167,6 +167,16 @@
                 Condition = "NO";
             },
             {
+                Name = LD_DETERMINISTIC_MODE;
+                Type = Boolean;
+                CommandLineArgs = ();
+            },
+            {
+                Name = "LD_DEPENDENCY_INFO_FILE";
+                Type = Path;
+                DefaultValue = "";
+            },
+            {
                 Name = "__INPUT_FILE_LIST_PATH__";
                 Type = Path;
                 DefaultValue = "$(LINK_FILE_LIST_$(variant)_$(arch))";

--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -363,7 +363,7 @@ extension RunDestinationInfo {
                 }
             }
             environment.prependPath(key: .path, value: core.developerPath.path.join("Runtimes").join(toolchain.version.description).join("usr/bin").str)
-        case .macho:
+        case .macho, .wasm:
             // Fall back to the OS provided Swift runtime
             break
         }

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -270,6 +270,7 @@
                 Name = "LIBRARY_SEARCH_PATHS";
                 Type = PathList;
                 "FlattenRecursiveSearchPathsInValue" = Yes;
+                Condition = "$(MACH_O_TYPE) != mh_object";
                 "CommandLinePrefixFlag" = "-L";
             },
             {

--- a/Sources/SWBUtil/ProcessInfo.swift
+++ b/Sources/SWBUtil/ProcessInfo.swift
@@ -337,6 +337,7 @@ public enum ImageFormat {
     case macho
     case elf
     case pe
+    case wasm
 }
 
 extension ImageFormat {
@@ -346,6 +347,8 @@ extension ImageFormat {
             return ""
         case .pe:
             return "exe"
+        case .wasm:
+            return "wasm"
         }
     }
 
@@ -361,6 +364,8 @@ extension ImageFormat {
             return "so"
         case .pe:
             return "dll"
+        case .wasm:
+            return "wasm"
         }
     }
 
@@ -371,6 +376,8 @@ extension ImageFormat {
         case .elf:
             return true
         case .pe:
+            return false
+        case .wasm:
             return false
         }
     }
@@ -388,7 +395,7 @@ extension ImageFormat {
         switch self {
             case .macho, .elf:
                 return true
-            case .pe:
+            case .pe, .wasm:
                 return false
         }
     }


### PR DESCRIPTION
Autolink extract and other library linker line propagation fails on the
mh_object resource type for the Swift standard libraries when pre-linking
using clang because clang doesn't have a resource dir that includes the
libraries. When pre-linking object files into a larger object file
doesn't make use of the libraries at this stage.

Disable autolink extract when using Wasm doesn't require this feature. Block
the adding of the libraries and library search paths for mh_object resource
types. Add wasm as an ImageFormat case and set the computed properties
to the values for this format.

Linkers for non-Apple platforms don't recognize certain linker parameters
such as deterministic mode and dependency info files. Clear these
parameters out in the generic unix platform.

Update the SwiftSDK struct to reflect the scheme of the JSON files that
are used in the popular SDKs.