### PR TITLE
[Bounds Safety] Add build setting to control enablement of soft traps

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -610,6 +610,25 @@
               // Hidden
             },
             {
+                Name = "CLANG_BOUNDS_SAFETY_SOFT_TRAPS";
+                Type = Enumeration;
+                FileTypes = (
+                    "sourcecode.c.c",
+                );
+                Values = (
+                    "compiler-default",
+                );
+                DefaultValue = "compiler-default";
+                CommandLineArgs = {
+                    // Use the compiler default which is hard traps (no compiler flag needed)
+                    "compiler-default" = ();
+                    // E.g. `call-minimal` or `call-with-str`
+                    "<<otherwise>>" = ( "-fbounds-safety-soft-traps=$(value)" );
+                };
+                Condition = "$(CLANG_ENABLE_BOUNDS_ATTRIBUTES) || $(CLANG_ENABLE_BOUNDS_SAFETY)";
+                // Hidden
+            },
+            {
                 Name = "CLANG_ENABLE_APP_EXTENSION";
                 Type = Boolean;
                 DefaultValue = "$(APPLICATION_EXTENSION_API_ONLY)";


### PR DESCRIPTION
This patch introduces the `CLANG_BOUNDS_SAFETY_SOFT_TRAPS` build setting. It takes one special value (`compiler-default`) that will cause `-fbounds-safety-soft-traps=` to not be passed. This is the default which preserves the existing build behavior (i.e. use hard traps).

Otherwise the build setting passes `-fbounds-safety-soft-traps=<value>` as a compiler flag where `<value>` is the value of the build setting. The compiler currently supports `call-minimal` and `call-with-str` as values but this may evolve over time which is why the build setting includes the flexibility to support different soft traps modes.

This new build settings only applies when all of following are true:

* `CLANG_ENABLE_BOUNDS_SAFETY` or `CLANG_ENABLE_BOUNDS_ATTRIBUTES` is enabled.
* For C source files

The existing `boundsSafetyCLanguageExtension` test case has been modified to test the behavior of these new flags.

rdar://170281128
