### PR TITLE
Add codeview debug format for windows

### DIFF
--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -171,7 +171,6 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
         }
         let testingLibraryPath = windowsPlatform.path.join("Developer").join("Library")
         let defaultProperties: [String: PropertyListItem] = [
-            "GCC_GENERATE_DEBUGGING_SYMBOLS": .plString("NO"),
             "LD_DEPENDENCY_INFO_FILE": .plString(""),
 
             "GENERATE_TEXT_BASED_STUBS": "NO",

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -60,6 +60,31 @@
         Description = "Apple Clang compiler (Windows)";
         IsAbstract = YES;
         ShowInCompilerSelectionPopup = NO;
+        Options = (
+            {
+                Name = "GCC_DEBUG_INFORMATION_FORMAT";
+                Type = Enumeration;
+                Values = (
+                    dwarf,
+                    "dwarf-with-dsym",
+                    "codeview",
+                );
+                CommandLineArgs = {
+                    dwarf = (
+                        "-g",
+                    );
+                    "dwarf-with-dsym" = (
+                        "-g",
+                    );
+                    "codeview" = (
+                        "-g", "-gcodeview",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "$(DEBUG_INFORMATION_FORMAT)";
+                Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS)";
+            },
+        );
     },
     {
         Domain = windows;
@@ -104,7 +129,30 @@
                 DefaultValue = YES;
                 Condition = "$(PRODUCT_TYPE) == 'com.apple.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.library.static' || $(PRODUCT_TYPE) == 'org.swift.product-type.common.object'";
                 CommandLineArgs = ("-static");
-            }
+            },
+            {
+                Name = "SWIFT_DEBUG_INFORMATION_FORMAT";
+                Type = Enumeration;
+                Values = (
+                    dwarf,
+                    "dwarf-with-dsym",
+                    "codeview",
+                );
+                CommandLineArgs = {
+                    dwarf = (
+                        "-g",
+                    );
+                    "dwarf-with-dsym" = (
+                        "-g",
+                    );
+                    "codeview" = (
+                        "-g", "-debug-info-format=codeview",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "$(DEBUG_INFORMATION_FORMAT)";
+                Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS)";
+            },
         );
     },
 )

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -74,7 +74,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
                 results.checkTaskExists(.matchRule(["SwiftCompile", "normal", results.runDestinationTargetArchitecture, "Compiling \(swiftFile.basename)", swiftFile.str]))
                 results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
-                if runDestination == .linux {  // FIXME: This needs to be investigated... We should be able to use core.hostOperatingSystem.imageFormat.requiresSwiftModulewrap to test for this, but on Windows using this causes the test to fail as the SwiftModuleWrap does not seem to be added.
+                if try await getCore().hostOperatingSystem.imageFormat.requiresSwiftModulewrap  {
                     results.checkTaskExists(.matchRule(["SwiftModuleWrap", "normal", results.runDestinationTargetArchitecture,  "Wrapping Swift module aLibrary"]))
                 }
                 results.checkNoTask()

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -1174,6 +1174,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                 "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "$OBJROOT/ExplicitModules/$TARGET_NAME",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1303,6 +1304,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1402,6 +1404,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                 "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "\(tmpDir.join("clangmodules").str)",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1426,6 +1429,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                     "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                     "HEADER_SEARCH_PATHS": "$(inherited) \(tmpDir.join("Test").join("aProject").strWithPosixSlashes)",
                                     "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "\(tmpDir.join("clangmodules").strWithPosixSlashes)",
+                                    "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                                 ])],
                             targets: [
                                 TestStandardTarget(


### PR DESCRIPTION
- update xcspec for Windows to support codeview debug format

closes: https://github.com/swiftlang/swift-build/issues/560
