### PR TITLE
[SWBCore/SwiftOutputParsing] Fix performance regression in message serialization for diagnostics

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3354,11 +3354,19 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 }
 
 extension SwiftCompilerSpec {
-    static public func computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(variant: String, arch: String, path: Path) -> ([String], ByteString) {
-        let ruleInfo = ["SwiftCompile", variant, arch, path.str.quotedDescription]
+    static public func computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(
+        variant: String,
+        arch: String,
+        path: Path?,
+        extraName: String? = nil,
+    ) -> ([String], ByteString) {
+        let ruleInfo = ["SwiftCompile", variant, arch] + (path.map{[$0.str.quotedDescription]} ?? [])
         let signature: ByteString = {
             let md5 = InsecureHashContext()
             md5.add(string: ruleInfo.joined(separator: " "))
+            if let extraName {
+                md5.add(string: extraName)
+            }
             return md5.signature
         }()
         return (ruleInfo, signature)


### PR DESCRIPTION
After refactoring of 9dfb22531bee966521a0ae96045913ab84f6eb6a diagnostics without a source file were using the signature of the compiler task which can be enormous, causing slowdown when sending a lot of diagnostics.

For a particular target it was taking ~30 seconds to send 455 diagnostics; after this change it goes back to under a second.