### PR TITLE
GHA: Update windows build timeout

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,7 @@ jobs:
       linux_build_command: 'swift test --no-parallel'
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       linux_host_archs: '["x86_64", "aarch64"]'
+      windows_build_timeout: 180
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_swift_versions: '["nightly-main", "nightly-6.3"]'
       windows_build_command: 'Invoke-Program swift test --no-parallel'
@@ -44,6 +45,7 @@ jobs:
     with:
       enable_linux_checks: false
       enable_windows_docker: false
+      windows_build_timeout: 180
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_swift_versions: '["nightly-main", "nightly-6.3"]'
       windows_build_command: 'Invoke-Program swift test --no-parallel'
@@ -62,6 +64,7 @@ jobs:
       macos_xcode_versions: '["26.0"]'
       macos_pre_build_command: SKIP_ANDROID=1 INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
       macos_build_command: 'export PATH=$PATH:$RUNNER_TOOL_CACHE && swift package cmake-smoke-test --disable-sandbox --cmake-path `which cmake` --ninja-path `which ninja` --extra-cmake-arg -DCMAKE_C_COMPILER=`which clang` --extra-cmake-arg -DCMAKE_CXX_COMPILER=`which clang++` --extra-cmake-arg -DCMAKE_Swift_COMPILER=`which swiftc`'
+      windows_build_timeout: 180
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1 -SkipAndroid -InstallCMake'
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'Invoke-Program swift package cmake-smoke-test --disable-sandbox --cmake-path (Get-Command cmake).Path --ninja-path (Get-Command ninja).Path --extra-cmake-arg "-DCMAKE_C_COMPILER=$((Get-Command clang).Path)" --extra-cmake-arg "-DCMAKE_CXX_COMPILER=$((Get-Command clang).Path)" --extra-cmake-arg "-DCMAKE_Swift_COMPILER=$((Get-Command swiftc).Path)" --extra-cmake-arg "-DCMAKE_STATIC_LIBRARY_PREFIX_Swift=lib" --extra-cmake-arg "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL"'


### PR DESCRIPTION
The windows GitHub actions workflows has a timeout defaut of 1 hours. Update the Windows build timeout to 180 minutes - 3 hours.