### PR TITLE
Revert "Drop use of -add_ast_path/modulewrap when building with explicit modules

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1047,6 +1047,7 @@ public final class BuiltinMacros {
     public static let SWIFT_ENABLE_OPAQUE_TYPE_ERASURE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_OPAQUE_TYPE_ERASURE")
     public static let SWIFT_ENABLE_LANGUAGE_FEATURE_ENABLEMENT_DIAGNOSTICS = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LANGUAGE_FEATURE_ENABLEMENT_DIAGNOSTICS")
     public static let SWIFT_EMIT_CONST_VALUE_PROTOCOLS = BuiltinMacros.declareStringListMacro("SWIFT_EMIT_CONST_VALUE_PROTOCOLS")
+    public static let SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS = BuiltinMacros.declareBooleanMacro("SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS")
     public static let SWIFT_USE_INTEGRATED_DRIVER = BuiltinMacros.declareBooleanMacro("SWIFT_USE_INTEGRATED_DRIVER")
     public static let SWIFT_EAGER_MODULE_EMISSION_IN_WMO = BuiltinMacros.declareBooleanMacro("SWIFT_EAGER_MODULE_EMISSION_IN_WMO")
     public static let SWIFT_ENABLE_EXPLICIT_MODULES = BuiltinMacros.declareEnumMacro("SWIFT_ENABLE_EXPLICIT_MODULES") as EnumMacroDeclaration<SwiftEnableExplicitModulesSetting>
@@ -2279,6 +2280,7 @@ public final class BuiltinMacros {
         SWIFT_ENABLE_OPAQUE_TYPE_ERASURE,
         SWIFT_ENABLE_LANGUAGE_FEATURE_ENABLEMENT_DIAGNOSTICS,
         SWIFT_EMIT_CONST_VALUE_PROTOCOLS,
+        SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS,
         SWIFT_ENABLE_TESTABILITY,
         SWIFT_EXEC,
         SWIFT_FORCE_DYNAMIC_LINK_STDLIB,

--- a/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
@@ -64,10 +64,11 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
         /// Whether the library should be found via the linker search path.
         public let useSearchPaths: Bool
 
-        public var knownToUseSwift: Bool
-
         /// The per-arch path to the corresponding Swift module file, if available.
-        public let swiftModulePathsToRegisterWithDebugger: [String: Path]
+        public let swiftModulePaths: [String: Path]
+
+        /// The per-arch path to the corresponding Swift module linker args response file, if available..
+        public let swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path]
 
         /// When a linker item is generated from a task within the target, the `explicitDependencies` allows for a direct dependency to be added to ensure proper ordering.
         public let explicitDependencies: [Path]
@@ -90,12 +91,12 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
 
         public let libPrefix: String?
 
-        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, knownToUseSwift: Bool, swiftModulePathsToRegisterWithDebugger: [String: Path], prefix: String? = nil, explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
+        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, swiftModulePaths: [String: Path], swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path], prefix: String? = nil, explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
             self.kind = kind
             self.path = path
             self.mode = mode
-            self.knownToUseSwift = knownToUseSwift
-            self.swiftModulePathsToRegisterWithDebugger = swiftModulePathsToRegisterWithDebugger
+            self.swiftModulePaths = swiftModulePaths
+            self.swiftModuleAdditionalLinkerArgResponseFilePaths = swiftModuleAdditionalLinkerArgResponseFilePaths
             self.explicitDependencies = explicitDependencies
             self.topLevelItemPath = topLevelItemPath
             self.dsymPath = dsymPath

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -740,8 +740,11 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         // anything but static archives and object files, because dynamic libraries and frameworks do not require this.
         if isLinkUsingSwift && cbc.scope.evaluate(BuiltinMacros.GCC_GENERATE_DEBUGGING_SYMBOLS) && !cbc.scope.evaluate(BuiltinMacros.PLATFORM_REQUIRES_SWIFT_MODULEWRAP) {
             for library in libraries {
-                if let swiftModulePath = library.swiftModulePathsToRegisterWithDebugger[cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)] {
+                if let swiftModulePath = library.swiftModulePaths[cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)] {
                     commandLine += ["-Xlinker", "-add_ast_path", "-Xlinker", swiftModulePath.str]
+                }
+                if let additionalArgsPath = library.swiftModuleAdditionalLinkerArgResponseFilePaths[cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)] {
+                    commandLine += ["@\(additionalArgsPath.str)"]
                 }
             }
         }

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
@@ -165,6 +165,18 @@ final public class SwiftDriverTaskAction: TaskAction, BuildValueValidatingTaskAc
                 }
             }
 
