### PR TITLE
Report command line/environment/task action diffs in signature change task backtraces

### DIFF
--- a/Sources/SWBBuildSystem/BuildManager.swift
+++ b/Sources/SWBBuildSystem/BuildManager.swift
@@ -43,7 +43,7 @@ package actor BuildManager {
     /// Enqueue a build operation.
     ///
     /// The build will not actually be initiated until it has been requested to start.
-    package nonisolated func enqueue(request: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, description: BuildDescription, operationDelegate: any BuildOperationDelegate, clientDelegate: any ClientDelegate) -> BuildOperation {
+    package nonisolated func enqueue(request: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, description: BuildDescription, operationDelegate: any BuildOperationDelegate, clientDelegate: any ClientDelegate, priorBuildDescription: BuildDescription?) -> BuildOperation {
 
         let buildOnlyThesePaths: [Path]?
         switch request.buildCommand {
@@ -81,7 +81,7 @@ package actor BuildManager {
 
         let nodesToBuild = description.buildNodesToPrepareForIndex(buildRequest: request, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext)
 
-        return BuildOperation(request, buildRequestContext, description, environment: workspaceContext.userInfo?.processEnvironment, operationDelegate, clientDelegate, cachedBuildSystems, persistent: true, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspaceContext.workspace, core: workspaceContext.core, userPreferences: workspaceContext.userPreferences)
+        return BuildOperation(request, buildRequestContext, description, environment: workspaceContext.userInfo?.processEnvironment, operationDelegate, clientDelegate, cachedBuildSystems, persistent: true, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspaceContext.workspace, core: workspaceContext.core, userPreferences: workspaceContext.userPreferences, priorBuildDescription: priorBuildDescription)
     }
 
     package nonisolated func enqueueClean(request buildRequest: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, style: BuildLocationStyle, operationDelegate: any BuildOperationDelegate, dependencyResolverDelegate: (any TargetDependencyResolverDelegate)?) -> CleanOperation {

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -102,6 +102,11 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         dir.join("build.db")
     }
 
+    /// The path to a file next to the build database which records build descriptions previously used in conjunction with that database.
+    package var priorBuildDescriptionsRecordPath: Path {
+        dir.join("prior-build-descriptions.txt")
+    }
+
     /// The path to the bundle which contains the serialized build description, manifest, etc.
     package var packagePath: Path {
         Self.buildDescriptionPackagePath(inDir: dir, signature: signature)

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingKeyQueryDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingKeyQueryDynamicTaskSpec.swift
@@ -14,7 +14,7 @@ import SWBCore
 import SWBUtil
 
 final class ClangCachingKeyQueryDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .clangCachingKeyQuery(clangCachingKeyQueryTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingMaterializeKeyDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingMaterializeKeyDynamicTaskSpec.swift
@@ -14,7 +14,7 @@ import SWBCore
 import SWBUtil
 
 final class ClangCachingMaterializeKeyDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .clangCachingMaterializeKey(clangCachingTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingOutputMaterializerDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangCachingOutputMaterializerDynamicTaskSpec.swift
@@ -54,7 +54,7 @@ public struct ClangCachingOutputMaterializerTaskKey: Serializable, CustomDebugSt
 }
 
 final class ClangCachingOutputMaterializerDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .clangCachingOutputMaterializer(outputMaterializerTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/DynamicTaskSpecRegistry.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/DynamicTaskSpecRegistry.swift
@@ -35,7 +35,7 @@ package final class DynamicTaskSpecRegistry {
 }
 
 package protocol DynamicTaskSpec: TaskTypeDescription {
-    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) throws -> any ExecutableTask
+    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) throws -> Task
 
     func buildTaskAction(dynamicTaskKey: DynamicTaskKey, context: DynamicTaskOperationContext) throws -> TaskAction
 }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/PrecompileClangModuleDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/PrecompileClangModuleDynamicTaskSpec.swift
@@ -110,7 +110,7 @@ final class PrecompileClangModuleDynamicTaskSpec: DynamicTaskSpec {
         return Payload.self
     }
 
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .precompileClangModule(PrecompileClangModuleTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftCachingDynamicTaskSpec.swift
@@ -14,7 +14,7 @@ import SWBCore
 import SWBUtil
 
 final class SwiftCachingKeyQueryDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .swiftCachingKeyQuery(swiftCachingKeyQueryTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }
@@ -48,7 +48,7 @@ final class SwiftCachingKeyQueryDynamicTaskSpec: DynamicTaskSpec {
 }
 
 final class SwiftCachingMaterializeKeyDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .swiftCachingMaterializeKey(swiftCachingTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }
@@ -82,7 +82,7 @@ final class SwiftCachingMaterializeKeyDynamicTaskSpec: DynamicTaskSpec {
 }
 
 final class SwiftCachingOutputMaterializerDynamicTaskSpec: DynamicTaskSpec {
-    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    package func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case let .swiftCachingOutputMaterializer(outputMaterializerTaskKey) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task key \(dynamicTask.taskKey)")
         }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
@@ -136,7 +136,7 @@ struct SwiftDriverJobDynamicTaskPayload: TaskPayload {
 }
 
 final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
-    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) throws -> any ExecutableTask {
+    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) throws -> Task {
         let commandLinePrefix: [ByteString] = [
             "builtin-swiftTaskExecution",
             "--"

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverPlanningDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverPlanningDynamicTaskSpec.swift
@@ -42,7 +42,7 @@ final class SwiftDriverPlanningDynamicTaskSpec: DynamicTaskSpec {
         SwiftTaskPayload.self
     }
 
-    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> any ExecutableTask {
+    func buildExecutableTask(dynamicTask: DynamicTask, context: DynamicTaskOperationContext) -> Task {
         guard case .swiftDriverPlanning(let key) = dynamicTask.taskKey else {
             fatalError("Unexpected dynamic task: \(dynamicTask)")
         }

--- a/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/AuxiliaryFileTaskAction.swift
@@ -80,6 +80,22 @@ public final class AuxiliaryFileTaskAction: TaskAction {
         return .succeeded
     }
 
+    override public func describeDifferences(comparedTo otherTaskAction: TaskAction, fs: any FSProxy) throws -> [String] {
+        guard let otherFileAction = otherTaskAction as? AuxiliaryFileTaskAction else {
+            return []
+        }
+
+        // The inputs are attachmnents identified by contents hash, so we only compare input paths here.
+        if context.input != otherFileAction.context.input {
+            let contents = try fs.read(context.input)
+            let otherContents = try fs.read(otherFileAction.context.input)
+            let diff = contents.asString.difference(from: otherContents.asString)
+            return ["file contents changed [\(diff.humanReadableDescription)]"]
+        } else {
+            return []
+        }
+    }
+
     // MARK: Serialization
 
     public override func serialize<T: Serializer>(to serializer: T) {

--- a/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TaskAction.swift
@@ -79,6 +79,10 @@ open class TaskAction: PlannedTaskAction, PolymorphicSerializable
         return md5.signature
     }
 
+    open func describeDifferences(comparedTo otherTaskAction: TaskAction, fs: any FSProxy) throws -> [String] {
+        []
+    }
+
     /// Hook for task actions to configure itself in the build system, if they need to.
     /// - parameter task: The `Task` the action is acting on behalf of.
     /// - parameter dynamicExecutionDelegate: The dynamic execution context to request dynamic dependencies from.

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1452,7 +1452,24 @@ package final class BuildOperationTester {
                 } else {
                     nodesToBuild = nil
                 }
-                operation = BuildOperation(operationBuildRequest, buildRequestContext, results.buildDescription, environment: userInfo.processEnvironment, delegate, results.clientDelegate, cachedBuildSystems, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspace, core: core, userPreferences: userPreferences)
+
+                let priorBuildDescription: BuildDescription?
+                if operationBuildRequest.recordBuildBacktraces,
+                   case let .viaWorkspace(_, _, buildDescriptionManager) = testVariant {
+                    let buildDescriptionDelegate = MockTestBuildDescriptionConstructionDelegate()
+                    priorBuildDescription = await buildDescriptionManager.attemptLoadingPriorBuildDescription(
+                        currentDescription: results.buildDescription,
+                        buildRequest: operationBuildRequest,
+                        buildRequestContext: buildRequestContext,
+                        workspaceContext: workspaceContext,
+                        clientDelegate: results.clientDelegate,
+                        constructionDelegate: buildDescriptionDelegate
+                    )
+                } else {
+                    priorBuildDescription = nil
+                }
+
+                operation = BuildOperation(operationBuildRequest, buildRequestContext, results.buildDescription, environment: userInfo.processEnvironment, delegate, results.clientDelegate, cachedBuildSystems, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspace, core: core, userPreferences: userPreferences, priorBuildDescription: priorBuildDescription)
             }
 
             // Perform the build.

--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(SWBUtil
   ByteString.swift
   Cache.swift
   Collection.swift
+  CollectionDifferenceExtensions.swift
   CountedSet.swift
   CSV.swift
   Debugger.swift

--- a/Sources/SWBUtil/CollectionDifferenceExtensions.swift
+++ b/Sources/SWBUtil/CollectionDifferenceExtensions.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension CollectionDifference<String> {
+    package var humanReadableDescription: String {
+        var changeDescriptions: [String] = []
+        var reportedMoves: Set<Int> = []
+        for change in self.inferringMoves() {
+            if reportedMoves.contains(change.offset) {
+                continue
+            }
+            switch change {
+            case .insert(offset: let offset, element: let element, associatedWith: let associatedWith):
+                if let associatedWith {
+                    reportedMoves.insert(associatedWith)
+                    changeDescriptions.append("moved '\(element)'")
+                } else {
+                    changeDescriptions.append("inserted '\(element)'")
+                }
+            case .remove(offset: let offset, element: let element, associatedWith: let associatedWith):
+                if let associatedWith {
+                    reportedMoves.insert(associatedWith)
+                    changeDescriptions.append("moved '\(element)'")
+                } else {
+                    changeDescriptions.append("removed '\(element)'")
+                }
+            }
+        }
+        return changeDescriptions.joined(separator: ", ")
+    }
+}
+
+extension CollectionDifference<Character> {
+    package var humanReadableDescription: String {
+        var processedChanges: [(verb: String, lastOffset: Int, string: String)] = []
+
+        for change in self.inferringMoves() {
+            switch change {
+            case .insert(offset: let offset, element: let element, associatedWith: let associatedWith):
+                if let lastIndex = processedChanges.indices.last, processedChanges[lastIndex].verb == "inserted", processedChanges[lastIndex].lastOffset == offset - 1 {
+                    processedChanges[lastIndex].string.append(element)
+                    processedChanges[lastIndex].lastOffset = offset
+                } else {
+                    processedChanges.append((verb: "inserted", lastOffset: offset, string: String(element)))
+                }
+            case .remove(offset: let offset, element: let element, associatedWith: _):
+                if let lastIndex = processedChanges.indices.last, processedChanges[lastIndex].verb == "removed", processedChanges[lastIndex].lastOffset == offset + 1 {
+                    processedChanges[lastIndex].string.insert(element, at: processedChanges[lastIndex].string.startIndex)
+                    processedChanges[lastIndex].lastOffset = offset
+                } else {
+                    processedChanges.append((verb: "removed", lastOffset: offset, string: String(element)))
+                }
+            }
+        }
+
+        let changeDescriptions = processedChanges.map { change in
+            "\(change.verb) '\(change.string)'"
+        }
+
+        return changeDescriptions.joined(separator: ", ")
+    }
+}
+
+extension CollectionDifference<(String, String)> {
+    public var humanReadableEnvironmentDiff: String {
+        var changeDescriptions: [String] = []
+        for change in self {
+            switch change {
+            case .insert(offset: _, element: let element, associatedWith: _):
+                changeDescriptions.append("inserted '\(element.0)=\(element.1)'")
+            case .remove(offset: _, element: let element, associatedWith: _):
+                changeDescriptions.append("removed '\(element.0)=\(element.1)'")
+            }
+        }
+        return changeDescriptions.joined(separator: ", ")
+    }
+}

--- a/Tests/SWBUtilTests/CollectionDifferenceExtensionsTests.swift
+++ b/Tests/SWBUtilTests/CollectionDifferenceExtensionsTests.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBUtil
+
+@Suite fileprivate struct CollectionDifferenceExtensionsTests {
+    @Test
+    func stringListDiffs() {
+        do {
+            let original: [String] = ["a", "b"]
+            let modified: [String] = ["a", "b", "c", "d"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "inserted 'c', inserted 'd'")
+        }
+
+        do {
+            let original: [String] = ["a", "b", "c", "d"]
+            let modified: [String] = ["a", "b"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'd', removed 'c'")
+        }
+
+        do {
+            let original: [String] = ["a", "b", "c"]
+            let modified: [String] = ["c", "a", "b"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "moved 'c'")
+        }
+
+        do {
+            let original: [String] = ["a", "b", "c"]
+            let modified: [String] = ["a", "d", "c"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'b', inserted 'd'")
+        }
+
+        do {
+            let original: [String] = ["a", "b"]
+            let modified: [String] = ["a", "b"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "")
+        }
+
+        do {
+            let original: [String] = ["a", "b", "c", "d"]
+            let modified: [String] = ["d", "c", "b", "a"]
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "moved 'c', moved 'a', moved 'b'")
+        }
+    }
+
+    @Test
+    func stringDiffs() {
+        do {
+            let original = "abc"
+            let modified = "abcd"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "inserted 'd'")
+        }
+
+        do {
+            let original = "ac"
+            let modified = "abxyc"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "inserted 'bxy'")
+        }
+
+        do {
+            let original = "abcd"
+            let modified = "abc"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'd'")
+        }
+
+        do {
+            let original = "abxyc"
+            let modified = "ac"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'bxy'")
+        }
+
+        do {
+            let original = "abc"
+            let modified = "cab"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'c', inserted 'c'")
+        }
+
+        do {
+            let original = "abcde"
+            let modified = "deabc"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'de', inserted 'de'")
+        }
+
+        do {
+            let original = "hello"
+            let modified = "hxllo"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'e', inserted 'x'")
+        }
+
+        do {
+            let original = "abc"
+            let modified = "abc"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "")
+        }
+
+        do {
+            let original = "ac"
+            let modified = "axcy"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "inserted 'x', inserted 'y'")
+        }
+
+        do {
+            let original = "axcy"
+            let modified = "ac"
+            let diff = modified.difference(from: original)
+            #expect(diff.humanReadableDescription == "removed 'y', removed 'x'")
+        }
+    }
+
+
+    @Test
+    func environmentDiffs() {
+        do {
+            let original: [(String, String)] = [("HOME", "/home/user")]
+            let modified: [(String, String)] = [("HOME", "/home/user"), ("PATH", "/usr/bin")]
+            let diff = modified.difference(from: original) { $0 == $1 }
+            #expect(diff.humanReadableEnvironmentDiff == "inserted 'PATH=/usr/bin'")
+        }
+
+        do {
+            let original: [(String, String)] = [("HOME", "/home/user"), ("PATH", "/usr/bin")]
+            let modified: [(String, String)] = [("HOME", "/home/user")]
+            let diff = modified.difference(from: original) { $0 == $1 }
+            #expect(diff.humanReadableEnvironmentDiff == "removed 'PATH=/usr/bin'")
+        }
+
+        do {
+            let original: [(String, String)] = [("HOME", "/home/user"), ("OLDVAR", "old")]
+            let modified: [(String, String)] = [("HOME", "/home/user"), ("NEWVAR", "new")]
+            let diff = modified.difference(from: original) { $0 == $1 }
+
+            let description = diff.humanReadableEnvironmentDiff
+            #expect(description.contains("removed 'OLDVAR=old'"))
+            #expect(description.contains("inserted 'NEWVAR=new'"))
+        }
+
+        do {
+            let original: [(String, String)] = [("HOME", "/home/user")]
+            let modified: [(String, String)] = [("HOME", "/home/user")]
+            let diff = modified.difference(from: original) { $0 == $1 }
+
+            #expect(diff.humanReadableEnvironmentDiff == "")
+        }
+    }
+}


### PR DESCRIPTION
Only when task backtraces are enabled, attempt to load the prior build description corresponding to the current build database on a best effort basis. Then, if a task is rebuilt due to a signature change, load the prior task and compare it to the current one, reporting a human-readable diff.