### PR TITLE
Fix nondeterminism serializing platform filters in PIF

### DIFF
--- a/Sources/SWBProjectModel/IDE/IDESwiftPackageExtensions.swift
+++ b/Sources/SWBProjectModel/IDE/IDESwiftPackageExtensions.swift
@@ -144,6 +144,14 @@ extension PIF.BaseTarget : PIFRepresentable {
     }
 }
 
+extension Set<PIF.PlatformFilter> {
+    public func serialize(to serializer: any IDEPIFSerializer) -> [PIFDict] {
+        return self.sorted().map {
+            $0.serialize(to: serializer)
+        }
+    }
+}
+
 extension PIF.PlatformFilter: PIFRepresentable {
     public func serialize(to serializer: any IDEPIFSerializer) -> PIFDict {
         if environment.isEmpty {
@@ -307,7 +315,7 @@ extension PIF.BuildFile : PIFRepresentable {
             dict[PIFKey_guid] = id
             dict[PIFKey_BuildFile_fileReference] = refId
             dict[PIFKey_BuildFile_headerVisibility] = headerVisibility?.rawValue
-            dict[PIFKey_platformFilters] = platformFilters.map{ $0.serialize(to: serializer) }
+            dict[PIFKey_platformFilters] = platformFilters.serialize(to: serializer)
 
             dict[PIFKey_BuildFile_codeSignOnCopy] = codeSignOnCopy ? "true" : "false"
             dict[PIFKey_BuildFile_removeHeadersOnCopy] = removeHeadersOnCopy ? "true" : "false"
@@ -335,7 +343,7 @@ extension PIF.BuildFile : PIFRepresentable {
             return [
                 PIFKey_guid: id,
                 PIFKey_BuildFile_targetReference: refId,
-                PIFKey_platformFilters: platformFilters.map{ $0.serialize(to: serializer) }
+                PIFKey_platformFilters: platformFilters.serialize(to: serializer)
             ]
         }
     }

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -263,7 +263,7 @@ public enum PIF {
                 PIFKey_name: name,
                 PIFKey_Target_dependencies: dependencies.map { [
                     PIFKey_guid: $0.targetId,
-                    PIFKey_platformFilters: $0.platformFilters.map{ $0.serialize(to: serializer) }
+                    PIFKey_platformFilters: $0.platformFilters.serialize(to: serializer)
                 ] },
                 PIFKey_Target_buildRules: buildRules.map{ $0.serialize(to: serializer) },
                 PIFKey_Target_buildPhases: buildPhases.map{ ($0 as! (any PIFRepresentable)).serialize(to: serializer) },
@@ -492,7 +492,7 @@ public enum PIF {
                     PIFKey_Target_customTasks: customTasks.map { $0.serialize(to: serializer) },
                     PIFKey_Target_dependencies: dependencies.map{ [
                         PIFKey_guid: $0.targetId,
-                        PIFKey_platformFilters: $0.platformFilters.map{ $0.serialize(to: serializer) }
+                        PIFKey_platformFilters: $0.platformFilters.serialize(to: serializer)
                     ] },
                     PIFKey_buildConfigurations: buildConfigs.map{ $0.serialize(to: serializer) },
                 ]
@@ -700,13 +700,17 @@ public enum PIF {
         }
     }
 
-    public struct PlatformFilter: Hashable, Sendable {
+    public struct PlatformFilter: Hashable, Sendable, Comparable {
         public var platform: String
         public var environment: String
 
         public init(platform: String, environment: String = "") {
             self.platform = platform
             self.environment = environment
+        }
+
+        public static func < (lhs: PIF.PlatformFilter, rhs: PIF.PlatformFilter) -> Bool {
+            return (lhs.platform, lhs.environment) < (rhs.platform, rhs.environment)
         }
     }
 

--- a/Sources/SwiftBuild/ProjectModel/BuildFile.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildFile.swift
@@ -100,7 +100,7 @@ extension ProjectModel.BuildFile: Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.id, forKey: .guid)
-        try container.encode(self.platformFilters, forKey: .platformFilters)
+        try container.encode(self.platformFilters.sorted(), forKey: .platformFilters)
 
         switch self.ref {
         case .reference(id: let refId):

--- a/Sources/SwiftBuild/ProjectModel/PlatformFilter.swift
+++ b/Sources/SwiftBuild/ProjectModel/PlatformFilter.swift
@@ -14,13 +14,17 @@ import Foundation
 import SWBProtocol
 
 extension ProjectModel {
-    public struct PlatformFilter: Hashable, Sendable {
+    public struct PlatformFilter: Hashable, Sendable, Comparable {
         public var platform: String
         public var environment: String
 
         public init(platform: String, environment: String = "") {
             self.platform = platform
             self.environment = environment
+        }
+
+        public static func < (lhs: ProjectModel.PlatformFilter, rhs: ProjectModel.PlatformFilter) -> Bool {
+            return (lhs.platform, lhs.environment) < (rhs.platform, rhs.environment)
         }
     }
 }

--- a/Sources/SwiftBuild/ProjectModel/TargetDependency.swift
+++ b/Sources/SwiftBuild/ProjectModel/TargetDependency.swift
@@ -38,7 +38,7 @@ extension ProjectModel.TargetDependency: Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.targetId, forKey: .guid)
-        try container.encode(self.platformFilters, forKey: .platformFilters)
+        try container.encode(self.platformFilters.sorted(), forKey: .platformFilters)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/SwiftBuildTests/ProjectModel/CustomTaskTests.swift
+++ b/Tests/SwiftBuildTests/ProjectModel/CustomTaskTests.swift
@@ -17,6 +17,7 @@ import Testing
 func testCodable<T>(
     _ original: T,
     _ modify: ((inout T) -> Void)? = nil,
+    _ expectedOutput: String? = nil,
     _ fileID: String = #fileID,
     _ filePath: String = #filePath,
     _ line: Int = #line,
@@ -24,9 +25,16 @@ func testCodable<T>(
 ) throws where T: Codable & Equatable {
     var original = original
     if let modify { modify(&original) }
-    let data = try JSONEncoder().encode(original)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+    let data = try encoder.encode(original)
     let obj = try JSONDecoder().decode(T.self, from: data)
     #expect(original == obj, sourceLocation: SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column))
+    let reencodedData = try encoder.encode(original)
+    #expect(data == reencodedData, sourceLocation: SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column))
+    if let expectedOutput {
+        #expect(String(decoding: data, as: UTF8.self) == expectedOutput, sourceLocation: SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column))
+    }
 }
 
 @Suite

--- a/Tests/SwiftBuildTests/ProjectModel/TargetsTests.swift
+++ b/Tests/SwiftBuildTests/ProjectModel/TargetsTests.swift
@@ -21,6 +21,85 @@ fileprivate struct TargetsTests {
         try testCodable(obj) { $0.signature = nil }
     }
 
+    @Test func deterministicPlatformFilterEncoding() throws {
+        let obj = ProjectModel.Target.example(.dynamicLibrary)
+        try testCodable(obj, { $0.signature = nil }, """
+        {
+          "approvedByUser" : "true",
+          "buildConfigurations" : [
+
+          ],
+          "buildPhases" : [
+            {
+              "buildFiles" : [
+
+              ],
+              "destinationSubfolder" : "<absolute>",
+              "destinationSubpath" : "",
+              "guid" : "foo",
+              "runOnlyForDeploymentPostprocessing" : "false",
+              "type" : "com.apple.buildphase.copy-files"
+            }
+          ],
+          "buildRules" : [
+
+          ],
+          "customTasks" : [
+            {
+              "commandLine" : [
+                "foo",
+                "bar"
+              ],
+              "enableSandboxing" : "true",
+              "environment" : [
+                [
+                  "a",
+                  "b"
+                ],
+                [
+                  "c",
+                  "d"
+                ]
+              ],
+              "executionDescription" : "execution description",
+              "inputFilePaths" : [
+                "input1",
+                "input2"
+              ],
+              "outputFilePaths" : [
+                "output1",
+                "output2"
+              ],
+              "preparesForIndexing" : "true",
+              "workingDirectory" : "tmp"
+            }
+          ],
+          "dependencies" : [
+            {
+              "guid" : "FAKE",
+              "platformFilters" : [
+                {
+                  "platform" : "linux"
+                },
+                {
+                  "platform" : "macosx"
+                }
+              ]
+            }
+          ],
+          "guid" : "MyTarget",
+          "name" : "TargetName",
+          "productReference" : {
+            "guid" : "PRODUCTREF-MyTarget",
+            "name" : "Product Name",
+            "type" : "file"
+          },
+          "productTypeIdentifier" : "com.apple.product-type.library.dynamic",
+          "type" : "standard"
+        }
+        """)
+    }
+
     @Test func basicAggregateTargetEncoding() throws {
         try testCodable(ProjectModel.AggregateTarget.example)
     }
@@ -36,6 +115,7 @@ extension ProjectModel.Target {
             target.common.addCopyFilesBuildPhase { _ in .example }
             target.common.signature = "signature"
             target.common.customTasks = [.example]
+            target.common.addDependency(on: ProjectModel.GUID("FAKE"), platformFilters: [.init(platform: "linux"), .init(platform: "macosx")])
             return target
         }
     }


### PR DESCRIPTION
Previously these were serialized are sets and could be reordered across process launches