### PR TITLE
[WIP] Consider SWIFT_EXEC when searching for testing library

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -4528,11 +4528,18 @@ private class SettingsBuilder: ProjectMatchLookup {
             table.push(BuiltinMacros.SWIFT_SYSTEM_INCLUDE_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "$(TEST_LIBRARY_SEARCH_PATHS$(TEST_BUILD_STYLE))"]))
 
             // If the toolchain contains a copy of Swift Testing, prefer it.
-            let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
-            if let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }) {
+            let swiftExecPath = Path(scope.evaluateAsString(BuiltinMacros.SWIFT_EXEC))
+            if swiftExecPath.exists(fs: workspaceContext.fs) {
                 let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
-                if let testingLibrarySearchPath = toolchain.testingLibrarySearchPath(forPlatformNamed: platformName) {
-                    table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", testingLibrarySearchPath.str]))
+                let testingLibraryRelativeSearchPath = Toolchain.testingLibaryRelativeSearchPath(forPlatformNamed: platformName)
+                table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "$(SWIFT_EXEC)/\(testingLibraryRelativeSearchPath.normalize().str)"]))
+            } else {
+                let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
+                if let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }) {
+                    let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
+                    if let testingLibrarySearchPath = toolchain.testingLibrarySearchPath(forPlatformNamed: platformName) {
+                        table.push(BuiltinMacros.TEST_LIBRARY_SEARCH_PATHS, BuiltinMacros.namespace.parseStringList(["$(inherited)", testingLibrarySearchPath.str]))
+                    }
                 }
             }
 
@@ -4584,6 +4591,8 @@ private class SettingsBuilder: ProjectMatchLookup {
             return flags
         }
 
+        let useSwiftExec = Path(scope.evaluateAsString(BuiltinMacros.SWIFT_EXEC)).dirname
+        print(">>>> DEBUG: useSwiftExec = \(useSwiftExec)")
         let toolchainPath = Path(scope.evaluateAsString(BuiltinMacros.TOOLCHAIN_DIR))
         guard let toolchain = core.toolchainRegistry.toolchains.first(where: { $0.path == toolchainPath }),
               let defaultToolchain = core.toolchainRegistry.defaultToolchain

--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -392,9 +392,13 @@ public final class Toolchain: Hashable, Sendable {
         return Version(numbers)
     }
 
+    static func testingLibaryRelativeSearchPath(forPlatformNamed platformName: String) -> Path {
+        return Path(".").join("usr").join("lib").join("swift").join(platformName).join("testing")
+    }
+
     func testingLibrarySearchPath(forPlatformNamed platformName: String) -> Path? {
         if testingLibraryPlatformNames.contains(platformName) {
-            path.join("usr").join("lib").join("swift").join(platformName).join("testing")
+            path.join(Self.testingLibaryRelativeSearchPath(forPlatformNamed: platformName))
         } else {
             nil
         }

--- a/Sources/SWBUtil/Path.swift
+++ b/Sources/SWBUtil/Path.swift
@@ -594,6 +594,14 @@ public struct Path: Serializable, Sendable {
         return nil
     }
 
+    /// Does the path exists on the filesystem `fs`
+    ///
+    /// - parameter fs: A file system proxy
+    /// - returns: `true` if the file exists. Otherwise, `false`
+    public func exists(fs: any FSProxy) -> Bool {
+        fs.exists(self)
+    }
+
     /// Resolves all symlinks in the path and returns a new path containing no symlinks.
     public func resolveSymlink(fs: any FSProxy) throws -> Path {
         return try fs.realpath(self)

--- a/Tests/SWBUtilTests/PathTests.swift
+++ b/Tests/SWBUtilTests/PathTests.swift
@@ -57,6 +57,10 @@ fileprivate struct PathTests {
         #expect(Path("/private").join("tmp").str == "/private/tmp")
         #expect(Path("/private/").join("tmp").str == "/private/tmp")
         #expect(Path("/private/").join("/tmp").str == "/tmp")
+        #expect(Path("/private/").join(Path("/tmp")).str == "/tmp")
+        #expect(Path("/private/").join(Path("./tmp")).str == "/private/./tmp")
+        #expect(Path("/private/").join(Path("tmp")).str == "/private/tmp")
+        #expect(Path("/private").join(Path("tmp")).str == "/private/tmp")
     }
 
     @Test
@@ -164,6 +168,7 @@ fileprivate struct PathTests {
     func normalize() {
         #expect(Path("").normalize() == Path(""))
         #expect(Path(".").normalize() == Path("."))
+        #expect(Path("./foo/bar").normalize() == Path("foo/bar"))
         #expect(Path("/a/b/./../c").normalize() == Path("/a/c"))
         #expect(Path(".././c").normalize() == Path("../c"))
         #expect(Path("/.././c").normalize() == Path("/c"))


### PR DESCRIPTION
When calculating the testing library search path, take into consideration if SWIFT_EXEC is defined