### PR TITLE
Introduce `[CLANG|SWIFT]_ENABLE_PROJECT_PREFIX_MAPPING`

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -527,6 +527,7 @@ public final class BuiltinMacros {
     public static let CLANG_CACHE_FINE_GRAINED_OUTPUTS_VERIFICATION = BuiltinMacros.declareEnumMacro("CLANG_CACHE_FINE_GRAINED_OUTPUTS_VERIFICATION") as EnumMacroDeclaration<FineGrainedCachingVerificationSetting>
     public static let CLANG_DISABLE_DEPENDENCY_INFO_FILE = BuiltinMacros.declareBooleanMacro("CLANG_DISABLE_DEPENDENCY_INFO_FILE")
     public static let CLANG_ENABLE_PREFIX_MAPPING = BuiltinMacros.declareBooleanMacro("CLANG_ENABLE_PREFIX_MAPPING")
+    public static let CLANG_ENABLE_PROJECT_PREFIX_MAPPING = BuiltinMacros.declareBooleanMacro("CLANG_ENABLE_PROJECT_PREFIX_MAPPING")
     public static let CLANG_OTHER_PREFIX_MAPPINGS = BuiltinMacros.declareStringListMacro("CLANG_OTHER_PREFIX_MAPPINGS")
     public static let CLANG_GENERATE_OPTIMIZATION_REMARKS = BuiltinMacros.declareBooleanMacro("CLANG_GENERATE_OPTIMIZATION_REMARKS")
     public static let CLANG_GENERATE_OPTIMIZATION_REMARKS_FILTER = BuiltinMacros.declareStringMacro("CLANG_GENERATE_OPTIMIZATION_REMARKS_FILTER")
@@ -1122,6 +1123,7 @@ public final class BuiltinMacros {
     public static let SWIFT_WHOLE_MODULE_OPTIMIZATION = BuiltinMacros.declareBooleanMacro("SWIFT_WHOLE_MODULE_OPTIMIZATION")
     public static let SWIFT_ENABLE_COMPILE_CACHE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_COMPILE_CACHE")
     public static let SWIFT_ENABLE_PREFIX_MAPPING = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_PREFIX_MAPPING")
+    public static let SWIFT_ENABLE_PROJECT_PREFIX_MAPPING = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_PROJECT_PREFIX_MAPPING")
     public static let SWIFT_OTHER_PREFIX_MAPPINGS = BuiltinMacros.declareStringListMacro("SWIFT_OTHER_PREFIX_MAPPINGS")
     public static let SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR = BuiltinMacros.declareStringMacro("SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR")
     public static let SYMBOL_GRAPH_EXTRACTOR_MODULE_NAME = BuiltinMacros.declareStringMacro("SYMBOL_GRAPH_EXTRACTOR_MODULE_NAME")
@@ -1539,6 +1541,7 @@ public final class BuiltinMacros {
         CLANG_CACHE_FINE_GRAINED_OUTPUTS_VERIFICATION,
         CLANG_DISABLE_DEPENDENCY_INFO_FILE,
         CLANG_ENABLE_PREFIX_MAPPING,
+        CLANG_ENABLE_PROJECT_PREFIX_MAPPING,
         CLANG_OTHER_PREFIX_MAPPINGS,
         CLANG_DISABLE_SERIALIZED_DIAGNOSTICS,
         CLANG_ENABLE_MODULES,
@@ -2373,6 +2376,7 @@ public final class BuiltinMacros {
         SWIFT_WHOLE_MODULE_OPTIMIZATION,
         SWIFT_ENABLE_COMPILE_CACHE,
         SWIFT_ENABLE_PREFIX_MAPPING,
+        SWIFT_ENABLE_PROJECT_PREFIX_MAPPING,
         SWIFT_OTHER_PREFIX_MAPPINGS,
         SYMBOL_GRAPH_EXTRACTOR_MODULE_NAME,
         SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR,

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
@@ -64,10 +64,25 @@ final class CompilationCachingConfigFileTaskProducer: StandardTaskProducer, Task
                     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
                     let casConfigContent = try encoder.encode(CASConfig(CASPath: casOpts.casPath.str, PluginPath: casOpts.pluginPath?.str))
 
-                    let prefixMapConfigContent: ByteString?
-                    if !scope.evaluate(BuiltinMacros.CLANG_ENABLE_PREFIX_MAPPING) && !scope.evaluate(BuiltinMacros.SWIFT_ENABLE_PREFIX_MAPPING) && scope.evaluate(BuiltinMacros.CLANG_OTHER_PREFIX_MAPPINGS).isEmpty && scope.evaluate(BuiltinMacros.SWIFT_OTHER_PREFIX_MAPPINGS).isEmpty {
-                        prefixMapConfigContent = nil
-                    } else {
+                    var prefixXcode = false
+                    var prefixProject = false
+                    var extraMaps: [String: String] = [:]
+
+                    func checkSettings(
+                        enableCache: BooleanMacroDeclaration,
+                        enablePrefix: BooleanMacroDeclaration,
+                        enableProjectPrefix: BooleanMacroDeclaration,
+                        otherMappings: StringListMacroDeclaration,
+                    ) {
+                        guard scope.evaluate(enableCache) && scope.evaluate(enablePrefix) else {
+                            return
+                        }
+
+                        prefixXcode = true
+                        if scope.evaluate(enableProjectPrefix) {
+                            prefixProject = true
+                        }
+
                         func rsplit(_ string: String, separator: Character) -> (String, String)? {
                             guard let splitIndex = string.lastIndex(of: separator) else {
                                 return nil
@@ -76,27 +91,40 @@ final class CompilationCachingConfigFileTaskProducer: StandardTaskProducer, Task
                             let value = String(string[string.index(after: splitIndex)...])
                             return (key, value)
                         }
+                        extraMaps.merge(
+                            scope.evaluate(otherMappings).compactMap { entry in
+                                rsplit(entry, separator: "=").map { (value, key) in (key, value) }
+                            }, uniquingKeysWith: { _, new in new })
+                    }
+                    checkSettings(
+                        enableCache: BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE,
+                        enablePrefix: BuiltinMacros.CLANG_ENABLE_PREFIX_MAPPING,
+                        enableProjectPrefix: BuiltinMacros.CLANG_ENABLE_PROJECT_PREFIX_MAPPING,
+                        otherMappings: BuiltinMacros.CLANG_OTHER_PREFIX_MAPPINGS
+                    )
+                    checkSettings(
+                        enableCache: BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE,
+                        enablePrefix: BuiltinMacros.SWIFT_ENABLE_PREFIX_MAPPING,
+                        enableProjectPrefix: BuiltinMacros.SWIFT_ENABLE_PROJECT_PREFIX_MAPPING,
+                        otherMappings: BuiltinMacros.SWIFT_OTHER_PREFIX_MAPPINGS
+                    )
 
-                        var prefixMaps: [String: String] = [:]
-                        if scope.evaluate(BuiltinMacros.CLANG_ENABLE_PREFIX_MAPPING) || !scope.evaluate(BuiltinMacros.SWIFT_ENABLE_PREFIX_MAPPING) {
-                            prefixMaps["/^sdk"] = scope.evaluate(BuiltinMacros.SDKROOT).str
-                            prefixMaps["/^xcode"] = scope.evaluate(BuiltinMacros.DEVELOPER_DIR).str
-                            prefixMaps["/^src"] = scope.evaluate(BuiltinMacros.PROJECT_DIR).str
-                            prefixMaps["/^derived"] = scope.evaluate(BuiltinMacros.PROJECT_TEMP_DIR).str
-                            prefixMaps["/^built"] = scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR).str
-                        }
-                        if scope.evaluate(BuiltinMacros.CLANG_ENABLE_COMPILE_CACHE) {
-                            prefixMaps.merge(
-                                scope.evaluate(BuiltinMacros.CLANG_OTHER_PREFIX_MAPPINGS).compactMap { entry in
-                                    rsplit(entry, separator: "=").map { (value, key) in (key, value) }
-                                }, uniquingKeysWith: { _, new in new })
-                        }
-                        if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_COMPILE_CACHE) {
-                            prefixMaps.merge(
-                                scope.evaluate(BuiltinMacros.SWIFT_OTHER_PREFIX_MAPPINGS).compactMap { entry in
-                                    rsplit(entry, separator: "=").map { (value, key) in (key, value) }
-                                }, uniquingKeysWith: { _, new in new })
-                        }
+                    var prefixMaps: [String: String] = [:]
+                    if prefixXcode {
+                        prefixMaps["/^sdk"] = scope.evaluate(BuiltinMacros.SDKROOT).str
+                        prefixMaps["/^xcode"] = scope.evaluate(BuiltinMacros.DEVELOPER_DIR).str
+                    }
+                    if prefixProject {
+                        prefixMaps["/^src"] = scope.evaluate(BuiltinMacros.PROJECT_DIR).str
+                        prefixMaps["/^derived"] = scope.evaluate(BuiltinMacros.PROJECT_TEMP_DIR).str
+                        prefixMaps["/^built"] = scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR).str
+                    }
+                    prefixMaps.merge(extraMaps, uniquingKeysWith: { _, new in new })
+
+                    let prefixMapConfigContent: ByteString?
+                    if prefixMaps.isEmpty {
+                        prefixMapConfigContent = nil
+                    } else {
                         prefixMapConfigContent = try ByteString(encoder.encode(prefixMaps))
                     }
                     return CompilationCachingConfigs(OutputDir: path, CASConfigContent: ByteString(casConfigContent), PrefixMapConfigContent: prefixMapConfigContent)

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3316,13 +3316,26 @@
                         "-fdepscan-prefix-map-sdk=/^sdk",
                         "-fdepscan-prefix-map-toolchain=/^toolchain",
                         "-fdepscan-prefix-map=$(DEVELOPER_DIR)=/^xcode",
+                    );
+                    NO = ();
+                };
+                Condition = "$(CLANG_ENABLE_COMPILE_CACHE)";
+                FeatureFlags = "depscan-prefix-map";
+                // Category is hidden.
+            },
+            {
+                Name = "CLANG_ENABLE_PROJECT_PREFIX_MAPPING";
+                Type = Boolean;
+                // `DefaultValue` is not set to allow configuring the setting via an environment variable.
+                CommandLineArgs = {
+                    YES = (
                         "-fdepscan-prefix-map=$(PROJECT_DIR)=/^src",
                         "-fdepscan-prefix-map=$(PROJECT_TEMP_DIR)=/^derived",
                         "-fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built",
                     );
                     NO = ();
                 };
-                Condition = "$(CLANG_ENABLE_COMPILE_CACHE)";
+                Condition = "$(CLANG_ENABLE_COMPILE_CACHE) && $(CLANG_ENABLE_PREFIX_MAPPING)";
                 FeatureFlags = "depscan-prefix-map";
                 // Category is hidden.
             },

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1442,13 +1442,24 @@
                         "-scanner-prefix-map-sdk", "/^sdk",
                         "-scanner-prefix-map-toolchain", "/^toolchain",
                         "-scanner-prefix-map", "$(DEVELOPER_DIR)=/^xcode",
