### PR TITLE
Use decodeIfPresent when decoding optional sdkVariant

### DIFF
--- a/Sources/SwiftBuild/SWBBuildParameters.swift
+++ b/Sources/SwiftBuild/SWBBuildParameters.swift
@@ -76,7 +76,7 @@ public struct SWBRunDestinationInfo: Codable, Sendable {
             // Handle the message payload from earlier versions that didn't have the buildTarget enumeration
             let platform = try container.decode(String.self, forKey: .platform)
             let sdk: String = try container.decode(String.self, forKey: .sdk)
-            let sdkVariant: String? = try container.decode(String?.self, forKey: .sdkVariant)
+            let sdkVariant: String? = try container.decodeIfPresent(String.self, forKey: .sdkVariant)
             self.buildTarget = .toolchainSDK(platform: platform, sdk: sdk, sdkVariant: sdkVariant)
         }
 


### PR DESCRIPTION
Use decodeIfPresent when decoding optional sdkVariant.  Fixes the following:

$swift package init --type executable
$swift run --build-system xcode
error: error: unable to load --buildParametersFile ('/var/folders/j0/_0tkly6x0hn_0nb98ptbkn7c0000gn/T/TemporaryFile.5Uyd0U'): Failed to decode contents of file '/var/folders/j0/_0tkly6x0hn_0nb98ptbkn7c0000gn/T/TemporaryFile.5Uyd0U' as SWBBuildParameters: {
 ...
  }
}