### PR TITLE
[compilation caching] Prefix map source and build directory

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3297,7 +3297,9 @@
                         "-fdepscan-prefix-map-sdk=/^sdk",
                         "-fdepscan-prefix-map-toolchain=/^toolchain",
                         "-fdepscan-prefix-map=$(DEVELOPER_DIR)=/^xcode",
-                        // FIXME: add source and build directory mappings by default
+                        "-fdepscan-prefix-map=$(PROJECT_DIR)=/^src",
+                        "-fdepscan-prefix-map=$(PROJECT_TEMP_DIR)=/^derived",
+                        "-fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built",
                     );
                     NO = ();
                 };

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1388,7 +1388,9 @@
                         "-scanner-prefix-map-sdk", "/^sdk",
                         "-scanner-prefix-map-toolchain", "/^toolchain",
                         "-scanner-prefix-map", "$(DEVELOPER_DIR)=/^xcode",
-                        // FIXME: add source and build directory mappings by default
+                        "-scanner-prefix-map", "$(PROJECT_DIR)=/^src",
+                        "-scanner-prefix-map", "$(PROJECT_TEMP_DIR)=/^derived",
+                        "-scanner-prefix-map", "$(BUILT_PRODUCTS_DIR)=/^built",
                     );
                     NO = ();
                 };

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1966,6 +1966,9 @@ import SWBMacro
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
+        let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
+        let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
+        let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
 
         func test(caching: Bool, prefixMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1973,6 +1976,9 @@ import SWBMacro
             table.push(enablePrefixMap, literal: prefixMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")
+            table.push(srcDir, literal: "/source")
+            table.push(projectTmpDir, literal: "/build")
+            table.push(builtDir, literal: "/products")
             let mockScope = MacroEvaluationScope(table: table)
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
@@ -1997,6 +2003,9 @@ import SWBMacro
                 "-fdepscan-prefix-map-sdk=/^sdk",
                 "-fdepscan-prefix-map-toolchain=/^toolchain",
                 "-fdepscan-prefix-map=/Xcode.app/Contents/Developer=/^xcode",
+                "-fdepscan-prefix-map=/source=/^src",
+                "-fdepscan-prefix-map=/build=/^derived",
+                "-fdepscan-prefix-map=/products=/^built",
             ])
         })
         try await test(caching: true, prefixMapping: true, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
@@ -2004,6 +2013,9 @@ import SWBMacro
                 "-fdepscan-prefix-map-sdk=/^sdk",
                 "-fdepscan-prefix-map-toolchain=/^toolchain",
                 "-fdepscan-prefix-map=/Xcode.app/Contents/Developer=/^xcode",
+                "-fdepscan-prefix-map=/source=/^src",
+                "-fdepscan-prefix-map=/build=/^derived",
+                "-fdepscan-prefix-map=/products=/^built",
                 "-fdepscan-prefix-map=/a=/b",
                 "-fdepscan-prefix-map=/c=/d",
             ])
@@ -2020,6 +2032,9 @@ import SWBMacro
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
+        let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
+        let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
+        let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
 
         func test(caching: Bool, prefixMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             // Create the mock table.
@@ -2040,6 +2055,9 @@ import SWBMacro
             table.push(enablePrefixMap, literal: prefixMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")
+            table.push(srcDir, literal: "/source")
+            table.push(projectTmpDir, literal: "/build")
+            table.push(builtDir, literal: "/products")
             let mockScope = MacroEvaluationScope(table: table)
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
@@ -2072,6 +2090,9 @@ import SWBMacro
                 "-scanner-prefix-map-sdk", "/^sdk",
                 "-scanner-prefix-map-toolchain", "/^toolchain",
                 "-scanner-prefix-map", "/Xcode.app/Contents/Developer=/^xcode",
+                "-scanner-prefix-map", "/source=/^src",
+                "-scanner-prefix-map", "/build=/^derived",
+                "-scanner-prefix-map", "/products=/^built",
             ])
         })
         try await test(caching: true, prefixMapping: true, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
@@ -2079,6 +2100,9 @@ import SWBMacro
                 "-scanner-prefix-map-sdk", "/^sdk",
                 "-scanner-prefix-map-toolchain", "/^toolchain",
                 "-scanner-prefix-map", "/Xcode.app/Contents/Developer=/^xcode",
+                "-scanner-prefix-map", "/source=/^src",
+                "-scanner-prefix-map", "/build=/^derived",
+                "-scanner-prefix-map", "/products=/^built",
                 "-scanner-prefix-map", "/a=/b",
                 "-scanner-prefix-map", "/c=/d",
             ])


### PR DESCRIPTION
In order for better relocatability for source and build directory (for derived source and etc.), prefix map source and build directory as well.

rdar://128486666
