### PR TITLE
Revert "SanitizerTaskProducer should include multiple runtimes libraries (#1068)"

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SanitizerTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SanitizerTaskProducer.swift
@@ -31,18 +31,11 @@ final class SanitizerTaskProducer: PhasedTaskProducer, TaskProducer {
             self.libraryNameInfix = libraryNameInfix
         }
 
-        func libraryNames(for sdkVariant: SDKVariant) -> [(source_name: String, dest_name: String, required: Bool)]? {
+        func libraryName(for sdkVariant: SDKVariant) -> String? {
             guard let clangRuntimeLibraryPlatformName = sdkVariant.clangRuntimeLibraryPlatformName else {
                 return nil
             }
-            let defaultRuntimeName = "libclang_rt.\(libraryNameInfix)_\(clangRuntimeLibraryPlatformName)_dynamic.dylib"
-            var runtimes = [(defaultRuntimeName, defaultRuntimeName, true)]
-            if sdkVariant.name == "iphoneos" {
-                // Include libraries for macOS and visionOS to support "iOS-on-Mac" and "iOS-on-visonOS"
-                runtimes.append(("libclang_rt.\(libraryNameInfix)_osx_dynamic.dylib", "libclang_rt.\(libraryNameInfix)_ios_dynamic_on_osx.dylib", false))
-                runtimes.append(("libclang_rt.\(libraryNameInfix)_xros_dynamic.dylib", "libclang_rt.\(libraryNameInfix)_ios_dynamic_on_xros.dylib", false))
-            }
-            return runtimes
+            return "libclang_rt.\(libraryNameInfix)_\(clangRuntimeLibraryPlatformName)_dynamic.dylib"
         }
 
         func errorForMissingLibrary(on platform: Platform?) -> Bool {
@@ -104,58 +97,52 @@ final class SanitizerTaskProducer: PhasedTaskProducer, TaskProducer {
         if sanitizerName == "Address" && scope.evaluate(BuiltinMacros.ENABLE_SYSTEM_SANITIZERS) {
             return
         }
-        guard let sdkVariant = context.settings.sdkVariant, let libraryNames = sanitizer.libraryNames(for: sdkVariant) else {
+        guard let sdkVariant = context.settings.sdkVariant, let libraryName = sanitizer.libraryName(for: sdkVariant) else {
             return
         }
 
-        for (sourceLibraryName, destLibraryName, isRequired) in libraryNames {
-            // The sanitizer libraries are bundled with the clang in the toolchain we're using.  Moreover, there is a separate library for each platform, and it lives in a directory based on the version of the clang in that platform.
-            // So, we have to do some path calculations to compute the location of the library.  Fortunately, we can ask the clang specification to be used for the its version.
-            guard let clangInfo = try? await context.clangSpec.discoveredCommandLineToolSpecInfo(context, scope, delegate, forLanguageOfFileType: nil), !clangInfo.toolPath.isEmpty else {
-                context.error("Could not find path to clang binary to locate \(sanitizerName) Sanitizer library")
-                continue
-            }
-            // The build description depends on the clang compiler due to the discovered info.
-            access(path: clangInfo.toolPath)
-            guard let clangLibDarwinPath = clangInfo.getLibDarwinPath() else {
-                context.error("Could not get lib darwin path")
-                continue
-            }
+        // The sanitizer libraries are bundled with the clang in the toolchain we're using.  Moreover, there is a separate library for each platform, and it lives in a directory based on the version of the clang in that platform.
+        // So, we have to do some path calculations to compute the location of the library.  Fortunately, we can ask the clang specification to be used for the its version.
+        guard let clangInfo = try? await context.clangSpec.discoveredCommandLineToolSpecInfo(context, scope, delegate, forLanguageOfFileType: nil), !clangInfo.toolPath.isEmpty else {
+            context.error("Could not find path to clang binary to locate \(sanitizerName) Sanitizer library")
+            return
+        }
+        // The build description depends on the clang compiler due to the discovered info.
+        access(path: clangInfo.toolPath)
+        guard let clangLibDarwinPath = clangInfo.getLibDarwinPath() else {
+            context.error("Could not get lib darwin path")
+            return
+        }
 
-            let libraryPath = clangLibDarwinPath.join(sourceLibraryName)
-            guard clangLibDarwinPath.isAbsolute else {
-                context.error("Unable to copy clang \(sanitizerName) Sanitizer library: Path to it is not an absolute path but is \(libraryPath.str)'")
-                continue
+        let libraryPath = clangLibDarwinPath.join(libraryName)
+        guard clangLibDarwinPath.isAbsolute else {
+            context.error("Unable to copy clang \(sanitizerName) Sanitizer library: Path to it is not an absolute path but is \(libraryPath.str)'")
+            return
+        }
+
+        guard context.fs.exists(libraryPath) else {
+            if sanitizer.errorForMissingLibrary(on: context.settings.platform) {
+                context.error("Unable to copy \(sanitizerName) Sanitizer library: Could not determine where it lives." )
             }
+            return
+        }
 
-            guard context.fs.exists(libraryPath) else {
-                if sanitizer.errorForMissingLibrary(on: context.settings.platform) {
-                    if isRequired {
-                        context.error("Unable to copy \(sourceLibraryName) Sanitizer library: Could not determine where it lives." )
-                    } else {
-                        context.warning("Unable to copy \(sourceLibraryName) Sanitizer library: Could not determine where it lives." )
-                    }
-                }
-                continue
-            }
+        // The path to copy the library to.
+        let libraryDstPath = Path(scope.evaluate(scope.namespace.parseString("$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/\(libraryName)")))
 
-            // The path to copy the library to.
-            let libraryDstPath = Path(scope.evaluate(scope.namespace.parseString("$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/\(destLibraryName)")))
+        // Create a virtual node to order the copy and code signing tasks.
+        let copySanitizerLibraryOrderingNode = delegate.createVirtualNode("Copy \(sanitizerName) Sanitizer library \(libraryDstPath.str)")
 
-            // Create a virtual node to order the copy and code signing tasks.
-            let copySanitizerLibraryOrderingNode = delegate.createVirtualNode("Copy \(sanitizerName) Sanitizer library \(libraryDstPath.str)")
+        // Copy the library.
+        do {
+            let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(absolutePath: libraryPath, inferringTypeUsing: context)], output: libraryDstPath, commandOrderingOutputs: [copySanitizerLibraryOrderingNode])
+            await context.copySpec.constructCopyTasks(cbc, delegate, executionDescription: "Copy \(sanitizerName) Sanitizer library", stripUnsignedBinaries: false, stripBitcode: false)
+        }
 
-            // Copy the library.
-            do {
-                let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(absolutePath: libraryPath, inferringTypeUsing: context)], output: libraryDstPath, commandOrderingOutputs: [copySanitizerLibraryOrderingNode])
-                await context.copySpec.constructCopyTasks(cbc, delegate, executionDescription: "Copy \(sanitizerName) Sanitizer library", stripUnsignedBinaries: false, stripBitcode: false)
-            }
-
-            // Code sign the copied library if appropriate.
-            do {
-                let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(absolutePath: libraryDstPath, inferringTypeUsing: context)], commandOrderingInputs: [copySanitizerLibraryOrderingNode])
-                context.codesignSpec.constructCodesignTasks(cbc, delegate, productToSign: libraryDstPath, isReSignTask: true)
-            }
+        // Code sign the copied library if appropriate.
+        do {
+            let cbc = CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(absolutePath: libraryDstPath, inferringTypeUsing: context)], commandOrderingInputs: [copySanitizerLibraryOrderingNode])
+            context.codesignSpec.constructCodesignTasks(cbc, delegate, productToSign: libraryDstPath, isReSignTask: true)
         }
     }
 }

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -4170,7 +4170,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
     /// Test that we properly generate commands for the compiler sanitizer features.
     @Test(
-        .requireSDKs(.macOS, .iOS),
+        .requireSDKs(.macOS),
         arguments:[
             (linkerDriver: "clang", expectedArgument: "-fsanitize=address"),
             (linkerDriver: "swiftc", expectedArgument: "-sanitize=address"),
@@ -4386,48 +4386,6 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
                 // Check there are no diagnostics.
                 results.checkNoDiagnostics()
-            }
-
-            let ios_overrides = [
-                "BUILD_VARIANTS": "normal asan",
-                "ENABLE_ADDRESS_SANITIZER[variant=asan]": "YES",
-                "SDKROOT": "iphoneos",
-                "AD_HOC_CODE_SIGNING_ALLOWED": "YES"
-            ]
-
-            // Check sanitizers iOS-on-macOS and iOS-on-visionOS
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ios_overrides), runDestination: .iOS, fs: fs) { results in
-                results.checkTarget(targetName) { target in
-                    // For iOS run destinations, swift-build should also include OSX and xrOS runtimes
-                    results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic_on_osx.dylib")) { task in
-                        task.checkRuleInfo([.equal("Copy"),
-                                            .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic_on_osx.dylib"),
-                                            .equal(clangLibDarwinPath.join("libclang_rt.asan_osx_dynamic.dylib").str),])
-                        #expect(task.execDescription == "Copy Address Sanitizer library")
-                    }
-                    results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic_on_xros.dylib")) { task in
-                        task.checkRuleInfo([.equal("Copy"),
-                                            .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic_on_xros.dylib"),
-                                            .equal(clangLibDarwinPath.join("libclang_rt.asan_xros_dynamic.dylib").str),])
-                        #expect(task.execDescription == "Copy Address Sanitizer library")
-                    }
-                    results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic.dylib")) { task in
-                        task.checkRuleInfo([.equal("Copy"),
-                                            .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic.dylib"),
-                                            .equal(clangLibDarwinPath.join("libclang_rt.asan_ios_dynamic.dylib").str),])
-                        #expect(task.execDescription == "Copy Address Sanitizer library")
-                    }
-                    // There should be one code signing task for each ASan library.
-                    results.checkTask(.matchTarget(target), .matchRuleType("CodeSign"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic_on_osx.dylib")) { task in
-                        task.checkRuleInfo([.equal("CodeSign"), .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic_on_osx.dylib")])
-                    }
-                    results.checkTask(.matchTarget(target), .matchRuleType("CodeSign"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic_on_xros.dylib")) { task in
-                        task.checkRuleInfo([.equal("CodeSign"), .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic_on_xros.dylib")])
-                    }
-                    results.checkTask(.matchTarget(target), .matchRuleType("CodeSign"), .matchRuleItemBasename("libclang_rt.asan_ios_dynamic.dylib")) { task in
-                        task.checkRuleInfo([.equal("CodeSign"), .equal("\(SRCROOT)/build/Debug-iphoneos/\(targetName).app/Frameworks/libclang_rt.asan_ios_dynamic.dylib")])
-                    }
-                }
             }
 
             await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug", overrides: overrides), runDestination: .macOS, fs: fs) { results in


### PR DESCRIPTION
This reverts commit 24725ae492c56812186a63bbac3114038c245c99.

This is not used right now, so reverting to avoid unnecessarily bloating app bundles.