### PR TITLE
Add integration test for the WebAssembly embedded Swift SDK

### DIFF
--- a/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -21,11 +21,19 @@ fileprivate extension Core {
     func findWebAssemblySwiftSDK() async throws -> SwiftSDK? {
         try await findSwiftSDK("wasm")
     }
+
+    func findWebAssemblyEmbeddedSwiftSDK() async throws -> SwiftSDK? {
+        try await findSwiftSDK("wasm-embedded")
+    }
 }
 
 fileprivate extension Trait where Self == Testing.ConditionTrait {
     static var requiresWebAssemblySwiftSDK: Self {
         requireSwiftSDK("wasm", in: { try await WebAssemblyIntegrationTests.getSwiftSDKIntegrationTestingCore() })
+    }
+
+    static var requiresEmbeddedWebAssemblySwiftSDK: Self {
+        requireSwiftSDK("wasm-embedded", in: { try await WebAssemblyIntegrationTests.getSwiftSDKIntegrationTestingCore() })
     }
 }
 
@@ -248,6 +256,66 @@ fileprivate struct WebAssemblyIntegrationTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.host), .requiresEmbeddedWebAssemblySwiftSDK, .skipXcodeToolchain)
+        func embeddedExecutable() async throws {
+            try await withTemporaryDirectory { (tmpDir: Path) in
+                let testProject = try await TestProject(
+                    "TestProject",
+                    sourceRoot: tmpDir,
+                    groupTree: TestGroup(
+                        "SomeFiles",
+                        children: [
+                            TestFile("main.swift"),
+                        ]),
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": swiftVersion,
+                            "SDKROOT": "auto",
+                            "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                            "LINKER_DRIVER": "auto",
+                        ])
+                    ],
+                    targets: [
+                        TestStandardTarget(
+                            "tool",
+                            type: .commandLineTool,
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug")
+                            ],
+                            buildPhases: [
+                                TestSourcesBuildPhase(["main.swift"])
+                            ],
+                        )
+                    ])
+                let core = try await WebAssemblyIntegrationTests.getSwiftSDKIntegrationTestingCore()
+                let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+                let projectDir = tester.workspace.projects[0].sourceRoot
+
+                try await tester.fs.writeFileContents(projectDir.join("main.swift")) { stream in
+                    stream <<< """
+                        #if hasFeature(Embedded) && os(WASI)
+                        print("Hello from WASI and Embedded Swift!")
+                        #else
+                        #error("Built incorrectly")
+                        #endif
+                    """
+                }
+
+                let swiftSDK = try #require(await core.findWebAssemblyEmbeddedSwiftSDK())
+                let destination = try SWBCore.RunDestinationInfo(sdkManifestPath: swiftSDK.manifestPath, triple: "wasm32-unknown-wasip1", targetArchitecture: "wasm32", supportedArchitectures: ["wasm32"], disableOnlyActiveArch: false, core: core)
+                try await tester.checkBuild(runDestination: destination) { results in
+                    results.checkNoErrors()
+                    let wasmKitPath = try #require(try core.coreSettings.defaultToolchain?.executableSearchPaths.lookup(subject: .executable(basename: "wasmkit"), operatingSystem: ProcessInfo.processInfo.hostOperatingSystem()))
+                    let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: wasmKitPath.str), arguments: ["run", projectDir.join("build").join("Debug-webassembly").join("tool.wasm").str])
+                    #expect(executionResult.exitStatus == .exit(0))
+                    #expect(String(decoding: executionResult.stdout, as: UTF8.self) == "Hello from WASI and Embedded Swift!\n")
+                    #expect(String(decoding: executionResult.stderr, as: UTF8.self) == "")
+                }
+            }
+        }
 }
 
 extension OperatingSystem {


### PR DESCRIPTION
Since we can run the resulting executable with wasmkit, this is our best way to get some coverage of Embedded Swift via a Swift SDK in CI