### PR TITLE
[6.3] BUILD_ONLY_KNOWN_LOCALIZATIONS should be respected in both Copy Files phases and during installloc

### DIFF
--- a/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
@@ -178,13 +178,13 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
                 }))
 
             case BuiltinMacros.ASSETCATALOG_COMPILER_INCLUDED_LANGUAGES:
-                if cbc.scope.evaluate(BuiltinMacros.BUILD_ONLY_KNOWN_LOCALIZATIONS), var knownLocalizations = cbc.producer.project?.knownLocalizations {
-
-                    knownLocalizations.removeAll(where: { $0 == "Base" })
-                    if !knownLocalizations.isEmpty {
-                        delegate.note("Asset Catalog will compile languages for known regions: \(knownLocalizations.joined(separator: ", "))", location: .path(cbc.input.absolutePath))
+                if var restrictedLocalizations = cbc.scope.restrictedLocRegionsToBuild(in: cbc.producer.project) {
+                    restrictedLocalizations.remove("Base") // Base is not a valid Asset Catalog locale
+                    let restrictedLocalizations = restrictedLocalizations.sorted()
+                    if !restrictedLocalizations.isEmpty {
+                        delegate.note("Asset Catalog will compile languages for known regions: \(restrictedLocalizations.joined(separator: ", "))", location: .path(cbc.input.absolutePath))
                     }
-                    return cbc.scope.namespace.parseLiteralStringList(knownLocalizations)
+                    return cbc.scope.namespace.parseLiteralStringList(restrictedLocalizations)
                 }
                 return nil
 

--- a/Sources/SWBApplePlatform/InterfaceBuilderShared.swift
+++ b/Sources/SWBApplePlatform/InterfaceBuilderShared.swift
@@ -59,8 +59,7 @@ extension IbtoolCompilerSupport {
         var result = [(Path, String)]()
 
         // Check if we should filter localizations based on the setting BUILD_ONLY_KNOWN_LOCALIZATIONS:
-        let shouldFilter = cbc.scope.evaluate(BuiltinMacros.BUILD_ONLY_KNOWN_LOCALIZATIONS)
-        let allowedLocalizations = shouldFilter ? cbc.producer.project?.knownLocalizations : nil
+        let allowedLocalizations = cbc.scope.restrictedLocRegionsToBuild(in: cbc.producer.project)
 
         for ftb in cbc.inputs {
             if let buildFile = ftb.buildFile {
@@ -72,7 +71,7 @@ extension IbtoolCompilerSupport {
                                 // Skip this .strings file.
                                 if region != "mul" {
                                     // Don't leave a note about mul.lproj
-                                    delegate.note("Skipping .lproj directory '\(region).lproj' because '\(region)' is not in project's known localizations (BUILD_ONLY_KNOWN_LOCALIZATIONS is enabled)", location: .path(ftb.absolutePath))
+                                    delegate.note("Skipping file in .lproj directory '\(region).lproj' because '\(region)' is not in project's known localizations (BUILD_ONLY_KNOWN_LOCALIZATIONS is enabled)", location: .path(ftb.absolutePath))
                                 }
                                 continue
                             }

--- a/Sources/SWBApplePlatform/XCStringsCompiler.swift
+++ b/Sources/SWBApplePlatform/XCStringsCompiler.swift
@@ -189,27 +189,21 @@ public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierTyp
 
     /// Generates a task for compiling the .xcstrings to .strings/dict files.
     private func constructCatalogCompilationTask(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
-        let isRunningInstallloc = cbc.scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc")
 
         /// Custom lookup function to overwrite `XCSTRINGS_LANGUAGES_TO_COMPILE`
         /// when `BUILD_ONLY_KNOWN_LOCALIZATIONS` is enabled for a regular build.
         func lookup(_ macro: MacroDeclaration) -> MacroExpression? {
             switch macro {
             case BuiltinMacros.XCSTRINGS_LANGUAGES_TO_COMPILE:
-                guard !isRunningInstallloc else {
-                    // No need to intercept anything for installloc, its
-                    // language specification should always take precedence.
-                    return nil
-                }
-                if cbc.scope.evaluate(BuiltinMacros.BUILD_ONLY_KNOWN_LOCALIZATIONS), var knownLocalizations = cbc.producer.project?.knownLocalizations {
-
-                    knownLocalizations.removeAll(where: { $0 == "Base" })
-                    if !knownLocalizations.isEmpty {
-                        delegate.note("XCStrings will compile languages for known regions: \(knownLocalizations.joined(separator: ", "))")
+                if var restrictedLocalizations = cbc.scope.restrictedLocRegionsToBuild(in: cbc.producer.project) {
+                    restrictedLocalizations.remove("Base") // Base locale will never be in a String Catalog
+                    let restrictedLocalizations = restrictedLocalizations.sorted()
+                    if !restrictedLocalizations.isEmpty {
+                        delegate.note("XCStrings will compile languages for known regions: \(restrictedLocalizations.joined(separator: ", "))", location: .path(cbc.input.absolutePath))
                     }
 
                     // Only build the languages specified by the project:
-                    return cbc.scope.namespace.parseLiteralStringList(knownLocalizations)
+                    return cbc.scope.namespace.parseLiteralStringList(restrictedLocalizations)
                 }
             default:
                 break

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -841,7 +841,7 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
             try context.workspaceContext.fs.traverse(path) { subPath in
                 if let relativePath = subPath.relativeSubpath(from: path),
                    context.workspaceContext.fs.isDirectory(subPath) &&
-                   subPath.join(".").isValidLocalizedContent(scope) {
+                   subPath.join(".").isValidLocalizedContentForInstallloc(scope, in: context.project) {
                     localizedContent.append(Path(relativePath))
                 }
             }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
@@ -96,7 +96,7 @@ final class ResourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBa
         // An exception is xcstrings files.
         let isXCStrings = group.files.contains(where: { $0.fileType.conformsTo(identifier: "text.json.xcstrings") })
         if scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc") {
-            guard isXCStrings || group.isValidLocalizedContent(scope) else { return }
+            guard isXCStrings || group.isValidLocalizedContentForInstallloc(scope, in: context.project) else { return }
         }
 
         var inputFiles = group.files
@@ -178,12 +178,12 @@ final class ResourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBa
                     await addTasksForEmbeddedLocalizedBundle(ftb, buildFilesContext, scope, &tasks)
                     return
                 }
-            } else if scope.evaluate(BuiltinMacros.INSTALLLOC_DIRECTORY_CONTENTS), !ftb.isValidLocalizedContent(scope), context.workspaceContext.fs.isDirectory(ftb.absolutePath) {
+            } else if scope.evaluate(BuiltinMacros.INSTALLLOC_DIRECTORY_CONTENTS), !ftb.isValidLocalizedContentForInstallloc(scope, in: context.project), context.workspaceContext.fs.isDirectory(ftb.absolutePath) {
                 // Treat any package or directory the same as a copied bundle and copy over the relevant lproj directories.
                 await addTasksForEmbeddedLocalizedBundle(ftb, buildFilesContext, scope, &tasks)
                 return
             }
-            guard ftb.isValidLocalizedContent(scope) || targetBundleProduct else { return }
+            guard ftb.isValidLocalizedContentForInstallloc(scope, in: context.project) || targetBundleProduct else { return }
         }
 
         await appendGeneratedTasks(&tasks) { delegate in

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1639,7 +1639,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
         if isForInstallLoc {
             // For installLoc, we really only care about valid localized content from the sources task producer
-            tasks = tasks.filter { $0.inputs.contains(where: { $0.path.isValidLocalizedContent(scope) || $0.path.fileExtension == "xcstrings" }) }
+            tasks = tasks.filter { $0.inputs.contains(where: { $0.path.isValidLocalizedContentForInstallloc(scope, in: context.project) || $0.path.fileExtension == "xcstrings" }) }
         } else if scope.evaluate(BuiltinMacros.BUILD_ONLY_KNOWN_LOCALIZATIONS) {
             // For non-installLoc builds, filter based on BUILD_ONLY_KNOWN_LOCALIZATIONS:
             tasks = tasks.filter { task in
@@ -1743,7 +1743,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         // An exception is xcstrings files, which can be in the Sources phase for symbol generation.
         if scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc") {
             let isXCStrings = group.files.contains(where: { $0.fileType.conformsTo(identifier: "text.json.xcstrings") })
-            guard isXCStrings || group.isValidLocalizedContent(scope) else { return }
+            guard isXCStrings || group.isValidLocalizedContentForInstallloc(scope, in: context.project) else { return }
         }
 
         var inputFiles = group.files

--- a/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCStringsTaskConstructionTests.swift
@@ -705,10 +705,10 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
             }
 
             // Check for note about XCStrings language filtering
-            results.checkNote(.contains("XCStrings will compile languages for known regions: en, de"))
+            results.checkNote(.contains("XCStrings will compile languages for known regions: de, en"))
 
             // Check for note about skipped localization
-            results.checkNote(.contains("Skipping .lproj directory 'ja.lproj' because 'ja' is not in project's known localizations"))
+            results.checkNote(.contains("Skipping file in .lproj directory 'ja.lproj' because 'ja' is not in project's known localizations"))
 
             results.checkNoDiagnostics()
         }
@@ -1682,7 +1682,7 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
             }
 
             // Check for note about skipped localizations
-            results.checkNote(.contains("Skipping .lproj directory 'de.lproj' because 'de' is not in project's known localizations"))
+            results.checkNote(.contains("Skipping file in .lproj directory 'de.lproj' because 'de' is not in project's known localizations"))
 
             results.checkNoDiagnostics()
         }
@@ -2106,8 +2106,8 @@ fileprivate struct XCStringsTaskConstructionTests: CoreBasedTests {
                 results.checkNoTask(.matchRule(["CopyStringsFile", "/tmp/Test/aProject/build/Debug/MyFramework.framework/Versions/A/Resources/ja.lproj/Localizable.strings", "/tmp/Test/aProject/Sources/ja.lproj/Localizable.strings"]))
             }
 
-            results.checkNote(.contains("Skipping .lproj directory 'ja.lproj'"))
-            results.checkNote(.contains("Skipping .lproj directory 'fr.lproj'"))
+            results.checkNote(.contains("Skipping file in .lproj directory 'ja.lproj'"))
+            results.checkNote(.contains("Skipping file in .lproj directory 'fr.lproj'"))
             results.checkNoDiagnostics()
         }
     }


### PR DESCRIPTION
- **Explanation**:
  `BUILD_ONLY_KNOWN_LOCALIZATIONS` should be respected for Copy Files phases in addition to Resources and Sources. If `INSTALLLOC_LANGUAGE` is also set, we now intersect those language sets.
This makes it possible for a project to opt out even of installloc languages.

- **Scope**:
  Projects with `BUILD_ONLY_KNOWN_LOCALIZATIONS` set, which is a new setting in 6.3.

- **Original PRs**:
  https://github.com/swiftlang/swift-build/pull/1096

- **Risk**:
  Only expected to impact projects with `BUILD_ONLY_KNOWN_LOCALIZATIONS=YES`, which should not apply to existing projects.

- **Testing**:
  Unit tests added here.

- **Reviewers**:
  @Tantalum73 @owenv 