### PR TITLE
Cleanup old Android SDK synthesis

### DIFF
--- a/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
+++ b/Sources/SWBCore/Extensions/PlatformInfoExtension.swift
@@ -36,6 +36,8 @@ public protocol PlatformInfoExtension: Sendable {
 
     func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path])
 
+    func swiftSDKAdditionalCustomProperties(context: any PlatformInfoExtensionSwiftSDKAdditionalCustomPropertiesContext) -> [String: PropertyListItem]
+
     func platformName(triple: LLVMTriple) -> String?
 }
 
@@ -67,6 +69,10 @@ extension PlatformInfoExtension {
     public func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path]) {
     }
 
+    public func swiftSDKAdditionalCustomProperties(context: any PlatformInfoExtensionSwiftSDKAdditionalCustomPropertiesContext) -> [String: PropertyListItem] {
+        [:]
+    }
+
     public func platformName(triple: LLVMTriple) -> String? {
         return nil
     }
@@ -76,4 +82,9 @@ public protocol PlatformInfoExtensionAdditionalPlatformsContext: Sendable {
     var hostOperatingSystem: OperatingSystem { get }
     var developerPath: Core.DeveloperPath { get }
     var fs: any FSProxy { get }
+}
+
+public protocol PlatformInfoExtensionSwiftSDKAdditionalCustomPropertiesContext: Sendable {
+    var hostOperatingSystem: OperatingSystem { get }
+    var platform: Platform { get }
 }

--- a/Sources/SWBCore/WorkspaceContext.swift
+++ b/Sources/SWBCore/WorkspaceContext.swift
@@ -214,8 +214,8 @@ public struct WorkspaceContextSDKRegistry: SDKRegistryLookup, Sendable {
             return try lookupInEach { try $0.lookup(nameOrPath: nameOrPath, basePath: basePath, activeRunDestination: activeRunDestination) }
         }
 
-        func synthesizedSDK(platform: Platform, sdkManifestPath: String, triple: String) throws -> SDK? {
-            return try lookupInEach { try $0.synthesizedSDK(platform: platform, sdkManifestPath: sdkManifestPath, triple: triple) }
+        func synthesizedSDK(platform: Platform, sdkManifestPath: String, triple: String, customProperties: [String: PropertyListItem]) throws -> SDK? {
+            return try lookupInEach { try $0.synthesizedSDK(platform: platform, sdkManifestPath: sdkManifestPath, triple: triple, customProperties: customProperties) }
         }
     }
 
@@ -251,8 +251,8 @@ public struct WorkspaceContextSDKRegistry: SDKRegistryLookup, Sendable {
         return try underlyingLookup.lookup(nameOrPath: nameOrPath, basePath: basePath, activeRunDestination: activeRunDestination)
     }
 
-    public func synthesizedSDK(platform: Platform, sdkManifestPath: String, triple: String) throws -> SDK? {
-        return try underlyingLookup.synthesizedSDK(platform: platform, sdkManifestPath: sdkManifestPath, triple: triple)
+    public func synthesizedSDK(platform: Platform, sdkManifestPath: String, triple: String, customProperties: [String: PropertyListItem]) throws -> SDK? {
+        return try underlyingLookup.synthesizedSDK(platform: platform, sdkManifestPath: sdkManifestPath, triple: triple, customProperties: customProperties)
     }
 }
 


### PR DESCRIPTION
Now that we have more general SDK synthesis for Swift SDKs included in the BuildRequest, let Android go through this as well.

Note that this is not quite enough to get things fully working; the SwiftPM side still has to stop passing a raw duplicate --sysroot flag. We also have to reconcile -sdk/SDKROOT and --sysroot/SYSROOT build settings and flags and how they will work with Android SDKs and Swift SDKs in general.