### PR TITLE
Add support for tests which require specific Swift SDK installations

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -68,6 +68,15 @@ jobs:
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1 -SkipAndroid -InstallCMake'
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'Invoke-Program swift package cmake-smoke-test --disable-sandbox --cmake-path (Get-Command cmake).Path --ninja-path (Get-Command ninja).Path --extra-cmake-arg "-DCMAKE_C_COMPILER=$((Get-Command clang).Path)" --extra-cmake-arg "-DCMAKE_CXX_COMPILER=$((Get-Command clang).Path)" --extra-cmake-arg "-DCMAKE_Swift_COMPILER=$((Get-Command swiftc).Path)" --extra-cmake-arg "-DCMAKE_STATIC_LIBRARY_PREFIX_Swift=lib" --extra-cmake-arg "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL"'
+  wasm-integration-tests:
+    name: WASM Integration Tests
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
+    with:
+      enable_linux_checks: false
+      enable_windows_checks: false
+      enable_macos_checks: false
+      enable_wasm_sdk_build: true
+      wasm_sdk_build_command: swift test --filter WebAssemblyIntegrationTests
 
   soundness:
     name: Soundness

--- a/Package.swift
+++ b/Package.swift
@@ -385,6 +385,12 @@ let package = Package(
             dependencies: ["SWBTestSupport"],
             swiftSettings: swiftSettings(languageMode: .v6)),
 
+        // Swift SDK integration tests
+        .testTarget(
+            name: "WebAssemblyIntegrationTests",
+            dependencies: ["SWBBuildService", "SWBBuildSystem", "SwiftBuildTestSupport", "SWBTestSupport"],
+            swiftSettings: swiftSettings(languageMode: .v6)),
+
         // Perf tests
         .testTarget(
             name: "SWBBuildSystemPerfTests",

--- a/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBTestSupport
+import SWBCore
+import SWBUtil
+
+@Suite
+fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
+    @Test
+    func stubTest() async throws {
+
+    }
+}


### PR DESCRIPTION
Begin stubbing out some support for a CI workflow which runs tests depending on particular Swift SDKs being installed. 