### PR TITLE
Override the toolchain when running Swift SDK integration tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,7 +79,7 @@ jobs:
       wasm_sdk_versions: '["nightly-main"]'
       wasm_sdk_pre_build_command: SKIP_ANDROID=1 ./.github/scripts/prebuild.sh
       # This is a hack - replace the build command with a test command and drop the --swift-sdk arg the workflow appends.
-      wasm_sdk_build_command: "swift test --filter WebAssemblyIntegrationTests #"
+      wasm_sdk_build_command: "env GENERIC_UNIX_DEVELOPER_DIR_TESTING_OVERRIDE=$(dirname $(dirname $(dirname \"$SWIFT_EXECUTABLE_FOR_WASM_SDK\"))) swift test --filter WebAssemblyIntegrationTests #"
 
   soundness:
     name: Soundness

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -56,6 +56,11 @@ struct GenericUnixDeveloperDirectoryExtension: DeveloperDirectoryExtension {
             return nil
         }
 
+        if let override = ProcessInfo.processInfo.environment["GENERIC_UNIX_DEVELOPER_DIR_TESTING_OVERRIDE"] {
+            print("GENERIC_UNIX_DEVELOPER_DIR_TESTING_OVERRIDE: \(override)")
+            return .swiftToolchain(Path(override), xcodeDeveloperPath: nil)
+        }
+
         return .swiftToolchain(.root, xcodeDeveloperPath: nil)
     }
 }


### PR DESCRIPTION
_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
