### PR TITLE
Skip RegisterExecutionPolicyException tasks on non-Darwin platforms

### DIFF
--- a/Sources/SWBApplePlatform/CMakeLists.txt
+++ b/Sources/SWBApplePlatform/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(SWBApplePlatform
   Plugin.swift
   PluginDCLT.swift
   RealityAssetsTaskProducer.swift
+  RegisterExecutionPolicyException.swift
   StringCatalogCompilerOutputParser.swift
   StubBinaryTaskProducer.swift
   XCStringsInputFileGroupingStrategy.swift)

--- a/Sources/SWBApplePlatform/RegisterExecutionPolicyException.swift
+++ b/Sources/SWBApplePlatform/RegisterExecutionPolicyException.swift
@@ -12,29 +12,34 @@
 
 import SWBProtocol
 import SWBUtil
-public import SWBMacro
+package import SWBMacro
+package import SWBCore
 
-public final class RegisterExecutionPolicyExceptionToolSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
-    public static let identifier = "com.apple.build-tasks.register-execution-policy-exception"
+package final class RegisterExecutionPolicyExceptionToolSpec: CommandLineToolSpec, SpecIdentifierType, SpecImplementationType, @unchecked Sendable {
+    package static let identifier = "com.apple.build-tasks.register-execution-policy-exception"
 
-    public static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
+    required convenience init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
+        self.init(parser, basedOnSpec, isGeneric: false)
+    }
+
+    package static func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
         return RegisterExecutionPolicyExceptionToolSpec(registry, proxy, ruleInfoTemplate: ["RegisterExecutionPolicyException", .input], commandLineTemplate: [.execPath, .options, .input])
     }
 
