### PR TITLE
Fix PRELINK_LIBS dependency tracking

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -133,6 +133,7 @@ struct AndroidPlatformExtension: PlatformInfoExtension {
 
             // Workaround to avoid `-dependency_info` on Linux.
             "LD_DEPENDENCY_INFO_FILE": .plString(""),
+            "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
 
             // Android uses lld, not the Apple linker
             // FIXME: Make this option conditional on use of the Apple linker (or perhaps when targeting an Apple triple?)

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -954,6 +954,7 @@ public final class BuiltinMacros {
     public static let PLIST_FILE_OUTPUT_FORMAT = BuiltinMacros.declareStringMacro("PLIST_FILE_OUTPUT_FORMAT")
     public static let PLUGINS_FOLDER_PATH = BuiltinMacros.declarePathMacro("PLUGINS_FOLDER_PATH")
     public static let __POPULATE_COMPATIBILITY_ARCH_MAP = BuiltinMacros.declareBooleanMacro("__POPULATE_COMPATIBILITY_ARCH_MAP")
+    public static let PRELINK_DEPENDENCY_INFO_FILE = BuiltinMacros.declarePathMacro("PRELINK_DEPENDENCY_INFO_FILE")
     public static let PRELINK_FLAGS = BuiltinMacros.declareStringListMacro("PRELINK_FLAGS")
     public static let PRELINK_LIBS = BuiltinMacros.declareStringListMacro("PRELINK_LIBS")
     public static let PRIVATE_HEADERS_FOLDER_PATH = BuiltinMacros.declarePathMacro("PRIVATE_HEADERS_FOLDER_PATH")
@@ -2125,6 +2126,7 @@ public final class BuiltinMacros {
         PLIST_FILE_OUTPUT_FORMAT,
         PLUGINS_FOLDER_PATH,
         __POPULATE_COMPATIBILITY_ARCH_MAP,
+        PRELINK_DEPENDENCY_INFO_FILE,
         PRELINK_FLAGS,
         PRELINK_LIBS,
         PRIVATE_HEADERS_FOLDER_PATH,

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -458,6 +458,11 @@
                 DefaultValue = "";
             },
             {
+                Name = "PRELINK_DEPENDENCY_INFO_FILE";
+                Type = Path;
+                DefaultValue = "$(OBJECT_FILE_DIR_$(CURRENT_VARIANT))/$(CURRENT_ARCH)/$(PRODUCT_NAME)_prelink_dependency_info.dat";
+            },
+            {
                 Name = "LD_NO_PIE";
                 Type = bool;
                 DefaultValue = NO;
@@ -1651,6 +1656,15 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleIdenti
                 Type = StringList;
                 Category = "Linking - General";
                 DefaultValue = "";
+                ConditionFlavors = (
+                    arch,
+                    sdk,
+                );
+            },
+            {
+                Name = "PRELINK_DEPENDENCY_INFO_FILE";
+                Type = Path;
+                DefaultValue = "$(OBJECT_FILE_DIR_$(CURRENT_VARIANT))/$(CURRENT_ARCH)/$(PRODUCT_NAME)_prelink_dependency_info.dat";
                 ConditionFlavors = (
                     arch,
                     sdk,

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -126,6 +126,7 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
                 defaultProperties = [
                     // Workaround to avoid `-dependency_info`.
                     "LD_DEPENDENCY_INFO_FILE": .plString(""),
+                    "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
 
                     "GENERATE_TEXT_BASED_STUBS": "NO",
                     "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -173,6 +173,7 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
         let defaultProperties: [String: PropertyListItem] = [
             "GCC_GENERATE_DEBUGGING_SYMBOLS": .plString("NO"),
             "LD_DEPENDENCY_INFO_FILE": .plString(""),
+            "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
 
             "GENERATE_TEXT_BASED_STUBS": "NO",
             "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -918,7 +918,9 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             .namePattern(.prefix("target-"))])
 
                         task.checkOutputs([
-                            .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-\(results.runDestinationTargetArchitecture)-prelink.o"),])
+                            .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/AppTarget-\(results.runDestinationTargetArchitecture)-prelink.o"),
+                            .path("\(SRCROOT)/build/aProject.build/Release/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_prelink_dependency_info.dat"),
+                        ])
 
                     }
 


### PR DESCRIPTION
Use -dependency_info on Darwin platforms to track dependencies on files specified in PRELINK_LIBS. Manually track file paths on platforms where -dependency_info is not supported.

rdar://140459877