+                    );
+                    NO = ();
+                };
+                Condition = "$(SWIFT_ENABLE_COMPILE_CACHE)";
+            },
+            {
+                Name = "SWIFT_ENABLE_PROJECT_PREFIX_MAPPING";
+                Type = Boolean;
+                // `DefaultValue` is not set to allow configuring the setting via an environment variable.
+                CommandLineArgs = {
+                    YES = (
                         "-scanner-prefix-map", "$(PROJECT_DIR)=/^src",
                         "-scanner-prefix-map", "$(PROJECT_TEMP_DIR)=/^derived",
                         "-scanner-prefix-map", "$(BUILT_PRODUCTS_DIR)=/^built",
                     );
                     NO = ();
                 };
-                Condition = "$(SWIFT_ENABLE_COMPILE_CACHE)";
+                Condition = "$(SWIFT_ENABLE_COMPILE_CACHE) && $(SWIFT_ENABLE_PREFIX_MAPPING)";
             },
             {
                 Name = "SWIFT_OTHER_PREFIX_MAPPINGS";

--- a/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangCompilationCachingTests.swift
@@ -1553,6 +1553,7 @@ fileprivate struct ClangCompilationCachingTests: CoreBasedTests {
                                     "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
                                     "HEADER_SEARCH_PATHS": "\(moduleDir.str) $DERIVED_FILE_DIR",
                                     "CLANG_ENABLE_PREFIX_MAPPING": "YES",
+                                    "CLANG_ENABLE_PROJECT_PREFIX_MAPPING": "YES",
                                     "CLANG_OTHER_PREFIX_MAPPINGS": "\(moduleDir.str)=/^mod",
                                     "DSTROOT": tmpDirPath.join("dstroot").str,
                                     "EMIT_FRONTEND_COMMAND_LINES": "YES",

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1964,16 +1964,18 @@ import SWBMacro
         let mockFileType = try core.specRegistry.getSpec("sourcecode.cpp.cpp", ofType: FileTypeSpec.self)
         let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
+        let enableProjectPrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_ENABLE_PROJECT_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("CLANG_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
         let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
         let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
         let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
 
-        func test(caching: Bool, prefixMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
+        func test(caching: Bool, prefixMapping: Bool, completeMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
             table.push(enableCompileCache, literal: caching)
             table.push(enablePrefixMap, literal: prefixMapping)
+            table.push(enableProjectPrefixMap, literal: completeMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")
             table.push(srcDir, literal: "/source")
@@ -1992,13 +1994,20 @@ import SWBMacro
             try completion(prefixMaps)
         }
 
-        try await test(caching: false, prefixMapping: true, extraMaps: ["/a=/b"], completion: { args in
+        try await test(caching: false, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b"], completion: { args in
             #expect(args == [])
         })
-        try await test(caching: true, prefixMapping: false, extraMaps: ["/a=/b"], completion: { args in
+        try await test(caching: true, prefixMapping: false, completeMapping: true, extraMaps: ["/a=/b"], completion: { args in
             #expect(args == [])
         })
-        try await test(caching: true, prefixMapping: true, extraMaps: [], completion: { args in
+        try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: [], completion: { args in
+            #expect(args == [
+                "-fdepscan-prefix-map-sdk=/^sdk",
+                "-fdepscan-prefix-map-toolchain=/^toolchain",
+                "-fdepscan-prefix-map=/Xcode.app/Contents/Developer=/^xcode",
+            ])
+        })
+        try await test(caching: true, prefixMapping: true, completeMapping: true, extraMaps: [], completion: { args in
             #expect(args == [
                 "-fdepscan-prefix-map-sdk=/^sdk",
                 "-fdepscan-prefix-map-toolchain=/^toolchain",
@@ -2008,14 +2017,11 @@ import SWBMacro
                 "-fdepscan-prefix-map=/products=/^built",
             ])
         })
-        try await test(caching: true, prefixMapping: true, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
+        try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
             #expect(args == [
                 "-fdepscan-prefix-map-sdk=/^sdk",
                 "-fdepscan-prefix-map-toolchain=/^toolchain",
                 "-fdepscan-prefix-map=/Xcode.app/Contents/Developer=/^xcode",
-                "-fdepscan-prefix-map=/source=/^src",
-                "-fdepscan-prefix-map=/build=/^derived",
-                "-fdepscan-prefix-map=/products=/^built",
                 "-fdepscan-prefix-map=/a=/b",
                 "-fdepscan-prefix-map=/c=/d",
             ])
@@ -2030,13 +2036,14 @@ import SWBMacro
         let mockFileType = try core.specRegistry.getSpec("sourcecode.swift", ofType: FileTypeSpec.self)
         let enableCompileCache = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_COMPILE_CACHE") as? BooleanMacroDeclaration)
         let enablePrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_PREFIX_MAPPING") as? BooleanMacroDeclaration)
+        let enableProjectPrefixMap = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_ENABLE_PROJECT_PREFIX_MAPPING") as? BooleanMacroDeclaration)
         let prefixMaps = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("SWIFT_OTHER_PREFIX_MAPPINGS") as? StringListMacroDeclaration)
         let devDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("DEVELOPER_DIR") as? PathMacroDeclaration)
         let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
         let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
         let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
 
-        func test(caching: Bool, prefixMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
+        func test(caching: Bool, prefixMapping: Bool, completeMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             // Create the mock table.
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
             try await table.push(BuiltinMacros.SWIFT_EXEC, literal: self.swiftCompilerPath.str)
@@ -2053,6 +2060,7 @@ import SWBMacro
             table.push(BuiltinMacros.USE_SWIFT_RESPONSE_FILE, literal: true)
             table.push(enableCompileCache, literal: caching)
             table.push(enablePrefixMap, literal: prefixMapping)
+            table.push(enableProjectPrefixMap, literal: completeMapping)
             table.push(prefixMaps, literal: extraMaps)
             table.push(devDir, literal: "/Xcode.app/Contents/Developer")
             table.push(srcDir, literal: "/source")
@@ -2079,13 +2087,20 @@ import SWBMacro
             try completion(prefixMaps)
         }
 
-        try await test(caching: false, prefixMapping: true, extraMaps: ["/a=/b"], completion: { args in
+        try await test(caching: false, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b"], completion: { args in
             #expect(args == [])
         })
-        try await test(caching: true, prefixMapping: false, extraMaps: ["/a=/b"], completion: { args in
+        try await test(caching: true, prefixMapping: false, completeMapping: true, extraMaps: ["/a=/b"], completion: { args in
             #expect(args == [])
         })
-        try await test(caching: true, prefixMapping: true, extraMaps: [], completion: { args in
+        try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: [], completion: { args in
+            #expect(args == [
+                "-scanner-prefix-map-sdk", "/^sdk",
+                "-scanner-prefix-map-toolchain", "/^toolchain",
+                "-scanner-prefix-map", "/Xcode.app/Contents/Developer=/^xcode",
+            ])
+        })
+        try await test(caching: true, prefixMapping: true, completeMapping: true, extraMaps: [], completion: { args in
             #expect(args == [
                 "-scanner-prefix-map-sdk", "/^sdk",
                 "-scanner-prefix-map-toolchain", "/^toolchain",
@@ -2095,14 +2110,11 @@ import SWBMacro
                 "-scanner-prefix-map", "/products=/^built",
             ])
         })
-        try await test(caching: true, prefixMapping: true, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
+        try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
             #expect(args == [
                 "-scanner-prefix-map-sdk", "/^sdk",
                 "-scanner-prefix-map-toolchain", "/^toolchain",
                 "-scanner-prefix-map", "/Xcode.app/Contents/Developer=/^xcode",
-                "-scanner-prefix-map", "/source=/^src",
-                "-scanner-prefix-map", "/build=/^derived",
-                "-scanner-prefix-map", "/products=/^built",
                 "-scanner-prefix-map", "/a=/b",
                 "-scanner-prefix-map", "/c=/d",
             ])


### PR DESCRIPTION
These settings take over for enabling the recent source & build directory prefix mappings. The separate settings are useful so we can do a controlled and staged adoption of the new prefix mappings.