### PR TITLE
Use llvm-strip as strip tool on Windows

### DIFF
--- a/Sources/SWBWindowsPlatform/CMakeLists.txt
+++ b/Sources/SWBWindowsPlatform/CMakeLists.txt
@@ -16,7 +16,8 @@ SwiftBuild_Bundle(MODULE SWBWindowsPlatform FILES
   Specs/Windows.xcspec
   Specs/WindowsCompile.xcspec
   Specs/WindowsLd.xcspec
-  Specs/WindowsLibtool.xcspec)
+  Specs/WindowsLibtool.xcspec
+  Specs/WindowsStripSymbols.xcspec)
 target_link_libraries(SWBWindowsPlatform PUBLIC
   SWBCore
   SWBMacro

--- a/Sources/SWBWindowsPlatform/Specs/WindowsStripSymbols.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsStripSymbols.xcspec
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+(
+    {
+        Domain = windows;
+        Identifier = com.apple.build-tools.strip;
+        Type = Tool;
+        BasedOn = "default:com.apple.build-tools.strip";
+        CommandLine = "llvm-strip [options] [input]";
+        Options = (
+            {
+                Name = "STRIP_SWIFT_SYMBOLS";
+                Type = Boolean;
+                Condition = "$(DEBUG_INFORMATION_FORMAT) == dwarf-with-dsym && $(STRIP_STYLE) != all";
+                CommandLineArgs = {
+                    YES = (
+                        "-T",
+                        );
+                    NO = ();
+                };
+            },
+        );
+    }
+)

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -9383,6 +9383,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             try await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: [:]), runDestination: .host, fs: fs) { results in
                 try results.checkTask(.matchRuleType("Strip")) { task in
                     switch try ProcessInfo.processInfo.hostOperatingSystem() {
+                    case .windows:
+                        task.checkCommandLineContains(["llvm-strip", "-T"])
                     case .macOS:
                         task.checkCommandLineContains(["-T"])
                     default:


### PR DESCRIPTION
swiftlang/swift-package-manager#9380 turns on deployment post processing for release builds which caused some tests on Windows CI to fail with "strip.exe not found" error.

strip is part of binutils and is not available by default on Windows, but llvm-strip is part of Swift Toolchain for Windows so we can use it instead.

Mutually exclusive with #1079
