### PR TITLE
swiftSDKRunDestination requires a host sdk

### DIFF
--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -3513,7 +3513,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test
+    @Test(.requireSDKs(.host))
     func swiftSDKRunDestination() async throws {
         try await withTemporaryDirectory { tmpDir in
             let clangCompilerPath = try await self.clangCompilerPath


### PR DESCRIPTION
This test technically requires a host SDK