### PR TITLE
Add codeview debug format for windows

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
@@ -35,11 +35,43 @@ public final class ObjectLibraryAssemblerTaskAction: TaskAction {
         do {
             let options = try Options.parse(Array(task.commandLineAsStrings.dropFirst()))
             try? executionDelegate.fs.remove(options.output)
-            try executionDelegate.fs.createDirectory(options.output)
-            _ = try await options.inputs.concurrentMap(maximumParallelism: 10) { input in
-                try executionDelegate.fs.copy(input, to: options.output.join(input.basename))
+            try executionDelegate.fs.createDirectory(options.output, recursive: true)
+
+            // Track basename usage for duplicate detection and build destination mappings
+            var basenameCount: [String: Int] = [:]
+            var inputsWithDestinations: [(source: Path, destination: String)] = []
+
+            // Process each input to determine its destination name
+            for input in options.inputs {
+                let basename = input.basename
+                let count = basenameCount[basename, default: 0]
+                basenameCount[basename] = count + 1
+
+                let destinationName: String
+                if count == 0 {
+                    // First occurrence, use original name
+                    destinationName = basename
+                } else {
+                    // Duplicate detected, add suffix before extension
+                    let nameWithoutSuffix = input.withoutSuffix
+                    let suffix = input.fileSuffix  // Includes the dot
+                    destinationName = "\(Path(nameWithoutSuffix).basename)-\(count)\(suffix)"
+                }
+
+                inputsWithDestinations.append((source: input, destination: destinationName))
             }
-            let args = options.inputs.map { options.output.join($0.basename).strWithPosixSlashes }
+
+            // Copy files with their resolved destination names
+            for item in inputsWithDestinations {
+                let destinationPath = options.output.join(item.destination)
+                try executionDelegate.fs.copy(item.source, to: destinationPath)
+            }
+
+            // Build args array with flattened paths
+            let args = inputsWithDestinations.map { item in
+                options.output.join(item.destination).strWithPosixSlashes
+            }
+
             try executionDelegate.fs.write(options.output.join("args.resp"), contents: ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: args, format: options.linkerResponseFileFormat)))
             return .succeeded
         } catch {

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -184,7 +184,6 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
         }
         let testingLibraryPath = windowsPlatform.path.join("Developer").join("Library")
         let defaultProperties: [String: PropertyListItem] = [
-            "GCC_GENERATE_DEBUGGING_SYMBOLS": .plString("NO"),
             "LD_DEPENDENCY_INFO_FILE": .plString(""),
             "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
 

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -60,6 +60,31 @@
         Description = "Apple Clang compiler (Windows)";
         IsAbstract = YES;
         ShowInCompilerSelectionPopup = NO;
+        Options = (
+            {
+                Name = "GCC_DEBUG_INFORMATION_FORMAT";
+                Type = Enumeration;
+                Values = (
+                    dwarf,
+                    "dwarf-with-dsym",
+                    "codeview",
+                );
+                CommandLineArgs = {
+                    dwarf = (
+                        "-g",
+                    );
+                    "dwarf-with-dsym" = (
+                        "-g",
+                    );
+                    "codeview" = (
+                        "-g", "-gcodeview",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "$(DEBUG_INFORMATION_FORMAT)";
+                Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS)";
+            },
+        );
     },
     {
         Domain = windows;
@@ -106,8 +131,27 @@
                 CommandLineArgs = ("-static");
             },
             {
-                Name = SYSROOT;
-                Type = Path;
+                Name = "SWIFT_DEBUG_INFORMATION_FORMAT";
+                Type = Enumeration;
+                Values = (
+                    dwarf,
+                    "dwarf-with-dsym",
+                    "codeview",
+                );
+                CommandLineArgs = {
+                    dwarf = (
+                        "-g",
+                    );
+                    "dwarf-with-dsym" = (
+                        "-g",
+                    );
+                    "codeview" = (
+                        "-g", "-debug-info-format=codeview",
+                    );
+                    "<<otherwise>>" = ();
+                };
+                DefaultValue = "$(DEBUG_INFORMATION_FORMAT)";
+                Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS)";
             },
         );
     },

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -47,7 +47,8 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                     )
                 ]
             )
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testWorkspace, simulated: false)
 
             // Create the input files.
             let cFile = testWorkspace.sourceRoot.join("aProject/CFile.c")
