### PR TITLE
[SwiftHeaderTool] Use writeIfChanged to avoid unnecessary ObjC recompilation

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/SwiftHeaderToolTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftHeaderToolTaskAction.swift
@@ -110,7 +110,7 @@ public final class SwiftHeaderToolTaskAction: TaskAction {
             // If there's only a single architecture, don't add ifdefs.
             if options.single {
                 if let path = options.inputs.values.only {
-                    try executionDelegate.fs.write(options.output, contents: executionDelegate.fs.read(path))
+                    _ = try executionDelegate.fs.writeIfChanged(options.output, contents: executionDelegate.fs.read(path))
                     return .succeeded
                 } else {
                     outputDelegate.emitError("Multiple architectures are not supported on this target.")
@@ -169,7 +169,7 @@ public final class SwiftHeaderToolTaskAction: TaskAction {
             byteString += ByteString(encodingAsUTF8: "#error unsupported Swift architecture\n")
             byteString += ByteString(encodingAsUTF8: "#endif\n")
 
-            try executionDelegate.fs.write(options.output, contents: byteString)
+            _ = try executionDelegate.fs.writeIfChanged(options.output, contents: byteString)
 
             return .succeeded
         } catch {

--- a/Tests/SWBTaskExecutionTests/SwiftHeaderToolTaskActionTests.swift
+++ b/Tests/SWBTaskExecutionTests/SwiftHeaderToolTaskActionTests.swift
@@ -18,13 +18,12 @@ import SWBTaskExecution
 struct SwiftHeaderToolTaskActionTests: CoreBasedTests {
 
     /// Utility function to create and run a `SwiftHeaderToolTaskAction` and call a block to check the results.
-    private func testSwiftHeaderToolTaskAction(archs: [String], validate: (ByteString) -> Void) async throws {
+    @discardableResult
+    private func runSwiftHeaderToolTaskAction(fs: PseudoFS, archs: [String]) async throws -> Path {
         guard !archs.isEmpty else {
             Issue.record("Must pass at least one architecture.")
-            return
+            return Path("/")
         }
-
-        let fs = PseudoFS()
 
         let inputDir = Path.root.join("Volumes/Inputs")
         let outputDir = Path.root.join("Volumes/Outputs")
@@ -58,16 +57,21 @@ struct SwiftHeaderToolTaskActionTests: CoreBasedTests {
         let task = Task(forTarget: nil, ruleInfo: [], commandLine: commandLine, workingDirectory: .root, outputs: [], action: action, execDescription: "")
         guard let result = await task.action?.performTaskAction(task, dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(), executionDelegate: executionDelegate, clientDelegate: MockTaskExecutionClientDelegate(), outputDelegate: outputDelegate) else {
             Issue.record("No result was returned.")
-            return
+            return outputPath
         }
 
         // Check the command succeeded with no errors.
         #expect(result == .succeeded)
         #expect(outputDelegate.messages == [])
 
-        // Read the output file and pass it to the validation block.
-        let outputFileContents = try fs.read(outputPath)
-        validate(outputFileContents)
+        return outputPath
+    }
+
+    /// Convenience wrapper that creates its own filesystem and validates the output contents.
+    private func testSwiftHeaderToolTaskAction(archs: [String], validate: (ByteString) -> Void) async throws {
+        let fs = PseudoFS()
+        let outputPath = try await runSwiftHeaderToolTaskAction(fs: fs, archs: archs)
+        validate(try fs.read(outputPath))
     }
 
     /// Test that running the tool for a single arch just copies the file and doesn't add any `#if` blocks.
@@ -133,6 +137,36 @@ struct SwiftHeaderToolTaskActionTests: CoreBasedTests {
                 "#endif\n"
             #expect(outputFileContents == expectedFileContents)
         }
+    }
+
+    // MARK: - writeIfChanged tests
+
+    /// Test that running the single-arch tool twice with identical input does not rewrite the output.
+    @Test
+    func testSingleArchDoesNotRewriteIdenticalOutput() async throws {
+        let fs = PseudoFS()
+
+        let outputPath = try await runSwiftHeaderToolTaskAction(fs: fs, archs: ["arm64"])
+        let timestampAfterFirstRun = try fs.getFileTimestamp(outputPath)
+
+        try await runSwiftHeaderToolTaskAction(fs: fs, archs: ["arm64"])
+        let timestampAfterSecondRun = try fs.getFileTimestamp(outputPath)
+
+        #expect(timestampAfterFirstRun == timestampAfterSecondRun, "Output header was rewritten despite identical content; expected writeIfChanged to skip the write")
+    }
+
+    /// Test that running the multi-arch tool twice with identical inputs does not rewrite the output.
+    @Test
+    func testMultiArchDoesNotRewriteIdenticalOutput() async throws {
+        let fs = PseudoFS()
+
+        let outputPath = try await runSwiftHeaderToolTaskAction(fs: fs, archs: ["arm64", "x86_64"])
+        let timestampAfterFirstRun = try fs.getFileTimestamp(outputPath)
+
+        try await runSwiftHeaderToolTaskAction(fs: fs, archs: ["arm64", "x86_64"])
+        let timestampAfterSecondRun = try fs.getFileTimestamp(outputPath)
+
+        #expect(timestampAfterFirstRun == timestampAfterSecondRun, "Output header was rewritten despite identical content; expected writeIfChanged to skip the write")
     }
 
 }


### PR DESCRIPTION
Fixes #1152

Replace `fs.write()` with `fs.writeIfChanged()` in both the single-arch and multi-arch code paths of `SwiftHeaderToolTaskAction`. This skips rewriting the merged `-Swift.h` header when its content hasn't changed, preserving its mtime and preventing unnecessary ObjC recompilation.

### Changes

  - `SwiftHeaderToolTaskAction.swift`: `fs.write()` → `fs.writeIfChanged()` on lines 113 and 172
  - `SwiftHeaderToolTaskActionTests.swift`: Refactor existing helper to accept a shared filesystem, add two new tests that run the header tool twice with identical inputs and verify the output is not rewritten

### Test plan

- [x] `swift test --filter SwiftHeaderToolTaskActionTests` — all 6 tests pass
- [x] New tests fail without the fix (timestamps 11→15 and 15→21), pass with it