### PR TITLE
Introduce a TARGET_TEMP_DIR_SUFFIX setting

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3048,7 +3048,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             table.push(BuiltinMacros.CONFIGURATION_BUILD_DIR, Static { BuiltinMacros.namespace.parseString("$(BUILD_DIR)") })
             table.push(BuiltinMacros.CONFIGURATION_TEMP_DIR, Static { BuiltinMacros.namespace.parseString("$(PROJECT_TEMP_DIR)") })
         }
-        table.push(BuiltinMacros.TARGET_TEMP_DIR, Static { BuiltinMacros.namespace.parseString("$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME).build") })
+        table.push(BuiltinMacros.TARGET_TEMP_DIR, Static { BuiltinMacros.namespace.parseString("$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME)$(TARGET_TEMP_DIR_SUFFIX).build") })
         table.push(BuiltinMacros.TARGET_BUILD_DIR, Static { BuiltinMacros.namespace.parseString("$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)") })
         table.push(BuiltinMacros.BUILT_PRODUCTS_DIR, Static { BuiltinMacros.namespace.parseString("$(CONFIGURATION_BUILD_DIR)") })
         table.push(BuiltinMacros.DEVELOPMENT_LANGUAGE, literal: project.developmentRegion ?? "en")

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3016,7 +3016,7 @@ For more information on mergeable libraries, see [Configuring your project to us
             {
                 Name = "TARGET_TEMP_DIR";
                 Type = Path;
-                DefaultValue = "$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME).build";
+                DefaultValue = "$(CONFIGURATION_TEMP_DIR)/$(TARGET_NAME)$(TARGET_TEMP_DIR_SUFFIX).build";
                 Description = "Identifies the directory containing the target’s intermediate build files. Run Script build phases should place intermediate files at the location indicated by `DERIVED_FILE_DIR`, not the directory identified by this build setting.";
             },
             {

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -72,6 +72,7 @@ extension ProjectModel {
             case SWIFT_VERSION
             case SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR
             case TARGET_NAME
+            case TARGET_TEMP_DIR_SUFFIX
             case TARGET_BUILD_DIR
             case TVOS_DEPLOYMENT_TARGET
             case USE_HEADERMAP


### PR DESCRIPTION
The intent is to have SwiftPM set this to differentiate the intermediate directories of PIF targets representing a SwiftPM target and product whose names differ only in case