### PR TITLE
Improve correctness of Swift SDK resource dir handling

### DIFF
--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -1118,9 +1118,10 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
 
             let sdkroot = swiftSDK.path.join(tripleProperties.sdkRootPath)
 
-            // TODO support dynamic resources path
-            let swiftResourceDir = swiftSDK.path.join(tripleProperties.swiftStaticResourcesPath)
-            let clangResourceDir = swiftSDK.path.join(tripleProperties.clangStaticResourcesPath)
+            let swiftResourceDir = swiftSDK.path.join(tripleProperties.swiftResourcesPath)
+            let swiftStaticResourceDir = swiftSDK.path.join(tripleProperties.swiftStaticResourcesPath)
+            let clangResourceDir = swiftSDK.path.join(tripleProperties.clangResourcesPath)
+            let clangStaticResourceDir = swiftSDK.path.join(tripleProperties.clangStaticResourcesPath)
 
             let unversionedTriple = versionedTriple.unversioned
 
@@ -1157,12 +1158,21 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
                     "SWIFT_SDK_TOOLSETS": .plArray(toolsetAbsolutePaths),
                 ].merging(defaultProperties, uniquingKeysWith: { _, new in new })),
                 "CustomProperties": .plDict([
+                    "SDKROOT": .plString(sdkroot.str),
+
+                    // Default search paths
                     "LIBRARY_SEARCH_PATHS": .plArray(librarySearchPaths),
                     "HEADER_SEARCH_PATHS": .plArray(headerSearchPaths),
-                    "SWIFTC_RESOURCE_DIR": .plString(swiftResourceDir.str), // Resource dir for linking Swift
-                    "SWIFT_RESOURCE_DIR": .plString(swiftResourceDir.str), // Resource dir for compiling Swift
-                    "CLANG_RESOURCE_DIR": .plString(clangResourceDir.str), // Resource dir for linking C/C++/Obj-C
-                    "SDKROOT": .plString(sdkroot.str),
+
+                    // Resource directory settings
+                    "SWIFT_RESOURCE_DIR_STATIC_STDLIB_NO": .plString(swiftResourceDir.str),
+                    "SWIFT_RESOURCE_DIR_STATIC_STDLIB_YES": .plString(swiftStaticResourceDir.str),
+                    "SWIFT_RESOURCE_DIR": .plString("$(SWIFT_RESOURCE_DIR_STATIC_STDLIB_$(SWIFT_FORCE_STATIC_LINK_STDLIB:default=NO))"),
+                    // The clang resource dir is also conditioned on SWIFT_FORCE_STATIC_LINK_STDLIB/-resource-dir
+                    // because it's ultimately determined by how the Swift SDK is being used.
+                    "CLANG_RESOURCE_DIR_STATIC_STDLIB_NO": .plString(clangResourceDir.str),
+                    "CLANG_RESOURCE_DIR_STATIC_STDLIB_YES": .plString(clangStaticResourceDir.str),
+                    "CLANG_RESOURCE_DIR": .plString("$(CLANG_RESOURCE_DIR_STATIC_STDLIB_$(SWIFT_FORCE_STATIC_LINK_STDLIB:default=NO))"),
                 ].merging(customProperties, uniquingKeysWith: { _, new in new})),
                 "SupportedTargets": .plDict([
                     platform.name: .plDict(targetProperties)

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2877,6 +2877,19 @@ private class SettingsBuilder: ProjectMatchLookup {
                             BuiltinMacros.OTHER_LDFLAGS,
                             table.namespace.parseStringList(["$(inherited)", "$(OTHER_LDFLAGS_FROM_TOOLSET_LINKER_DRIVER_$(LINKER_DRIVER))"])
                         )
+
+                        for option in extraCLIOptions {
+                            switch option {
+                            case "-static-stdlib", "-static-executable":
+                                // Swift SDKs which only support static linking (like the static Linux SDK) may
+                                // include it in the compiler's extra CLI options. We want to ensure the build
+                                // system is aware of this selection so it can pick the right resource directory
+                                // if it's provided by the Swift SDK.
+                                table.push(BuiltinMacros.SWIFT_FORCE_STATIC_LINK_STDLIB, literal: true)
+                            default:
+                                break
+                            }
+                        }
                     }
                     if let path = toolset.cCompiler?.path {
                         table.push(BuiltinMacros.CC, literal: toolset.resolveToolPath(path, toolsetPath: toolsetPath).str)

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -212,6 +212,8 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
             return .deferred
         case "ld" where args == ["-version_details"]:
             return .deferred
+        case "ld.lld" where args == ["-v"] || args == ["-version_details"]:
+            return .deferred
         case "libtool" where args == ["-V"] || args == ["--version"]:
             return .deferred
         case "mig" where args == ["-version"]:
@@ -225,7 +227,7 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
         default:
             break
         }
-        throw StubError.error("Unit test should implement its own instance of TaskPlanningClientDelegate.")
+        throw StubError.error("Unit test should implement its own instance of TaskPlanningClientDelegate for external tool execution handling (\(commandLine).")
     }
 }
 

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -204,7 +204,7 @@
                 IsInputDependency = Yes;
             },
             {
-                Name = SWIFTC_RESOURCE_DIR;
+                Name = SWIFT_RESOURCE_DIR;
                 Type = Path;
                 Condition = "$(LINKER_DRIVER) == swiftc";
                 CommandLineArgs = {

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -393,7 +393,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
             results.checkTarget(targetName) { _ in }
 
             // Check diagnostics.
-            results.checkError(.prefix("Could not determine generated file paths for Core Data code generation: Unit test should implement its own instance of TaskPlanningClientDelegate."))
+            results.checkError(.prefix("Could not determine generated file paths for Core Data code generation: Unit test should implement its own instance of TaskPlanningClientDelegate"))
             results.checkNoDiagnostics()
         }
     }