+            if let linkerResponseFilePath = driverPayload.linkerResponseFilePath {
+                var responseFileCommandLine: [String] = []
+                if driverPayload.explicitModulesEnabled {
+                    for swiftmodulePath in try dependencyGraph.querySwiftmodulesNeedingRegistrationForDebugging(for: driverPayload.uniqueID) {
+                        responseFileCommandLine.append(contentsOf: ["-Xlinker", "-add_ast_path", "-Xlinker", "\(swiftmodulePath)"])
+                    }
+                }
+                let contents = ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: responseFileCommandLine, format: driverPayload.linkerResponseFileFormat))
+                try executionDelegate.fs.createDirectory(linkerResponseFilePath.dirname, recursive: true)
+                try executionDelegate.fs.write(linkerResponseFilePath, contents: contents, atomically: true)
+            }
+
             return .succeeded
         } catch {
             outputDelegate.error("Unexpected error in querying jobs from dependency graph: \(error)")

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1078,6 +1078,16 @@
                 DefaultValue = "$(COMPILATION_CACHE_ENABLE_CACHING)";
             },
             {
+                Name = "SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS";
+                Type = Boolean;
+                DefaultValue = "$(_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES:default=$(SWIFT_ENABLE_EXPLICIT_MODULES))";
+            },
+            {
+                Name = "SWIFT_ADDITIONAL_LINKER_ARGS_OUTPUT_PATH";
+                Type = Path;
+                DefaultValue = "$(PER_ARCH_OBJECT_FILE_DIR)/$(SWIFT_MODULE_NAME)-linker-args.resp";
+            },
+            {
                 Name = "SWIFT_SERIALIZE_DEBUGGING_OPTIONS";
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -5062,6 +5062,179 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS), .flaky("Occasionally fails in CI due to the response file being empty"), .bug("rdar://138227317"))
+    func explicitModulesLinkerSwiftmoduleRegistration() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = try await TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            path: "Sources",
+                            children: [
+                                TestFile("fileA1.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "BUILD_VARIANTS": "normal",
+                                    "SWIFT_USE_INTEGRATED_DRIVER": "YES",
+                                    "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                                ])
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "TargetA",
+                                type: .framework,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "fileA1.swift",
+                                    ]),
+                                ]),
+                        ])
+                ])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            tester.userInfo = tester.userInfo.withAdditionalEnvironment(environment: ["SWIFT_FORCE_MODULE_LOADING": "only-interface"])
+            let parameters = BuildParameters(configuration: "Debug", overrides: [
+                // Redirect the prebuilt cache so we always build modules from source
+                "SWIFT_OVERLOAD_PREBUILT_MODULE_CACHE_PATH": tmpDirPath.str
+            ])
+            let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            // Create the source files.
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/fileA1.swift")) { file in
+                file <<<
+                        """
+                        public struct A {
+                            public init() { }
+                        }
+                        """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
+                var responseFile: Path? = nil
+                results.checkTask(.matchRuleType("SwiftDriver Compilation Requirements")) { driverTask in
+                    responseFile = driverTask.outputPaths.filter { $0.str.hasSuffix("-linker-args.resp") }.only
+                }
+                try results.checkTask(.matchRuleType("Ld")) { linkTask in
+                    linkTask.checkCommandLineContains("@\(try #require(responseFile).str)")
+                }
+                let responseFileContents = try tester.fs.read(try #require(responseFile))
+                #expect(!responseFileContents.isEmpty)
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func incrementalExplicitModulesLinkerSwiftmoduleRegistration() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = try await TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            path: "Sources",
+                            children: [
+                                TestFile("fileA1.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_VERSION": swiftVersion,
+                                    "BUILD_VARIANTS": "normal",
+                                    "SWIFT_USE_INTEGRATED_DRIVER": "YES",
+                                    "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                                ])
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "TargetA",
+                                type: .framework,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "fileA1.swift",
+                                    ]),
+                                ]),
+                        ])
+                ])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            tester.userInfo = tester.userInfo.withAdditionalEnvironment(environment: ["SWIFT_FORCE_MODULE_LOADING": "only-interface"])
+            let parameters = BuildParameters(configuration: "Debug", overrides: [
+                // Redirect the prebuilt cache so we always build modules from source
+                "SWIFT_OVERLOAD_PREBUILT_MODULE_CACHE_PATH": tmpDirPath.str
+            ])
+            let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            // Create the source files.
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/fileA1.swift")) { file in
+                file <<<
+                        """
+                        public struct A {
+                            public init() { }
+                        }
+                        """
+            }
+
+            var cleanResponseFileContents: ByteString? = nil
+            try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
+                var responseFile: Path? = nil
+                results.checkTask(.matchRuleType("SwiftDriver Compilation Requirements")) { driverTask in
+                    responseFile = driverTask.outputPaths.filter { $0.str.hasSuffix("-linker-args.resp") }.only
+                }
+                try results.checkTask(.matchRuleType("Ld")) { linkTask in
+                    linkTask.checkCommandLineContains("@\(try #require(responseFile).str)")
+                }
+                let responseFileContents = try tester.fs.read(try #require(responseFile))
+                #expect(!responseFileContents.isEmpty)
+                cleanResponseFileContents = responseFileContents
+            }
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/fileA1.swift")) { file in
+                file <<<
+                        """
+                        public struct A {
+                            public init() { }
+                        }
+
+                        public func foo() { }
+                        """
+            }
+
+            var incrementalResponseFileContents: ByteString? = nil
+            try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
+                var responseFile: Path? = nil
+                results.checkTask(.matchRuleType("SwiftDriver Compilation Requirements")) { driverTask in
+                    responseFile = driverTask.outputPaths.filter { $0.str.hasSuffix("-linker-args.resp") }.only
+                }
+                try results.checkTask(.matchRuleType("Ld")) { linkTask in
+                    linkTask.checkCommandLineContains("@\(try #require(responseFile).str)")
+                }
+                let responseFileContents = try tester.fs.read(try #require(responseFile))
+                #expect(!responseFileContents.isEmpty)
+                incrementalResponseFileContents = responseFileContents
+            }
+
+            let cleanContents = try #require(cleanResponseFileContents)
+            let incrementalContents = try #require(incrementalResponseFileContents)
+            #expect(cleanContents == incrementalContents)
+        }
+    }
+
     @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.compilationCaching), .skipSwiftPackage)
     func ensureIdenticalCommandLinesWithDifferentDependenciesAreNotDeduplicated() async throws {
         try await withTemporaryDirectory { tmpDir in

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1369,7 +1369,7 @@ import SWBMacro
                         prefix = nil
                         continue
                     }
-                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:], prefix: prefix))
+                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:], prefix: prefix))
                 }
             }
             return result
