### PR TITLE
Fix the search path order for the clang module verifier

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
@@ -257,11 +257,20 @@ final class ModuleVerifierTaskProducer: PhasedTaskProducer, TaskProducer {
 
         table.push(BuiltinMacros.CLANG_ENABLE_MODULES, literal: true)
         table.push(BuiltinMacros.CLANG_ENABLE_OBJC_ARC, literal: true)
+
+        // Set up the search paths. Remove headermaps. Clear ENABLE_DEFAULT_SEARCH_PATHS so that
+        // GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(_:_:usesModules:) doesn't add
+        // search paths into DERIVED_FILE_DIR. Add the path to the test inputs, and the default search
+        // paths to BUILT_PRODUCTS_DIR. The latter would normally be added by Settings for the target,
+        // but there isn't a way to run a clean table through Settings, and the ones on the context
+        // have the target overrides applied.
         table.push(BuiltinMacros.USE_HEADERMAP, literal: false)
         table.push(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS, literal: false)
+        table.push(BuiltinMacros.FRAMEWORK_SEARCH_PATHS, table.namespace.parseStringList([inputs.dir.str, "$(BUILT_PRODUCTS_DIR)", "$(inherited)"]))
+        table.push(BuiltinMacros.HEADER_SEARCH_PATHS, table.namespace.parseStringList(["$(BUILT_PRODUCTS_DIR)/include", "$(inherited)"]))
+
         table.push(BuiltinMacros.GCC_C_LANGUAGE_STANDARD, literal: targetSet.standard.rawValue)
         table.push(BuiltinMacros.CLANG_CXX_LANGUAGE_STANDARD, literal: targetSet.standard.rawValue)
-        table.push(BuiltinMacros.FRAMEWORK_SEARCH_PATHS, table.namespace.parseStringList("$(inherited) $(BUILT_PRODUCTS_DIR) '\(inputs.dir.str)'"))
         table.push(BuiltinMacros.OTHER_CFLAGS, literal: otherCFlags)
         table.push(BuiltinMacros.OTHER_CPLUSPLUSFLAGS, literal: otherCPlusPlusFlags)
         table.push(BuiltinMacros.CURRENT_ARCH, literal: targetSet.target.architecture!)

--- a/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
@@ -97,6 +97,12 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                     TestFile("Orange.defs"),
                     TestFile("main.m"),
                 ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "FRAMEWORK_SEARCH_PATHS": "$(inherited) /PROJECT_PATH",
+                    "OTHER_CFLAGS": "$(inherited) -DPROJECT_FLAG",
+                ]),
+            ],
             targets: [
                 TestStandardTarget(
                     targetName,
@@ -116,8 +122,8 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                             "OTHER_MODULE_VERIFIER_FLAGS": "-- -I$(BUILT_PRODUCTS_DIR)/usr/include",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CC": clangCompilerPath.str,
-                            "OTHER_CFLAGS": "-DTARGET_FLAG",
-                            "FRAMEWORK_SEARCH_PATHS": "/TARGET_PATH",
+                            "OTHER_CFLAGS": "$(inherited) -DTARGET_FLAG",
+                            "FRAMEWORK_SEARCH_PATHS": "$(inherited) /TARGET_PATH",
                             "CLANG_USE_RESPONSE_FILE": "NO",
                         ]),
                     ],
@@ -158,8 +164,9 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                         task.checkCommandLineContainsUninterrupted(["-x", language])
                         task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)"])
                         task.checkCommandLineContains([
-                            "-F\(SRCROOT)/build/Debug",
                             "-F\(SRCROOT)/build/aProject.build/Debug/Orange.build/VerifyModule/Orange/\(language)",
+                            "-F\(SRCROOT)/build/Debug",
+                            "-F/XCCONFIG_PATH",
                             "-Wsystem-headers-in-module=Orange",
                             "-Werror=non-modular-include-in-module",
                             "-Werror=non-modular-include-in-framework-module",
@@ -176,9 +183,10 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                         ])
 
                         task.checkCommandLineContains(["-DCLI_FLAG"])
+                        task.checkCommandLineDoesNotContain("-DPROJECT_FLAG")
                         task.checkCommandLineDoesNotContain("-DTARGET_FLAG")
 
-                        task.checkCommandLineContains(["-F/XCCONFIG_PATH"])
+                        task.checkCommandLineDoesNotContain("-F/PROJECT_PATH")
                         task.checkCommandLineDoesNotContain("-F/TARGET_PATH")
 
                         if language.hasSuffix("++") {


### PR DESCRIPTION
The clang module verifier is putting BUILT_PRODUCTS_DIR at the end of the search path list, but it's very important that it comes first. Otherwise includes from the framework being tested can resolve to a different copy of the framework depending on what gets added on the command line/from the SDK/etc.

rdar://161918113