-    public override func computeExecutablePath(_ cbc: CommandBuildContext) -> String {
+    package override func computeExecutablePath(_ cbc: CommandBuildContext) -> String {
         return "builtin-RegisterExecutionPolicyException"
     }
 
-    public override func resolveExecutionDescription(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String {
+    package override func resolveExecutionDescription(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String {
         return cbc.scope.evaluate(cbc.scope.namespace.parseString("Register execution policy exception for $(InputFileName)"), lookup: { self.lookup($0, cbc, delegate, lookup) })
     }
 
-    public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
+    package override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // FIXME: We should ensure this cannot happen.
         fatalError("unexpected direct invocation")
     }
 
-    public func constructRegisterExecutionPolicyExceptionTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
+    package func constructRegisterExecutionPolicyExceptionTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         let input = cbc.input
         let outputs = [delegate.createVirtualNode("RegisterExecutionPolicyException \(input.absolutePath.str)")]
 

--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -147,7 +147,6 @@ add_library(SWBCore
   SpecImplementations/Tools/ProcessSDKImports.swift
   SpecImplementations/Tools/ProcessXCFrameworkLibrary.swift
   SpecImplementations/Tools/ProductPackaging.swift
-  SpecImplementations/Tools/RegisterExecutionPolicyException.swift
   SpecImplementations/Tools/SetAttributes.swift
   SpecImplementations/Tools/ShellScriptTool.swift
   SpecImplementations/Tools/SignatureCollection.swift

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1197,7 +1197,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
     public static let fallbackExecutionDescription: String = "Processing…"
 
     /// Resolve the execution description to use for the given context.
-    public func resolveExecutionDescription(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String {
+    open func resolveExecutionDescription(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> String {
         guard let execDescription else {
             // FIXME: We should either require an execution description, or make up a better fallback description.
             return Self.fallbackExecutionDescription

--- a/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
+++ b/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
@@ -126,7 +126,6 @@ public struct BuiltinSpecsExtension: SpecificationsExtension {
             MergeInfoPlistSpec.self,
             ProcessSDKImportsSpec.self,
             ProcessXCFrameworkLibrarySpec.self,
-            RegisterExecutionPolicyExceptionToolSpec.self,
             SwiftHeaderToolSpec.self,
             TAPIMergeToolSpec.self,
             ValidateDependenciesSpec.self,

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SWBCore
+package import SWBCore
 import SWBUtil
 import SWBMacro
 import SWBProtocol
@@ -40,7 +40,7 @@ enum InstallAPIDestination {
     }
 }
 
-final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer {
+package final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer {
 
     /// Set of auxiliary files we've created tasks for which only need to be created once per variant.
     fileprivate var uniqueAuxiliaryFilePaths = Set<Path>()
@@ -62,7 +62,7 @@ final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer 
 
     // MARK: Task generation
 
-    func generateTasks() async -> [any PlannedTask] {
+    package func generateTasks() async -> [any PlannedTask] {
         let scope = context.settings.globalScope
         var tasks: [any PlannedTask] = []
 
@@ -118,7 +118,11 @@ final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer 
         // CodeSign is actually per-variant, but it enumerates variants itself because it might need to coalesce tasks (see `testPerVariantSigning()`)
         addPostprocessingFunction("CodeSign", addCodeSignTasks, perVariant: false, .productPostprocessor)
         if isProducingProduct {
-            addPostprocessingFunction("RegisterExecutionPolicyException", addExecutionPolicyExceptionTasks, perVariant: usePerVariantForUnbundled, .productPostprocessor)
+            for ext in await taskProducerExtensions(context.workspaceContext) {
+                for step in ext.productPostprocessingSteps() {
+                    addPostprocessingFunction(step.name, { scope, tasks in await step.generateTasks(scope: scope, tasks: &tasks, producer: self) }, perVariant: step.shouldRunPerVariant(producer: self), .productPostprocessor)
+                }
+            }
             addPostprocessingFunction("Validate", addProductValidationTasks, perVariant: false, .productPostprocessor)
         }
         addPostprocessingFunction("RegisterProduct", addProductRegistrationTasks, perVariant: false, .productPostprocessor)
@@ -510,24 +514,6 @@ final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer 
             if isSigningBinary {
                 nestedSigningTaskOrderingNodes.append(signingOrderingNode)
             }
-        }
-    }
-
-    private func addExecutionPolicyExceptionTasks(_ scope: MacroEvaluationScope, _ tasks: inout [any PlannedTask]) async {
-        guard scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("build") else {
-            return
-        }
-
-        // Pointless for static libraries/frameworks
-        if context.productType is StaticLibraryProductTypeSpec || context.productType is StaticFrameworkProductTypeSpec {
-            return
-        }
-
-        await appendGeneratedTasks(&tasks) { delegate in
-            let path = scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.FULL_PRODUCT_NAME))
-            let input = FileToBuild(context: context, absolutePath: path.normalize())
-            let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [input])
-            await context.registerExecutionPolicyExceptionSpec?.constructRegisterExecutionPolicyExceptionTask(cbc, delegate)
         }
     }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -251,8 +251,6 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     let modulesVerifierSpec: ModulesVerifierToolSpec
     let clangModuleVerifierInputGeneratorSpec: ClangModuleVerifierInputGeneratorSpec
     let productPackagingSpec: ProductPackagingToolSpec
-    public let _registerExecutionPolicyExceptionSpec: Result<RegisterExecutionPolicyExceptionToolSpec, any Error>
-    var registerExecutionPolicyExceptionSpec: RegisterExecutionPolicyExceptionToolSpec? { return specForResult(_registerExecutionPolicyExceptionSpec) }
     let setAttributesSpec: SetAttributesSpec
     let shellScriptSpec: ShellScriptToolSpec
     let signatureCollectionSpec: SignatureCollectionSpec
@@ -374,7 +372,6 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.modulesVerifierSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.modules-verifier", domain: domain, ofType: ModulesVerifierToolSpec.self)
         self.clangModuleVerifierInputGeneratorSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.module-verifier-input-generator", domain: domain, ofType: ClangModuleVerifierInputGeneratorSpec.self)
         self.productPackagingSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ProductPackagingToolSpec.self)
-        self._registerExecutionPolicyExceptionSpec = .init(workspaceContext, settings)
         self.setAttributesSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.set-attributes", domain: domain, ofType: SetAttributesSpec.self)
         self.shellScriptSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.commands.shell-script", domain: domain, ofType: ShellScriptToolSpec.self)
         self.signatureCollectionSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.signature-collection", domain: domain, ofType: SignatureCollectionSpec.self)

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducerExtensionPoint.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducerExtensionPoint.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 package import SWBCore
+package import SWBMacro
 import SWBUtil
 
 package struct TaskProducerExtensionPoint: ExtensionPoint, Sendable {
@@ -30,6 +31,8 @@ package protocol TaskProducerExtension: Sendable {
     var globalTaskProducers: [any GlobalTaskProducerFactory] { get }
 
     func generateAdditionalTasks(_ tasks: inout [any PlannedTask], _ producer: any TaskProducer) async
+
+    func productPostprocessingSteps() -> [any ProductPostprocessingStep.Type]
 }
 
 package protocol TaskProducerFactory: Sendable {
@@ -40,4 +43,10 @@ package protocol TaskProducerFactory: Sendable {
 
 package protocol GlobalTaskProducerFactory: Sendable {
     func createGlobalTaskProducer(_ globalContext: TaskProducerContext, targetContexts: [TaskProducerContext]) -> any TaskProducer
+}
+
+package protocol ProductPostprocessingStep {
+    static var name: String { get }
+    static func shouldRunPerVariant(producer: ProductPostprocessingTaskProducer) -> Bool
+    static func generateTasks(scope: MacroEvaluationScope, tasks: inout [any PlannedTask], producer: ProductPostprocessingTaskProducer) async
 }

--- a/Sources/SWBUniversalPlatform/Plugin.swift
+++ b/Sources/SWBUniversalPlatform/Plugin.swift
@@ -80,6 +80,10 @@ struct UniversalPlatformTaskProducerExtension: TaskProducerExtension {
 
     func generateAdditionalTasks(_ tasks: inout [any SWBCore.PlannedTask], _ producer: any SWBTaskConstruction.TaskProducer) {
     }
+
+    func productPostprocessingSteps() -> [any ProductPostprocessingStep.Type] {
+        []
+    }
 }
 
 struct UniversalPlatformTaskActionExtension: TaskActionExtension {


### PR DESCRIPTION
These were already a no-op on Darwin, but we shouldn't be planning them in the first place