### PR TITLE
Stub binaries injected into codeless frameworks should have an explicit install name

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -249,11 +249,15 @@ public struct FileCopyTaskActionContext {
             targetTripleOSVersion = llvmTargetTripleOSVersion
         }
 
+        // Compute a proper install name for the stub binary based on the framework path.
+        // Use @rpath-based install name to avoid embedding temporary paths (rdar://154514099).
+        let stubInstallName = "@rpath/\(frameworkPath.basename)/\(frameworkPath.basenameWithoutSuffix)"
+
         return (
             compileAndLink: partialTargetValues.map { partialTargetValue in
                     (
                         compile: stubPartialCompilerCommandLine + ["-target", "\(partialTargetValue)-\(targetTripleOSVersion)\(llvmTargetTripleSuffix)", "-o", tempDir.join("\(partialTargetValue).o").str],
-                        link: stubPartialLinkerCommandLine + ["-target", "\(partialTargetValue)-\(targetTripleOSVersion)\(llvmTargetTripleSuffix)", "-o", tempDir.join("\(partialTargetValue)").str, tempDir.join("\(partialTargetValue).o").str]
+                        link: stubPartialLinkerCommandLine + ["-target", "\(partialTargetValue)-\(targetTripleOSVersion)\(llvmTargetTripleSuffix)", "-install_name", stubInstallName, "-o", tempDir.join("\(partialTargetValue)").str, tempDir.join("\(partialTargetValue).o").str]
                     )
                 },
             lipo: stubPartialLipoCommandLine + ["-output", frameworkPath.join(isDeepBundle ? "Versions/A" : nil).join(frameworkPath.basenameWithoutSuffix).str] + partialTargetValues.map { partialTargetValue in tempDir.join("\(partialTargetValue)").str }

--- a/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/MergeableLibrariesBuildOperationTests.swift
@@ -244,6 +244,11 @@ fileprivate struct MergeableLibrariesBuildOperationTests: CoreBasedTests {
                                 task.checkCommandLineContains("-no_merged_libraries_hook")
                             }
                             task.checkCommandLineContains(["-o", "\(SYMROOT)/Debug-iphoneos/\(targetName).framework/\(targetName)"])
+                            if useAppStoreCodelessFrameworksWorkaround {
+                                // Verify stub binary linker command has correct install name (rdar://154514099)
+                                let expectedInstallName = "/\(targetName).framework/\(targetName)"
+                                task.checkCommandLineContains(["-install_name", expectedInstallName])
+                            }
                         }
                         results.checkTasks(.matchTargetName(targetName), .matchRuleType("Copy")) { _ in /* likely Swift-related */ }
                         results.checkTask(.matchTargetName(targetName), .matchRuleType("GenerateTAPI")) { _ in }


### PR DESCRIPTION

rdar://154514099