--- a/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
@@ -14,12 +14,249 @@ import Foundation
 import Testing
 
 import SWBCore
+import SWBProtocol
 import SWBTaskConstruction
 import SWBTestSupport
 @_spi(Testing) import SWBUtil
 
 @Suite
 fileprivate struct ToolsetTaskConstructionTests: CoreBasedTests {
+    @Test(.requireSDKs(.host))
+    func staticResourceDirectorySelection() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let sdkManifestDir = tmpDir.join("TestSDK.artifactbundle")
+
+            let dynamicSwiftResourcesPath = "swift.xctoolchain/usr/lib/swift"
+            let staticSwiftResourcesPath = "swift.xctoolchain/usr/lib/swift_static"
+            let staticSwiftResourceDir = sdkManifestDir.join(staticSwiftResourcesPath)
+            let staticClangResourceDir = staticSwiftResourceDir.join("clang")
+
+            try localFS.createDirectory(sdkManifestDir)
+            let sdkManifestPath = sdkManifestDir.join("swift-sdk.json")
+            try await localFS.writeFileContents(sdkManifestPath) { $0 <<< """
+                {
+                    "schemaVersion" : "4.0",
+                    "targetTriples" : {
+                        "x86_64-unknown-linux-gnu" : {
+                            "sdkRootPath" : "sysroot",
+                            "swiftResourcesPath" : "\(dynamicSwiftResourcesPath)",
+                            "swiftStaticResourcesPath" : "\(staticSwiftResourcesPath)",
+                            "toolsetPaths" : [
+                                "static-toolset.json"
+                            ]
+                        }
+                    }
+                }
+                """
+            }
+
+            try await localFS.writeFileContents(sdkManifestDir.join("static-toolset.json")) { stream in
+                stream.write("""
+                {
+                    "schemaVersion" : "1.0",
+                    "swiftCompiler" : {
+                        "extraCLIOptions" : [
+                            "-static-stdlib"
+                        ]
+                    }
+                }
+                """)
+            }
+
+            let testProject = TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("a.c"),
+                        TestFile("b.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "SwiftTool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SWIFT_VERSION": try await swiftVersion,
+                                                    "LINKER_DRIVER": "swiftc",
+                                                    "SWIFT_EXEC": try await swiftCompilerPath.strWithPosixSlashes,
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("b.swift"),
+                            ]),
+                        ], dependencies: ["ClangTool"]),
+                    TestStandardTarget(
+                        "ClangTool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                    "LINKER_DRIVER": "clang",
+                                                    "CC": try await clangCompilerPath.strWithPosixSlashes,
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("a.c"),
+                            ]),
+                        ]),
+                ])
+
+            let core = try await Self.makeCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            let destination = RunDestinationInfo(buildTarget: .swiftSDK(sdkManifestPath: sdkManifestPath.str, triple: "x86_64-unknown-linux-gnu"), targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
+
+            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
+
+                results.checkTarget("SwiftTool") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-resource-dir", staticSwiftResourceDir.str])
+                        task.checkCommandLineContains(["-static-stdlib"])
+                    }
+
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-resource-dir", staticSwiftResourceDir.str])
+                        task.checkCommandLineContains(["-Xclang-linker", "-resource-dir", "-Xclang-linker", staticClangResourceDir.str])
+                    }
+                }
+
+                results.checkTarget("ClangTool") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-resource-dir", staticClangResourceDir.str])
+                    }
+                }
+
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host))
+    func dynamicResourceDirectorySelection() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let sdkManifestDir = tmpDir.join("TestSDK.artifactbundle")
+
+            let dynamicSwiftResourcesPath = "swift.xctoolchain/usr/lib/swift"
+            let staticSwiftResourcesPath = "swift.xctoolchain/usr/lib/swift_static"
+            let dynamicSwiftResourceDir = sdkManifestDir.join(dynamicSwiftResourcesPath)
+            let dynamicClangResourceDir = dynamicSwiftResourceDir.join("clang")
+
+            try localFS.createDirectory(sdkManifestDir)
+            let sdkManifestPath = sdkManifestDir.join("swift-sdk.json")
+            try await localFS.writeFileContents(sdkManifestPath) { $0 <<< """
+                {
+                    "schemaVersion" : "4.0",
+                    "targetTriples" : {
+                        "x86_64-unknown-linux-gnu" : {
+                            "sdkRootPath" : "sysroot",
+                            "swiftResourcesPath" : "\(dynamicSwiftResourcesPath)",
+                            "swiftStaticResourcesPath" : "\(staticSwiftResourcesPath)",
+                            "toolsetPaths" : [
+                                "toolset.json"
+                            ]
+                        }
+                    }
+                }
+                """
+            }
+
+            try await localFS.writeFileContents(sdkManifestDir.join("toolset.json")) { stream in
+                stream.write("""
+                {
+                    "schemaVersion" : "1.0",
+                    "swiftCompiler" : {
+                        "extraCLIOptions" : [
+                            "-DWhatever"
+                        ]
+                    }
+                }
+                """)
+            }
+
+            let testProject = TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("a.c"),
+                        TestFile("b.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "SwiftTool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SWIFT_VERSION": try await swiftVersion,
+                                                    "LINKER_DRIVER": "swiftc",
+                                                    "SWIFT_EXEC": try await swiftCompilerPath.strWithPosixSlashes,
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("b.swift"),
+                            ]),
+                        ], dependencies: ["ClangTool"]),
+                    TestStandardTarget(
+                        "ClangTool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                    "LINKER_DRIVER": "clang",
+                                                    "CC": try await clangCompilerPath.strWithPosixSlashes,
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("a.c"),
+                            ]),
+                        ]),
+                ])
+
+            let core = try await Self.makeCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            let destination = RunDestinationInfo(buildTarget: .swiftSDK(sdkManifestPath: sdkManifestPath.str, triple: "x86_64-unknown-linux-gnu"), targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
+
+            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
+
+                results.checkTarget("SwiftTool") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-resource-dir", dynamicSwiftResourceDir.str])
+                        task.checkCommandLineDoesNotContain("-static-stdlib")
+                    }
+
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-resource-dir", dynamicSwiftResourceDir.str])
+                        task.checkCommandLineContains(["-Xclang-linker", "-resource-dir", "-Xclang-linker", dynamicClangResourceDir.str])
+                    }
+                }
+
+                results.checkTarget("ClangTool") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-resource-dir", dynamicClangResourceDir.str])
+                    }
+                }
+
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
     @Test(.requireSDKs(.host))
     func toolsetCustomization() async throws {
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
Ensure we correctly select the dynamic or static resource dir based on the value of SWIFT_FORCE_STATIC_LINK_STDLIB, and infer SWIFT_FORCE_STATIC_LINK_STDLIB if a toolset.json passes -static-stdlib or -static-executable as extraCLIOptions. Also collapse the recently added SWIFTC_RESOURCE_DIR into the existing SWIFT_RESOURCE_DIR setting.