### PR TITLE
Don't delete relative paths computed when cleaning

### DIFF
--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -265,6 +265,11 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
                 continue
             }
 
+            guard buildFolderPath.isAbsolute else {
+                buildOutputDelegate.warning("Skipping clean of '\(buildFolderPath.str)' because it is a relative path, which may be unexpected")
+                continue
+            }
+
             if isBuildFolder(buildFolderPath) || ignoreCreatedByBuildSystemAttribute {
                 do {
                     try deleteBuildFolder(buildFolderPath)

--- a/Tests/SWBBuildSystemTests/CleanOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CleanOperationTests.swift
@@ -320,7 +320,7 @@ fileprivate struct CleanOperationTests: CoreBasedTests {
             try await tester.checkBuild(runDestination: .macOS, buildCommand: .cleanBuildFolder(style: type), persistent: true) { results in
                 results.checkTask(.matchRule(["\(try await getCore().developerPath.path.str)/usr/bin/make", "clean"])) { _ in }
                 results.checkNoTask()
-                results.checkNoDiagnostics()
+                results.checkNoErrors()
             }
 
             #expect(!tester.fs.exists(sourceRoot.join("out.txt")))


### PR DESCRIPTION
If a macro like OBJROOT evaluates to a relative path, we shouldn't attempt to delete it while cleaning because build configuration can't make assumptions about the build service executable's current working directory, so the resulting behavior will be unpredictable.

I discovered this while debugging an occasional SQLite assert in the test suite which reported a build db being unlinked while open. It turns out:
1. The Swift dependency scanner is configuring the clang importer with a working directory, which clang is then setting with chdir (we should fix this in the compiler)
2. The external target build system tests which run a clean operation had OBJROOT evaluate to 'build/'
3. When these two raced in just the right way, the cleaning tests could delete another random test's build directory at just the right time to trigger the llbuild assert