### PR TITLE
Teach Swift Build how to work with Command Line Tools installations

### DIFF
--- a/Sources/SWBApplePlatform/CMakeLists.txt
+++ b/Sources/SWBApplePlatform/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(SWBApplePlatform
   LocalizationInputFileGroupingStrategy.swift
   MacCatalystInfoExtension.swift
   Plugin.swift
+  PluginDCLT.swift
   RealityAssetsTaskProducer.swift
   StringCatalogCompilerOutputParser.swift
   StubBinaryTaskProducer.swift

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -28,6 +28,7 @@ public let initializePlugin: PluginInitializationFunction = { manager in
     manager.register(MacCatalystInfoExtension(), type: SDKVariantInfoExtensionPoint.self)
     manager.register(ApplePlatformInfoExtension(), type: PlatformInfoExtensionPoint.self)
     manager.register(AppleSettingsBuilderExtension(), type: SettingsBuilderExtensionPoint.self)
+    manager.registerDeveloperCommandLineToolsExtensions()
 }
 
 struct AppleDeveloperDirectoryExtension: DeveloperDirectoryExtension {

--- a/Sources/SWBApplePlatform/PluginDCLT.swift
+++ b/Sources/SWBApplePlatform/PluginDCLT.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SWBUtil
+import SWBCore
+
+extension MutablePluginManager {
+    func registerDeveloperCommandLineToolsExtensions() {
+        register(DeveloperCommandLineToolsSDKRegistryExtension(), type: SDKRegistryExtensionPoint.self)
+        register(DeveloperCommandLineToolsPlatformInfoExtension(), type: PlatformInfoExtensionPoint.self)
+        register(DeveloperCommandLineToolsToolchainRegistryExtension(), type: ToolchainRegistryExtensionPoint.self)
+    }
+}
+
+struct DeveloperCommandLineToolsSDKRegistryExtension: SDKRegistryExtension {
+    func additionalSDKs(context: any SDKRegistryExtensionAdditionalSDKsContext) async throws -> [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] {
+        let operatingSystem = context.hostOperatingSystem
+        guard operatingSystem == .macOS, let commandLineToolsPath = context.developerPath.commandLineToolsPath, let platform = context.platformRegistry.lookup(name: "macosx") else {
+            return []
+        }
+
+        let sdksPath = commandLineToolsPath.join("SDKs")
+        let sdkPaths = try Set(context.fs.listdir(sdksPath).filter({ $0.hasSuffix(".sdk") }).map { try context.fs.realpath(sdksPath.join($0)) }).sorted()
+        return try sdkPaths.map { sdkPath in
+            guard let settings = try PropertyList.fromPath(sdkPath.join("SDKSettings.plist"), fs: context.fs).dictValue else {
+                // The data should always be a dictionary.
+                throw StubError.error("unexpected SDK data")
+            }
+            return (sdkPath, platform, settings)
+        }
+    }
+}
+
+struct DeveloperCommandLineToolsPlatformInfoExtension: PlatformInfoExtension {
+    func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
+        let operatingSystem = context.hostOperatingSystem
+        guard operatingSystem == .macOS, let commandLineToolsPath = context.developerPath.commandLineToolsPath else {
+            return []
+        }
+
+        let sdksPath = commandLineToolsPath.join("SDKs")
+        let sdkVersions = try context.fs.listdir(sdksPath).compactMap { sdkName -> Version? in
+            let settings = try PropertyList.fromPath(sdksPath.join(sdkName).join("SDKSettings.plist"), fs: context.fs)
+            guard let sdkVersion = settings.dictValue?["Version"]?.stringValue else {
+                return nil
+            }
+            return try Version(sdkVersion)
+        }
+
+        guard let latestVersion = sdkVersions.sorted().last else {
+            return []
+        }
+
+        let versionString = latestVersion.normalized(toNumberOfComponents: 2).description
+
+        return try [
+            (
+                commandLineToolsPath,
+                [
+                    "Type": .plString("Platform"),
+                    "Name": .plString(operatingSystem.xcodePlatformName),
+                    "Identifier": .plString("com.apple.platform.macosx"),
+                    "Version": .plString(versionString),
+                    "Description": .plString("macOS"),
+                    "FamilyName": .plString("macOS"),
+                    "FamilyDisplayName": .plString("macOS"),
+                    "FamilyIdentifier": .plString(operatingSystem.xcodePlatformName),
+
+                    // DefaultProperties/AdditionalInfo matches what's actually in the platform... we should aim to minimize/remove this.
+                    "DefaultProperties": .plDict([
+                        "COMPRESS_PNG_FILES": .plString("NO"),
+                        "DEFAULT_COMPILER": .plString("com.apple.compilers.llvm.clang.1_0"),
+                        "DEPLOYMENT_TARGET_SETTING_NAME": .plString("MACOSX_DEPLOYMENT_TARGET"),
+                        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": .plString("YES"),
+                        "STRIP_PNG_TEXT": .plString("NO")
+                    ]),
+                    "AdditionalInfo": .plDict([
+                        "BuildMachineOSBuild": .plString("$(MAC_OS_X_PRODUCT_BUILD_VERSION)"),
+                        "CFBundleSupportedPlatforms": .plArray([.plString("MacOSX")]),
+                        "DTCompiler": .plString("$(GCC_VERSION)"),
+                        "DTPlatformBuild": .plString("$(PLATFORM_PRODUCT_BUILD_VERSION)"),
+                        "DTPlatformName": .plString(operatingSystem.xcodePlatformName),
+                        "DTPlatformVersion": .plString(versionString),
+                        "DTSDKBuild": .plString("$(SDK_PRODUCT_BUILD_VERSION)"),
+                        "DTSDKName": .plString("$(SDK_NAME)"),
+                        "DTXcode": .plString("$(XCODE_VERSION_ACTUAL)"),
+                        "DTXcodeBuild": .plString("$(XCODE_PRODUCT_BUILD_VERSION)"),
+                        "LSMinimumSystemVersion": .plString("$($(DEPLOYMENT_TARGET_SETTING_NAME))")
+                    ]),
+                ]
+            )]
+    }
+}
+
+struct DeveloperCommandLineToolsToolchainRegistryExtension: ToolchainRegistryExtension {
+    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
+        guard context.hostOperatingSystem == .macOS, let commandLineToolsPath = context.developerPath.commandLineToolsPath else {
+            return []
+        }
+
+        let fs = context.fs
+        return [
+            Toolchain(
+                identifier: ToolchainRegistry.defaultToolchainIdentifier,
+                displayName: "Default",
+                version: Version(),
+                aliases: ["default"],
+                path: commandLineToolsPath,
+                frameworkPaths: [],
+                libraryPaths: [commandLineToolsPath.join("usr").join("lib").str],
+                defaultSettings: [:],
+                overrideSettings: [:],
+                defaultSettingsWhenPrimary: [:],
+                executableSearchPaths: [commandLineToolsPath.join("usr").join("bin")],
+                testingLibraryPlatformNames: [],
+                fs: fs)
+        ]
+    }
+}
+
+extension Core.DeveloperPath {
+    var commandLineToolsPath: Path? {
+        switch self {
+        case let .swiftToolchain(_, xcodeDeveloperPath: path?), let .xcode(path):
+            // We shouldn't rely so heavily on the last path component being "CommandLineTools", but this is how xcrun does it.
+            return path.basename == "CommandLineTools" ? path : nil
+        case .swiftToolchain(_, xcodeDeveloperPath: nil):
+            return nil
+        }
+    }
+}

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -122,13 +122,14 @@ public final class Core: Sendable {
 
             struct Context: SDKRegistryExtensionAdditionalSDKsContext {
                 var hostOperatingSystem: OperatingSystem
+                var developerPath: Core.DeveloperPath
                 var platformRegistry: PlatformRegistry
                 var fs: any FSProxy
             }
 
             for `extension` in await pluginManager.extensions(of: SDKRegistryExtensionPoint.self) {
                 do {
-                    try await sdkRegistry.registerSDKs(extension: `extension`, context: Context(hostOperatingSystem: hostOperatingSystem, platformRegistry: core.platformRegistry, fs: localFS))
+                    try await sdkRegistry.registerSDKs(extension: `extension`, context: Context(hostOperatingSystem: hostOperatingSystem, developerPath: resolvedDeveloperPath, platformRegistry: core.platformRegistry, fs: localFS))
                 } catch {
                     delegate.emit(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("\(error)")))
                 }

--- a/Sources/SWBCore/Extensions/SDKRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/SDKRegistryExtension.swift
@@ -38,6 +38,7 @@ extension SDKRegistryExtension {
 
 public protocol SDKRegistryExtensionAdditionalSDKsContext: Sendable {
     var hostOperatingSystem: OperatingSystem { get }
+    var developerPath: Core.DeveloperPath { get }
     var platformRegistry: PlatformRegistry { get }
     var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
+++ b/Sources/SWBCore/Extensions/ToolchainRegistryExtension.swift
@@ -33,6 +33,7 @@ extension ToolchainRegistryExtension {
 
 public protocol ToolchainRegistryExtensionAdditionalToolchainsContext: Sendable {
     var hostOperatingSystem: OperatingSystem { get }
+    var developerPath: Core.DeveloperPath { get }
     var toolchainRegistry: ToolchainRegistry { get }
     var fs: any FSProxy { get }
 }

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -20,6 +20,7 @@ import SWBMacro
 @_spi(Testing) public protocol ToolchainRegistryDelegate: DiagnosticProducingDelegate {
     var pluginManager: any PluginManager { get }
     var platformRegistry: PlatformRegistry? { get }
+    var developerPath: Core.DeveloperPath { get }
 }
 
 /// Some problems are reported as either errors or warnings depending on if we're loading a built-in toolchain or an external toolchain
@@ -474,13 +475,14 @@ public final class ToolchainRegistry: @unchecked Sendable {
 
         struct Context: ToolchainRegistryExtensionAdditionalToolchainsContext {
             var hostOperatingSystem: OperatingSystem
+            var developerPath: Core.DeveloperPath
             var toolchainRegistry: ToolchainRegistry
             var fs: any FSProxy
         }
 
         for toolchainExtension in delegate.pluginManager.extensions(of: ToolchainRegistryExtensionPoint.self) {
             do {
-                for toolchain in try await toolchainExtension.additionalToolchains(context: Context(hostOperatingSystem: hostOperatingSystem, toolchainRegistry: self, fs: fs)) {
+                for toolchain in try await toolchainExtension.additionalToolchains(context: Context(hostOperatingSystem: hostOperatingSystem, developerPath: delegate.developerPath, toolchainRegistry: self, fs: fs)) {
                     try register(toolchain)
                 }
             } catch {

--- a/Tests/SWBCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SWBCoreTests/ToolchainRegistryTests.swift
@@ -50,8 +50,9 @@ import SWBServiceCore
             class TestDataDelegate : ToolchainRegistryDelegate {
                 private let _diagnosticsEngine = DiagnosticsEngine()
 
-                init(pluginManager: any PluginManager) {
+                init(pluginManager: any PluginManager, developerPath: Core.DeveloperPath) {
                     self.pluginManager = pluginManager
+                    self.developerPath = developerPath
                 }
 
                 var diagnosticsEngine: DiagnosticProducingDelegateProtocolPrivate<DiagnosticsEngine> {
@@ -67,6 +68,7 @@ import SWBServiceCore
                 }
 
                 var pluginManager: any PluginManager
+                var developerPath: Core.DeveloperPath
 
                 var platformRegistry: PlatformRegistry? {
                     nil
@@ -106,7 +108,7 @@ import SWBServiceCore
                 }
                 return
             }
-            let delegate = TestDataDelegate(pluginManager: core.pluginManager)
+            let delegate = TestDataDelegate(pluginManager: core.pluginManager, developerPath: core.developerPath)
             let registry = await ToolchainRegistry(delegate: delegate, searchPaths: [.init(path: tmpDirPath, strict: strict)], fs: fs, hostOperatingSystem: core.hostOperatingSystem)
             try perform(registry, delegate.warnings, delegate.errors)
         }


### PR DESCRIPTION
This adds a few new extensions in the Apple plugin which load the SDKs, synthesize a macOS platform, and synthesize a toolchain, from a Command Line Tools installation, since its internal layout is substantially different from that of an Xcode-based developer directory.