### PR TITLE
[swift][EmitConst] Use driver flag when available

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2046,8 +2046,13 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 }
                 cbc.producer.writeFileSpec.constructFileTasks(CommandBuildContext(producer: cbc.producer, scope: cbc.scope, inputs: [], output: protocolListPath),
                                                               delegate, contents: protocolListContents, permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
-                args += ["-Xfrontend", "-const-gather-protocols-file",
-                         "-Xfrontend", protocolListPath.str]
+                if LibSwiftDriver.supportsDriverFlag(spelled: "-const-gather-protocols-list") {
+                    // Use the driver option if supported.
+                    args += ["-const-gather-protocols-list", protocolListPath.str]
+                } else {
+                    args += ["-Xfrontend", "-const-gather-protocols-file",
+                             "-Xfrontend", protocolListPath.str]
+                }
                 extraInputPaths.append(protocolListPath)
             }
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -2087,10 +2087,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     results.checkNoDiagnostics()
                     if swiftFeatures.has(.emitContValuesSidecar) {
                         task.checkCommandLineContains(["-emit-const-values"])
-                        task.checkCommandLineContains(["-const-gather-protocols-file"])
+                        task.checkCommandLineMatches([.or("-const-gather-protocols-file", "-const-gather-protocols-list")])
                     } else {
                         task.checkCommandLineDoesNotContain("-emit-const-values")
                         task.checkCommandLineDoesNotContain("-const-gather-protocols-file")
+                        task.checkCommandLineDoesNotContain("-const-gather-protocols-list")
                     }
                 }
 


### PR DESCRIPTION
Pass `-const-gather-protocols-list` driver flag when available.

rdar://169280604