### PR TITLE
Use a matching linker driver when swift compiler path is overridden

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -266,16 +266,16 @@ public struct FileCopyTaskActionContext {
 }
 
 extension FileCopyTaskActionContext {
-    public init(_ cbc: CommandBuildContext) {
+    public init(_ cbc: CommandBuildContext, delegate: any CoreClientTargetDiagnosticProducingDelegate) async {
         let compilerPath = cbc.producer.clangSpec.resolveExecutablePath(cbc, forLanguageOfFileType: cbc.producer.lookupFileType(languageDialect: .c))
-        let linkerPath = cbc.producer.ldLinkerSpec.resolveExecutablePath(cbc.producer, cbc.producer.ldLinkerSpec.computeLinkerPath(cbc, usedCXX: false, lookup: { macro in
+        let linkerPath = await cbc.producer.ldLinkerSpec.resolveExecutablePath(cbc.producer, cbc.producer.ldLinkerSpec.computeLinkerPath(cbc, usedCXX: false, lookup: { macro in
             switch macro {
             case BuiltinMacros.LINKER_DRIVER:
                 return cbc.scope.namespace.parseString("clang")
             default:
                 return nil
             }
-        }))
+        }, delegate))
         let lipoPath = cbc.producer.lipoSpec.resolveExecutablePath(cbc.producer, Path(cbc.producer.lipoSpec.computeExecutablePath(cbc)))
 
         // If we couldn't find clang, skip the special stub binary handling. We may be using an Open Source toolchain which only has Swift. Also skip it for installLoc builds.

--- a/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
@@ -153,7 +153,7 @@ public final class CopyToolSpec : CompilerSpec, SpecIdentifierType, @unchecked S
         assert(inputPath.str == ruleInfo[payload.inputIndexInRuleInfo])
 
         // Note that the order of rule info here is against the usual conventions.
-        let action = delegate.taskActionCreationDelegate.createFileCopyTaskAction(FileCopyTaskActionContext(cbc))
+        let action = await delegate.taskActionCreationDelegate.createFileCopyTaskAction(FileCopyTaskActionContext(cbc, delegate: delegate))
         let inputs: [any PlannedNode] = cbc.inputs.map{ delegate.createDirectoryTreeNode($0.absolutePath) } + cbc.commandOrderingInputs
         let outputs: [any PlannedNode] = [delegate.createNode(outputPath)] + additionalPresumedOutputs + cbc.commandOrderingOutputs
         delegate.createTask(

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -723,7 +723,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
         // Select the driver to use based on the input file types, replacing the value computed by commandLineFromTemplate().
         let usedCXX = usedTools.values.contains(where: { $0.contains(where: { $0.languageDialect?.isPlusPlus ?? false }) })
-        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX, lookup: linkerDriverLookup), delegate: delegate).str
+        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX, lookup: linkerDriverLookup, delegate), delegate: delegate).str
 
         let entitlementsSection = cbc.scope.evaluate(BuiltinMacros.LD_ENTITLEMENTS_SECTION)
         if !entitlementsSection.isEmpty {
@@ -982,7 +982,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
         // Select the driver to use based on the input file types, replacing the value computed by commandLineFromTemplate().
         let usedCXX = usedTools.values.contains(where: { $0.contains(where: { $0.languageDialect?.isPlusPlus ?? false }) })
-        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX, lookup: linkerDriverLookup), delegate: delegate).str
+        commandLine[0] = await resolveExecutablePath(cbc, computeLinkerPath(cbc, usedCXX: usedCXX, lookup: linkerDriverLookup, delegate), delegate: delegate).str
 
         let entitlementsSection = cbc.scope.evaluate(BuiltinMacros.LD_ENTITLEMENTS_SECTION)
         if !entitlementsSection.isEmpty {
@@ -1257,7 +1257,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         return cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "clang")
     }
 
-    public func computeLinkerPath(_ cbc: CommandBuildContext, usedCXX: Bool, lookup: @escaping ((MacroDeclaration) -> MacroStringExpression?)) -> Path {
+    public func computeLinkerPath(_ cbc: CommandBuildContext, usedCXX: Bool, lookup: @escaping ((MacroDeclaration) -> MacroStringExpression?), _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Path {
         if usedCXX {
             let perArchValue = cbc.scope.evaluate(BuiltinMacros.PER_ARCH_LDPLUSPLUS, lookup: lookup)
             if !perArchValue.isEmpty {
@@ -1294,7 +1294,12 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
                 return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "qcc"))
             }
         case .swiftc:
-            return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "swiftc"))
+            // If we've overridden the swiftc used for compilation, prefer to use the same swiftc as the linker driver.
+            if let swiftInfo = await cbc.producer.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate) {
+                return swiftInfo.toolPath
+            } else {
+                return Path(cbc.producer.hostOperatingSystem.imageFormat.executableName(basename: "swiftc"))
+            }
         case .auto:
             preconditionFailure("LINKER_DRIVER was expected to be bound to a concrete value")
         }


### PR DESCRIPTION
If overriding the compiler path with SWIFT_EXEC, we should override the linker driver path as well (when using swiftc) to avoid library mismatches