### PR TITLE
Don't add strip symbols task on Windows

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -221,6 +221,11 @@ final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer 
             return
         }
 
+        // we can't rely on strip.exe being availalbe on Windows
+        guard !scope.evaluate(BuiltinMacros.HOST_PLATFORM).contains("windows") else {
+            return
+        }
+
         // NOTE: These must be captured here; they are mutable and used to define the task order gating.
         let phaseStartNodes = self.phaseStartNodes
         let phaseEndTask = self.phaseEndTask


### PR DESCRIPTION
During CI runs of https://github.com/swiftlang/swift-package-manager/pull/9380 it was discovered that some tests were failing on Windows due to strip command not being found.
As [suggested](https://github.com/swiftlang/swift-package-manager/pull/9380#issuecomment-3880953936) this PR aims to turn off adding strip symbols task on Windows builds.