@@ -1379,7 +1379,7 @@ import SWBMacro
             libraries.append(contentsOf: generateLibrarySpecifiers(kind: kind))
         }
         // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
-        libraries.append(LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]))
+        libraries.append(LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]))
 
         await linkerSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 
@@ -1596,28 +1596,28 @@ import SWBMacro
         let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/obj/normal/x86_64/file1.o"), fileType: mockFileType)], output: Path.root.join("tmp/obj/normal/x86_64/output"))
         let libraries = [
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo1.a"), mode: .normal, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo2.a"), mode: .weak, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo3.a"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo4.a"), mode: .weak, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo1.a"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo2.a"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo3.a"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo4.a"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar1.dylib"), mode: .normal, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar2.dylib"), mode: .weak, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar3.dylib"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar4.dylib"), mode: .weak, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar1.dylib"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar2.dylib"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar3.dylib"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar4.dylib"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz1.tbd"), mode: .normal, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz2.tbd"), mode: .weak, useSearchPaths: true,knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz3.tbd"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz4.tbd"), mode: .weak, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz1.tbd"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz2.tbd"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz3.tbd"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz4.tbd"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo1.framework"), mode: .normal, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo2.framework"), mode: .weak, useSearchPaths: true, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo3.framework"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo4.framework"), mode: .weak, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo1.framework"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo2.framework"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo3.framework"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo4.framework"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
             // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
