### PR TITLE
Fix a handful of assorted test issues

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AppIntentsNLTraining.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppIntentsNLTraining.xcspec
@@ -21,6 +21,9 @@
         RuleName = "AppIntentsSSUTraining";
         ExecDescription = "Generate SSU asset files";
         Outputs = ("$(TARGET_TEMP_DIR)/ssu/root.ssu.yaml");
+        EnvironmentVariables = {
+            "DEVELOPER_DIR" = "$(DEVELOPER_DIR)";
+        };
         IsArchitectureNeutral = YES;
         Options = (
             {

--- a/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
@@ -154,6 +154,7 @@ extension CoreBasedTests {
 
                     // Not actually recognized by clang
                     "ANDROID_DEPLOYMENT_TARGET",
+                    "FREEBSD_DEPLOYMENT_TARGET",
                     "QNX_DEPLOYMENT_TARGET",
                 ])
                 let suffix = "_DEPLOYMENT_TARGET"

--- a/Tests/SwiftBuildTests/ValidationTests.swift
+++ b/Tests/SwiftBuildTests/ValidationTests.swift
@@ -64,8 +64,15 @@ fileprivate struct ValidationTests: CoreBasedTests {
                             }
                         }
                     }
-                case .merged, .none:
-                    preconditionFailure()
+                case let .merged(output):
+                    let errors = output.unsafeStringValue.split(separator: "\n").filter { $0.hasPrefix("error: ") }
+                    if !errors.isEmpty {
+                        for error in errors {
+                            Issue.record(Comment(rawValue: String(error).withoutPrefix("error: ")), sourceLocation: sourceLocation)
+                        }
+                    }
+                case .none:
+                    break
                 }
                 throw error
             }


### PR DESCRIPTION
- Forward DEVELOPER_DIR to appintentsnltrainingprocessor: it uses xcrun to find ssu-cli, which fails if the xcode-select'ed Xcode is not the running one
- Update a test to account for the fact that FREEBSD_DEPLOYMENT_TARGET is only a build setting and not a Clang-recognized environment variable
- Implement a preconditionFailure branch in a test that wasn't actually a precondition failure
