### PR TITLE
Add the new experimentalWindowDLL to SwiftBuild's copy

### DIFF
--- a/Sources/SWBCore/ArtifactBundleMetadata.swift
+++ b/Sources/SWBCore/ArtifactBundleMetadata.swift
@@ -37,6 +37,7 @@ package struct ArtifactBundleMetadata: Sendable, Hashable, Decodable {
         case executable
         case staticLibrary
         case swiftSDK
+        case experimentalWindowsDLL
         case crossCompilationDestination
     }
 

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1677,7 +1677,7 @@ private class SettingsBuilder: ProjectMatchLookup {
                                 }
                             }
                         }
-                    case .crossCompilationDestination, .swiftSDK, .executable:
+                    case .crossCompilationDestination, .swiftSDK, .executable, .experimentalWindowsDLL:
                         break
                     }
                 }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -688,8 +688,11 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }
                 for (name, artifact) in metadata.artifacts {
                     switch artifact.type {
-                    case .crossCompilationDestination, .executable, .swiftSDK:
+                    case .crossCompilationDestination, .swiftSDK:
                         context.warning("ignoring artifact '\(name)' of type '\(artifact.type)' because it cannot be linked", location: .path(absolutePath))
+                        continue
+                    case .executable, .experimentalWindowsDLL:
+                        // Just ignore, these are used by SwiftPM
                         continue
                     case .staticLibrary:
                         var foundMatch = false


### PR DESCRIPTION
SwiftBuild has a copy of the ArtifactBundleMetadata structure from SwiftPM. Add the new ArtifactType experimentalWindowsDLL so it can continue to parse the artifact bundle metadata.

Also cleaned up a warning about exectuable artifacts which are used by SwiftPM plugins and should just be ignored.
