### PR TITLE
Add new product types to supportsInstallAPI check

### DIFF
--- a/Sources/SWBCore/ProductTypeIdentifier.swift
+++ b/Sources/SWBCore/ProductTypeIdentifier.swift
@@ -20,19 +20,6 @@ public struct ProductTypeIdentifier: Equatable {
 }
 
 public extension ProductTypeIdentifier {
-    var supportsInstallAPI: Bool {
-        // Static frameworks/libraries need to run installAPI if they contain Swift source code because we need .swiftmodule to build downstream targets.
-        return stringValue == "com.apple.product-type.framework"
-            || stringValue == "com.apple.product-type.framework.static"
-            || stringValue == "com.apple.product-type.library.dynamic"
-            || stringValue == "com.apple.product-type.library.static"
-            // Swift packages need to run installAPI.
-            || stringValue == "com.apple.product-type.objfile"
-            // SwiftPM's new PIF builder uses these product types.
-            || stringValue == "org.swift.product-type.common.object"
-            || stringValue == "org.swift.product-type.library.static"
-    }
-
     var supportsEagerLinking: Bool {
         return stringValue == "com.apple.product-type.framework"
             || stringValue == "com.apple.product-type.library.dynamic"

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -315,7 +315,13 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
     ///
     /// In particular, Swift compilation runs during InstallAPI builds even when building static libraries, but only generates TBD files when building dylibs.
     public var supportsInstallAPI: Bool {
-        return ProductTypeIdentifier(identifier).supportsInstallAPI
+        // Static frameworks/libraries need to run installAPI if they contain Swift
+        // source code because we need .swiftmodule to build downstream targets.
+        return conformsTo(identifier: "com.apple.product-type.framework")
+            || conformsTo(identifier: "com.apple.product-type.framework.static")
+            || conformsTo(identifier: "com.apple.product-type.library.dynamic")
+            || conformsTo(identifier: "com.apple.product-type.library.static")
+            || conformsTo(identifier: "com.apple.product-type.objfile") // Swift packages need to run installAPI.
     }
 
     public var supportsEagerLinking: Bool {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1229,14 +1229,15 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             }
 
             func addTBDEmissionIfRequired() {
-                let typeStr = cbc.scope.evaluate(BuiltinMacros.PRODUCT_TYPE)
-                let productType = ProductTypeIdentifier(typeStr)
-
                 // For some targets, a tbd can be emitted to allow downstream targets to begin linking earlier.
                 let supportsTBDEmissionForEagerLinking = cbc.producer.supportsEagerLinking(scope: cbc.scope)
 
                 // InstallAPI support requires explicit opt-in and a compatible product type.
-                let supportsInstallAPI = productType.supportsInstallAPI && cbc.scope.evaluate(BuiltinMacros.SUPPORTS_TEXT_BASED_API)
+                let supportsInstallAPI = if let productType = cbc.producer.productType, productType.supportsInstallAPI && cbc.scope.evaluate(BuiltinMacros.SUPPORTS_TEXT_BASED_API) {
+                    true
+                } else {
+                    false
+                }
 
                 guard supportsInstallAPI || supportsTBDEmissionForEagerLinking else {
                     return

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -411,11 +411,9 @@ final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer 
             //
             // FIXME: This is not strictly correct, because there are situations where these methods return true but we don't actually enable InstallAPI. We should resolve this eventually.
             //
-            // FIXME: This is very gross, we currently only have access to the scope here, so we can't use the actual product type object. However, we will hopefully replace all of this logic by eliminating the
-            let productType = ProductTypeIdentifier(subscope.evaluate(BuiltinMacros.PRODUCT_TYPE))
-
-            // TAPI will only be run when the output is a dylib. Swift static library may schedule installAPI phase to generate a swiftmodule.
-            if productType.supportsInstallAPI && (shouldUseInstallAPI(subscope, settings) || stubAPIDestination(subscope, settings) == .builtProduct) {
+            // TAPI will only be run when the output is a dylib.
+            // Swift static library may schedule installAPI phase to generate a swiftmodule.
+            if let productType = settings.productType, productType.supportsInstallAPI && (shouldUseInstallAPI(subscope, settings) || stubAPIDestination(subscope, settings) == .builtProduct) {
                 let tapiOutputPath = Path(subscope.evaluate(BuiltinMacros.TAPI_OUTPUT_PATH))
                 paths.append((tapiOutputPath, subscope, false, false, false))
             }


### PR DESCRIPTION
### Motivation ###

When building Swift packages with SwiftPM's new PIF builder with the `xcodebuild installapi` action, the build system was skipping `swiftmodule` emission with the following warning (e.g., for the https://github.com/swiftlang/swift-subprocess project):

```
Skipping installAPI swiftmodule emission for target 'Subprocess'
```

This occurred because the new PIF builder uses different product type identifiers (`org.swift.product-type.common.object` and `org.swift.product-type.library.static`) that were not recognized by `supportsInstallAPI`. The old PIF builder used `com.apple.product-type.objfile` which was already supported.

Without `swiftmodule` emission, downstream targets cannot compile against the module, breaking `installapi` builds for Swift packages.

### Changes ###

Extended `ProductTypeIdentifier.supportsInstallAPI` to recognize the product types used by SwiftPM's new PIF builder:

- `org.swift.product-type.common.object` — used for object file targets
- `org.swift.product-type.library.static` — used for static library targets

Both types inherit from `com.apple.product-type.objfile` (in `ProductTypes.xcspec`) but have distinct identifiers that need explicit support.

### Fixed Radar ###

* rdar://168454272 *(Skipping installAPI swiftmodule emission for target)*
