### PR TITLE
Linux fixes for excessive Swift invalidation

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1855,7 +1855,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 cbc.scope.evaluate(BuiltinMacros.GCC_GENERATE_DEBUGGING_SYMBOLS) &&
                 emittingModuleSeparately {
                 let moduleWrapOutput = Path(moduleFilePath.withoutSuffix + ".o")
-                moduleOutputPaths.append(moduleWrapOutput)
+                // The modulewrap task depends on the module, but its outputs are linking requirements,
+                // not downstream compilation requirements track it as an extra output.
+                extraOutputPaths.append(moduleWrapOutput)
             }
 
             let dependencyValidationPayload: SwiftDependencyValidationPayload?

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1054,7 +1054,7 @@
             {
                 Name = "SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH";
                 Type = Path;
-                DefaultValue = "$(PER_ARCH_OBJECT_FILE_DIR)/$(SWIFT_MODULE_NAME).autolink";
+                DefaultValue = "$(PER_ARCH_OBJECT_FILE_DIR)/$(SWIFT_MODULE_NAME)-swiftbuild.autolink";
             },
             {
                 Name = "SWIFT_VALIDATE_CLANG_MODULES_ONCE_PER_BUILD_SESSION";

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -156,6 +156,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                 }
                 #expect(String(decoding: executionResult.stderr, as: UTF8.self) == "")
             }
+
+            try await tester.checkNullBuild(runDestination: destination, signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs)
         }
     }
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -3727,14 +3727,14 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 results.checkNoDiagnostics()
 
                 results.checkTask(.matchRuleType("SwiftAutolinkExtract")) { task in
-                    task.checkCommandLineMatches([.suffix("swift-autolink-extract"), .suffix("File1.o"), .suffix("File2.o"), "-o", .suffix("Tool.autolink")])
+                    task.checkCommandLineMatches([.suffix("swift-autolink-extract"), .suffix("File1.o"), .suffix("File2.o"), "-o", .suffix("Tool-swiftbuild.autolink")])
                     task.checkInputs([.pathPattern(.suffix("File1.o")), .pathPattern(.suffix("File2.o")), .any, .any, .any])
-                    task.checkOutputs([.pathPattern(.suffix("Tool.autolink"))])
+                    task.checkOutputs([.pathPattern(.suffix("Tool-swiftbuild.autolink"))])
                     results.checkTaskFollows(task, .matchRuleType("SwiftDriver Compilation"))
                 }
                 results.checkTask(.matchRuleType("Ld")) { task in
                     results.checkTaskFollows(task, .matchRuleType("SwiftAutolinkExtract"))
-                    task.checkInputs(contain: [.pathPattern(.suffix("Tool.autolink"))])
+                    task.checkInputs(contain: [.pathPattern(.suffix("Tool-swiftbuild.autolink"))])
                 }
             }
         }


### PR DESCRIPTION
1. Modulewrap was tracked as a compilation requirements output instead of a link requirements output. As a result, it could be written after the compilation requirements task completed, invalidating the compile on the next build.
2. In some cases, the Swift driver will write autolink files alongside the module in the same location we were using for the output of our autolink-extract task. Rename the output to avoid this.
3. Add a null build check to the end to end commandLineTool test to avoid regressions in this area

(found these with https://github.com/swiftlang/swift-llbuild/pull/1017, which I should really try to clean up and land)