@@ -74,7 +75,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
                 results.consumeTasksMatchingRuleTypes(excludedTypes)
                 results.checkTaskExists(.matchRule(["SwiftCompile", "normal", results.runDestinationTargetArchitecture, "Compiling \(swiftFile.basename)", swiftFile.str]))
                 results.checkTaskExists(.matchRule(["SwiftEmitModule", "normal", results.runDestinationTargetArchitecture, "Emitting module for aLibrary"]))
-                if runDestination == .linux {  // FIXME: This needs to be investigated... We should be able to use core.hostOperatingSystem.imageFormat.requiresSwiftModulewrap to test for this, but on Windows using this causes the test to fail as the SwiftModuleWrap does not seem to be added.
+                if try await core.hostOperatingSystem.imageFormat.requiresSwiftModulewrap  {
                     results.checkTaskExists(.matchRule(["SwiftModuleWrap", "normal", results.runDestinationTargetArchitecture,  "Wrapping Swift module aLibrary"]))
                 }
                 results.checkNoTask()

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -1174,6 +1174,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                 "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "$OBJROOT/ExplicitModules/$TARGET_NAME",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1303,6 +1304,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1402,6 +1404,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                 "CLANG_ENABLE_MODULES": "YES",
                                 "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                 "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "\(tmpDir.join("clangmodules").str)",
+                                "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                             ])],
                         targets: [
                             TestStandardTarget(
@@ -1426,6 +1429,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                                     "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                     "HEADER_SEARCH_PATHS": "$(inherited) \(tmpDir.join("Test").join("aProject").strWithPosixSlashes)",
                                     "CLANG_EXPLICIT_MODULES_OUTPUT_PATH": "\(tmpDir.join("clangmodules").strWithPosixSlashes)",
+                                    "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
                                 ])],
                             targets: [
                                 TestStandardTarget(

--- a/Tests/SWBTaskExecutionTests/ObjectLibraryAssemblerTaskActionTests.swift
+++ b/Tests/SWBTaskExecutionTests/ObjectLibraryAssemblerTaskActionTests.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBCore
+import SWBTaskExecution
+import SWBTestSupport
+import SWBUtil
+
+@Suite
+fileprivate struct ObjectLibraryAssemblerTaskActionTests {
+    @Test
+    func duplicateFileHandling() async throws {
+        // Create input files with duplicate basenames (all named file.o)
+        let inputOne = Path.root.join("input1").join("file.o")
+        let inputTwo = Path.root.join("input2").join("file.o")
+        let inputThree = Path.root.join("input3").join("file.o")
+        let inputUnique = Path.root.join("unique.o")
+        let output = Path.root.join("output")
+
+        let executionDelegate = MockExecutionDelegate()
+        try executionDelegate.fs.createDirectory(inputOne.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputTwo.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputThree.dirname, recursive: true)
+        try executionDelegate.fs.write(inputOne, contents: ByteString(encodingAsUTF8: "one"))
+        try executionDelegate.fs.write(inputTwo, contents: ByteString(encodingAsUTF8: "two"))
+        try executionDelegate.fs.write(inputThree, contents: ByteString(encodingAsUTF8: "three"))
+        try executionDelegate.fs.write(inputUnique, contents: ByteString(encodingAsUTF8: "unique"))
+
+        let outputDelegate = MockTaskOutputDelegate()
+
+        let commandLine = [
+            "builtin-ObjectLibraryAssembler",
+            "--linker-response-file-format",
+            "unixShellQuotedSpaceSeparated",
+            inputOne.str,
+            inputTwo.str,
+            inputThree.str,
+            inputUnique.str,
+            "--output",
+            output.str
+        ].map { ByteString(encodingAsUTF8: $0) }
+
+        let inputs = [inputOne, inputTwo, inputThree, inputUnique].map { MakePlannedPathNode($0) }
+        var builder = PlannedTaskBuilder(type: mockTaskType, ruleInfo: [], commandLine: commandLine.map { .literal($0) }, inputs: inputs, outputs: [MakePlannedPathNode(output)])
+        let task = Task(&builder)
+
+        let result = await ObjectLibraryAssemblerTaskAction().performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        #expect(result == .succeeded, "Task should succeed")
+        #expect(outputDelegate.messages == [], "Should have no error messages")
+
+        // Verify the output directory was created
+        #expect(executionDelegate.fs.exists(output), "Output directory should exist")
+
+        // Verify that files were copied with proper duplicate handling
+        let copiedOriginal = output.join("file.o")
+        let copiedDuplicate1 = output.join("file-1.o")
+        let copiedDuplicate2 = output.join("file-2.o")
+        let copiedUnique = output.join("unique.o")
+
+        #expect(executionDelegate.fs.exists(copiedOriginal), "First file.o should exist")
+        #expect(executionDelegate.fs.exists(copiedDuplicate1), "file-1.o should exist")
+        #expect(executionDelegate.fs.exists(copiedDuplicate2), "file-2.o should exist")
+        #expect(executionDelegate.fs.exists(copiedUnique), "unique.o should exist")
+
+        // Verify content of copied files
+        #expect(try executionDelegate.fs.read(copiedOriginal).asString == "one")
+        #expect(try executionDelegate.fs.read(copiedDuplicate1).asString == "two")
+        #expect(try executionDelegate.fs.read(copiedDuplicate2).asString == "three")
+        #expect(try executionDelegate.fs.read(copiedUnique).asString == "unique")
+
+        // Verify the response file was created with correct paths
+        let responseFile = output.join("args.resp")
+        #expect(executionDelegate.fs.exists(responseFile), "Response file should exist")
+
+        let responseContent = try executionDelegate.fs.read(responseFile).asString
+        #expect(responseContent.contains("file.o"), "Response should contain file.o")
+        #expect(responseContent.contains("file-1.o"), "Response should contain file-1.o")
+        #expect(responseContent.contains("file-2.o"), "Response should contain file-2.o")
+        #expect(responseContent.contains("unique.o"), "Response should contain unique.o")
+    }
+
+    @Test
+    func noDuplicates() async throws {
+        // Test that files with unique basenames are not renamed
+        let inputOne = Path.root.join("a.o")
+        let inputTwo = Path.root.join("b.o")
+        let inputThree = Path.root.join("c.o")
+        let output = Path.root.join("output")
+
+        let executionDelegate = MockExecutionDelegate()
+        try executionDelegate.fs.write(inputOne, contents: ByteString(encodingAsUTF8: "a"))
+        try executionDelegate.fs.write(inputTwo, contents: ByteString(encodingAsUTF8: "b"))
+        try executionDelegate.fs.write(inputThree, contents: ByteString(encodingAsUTF8: "c"))
+
+        let outputDelegate = MockTaskOutputDelegate()
+
+        let commandLine = [
+            "builtin-ObjectLibraryAssembler",
+            "--linker-response-file-format",
+            "unixShellQuotedSpaceSeparated",
+            inputOne.str,
+            inputTwo.str,
+            inputThree.str,
+            "--output",
+            output.str
+        ].map { ByteString(encodingAsUTF8: $0) }
+
+        let inputs = [inputOne, inputTwo, inputThree].map { MakePlannedPathNode($0) }
+        var builder = PlannedTaskBuilder(type: mockTaskType, ruleInfo: [], commandLine: commandLine.map { .literal($0) }, inputs: inputs, outputs: [MakePlannedPathNode(output)])
+        let task = Task(&builder)
+
+        let result = await ObjectLibraryAssemblerTaskAction().performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        #expect(result == .succeeded, "Task should succeed")
+
+        // Verify files are copied with their original names (no -N suffix)
+        let copiedA = output.join("a.o")
+        let copiedB = output.join("b.o")
+        let copiedC = output.join("c.o")
+
+        #expect(executionDelegate.fs.exists(copiedA), "a.o should exist")
+        #expect(executionDelegate.fs.exists(copiedB), "b.o should exist")
+        #expect(executionDelegate.fs.exists(copiedC), "c.o should exist")
+
+        // Verify that no renamed versions exist
+        #expect(!executionDelegate.fs.exists(output.join("a-1.o")), "a-1.o should not exist")
+        #expect(!executionDelegate.fs.exists(output.join("b-1.o")), "b-1.o should not exist")
+        #expect(!executionDelegate.fs.exists(output.join("c-1.o")), "c-1.o should not exist")
+    }
+}


### PR DESCRIPTION
- update xcspec for Windows to support codeview debug format
- update ObjectLibraryAssembler to support files with the same basename by finding a common root of the inputs copying the directory structure that are children of that root.

closes: https://github.com/swiftlang/swift-build/issues/560

