### PR TITLE
Make parsing generated file paths from tools more robust

### DIFF
--- a/Sources/SWBApplePlatform/CoreMLCompiler.swift
+++ b/Sources/SWBApplePlatform/CoreMLCompiler.swift
@@ -246,7 +246,7 @@ public final class CoreMLCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
             delegate.access(path: input.absolutePath)
 
             generatedFiles = try await generatedFilePaths(cbc, delegate, commandLine: commandLine[0...3] + ["--dry-run", "yes"] + commandLine[4...], workingDirectory: cbc.producer.defaultWorkingDirectory, environment: self.environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute CoreML model \(input.absolutePath.basename) code generation output paths") { output in
-                return output.unsafeStringValue.split(separator: "\n").map(Path.init)
+                return try output.unsafeStringValue.split(separator: "\n").map { try AbsolutePath(validating: String($0)) }
             }
             guard !generatedFiles.isEmpty else {
                 // If we were given an empty list of generated files, then there were just no files to be generated, so we return.

--- a/Sources/SWBApplePlatform/XCStringsCompiler.swift
+++ b/Sources/SWBApplePlatform/XCStringsCompiler.swift
@@ -227,7 +227,7 @@ public final class XCStringsCompilerSpec: GenericCompilerSpec, SpecIdentifierTyp
             dryRunCommandLine.insert("--dry-run", at: 2)
 
             outputs = try await generatedFilePaths(cbc, delegate, commandLine: dryRunCommandLine, workingDirectory: cbc.producer.defaultWorkingDirectory, environment: environmentFromSpec(cbc, delegate).bindingsDictionary, executionDescription: "Compute XCStrings \(cbc.input.absolutePath.basename) output paths") { output in
-                return output.unsafeStringValue.split(separator: "\n").map(Path.init)
+                return try output.unsafeStringValue.split(separator: "\n").map { try AbsolutePath(validating: String($0)) }
             }
         } catch {
             emitErrorsFromDryRunFailure(error, path: cbc.input.absolutePath, delegate: delegate)

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1437,8 +1437,8 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         return try parse(ByteString(executionResult.stdout))
     }
 
-    public func generatedFilePaths(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: Path?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> [Path]) async throws -> [Path] {
-        return try await executeExternalTool(cbc, delegate, commandLine: commandLine, workingDirectory: workingDirectory, environment: environment, executionDescription: executionDescription, parse)
+    public func generatedFilePaths(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, commandLine: [String], workingDirectory: Path?, environment: [String: String], executionDescription: String?, _ parse: @escaping (ByteString) throws -> [AbsolutePath]) async throws -> [Path] {
+        return try await executeExternalTool(cbc, delegate, commandLine: commandLine, workingDirectory: workingDirectory, environment: environment, executionDescription: executionDescription, { try parse($0).map { $0.path } })
     }
 }
 


### PR DESCRIPTION
Output of invoked tools is expected to always be an absolute path. Output from tools in untrusted, so validate it to ensure we don't fail preconditions and potentially crash on malformed output.

rdar://170834370