### PR TITLE
Add full support for respecting ResourceRule.copy on BuildFile

### DIFF
--- a/Sources/SWBCore/FileToBuild.swift
+++ b/Sources/SWBCore/FileToBuild.swift
@@ -25,6 +25,15 @@ public struct FileToBuild : Hashable, Sendable {
     /// The build file for the referenced file, if any.
     public let buildFile: BuildFile?
 
+    public var resolveBuildRules: Bool {
+        switch buildFile?.resourceRule {
+        case nil, .process:
+            return true
+        case .copy, .embedInCode:
+            return false
+        }
+    }
+
     /// Header visibility of the file, if specified.  This is derived from the build file.
     public var headerVisibility: HeaderVisibility? {
         return buildFile?.headerVisibility

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -110,7 +110,7 @@ package final class BuildFilesProcessingContext: BuildFileFilteringContext {
     /// - parameter addIfNoBuildRuleFound: If `true`, then the file-to-build will be added as an ungrouped file if no build rule to process it could be found. If `false`, then the file-to-build is added only if a build rule to process it can be found.
     fileprivate func addFile(_ ftb: FileToBuild, _ taskProducerContext: TaskProducerContext, _ scope: MacroEvaluationScope, _ generatedByBuildRuleAction: (any BuildRuleAction)? = nil, addIfNoBuildRuleFound: Bool = false) {
         // If not honoring build rules, assign each file to an individual group.
-        guard resolveBuildRules else {
+        guard resolveBuildRules && ftb.resolveBuildRules else {
             addFileGroup(FileToBuildGroup(files: [ftb], action: nil), false)
             return
         }
@@ -858,7 +858,7 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
     /// - parameter productDirectories: The file will _not_ be added if it is inside one of these directories.  This is because files which are in directories considered part of the product should not be reprocessed (but we don't just look at the `SYMROOT` or `DSTROOT` because some projects put content there to share across targets).
     func shouldAddOutputFile(_ ftb: FileToBuild, _ buildFilesContext: BuildFilesProcessingContext, _ productDirectories: [Path], _ scope: MacroEvaluationScope) -> Bool {
         // If we're not resolving build rules, then outputs will not be further processed.
-        guard buildFilesContext.resolveBuildRules else { return false }
+        guard buildFilesContext.resolveBuildRules && ftb.resolveBuildRules else { return false }
 
         // Don't process output files which are already in the resources folder of a wrapped product, or a product directory we were passed.  (If further processing is desired, then the tool should place it somewhere else, such as in the derived files folder.)
         // FIXME: This applies to all task producers because the Metal linker expects it (in the Sources producer).  Consider a more general approach, e.g. any file in the product should not be reprocessed.

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -3178,6 +3178,51 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS))
+    func copyResourceRuleSkipsBuildRules() async throws {
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("unprocessed.png"),
+                    TestFile("processed.png"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget("App", type: .application, buildPhases: [
+                    TestResourcesBuildPhase([
+                        TestBuildFile(.auto("unprocessed.png"), resourceRule: .copy),
+                        TestBuildFile(.auto("processed.png"), resourceRule: .process)
+                    ]),
+                ])
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .macOS) { results in
+            results.checkTarget("App") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("CpResource"), .matchRuleItemBasename("unprocessed.png")) { task in
+                    task.checkRuleInfo(["CpResource", "\(SRCROOT)/build/Debug/App.app/Contents/Resources/unprocessed.png", "\(SRCROOT)/Sources/unprocessed.png"])
+                }
+
+                results.checkTask(.matchTarget(target), .matchRuleType("CopyPNGFile"), .matchRuleItemBasename("processed.png")) { task in
+                    task.checkRuleInfo(["CopyPNGFile", "\(SRCROOT)/build/Debug/App.app/Contents/Resources/processed.png", "\(SRCROOT)/Sources/processed.png"])
+                }
+
+                results.checkNoTask(.matchTarget(target), .matchRuleType("CopyPNGFile"), .matchRuleItemBasename("image.png"))
+            }
+
+            results.checkNoDiagnostics()
+        }
+    }
 }
 
 private func XCTAssertEqual(_ lhs: EnvironmentBindings, _ rhs: [String: String], file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
Previously, Swift Build would unconditionally apply build rules to resources in packages, even if they were specified with .copy. Finish support for ResourceRule.copy at the build system level so SwiftPM PIF generation can properly adopt it