### PR TITLE
Revert "[SWBCore/SwiftOutputParsing] Fix performance regression in me…

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3354,19 +3354,11 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 }
 
 extension SwiftCompilerSpec {
-    static public func computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(
-        variant: String,
-        arch: String,
-        path: Path?,
-        extraName: String? = nil,
-    ) -> ([String], ByteString) {
-        let ruleInfo = ["SwiftCompile", variant, arch] + (path.map{[$0.str.quotedDescription]} ?? [])
+    static public func computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(variant: String, arch: String, path: Path) -> ([String], ByteString) {
+        let ruleInfo = ["SwiftCompile", variant, arch, path.str.quotedDescription]
         let signature: ByteString = {
             let md5 = InsecureHashContext()
             md5.add(string: ruleInfo.joined(separator: " "))
-            if let extraName {
-                md5.add(string: extraName)
-            }
             return md5.signature
         }()
         return (ruleInfo, signature)

--- a/Sources/SWBCore/SwiftOutputParsing.swift
+++ b/Sources/SWBCore/SwiftOutputParsing.swift
@@ -33,57 +33,57 @@ public final class SwiftCompilerOutputParser: TaskOutputParser {
 
     public func close(result: TaskResult?) {
         for entry in task.type.serializedDiagnosticsInfo(task, workspaceContext.fs) {
-            // Use a subtask even if there's not source file, otherwise the diagnostic will get the signature
-            // of the compiler task which can be very large, causing slowdown when needing to serialize and send
-            // a lot of diagnostics for a compilation.
-            let sourceFilePath = entry.sourceFilePath
-            // FIXME: find a better way to get at these
-            let variant = task.ruleInfo[1]
-            let arch = task.ruleInfo[2]
-            let (ruleInfo, signature) = SwiftCompilerSpec.computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(variant: variant, arch: arch, path: sourceFilePath, extraName: entry.sourceFilePath == nil ? task.ruleInfo[0] : nil)
-            let subtaskDelegate = delegate.startSubtask(
-                buildOperationIdentifier: self.delegate.buildOperationIdentifier,
-                taskName: "Swift Compiler",
-                signature: signature,
-                ruleInfo: ruleInfo.joined(separator: " "),
-                executionDescription: "Compile\(sourceFilePath.map{" \($0.basename)"} ?? "")",
-                commandLine: sourceFilePath.map{["builtin-SwiftPerFileCompile", ByteString(encodingAsUTF8: $0.basename)]} ?? [],
-                additionalOutput: [],
-                interestingPath: sourceFilePath,
-                workingDirectory: task.workingDirectory,
-                serializedDiagnosticsPaths: [entry.serializedDiagnosticsPath]
-            )
-            let diagnostics = subtaskDelegate.processSerializedDiagnostics(at: entry.serializedDiagnosticsPath, workingDirectory: task.workingDirectory, workspaceContext: workspaceContext)
-            let exitStatus: Processes.ExitStatus
-            switch result {
-            case .exit(let status, _)?:
-                switch status {
-                case .exit(let exitCode):
-                    if exitCode == 0 {
-                        // The batch compile succeeded, mark the individual files as succeeded.
-                        exitStatus = status
-                    } else {
-                        // The batch compile failed. Mark files which reported errors as failed, and files which did not as cancelled.
-                        if diagnostics.contains(where: { $0.behavior == .error }) {
+            if let sourceFilePath = entry.sourceFilePath {
+                // FIXME: find a better way to get at these
+                let variant = task.ruleInfo[1]
+                let arch = task.ruleInfo[2]
+                let (ruleInfo, signature) = SwiftCompilerSpec.computeRuleInfoAndSignatureForPerFileVirtualBatchSubtask(variant: variant, arch: arch, path: sourceFilePath)
+                let subtaskDelegate = delegate.startSubtask(
+                    buildOperationIdentifier: self.delegate.buildOperationIdentifier,
+                    taskName: "Swift Compiler",
+                    signature: signature,
+                    ruleInfo: ruleInfo.joined(separator: " "),
+                    executionDescription: "Compile \(sourceFilePath.basename)",
+                    commandLine: ["builtin-SwiftPerFileCompile", ByteString(encodingAsUTF8: sourceFilePath.basename)],
+                    additionalOutput: [],
+                    interestingPath: sourceFilePath,
+                    workingDirectory: task.workingDirectory,
+                    serializedDiagnosticsPaths: [entry.serializedDiagnosticsPath]
+                )
+                let diagnostics = subtaskDelegate.processSerializedDiagnostics(at: entry.serializedDiagnosticsPath, workingDirectory: task.workingDirectory, workspaceContext: workspaceContext)
+                let exitStatus: Processes.ExitStatus
+                switch result {
+                case .exit(let status, _)?:
+                    switch status {
+                    case .exit(let exitCode):
+                        if exitCode == 0 {
+                            // The batch compile succeeded, mark the individual files as succeeded.
                             exitStatus = status
                         } else {
-                            exitStatus = .buildSystemCanceledTask
+                            // The batch compile failed. Mark files which reported errors as failed, and files which did not as cancelled.
+                            if diagnostics.contains(where: { $0.behavior == .error }) {
+                                exitStatus = status
+                            } else {
+                                exitStatus = .buildSystemCanceledTask
+                            }
                         }
+                    case .uncaughtSignal(_):
+                        // If the batch compile failed due to a signal, there is likely not enough information to attribute the failure
+                        // to a particular file.
+                        exitStatus = status
                     }
-                case .uncaughtSignal(_):
-                    // If the batch compile failed due to a signal, there is likely not enough information to attribute the failure
-                    // to a particular file.
-                    exitStatus = status
+                case .failedSetup?:
+                    exitStatus = .buildSystemCanceledTask
+                case .skipped?:
+                    exitStatus = .exit(0)
+                case nil:
+                    exitStatus = .buildSystemCanceledTask
                 }
-            case .failedSetup?:
-                exitStatus = .buildSystemCanceledTask
-            case .skipped?:
-                exitStatus = .exit(0)
-            case nil:
-                exitStatus = .buildSystemCanceledTask
+                subtaskDelegate.taskCompleted(exitStatus: exitStatus)
+                subtaskDelegate.close()
+            } else {
+                delegate.processSerializedDiagnostics(at: entry.serializedDiagnosticsPath, workingDirectory: task.workingDirectory, workspaceContext: workspaceContext)
             }
-            subtaskDelegate.taskCompleted(exitStatus: exitStatus)
-            subtaskDelegate.close()
         }
         delegate.close()
     }


### PR DESCRIPTION
…ssage serialization for diagnostics"

This reverts commit 5f434c09ddc0026a21947cddb2336e340f518bbe.

This broke at least one SwiftPM test in Swift CI. To reproduce:

`SWIFTCI_USE_LOCAL_DEPS=1 swift test --filter noWarningFromRemoteDependencies` from the SwiftPM repo

cc @akyrtzi 