### PR TITLE
Prevent CAS size limiting during script phases

### DIFF
--- a/Sources/SWBCore/ShellScript.swift
+++ b/Sources/SWBCore/ShellScript.swift
@@ -217,8 +217,9 @@ public func computeScriptEnvironment(_ type: ScriptType, scope: MacroEvaluationS
     result.removeValue(forKey: BuiltinMacros.BUILD_DESCRIPTION_CACHE_DIR.name)
 
     if scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE) {
-        // Make sure the cache directory is not going to be deleted via an `xcodebuild` invocation from the script.
+        // Make sure the cache directory is not going to be deleted or pruned via an `xcodebuild` invocation from the script.
         result["COMPILATION_CACHE_KEEP_CAS_DIRECTORY"] = "YES"
+        result["COMPILATION_CACHE_LIMIT_SIZE"] = "0"
     }
 
     return result

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -1791,9 +1791,11 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
             try await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTask(.matchRuleType("PhaseScriptExecution")) { task in
                     #expect(task.environment.bindings.contains(where: { $0 == ("COMPILATION_CACHE_KEEP_CAS_DIRECTORY", "YES") }))
+                    #expect(task.environment.bindings.contains(where: { $0 == ("COMPILATION_CACHE_LIMIT_SIZE", "0") }))
                 }
                 results.checkTask(.matchRuleType("RuleScriptExecution")) { task in
                     #expect(task.environment.bindings.contains(where: { $0 == ("COMPILATION_CACHE_KEEP_CAS_DIRECTORY", "YES") }))
+                    #expect(task.environment.bindings.contains(where: { $0 == ("COMPILATION_CACHE_LIMIT_SIZE", "0") }))
                 }
                 results.checkWarning(.prefix("Run script build phase 'Script' will be run during every build"))
             }


### PR DESCRIPTION
When a script phase runs a build of its own, we do not want to limit the size of the CAS within the sub build, and only the limit (if any) that is set for the parent build should take effect. This avoids unnecessary work and could prevent correctness issues if we ever want to release the build system's access to the CAS temporarily during a build for any reason.

rdar://170093561
