### PR TITLE
Don't emit package deployment target diags for aggregate targets

### DIFF
--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -736,7 +736,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
 
     func diagnoseInvalidDeploymentTargets(diagnosticDelegate: any TargetDiagnosticProducingDelegate) {
         for target in planRequest.buildGraph.allTargets.filter({
-            planRequest.workspaceContext.workspace.project(for: $0.target).isPackage && $0.target.type != .packageProduct
+            planRequest.workspaceContext.workspace.project(for: $0.target).isPackage && $0.target.type == .standard
         }) {
             let settings = getTargetSettings(target)
             let platformDeploymentTargetMacro: StringMacroDeclaration?


### PR DESCRIPTION
There are a few places in SwiftPM where aggregate targets are used as a top-level grouping mechanism so a CLI invocation can easily build them together. We shouldn't need to specify settings for these targets, so don't check their deployment targets against that of their dependencies