### PR TITLE
Restrict link phase changes to package projects

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1004,7 +1004,13 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     createLinkerTask = false
                 // If we're not merging libraries and this isn't installAPI, link if we have inputs.
                 } else if !linkerInputNodes.isEmpty || !staticallyLinkedItemsInFrameworkPhase.isEmpty {
-                    createLinkerTask = true
+                    if linkerInputNodes.isEmpty && objectsInFrameworksPhase.isEmpty && context.project?.isPackage != true {
+                        // Compatibility hack for existing Xcode projects
+                        context.warning("Target '\(context.configuredTarget?.target.name ?? "<unknown>")' contains a non-empty linked libraries phase, but it contains no object files, and no sources are being compiled. For compatibility, no binary will be produced. Remove unused entries in the linked libraries phase to suppress this warning.")
+                        createLinkerTask = false
+                    } else {
+                        createLinkerTask = true
+                    }
                 } else {
                     createLinkerTask = false
                 }

--- a/Tests/SWBTaskConstructionTests/ObjectLibraryTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ObjectLibraryTaskConstructionTests.swift
@@ -143,7 +143,7 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
         let testWorkspace = TestWorkspace(
             "Test",
             projects: [
-                TestProject(
+                TestPackageProject(
                     "aProject",
                     groupTree: TestGroup(
                         "Sources",


### PR DESCRIPTION
Restrict the changes in https://github.com/swiftlang/swift-build/pull/1022 to packages. Preserve the previous behavior for Xcode projects, but emit a warning since it doesn't make sense to have a non-empty linked libraries phase when nothing is being linked

rdar://169442181