### PR TITLE
Teach Swift Build how to handle testing libraries in DCLT

### DIFF
--- a/Sources/SWBApplePlatform/PluginDCLT.swift
+++ b/Sources/SWBApplePlatform/PluginDCLT.swift
@@ -82,7 +82,11 @@ struct DeveloperCommandLineToolsPlatformInfoExtension: PlatformInfoExtension {
                         "DEFAULT_COMPILER": .plString("com.apple.compilers.llvm.clang.1_0"),
                         "DEPLOYMENT_TARGET_SETTING_NAME": .plString("MACOSX_DEPLOYMENT_TARGET"),
                         "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": .plString("YES"),
-                        "STRIP_PNG_TEXT": .plString("NO")
+                        "STRIP_PNG_TEXT": .plString("NO"),
+
+                        // NOT currently in the platform...
+                        "TEST_FRAMEWORK_SEARCH_PATHS": .plString("$(inherited) $(DEVELOPER_DIR)/Library/Developer/Frameworks"),
+                        "NO_XCTEST": .plString("YES"),
                     ]),
                     "AdditionalInfo": .plDict([
                         "BuildMachineOSBuild": .plString("$(MAC_OS_X_PRODUCT_BUILD_VERSION)"),

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/XCTestProductTypeTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/XCTestProductTypeTaskProducer.swift
@@ -322,9 +322,15 @@ final class XCTestProductPostprocessingTaskProducer: PhasedTaskProducer, TaskPro
 
     /// The path to the copy of `Testing.framework` which should be used by clients.
     static fileprivate func swiftTestingFrameworkPath(_ scope: MacroEvaluationScope, _ platform: Platform?, _ fs: any FSProxy) -> Path {
-         let testingFrameworkPath = Path(scope.evaluate(BuiltinMacros.PLATFORM_DIR)).join("Developer/Library/Frameworks/Testing.framework")
-         return fs.exists(testingFrameworkPath) ? testingFrameworkPath : Path("")
-     }
+        let testingFrameworkPaths = [
+            // Swift.org toolchains, Apple Xcode
+            Path(scope.evaluate(BuiltinMacros.PLATFORM_DIR)).join("Developer/Library/Frameworks/Testing.framework"),
+
+            // Apple Developer Command Line Tools
+            scope.evaluate(BuiltinMacros.DEVELOPER_DIR).join("Library/Developer/Frameworks/Testing.framework"),
+        ]
+        return testingFrameworkPaths.first(where: fs.exists) ?? Path("")
+    }
 
      /// The paths to libraries and frameworks produced by the XCTest project, including `XCTest.framework` and some
      /// of its dependencies, which should be used by clients.

--- a/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec
@@ -342,8 +342,10 @@
         DefaultBuildProperties = {
             WRAPPER_EXTENSION = "xctest";
             ENABLE_TESTING_SEARCH_PATHS = YES;
-            PRODUCT_SPECIFIC_LDFLAGS = "-Xlinker -needed_framework -Xlinker XCTest -framework XCTest -Xlinker -needed-lXCTestSwiftSupport -lXCTestSwiftSupport";
-            PRODUCT_TYPE_SWIFT_STDLIB_TOOL_FLAGS = "--scan-executable \"$(PLATFORM_DIR)/Developer/usr/lib/libXCTestSwiftSupport.dylib\"";
+            PRODUCT_SPECIFIC_LDFLAGS = "$(PRODUCT_SPECIFIC_LDFLAGS_NO_XCTEST_$(NO_XCTEST:default=NO))";
+            PRODUCT_SPECIFIC_LDFLAGS_NO_XCTEST_NO = (-Xlinker, -needed_framework, -Xlinker, XCTest, -framework, XCTest, -Xlinker, -needed-lXCTestSwiftSupport, -lXCTestSwiftSupport);
+            PRODUCT_TYPE_SWIFT_STDLIB_TOOL_FLAGS = "$(PRODUCT_TYPE_SWIFT_STDLIB_TOOL_FLAGS_NO_XCTEST_$(NO_XCTEST:default=NO))";
+            PRODUCT_TYPE_SWIFT_STDLIB_TOOL_FLAGS_NO_XCTEST_NO = ("--scan-executable", "$(PLATFORM_DIR)/Developer/usr/lib/libXCTestSwiftSupport.dylib");
             XCTRUNNER_PATH = "$(XCTRUNNER_PATH$(TEST_BUILD_STYLE))";
             LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))";
             LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_YES = "@loader_path/Frameworks";

--- a/Sources/SWBUniversalPlatform/TestEntryPointGenerationTaskAction.swift
+++ b/Sources/SWBUniversalPlatform/TestEntryPointGenerationTaskAction.swift
@@ -57,8 +57,10 @@ class TestEntryPointGenerationTaskAction: TaskAction {
 
             \(testObservationFragment)
 
+            #if canImport(XCTest)
             public import XCTest
             \(discoveredTestsFragment(tests: tests, options: options))
+            #endif
 
             @main
             @available(macOS 10.15, iOS 11, watchOS 4, tvOS 11, visionOS 1, *)
@@ -188,6 +190,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
         """
         #if !os(Windows) // Test observation is not supported on Windows
         public import Foundation
+        #if canImport(XCTest)
         public import XCTest
 
         public final class __SwiftPMXCTestObserver: NSObject {
@@ -287,6 +290,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
                 write(record: __SwiftPMTestEventRecord(bundleEvent: record))
             }
         }
+        #endif
 
         // FIXME: Copied from `Lock.swift` in TSCBasic, would be nice if we had a better way
 
@@ -572,6 +576,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
             }
         }
 
+        #if canImport(XCTest)
         public import XCTest
 
         #if canImport(Darwin) // XCTAttachment is unavailable in swift-corelibs-xctest.
@@ -585,6 +590,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
             }
         }
         #endif
+        #endif
 
         extension __SwiftPMTestBundle {
             init(_ testBundle: Bundle) {
@@ -595,11 +601,13 @@ class TestEntryPointGenerationTaskAction: TaskAction {
             }
         }
 
+        #if canImport(XCTest)
         extension __SwiftPMTestCase {
             init(_ testCase: XCTestCase) {
                 self.init(name: testCase.name)
             }
         }
+        #endif
 
         extension __SwiftPMTestErrorInfo {
             init(_ error: any Swift.Error) {
@@ -607,6 +615,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
             }
         }
 
+        #if canImport(XCTest)
         #if canImport(Darwin) // XCTIssue is unavailable in swift-corelibs-xctest.
         extension __SwiftPMTestIssue {
             init(_ issue: XCTIssue) {
@@ -681,6 +690,7 @@ class TestEntryPointGenerationTaskAction: TaskAction {
                 self.init(name: testSuite.name)
             }
         }
+        #endif
         #endif
         """
 }


### PR DESCRIPTION
- Testing is located at a different path in DCLT vs Xcode/Swift.org
- XCTest is not present