-            LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, knownToUseSwift: false, swiftModulePathsToRegisterWithDebugger: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
         ]
         await librarianSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -290,6 +290,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     task.checkOutputs([
                         .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget Swift Compilation Requirements Finished"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule"),
+                        .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-dependency-scan.dia"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftsourceinfo"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.abi.json"),
@@ -792,7 +793,9 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     task.checkOutputs([
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo Swift Compilation Requirements Finished"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.swiftmodule"),
+                        .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo-linker-args.resp"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo-dependency-scan.dia"),
+
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.swiftsourceinfo"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.abi.json"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.swiftinterface"),
@@ -1037,6 +1040,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     task.checkOutputs([
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo Swift Compilation Requirements Finished"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.swiftmodule"),
+                        .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo-linker-args.resp"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo-dependency-scan.dia"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.swiftsourceinfo"),
                         .path("\(SRCROOT)/build/aProject.build/Debug/CoreFoo.build/Objects-normal/\(results.runDestinationTargetArchitecture)/CoreFoo.abi.json"),
@@ -2355,7 +2359,6 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     "SWIFT_EXEC": swiftCompilerPath.str,
                     "SWIFT_VERSION": swiftVersion,
                     "PRODUCT_NAME": "$(TARGET_NAME)",
-                    "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
                 ]),
             ],
             targets: [
@@ -2415,7 +2418,6 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     "CODE_SIGNING_ALLOWED": "NO",
                     "SWIFT_EXEC": swiftCompilerPath.str,
                     "SWIFT_VERSION": swiftVersion,
-                    "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "SDKROOT": "auto",
                     "SDK_VARIANT": "auto",
@@ -2963,7 +2965,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
 
         await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Ld")) { task in
-                task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
             }
             results.checkNoDiagnostics()
         }
@@ -2980,7 +2982,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
                     ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
-                    ["-filelist", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/System/iOSSupport/usr/lib/swift", "-L/usr/lib/swift", "-o", "\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.app/Contents/MacOS/AppTarget"],
+                    ["-filelist", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/System/iOSSupport/usr/lib/swift", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.app/Contents/MacOS/AppTarget"],
                 ].reduce([], +)
                 task.checkCommandLine(expectedCommandLine)
             }
@@ -2989,7 +2991,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
 
         await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["IS_ZIPPERED": "YES"]), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Ld")) { task in
-                task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
             }
             results.checkNoDiagnostics()
         }
@@ -3002,7 +3004,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
                     ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
-                    ["-filelist", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-o", "\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.app/Contents/MacOS/AppTarget"],
+                    ["-filelist", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)/AppTarget.app/Contents/MacOS/AppTarget"],
                 ].reduce([], +)
                 task.checkCommandLine(expectedCommandLine)
             }
@@ -3279,6 +3281,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 moduleTask.checkOutputs([.pathPattern(.suffix("Core Swift Compilation Requirements Finished")),
                                          .pathPattern(.suffix("Swift-API.tbd")),
                                          .pathPattern(.suffix("Core.swiftmodule")),
+                                         .pathPattern(.suffix("Core-linker-args.resp")),
                                          .pathPattern(.suffix("Core-dependency-scan.dia")),
                                          .pathPattern(.suffix("Core.swiftsourceinfo")),
                                          .pathPattern(.suffix("Core.abi.json")),
@@ -4244,6 +4247,59 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             await tester.checkBuild(runDestination: .macOS) { results in
                 results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
                     task.checkCommandLineNoMatch([.prefix("-D_LIBCPP_HARDENING_MODE=")])
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func cxxInteropLinkerArgGeneration() async throws {
+        // When Swift is generating additional linker args, we should not try to inject the response file when a target is a dependent of a cxx-interop target but has no Swift source of its own.
+        let testProject = try await TestProject(
+            "Test",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("File1.swift"),
+                    TestFile("File2.c"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "LIBTOOL": libtoolPath.str,
+                    "SWIFT_VERSION": swiftVersion,
+                    "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Framework",
+                    type: .framework,
+                    buildPhases: [
+                        TestSourcesBuildPhase([TestBuildFile("File2.c")]),
+                        TestFrameworksBuildPhase(["libStaticLib.a"])
+                    ], dependencies: ["StaticLib"]),
+                TestStandardTarget(
+                    "StaticLib",
+                    type: .staticLibrary,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "SWIFT_OBJC_INTEROP_MODE": "objcxx"
+                        ])
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase([TestBuildFile("File1.swift")])
+                    ]),
+            ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        await tester.checkBuild(runDestination: .macOS) { results in
+            results.checkNoDiagnostics()
+            results.checkTarget("Framework") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                    task.checkCommandLineNoMatch([.suffix("-linker-args.resp")])
                 }
             }
         }


### PR DESCRIPTION

This reverts commit 94ce361cfb97e053921dd0bc3c2e009787328182.

We found a few compiler side issues that need to be worked through first