### PR TITLE
Fix support for Windows -> Android cross compilation

### DIFF
--- a/Sources/SWBAndroidPlatform/Plugin.swift
+++ b/Sources/SWBAndroidPlatform/Plugin.swift
@@ -114,17 +114,35 @@ struct AndroidPlatformExtension: PlatformInfoExtension {
     let plugin: AndroidPlugin
 
     func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
-        [
-            (.root, [
-                "Type": .plString("Platform"),
-                "Name": .plString("android"),
-                "Identifier": .plString("android"),
-                "Description": .plString("android"),
-                "FamilyName": .plString("Android"),
-                "FamilyIdentifier": .plString("android"),
-                "IsDeploymentPlatform": .plString("YES"),
-            ])
+        let androidPlatformInfoPlist: [String: PropertyListItem] = [
+            "Type": .plString("Platform"),
+            "Name": .plString("android"),
+            "Identifier": .plString("android"),
+            "Description": .plString("android"),
+            "FamilyName": .plString("Android"),
+            "FamilyIdentifier": .plString("android"),
+            "IsDeploymentPlatform": .plString("YES"),
         ]
+
+        if context.hostOperatingSystem == .windows {
+            let platforms = try context.developerPath.withPlatformsInWindowsLayout(named: "Android", fs: context.fs) { platformInfoPlistPath, platformInfoPlist, version in
+                (platformInfoPlistPath.dirname, platformInfoPlist.addingContents(of: androidPlatformInfoPlist).addingContents(of: ["Version": .plString(version)]))
+            }
+
+            if !platforms.isEmpty {
+                return platforms
+            }
+        }
+
+        return [(.root, androidPlatformInfoPlist)]
+    }
+
+    public func adjustPlatformSDKSearchPaths(platformName: String, platformPath: Path, sdkSearchPaths: inout [Path]) {
+        // Block the default registration mechanism from picking up the incomplete SDKSettings.plist on disk.
+        // The AndroidSDKRegistryExtension will handle discovery and registration of the SDK.
+        if platformName == "android" {
+            sdkSearchPaths = []
+        }
     }
 
     func platformName(triple: LLVMTriple) -> String? {
@@ -178,30 +196,60 @@ fileprivate func androidSDKAdditionalCustomProperties(ndk: AndroidSDK.NDK, hostO
             return []
         }
 
-        return [
+        let defaultProperties: [String: PropertyListItem] = [
+            "SDK_STAT_CACHE_ENABLE": "NO",
+
+            // Workaround to avoid `-dependency_info` on Linux.
+            "LD_DEPENDENCY_INFO_FILE": .plString(""),
+            "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
+
+            // Android uses lld, not the Apple linker
+            // FIXME: Make this option conditional on use of the Apple linker (or perhaps when targeting an Apple triple?)
+            "LD_DETERMINISTIC_MODE": "NO",
+
+            "GENERATE_TEXT_BASED_STUBS": "NO",
+            "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
+
+            "LIBTOOL": .plString(host.imageFormat.executableName(basename: "llvm-lib")),
+            "AR": .plString(host.imageFormat.executableName(basename: "llvm-ar")),
+        ]
+
+        // Synthesize an SDK for the SDK layout for Android that's embedded in the Windows installer
+        let windowsSDKSettingsPlistPath = androidPlatform.path.join("Developer").join("SDKs").join("Android.sdk").join("SDKSettings.plist")
+        let windowsInstallerSDK: [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])]
+        if host == .windows && context.fs.exists(windowsSDKSettingsPlistPath) {
+            let windowsSDKSettingsPlist = try PropertyList.fromPath(windowsSDKSettingsPlistPath, fs: context.fs)
+            guard case .plDict = windowsSDKSettingsPlist else {
+                throw StubError.error("Unexpected top-level property list type in \(windowsSDKSettingsPlistPath.str) (expected dictionary)")
+            }
+            let testingLibraryPath = androidPlatform.path.join("Developer").join("Library")
+
+            windowsInstallerSDK = [sdk(
+                sdkPath: windowsSDKSettingsPlistPath.dirname,
+                canonicalName: "android.windows",
+                androidPlatform: androidPlatform,
+                androidNdk: androidNdk,
+                host: host,
+                defaultProperties: defaultProperties,
+                customProperties: [
+                    "LIBRARY_SEARCH_PATHS": "$(inherited) $(SWIFT_LIBRARY_PATH)/$(CURRENT_ARCH)",
+                    "SWIFT_LIBRARY_PATH": .plString(windowsSDKSettingsPlistPath.dirname.join("usr").join("lib").join("swift").join("android").strWithPosixSlashes),
+                    "SWIFT_RESOURCE_DIR": .plString(windowsSDKSettingsPlistPath.dirname.join("usr").join("lib").join("swift").strWithPosixSlashes),
+                    "TEST_LIBRARY_SEARCH_PATHS": .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/android/$(CURRENT_ARCH) \(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/android/$(CURRENT_ARCH)"),
+                ]
+            )]
+        } else {
+            windowsInstallerSDK = []
+        }
+
+        return windowsInstallerSDK + [
             // An NDK-only SDK that can be used for C/C++-only code if an NDK is present on the system even if there are no Swift SDKs
-            sdk(androidPlatform: androidPlatform, androidNdk: androidNdk, host: host, defaultProperties: [
-                "SDK_STAT_CACHE_ENABLE": "NO",
-
-                // Workaround to avoid `-dependency_info` on Linux.
-                "LD_DEPENDENCY_INFO_FILE": .plString(""),
-                "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
-
-                // Android uses lld, not the Apple linker
-                // FIXME: Make this option conditional on use of the Apple linker (or perhaps when targeting an Apple triple?)
-                "LD_DETERMINISTIC_MODE": "NO",
-
-                "GENERATE_TEXT_BASED_STUBS": "NO",
-                "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
-
-                "LIBTOOL": .plString(host.imageFormat.executableName(basename: "llvm-lib")),
-                "AR": .plString(host.imageFormat.executableName(basename: "llvm-ar")),
-            ])
+            sdk(sdkPath: androidNdk.sysroot.path, androidPlatform: androidPlatform, androidNdk: androidNdk, host: host, defaultProperties: defaultProperties)
         ]
     }
 
-    private func sdk(canonicalName: String? = nil, androidPlatform: Platform, androidNdk: AndroidSDK.NDK, host: OperatingSystem, defaultProperties: [String: PropertyListItem], customProperties: [String: PropertyListItem] = [:]) -> (path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem]) {
-        return (androidNdk.sysroot.path, androidPlatform, [
+    private func sdk(sdkPath: Path, canonicalName: String? = nil, androidPlatform: Platform, androidNdk: AndroidSDK.NDK, host: OperatingSystem, defaultProperties: [String: PropertyListItem], customProperties: [String: PropertyListItem] = [:]) -> (path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem]) {
+        return (sdkPath, androidPlatform, [
             "Type": .plString("SDK"),
             "Version": .plString(androidNdk.version.description),
             "CanonicalName": .plString(canonicalName ?? "android\(androidNdk.version.description)"),

--- a/Sources/SWBCore/PlatformRegistry.swift
+++ b/Sources/SWBCore/PlatformRegistry.swift
@@ -741,3 +741,41 @@ extension Platform {
         }
     }
 }
+
+extension Core.DeveloperPath {
+    /// Enumerates platform directories with the specified name that are laid out in the Swift for Windows installer style.
+    public func withPlatformsInWindowsLayout<T>(named platformName: String, allowUnversionedPlatforms: Bool = false, fs: any FSProxy, _ block: (_ platformInfoPlistPath: Path, _ platformInfoPlist: [String: PropertyListItem], _ version: String) -> T) throws -> [T] {
+        let platformsPath = self.path.join("Platforms")
+        let platformDirName = "\(platformName).platform"
+        return try fs.listdir(platformsPath).compactMap { versionOrPlatform -> T? in
+            // Normally, the platforms will be in versioned subdirectories of the Platforms directory.
+            // However, during the build of the toolchain itself in CI, Windows.platform will be
+            // directly under Platforms with no version component.
+            let platformInfoPlistPath: Path
+            let version: String
+            if allowUnversionedPlatforms && versionOrPlatform == platformDirName {
+                platformInfoPlistPath = platformsPath.join(platformDirName).join("Info.plist")
+                version = "0.0.0"
+            } else {
+                let versionedPlatformsPath = platformsPath.join(versionOrPlatform)
+                guard fs.isDirectory(versionedPlatformsPath) else {
+                    return nil
+                }
+
+                platformInfoPlistPath = versionedPlatformsPath.join(platformDirName).join("Info.plist")
+                version = versionOrPlatform
+            }
+
+            guard fs.exists(platformInfoPlistPath) else {
+                return nil
+            }
+
+            let platformInfoPlist = try PropertyList.fromPath(platformInfoPlistPath, fs: fs)
+            guard case let .plDict(dict) = platformInfoPlist else {
+                throw StubError.error("Unexpected top-level property list type in \(platformInfoPlistPath.str) (expected dictionary)")
+            }
+
+            return block(platformInfoPlistPath, dict, version)
+        }
+    }
+}

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1818,6 +1818,27 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 docFilePath = nil
             }
 
+            let environmentForHostExecutables: [(String, String)]
+            if cbc.producer.hostOperatingSystem == .windows {
+                // On Windows, the Swift compiler needs additional entries in PATH to find its dependent DLLs, as there is no rpath equivalent.
+                // The way this is computed is a little fragile, since we when targeting Android we synthesize a toolchain pointing into the NDK,
+                // which ends up being at the front of the list, so we find the first toolchain that's in a subdirectory of the DEVELOPER_DIR
+                // (the Swift installation path) and use it to determine the toolchain path and version.
+                var paths: [String] = []
+                let developerDir = cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR)
+                for toolchain in cbc.producer.toolchains where developerDir.isAncestor(of: toolchain.path) {
+                    paths += [
+                        toolchain.path.join("usr").join("bin").str,
+                        developerDir.join("Runtimes").join(toolchain.version.description).join("usr").join("bin").str,
+                        cbc.scope.evaluate(BuiltinMacros.PATH),
+                    ]
+                    break
+                }
+                environmentForHostExecutables = [("Path", paths.compactMap { $0.nilIfEmpty }.joined(separator: String(Path.pathEnvironmentSeparator)))]
+            } else {
+                environmentForHostExecutables = []
+            }
+
             // Set up the environment.
             var environment: [(String, String)] = environmentFromSpec(cbc, delegate)
             environment.append(("DEVELOPER_DIR", cbc.scope.evaluate(BuiltinMacros.DEVELOPER_DIR).str))
@@ -1829,6 +1850,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             if !toolchains.isEmpty {
                 environment.append(("TOOLCHAINS", toolchains))
             }
+            environment.append(contentsOf: environmentForHostExecutables)
             let additionalSignatureData = "SWIFTC: \(toolSpecInfo.swiftTag)"
             let environmentBindings = EnvironmentBindings(environment)
 
@@ -2028,7 +2050,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     type: self,
                     ruleInfo: ["SwiftAutolinkExtract", moduleName],
                     commandLine: [toolPath.str] + objectOutputPaths.map(\.str) + ["-o", cbc.scope.evaluate(BuiltinMacros.SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH).str],
-                    environment: EnvironmentBindings(),
+                    environment: EnvironmentBindings(environmentForHostExecutables),
                     workingDirectory: compilerWorkingDirectory(cbc),
                     inputs: objectOutputPaths,
                     outputs: [cbc.scope.evaluate(BuiltinMacros.SWIFT_AUTOLINK_EXTRACT_OUTPUT_PATH)],

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1179,13 +1179,14 @@ package final class BuildOperationTester {
                 uid: 1234,
                 gid: 12345,
                 home: Path("/Users/exampleUser"),
-                environment: ["PATH": defaultPathEntries.joined(separator: String(Path.pathEnvironmentSeparator))].addingContents(of: ProcessInfo.processInfo.cleanEnvironment.filter(keys: ["__XCODE_BUILT_PRODUCTS_DIR_PATHS", "XCODE_DEVELOPER_DIR_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_LIBRARY_PATH", "TEMP", "VCToolsInstallDir"])))
+                environment: (["PATH": defaultPathEntries.joined(separator: String(Path.pathEnvironmentSeparator)).nilIfEmpty].compactMapValues { $0 }).addingContents(of: ProcessInfo.processInfo.cleanEnvironment.filter(keys: ["__XCODE_BUILT_PRODUCTS_DIR_PATHS", "XCODE_DEVELOPER_DIR_PATH", "DYLD_FRAMEWORK_PATH", "DYLD_LIBRARY_PATH", "TEMP", "VCToolsInstallDir"])))
         }
     }
 
     package static var defaultPathEntries: [String] {
         get throws {
             if try ProcessInfo.processInfo.hostOperatingSystem() == .windows {
+                // FIXME: This should probably replicate a minimal Windows system environment (%WINDIR%\System32, etc.) rather than being empty
                 return []
             }
             return ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -94,37 +94,8 @@ struct WindowsPlatformExtension: PlatformInfoExtension {
             return []
         }
 
-        let platformsPath = context.developerPath.path.join("Platforms")
-        let platformDirName = "Windows.platform"
-        return try context.fs.listdir(platformsPath).compactMap { versionOrPlatform in
-            // Normally, the platforms will be in versioned subdirectories of the Platforms directory.
-            // However, during the build of the toolchain itself in CI, Windows.platform will be
-            // directly under Platforms with no version component.
-            let windowsInfoPlistPath: Path
-            let version: String
-            if versionOrPlatform == platformDirName {
-                windowsInfoPlistPath = platformsPath.join(platformDirName).join("Info.plist")
-                version = "0.0.0"
-            } else {
-                let versionedPlatformsPath = platformsPath.join(versionOrPlatform)
-                guard context.fs.isDirectory(versionedPlatformsPath) else {
-                    return nil
-                }
-
-                windowsInfoPlistPath = versionedPlatformsPath.join(platformDirName).join("Info.plist")
-                version = versionOrPlatform
-            }
-
-            guard context.fs.exists(windowsInfoPlistPath) else {
-                return nil
-            }
-
-            let windowsInfoPlist = try PropertyList.fromPath(windowsInfoPlistPath, fs: context.fs)
-            guard case let .plDict(dict) = windowsInfoPlist else {
-                throw StubError.error("Unexpected top-level property list type in \(windowsInfoPlistPath.str) (expected dictionary)")
-            }
-
-            return (windowsInfoPlistPath.dirname, dict.merging([
+        return try context.developerPath.withPlatformsInWindowsLayout(named: "Windows", allowUnversionedPlatforms: true, fs: context.fs) { platformInfoPlistPath, platformInfoPlist, version in
+            (platformInfoPlistPath.dirname, platformInfoPlist.addingContents(of: [
                 "Type": .plString("Platform"),
                 "Name": .plString("windows"),
                 "Identifier": .plString("windows"),
@@ -133,7 +104,7 @@ struct WindowsPlatformExtension: PlatformInfoExtension {
                 "FamilyIdentifier": .plString("windows"),
                 "IsDeploymentPlatform": .plString("YES"),
                 "Version": .plString(version),
-            ]) { old, new in new })
+            ]))
         }
     }
 

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -119,9 +119,6 @@
         Identifier = "com.apple.xcode.tools.swift.compiler";
         Type = Compiler;
         BasedOn = "default:com.apple.xcode.tools.swift.compiler";
-        EnvironmentVariables = {
-            "PATH" = "$(TOOLCHAIN_DIR)/usr/bin;$(DEVELOPER_DIR)/Runtimes/$(TOOLCHAIN_VERSION)/usr/bin;$(PATH)";
-        };
         Options = (
             {
                 Name = __WINDOWS_STATIC_FLAG;

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -296,4 +296,176 @@ fileprivate struct AndroidBuildOperationTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.android), .requireHostOS(.windows), .disabled("Android SDK is not installed on Windows on ARM on GitHub", {
+        if getEnvironmentVariable("GITHUB_ACTIONS") != nil {
+            #if os(Windows) && arch(arm64)
+            return true
+            #endif
+        }
+        return false
+    }), arguments: ["aarch64", "x86_64"])
+    func androidCommandLineToolWithSwift(arch: String) async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("main.swift"),
+                        TestFile("dynamic.swift"),
+                        TestFile("static.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ARCHS": arch,
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "DEFINES_MODULE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "android.windows",
+                        "SUPPORTED_PLATFORMS": "android",
+                        "SWIFT_VERSION": "6.0",
+                        "ANDROID_DEPLOYMENT_TARGET": "22.0",
+                        "ANDROID_DEPLOYMENT_TARGET[arch=riscv64]": "35.0",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "tool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [:])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                            TestFrameworksBuildPhase([
+                                TestBuildFile(.target("dynamiclib")),
+                                TestBuildFile(.target("staticlib")),
+                            ])
+                        ],
+                        dependencies: [
+                            "dynamiclib",
+                            "staticlib",
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "dynamiclib",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "DYLIB_INSTALL_NAME_BASE": "$ORIGIN",
+
+                                // FIXME: Find a way to make these default
+                                "EXECUTABLE_PREFIX": "lib",
+                            ])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["dynamic.swift"]),
+                        ],
+                        productReferenceName: "libdynamiclib.so"
+                    ),
+                    TestStandardTarget(
+                        "staticlib",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                // FIXME: Find a way to make these default
+                                "EXECUTABLE_PREFIX": "lib",
+                            ])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["static.swift"]),
+                        ]
+                    ),
+                ])
+            let core = try await getCore()
+            let androidExtension = try #require(core.pluginManager.extensions(of: SDKRegistryExtensionPoint.self).compactMap { $0 as? AndroidSDKRegistryExtension }.only)
+            let (_, androidNdk) = try #require(await androidExtension.plugin.effectiveInstallation(host: core.hostOperatingSystem))
+            if androidNdk.version < Version(27) && arch == "riscv64" {
+                return // riscv64 support was introduced in NDK r27
+            }
+
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("main.swift")) { stream in
+                stream <<< "func main() { }\n"
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("dynamic.swift")) { stream in
+                stream <<< "func dynamicLib() { }"
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("static.swift")) { stream in
+                stream <<< "func staticLib() { }"
+            }
+
+            let minOS = arch == "riscv64" ? "35.0" : "22.0"
+
+            let destination: RunDestinationInfo = .init(platform: "android", sdk: "android.windows", sdkVariant: "android", targetArchitecture: "undefined_arch", supportedArchitectures: ["armv7", "aarch64", "riscv64", "i686", "x86_64"], disableOnlyActiveArch: true)
+            try await tester.checkBuild(runDestination: destination) { results in
+                results.checkNoErrors()
+                results.checkWarnings([.contains("next compile won't be incremental")], failIfNotFound: false)
+
+                let clang = Path("bin").join(core.hostOperatingSystem.imageFormat.executableName(basename: "clang"))
+
+                let sdk = try #require(results.core.sdkRegistry.lookup("android.windows"))
+
+                results.checkTask(.matchRuleType("Ld"), .matchRuleItemPattern(.suffix(Path("build/Debug-android/libdynamiclib.so").str))) { task in
+                    task.checkCommandLineMatches([
+                        .suffix(clang.str),
+                        "-target", "\(arch)-none-linux-android\(minOS)",
+                        "-shared",
+                        "--sysroot",
+                        .contains(Path("/toolchains/llvm/prebuilt/").str),
+                        "-resource-dir",
+                        .and(.contains(Path("/toolchains/llvm/prebuilt/").str), .contains(Path("/lib/clang/").str)),
+                        "-Os",
+                        .pathEqual(prefix: "-L", tmpDir.join("build/EagerLinkingTBDs/Debug-android")),
+                        .pathEqual(prefix: "-L", tmpDir.join("build/Debug-android")),
+                        .pathEqual(prefix: "-L", sdk.path.join("usr/lib/swift/android/\(arch)")),
+                        .pathEqual(prefix: "@", tmpDir.join("build/TestProject.build/Debug-android/dynamiclib.build/Objects-normal/\(arch)/dynamiclib.LinkFileList")),
+                        "-Xlinker", "-soname", "-Xlinker", "$ORIGIN/libdynamiclib.so",
+                        "-lswiftCore",
+                        .pathEqual(prefix: "-L", sdk.path.join("usr/lib/swift/android")),
+                        .pathEqual(prefix: "-L", Path("/usr/lib/swift")),
+                        .pathEqual(prefix: "@", tmpDir.join("build/TestProject.build/Debug-android/dynamiclib.build/Objects-normal/\(arch)/dynamiclib-swiftbuild.autolink")),
+                    ] + (["aarch64", "x86_64"].contains(arch) ? ["-Xlinker", "-z", "-Xlinker", "max-page-size=16384"] : []) + [
+                        "-fuse-ld=lld",
+                        .and(.prefix("--ld-path="), .contains("ld.lld")),
+                        "-o", .path(tmpDir.join("build/Debug-android/libdynamiclib.so"))
+                    ])
+                }
+
+                results.checkTask(.matchRuleType("Ld"), .matchRuleItemPattern(.suffix(Path("build/Debug-android/tool").str))) { task in
+                    task.checkCommandLineMatches([
+                        .suffix(clang.str),
+                        "-target", "\(arch)-none-linux-android\(minOS)",
+                        "--sysroot", .contains(Path("/toolchains/llvm/prebuilt/").str),
+                        "-resource-dir",
+                        .and(.contains(Path("/toolchains/llvm/prebuilt/").str), .contains(Path("/lib/clang/").str)),
+                        "-Os",
+                        .pathEqual(prefix: "-L", tmpDir.join("build/EagerLinkingTBDs/Debug-android")),
+                        .pathEqual(prefix: "-L", tmpDir.join("build/Debug-android")),
+                        .pathEqual(prefix: "-L", sdk.path.join("usr/lib/swift/android/\(arch)")),
+                        .pathEqual(prefix: "@", tmpDir.join("build/TestProject.build/Debug-android/tool.build/Objects-normal/\(arch)/tool.LinkFileList")),
+                        "-lswiftCore",
+                        .pathEqual(prefix: "-L", sdk.path.join("usr/lib/swift/android")),
+                        .pathEqual(prefix: "-L", Path("/usr/lib/swift")),
+                        .pathEqual(prefix: "@", tmpDir.join("build/TestProject.build/Debug-android/tool.build/Objects-normal/\(arch)/tool-swiftbuild.autolink")),
+                    ] + (["aarch64", "x86_64"].contains(arch) ? ["-Xlinker", "-z", "-Xlinker", "max-page-size=16384"] : []) + [
+                        "-fuse-ld=lld",
+                        .and(.prefix("--ld-path="), .contains("ld.lld")),
+                        "-ldynamiclib",
+                        "-lstaticlib",
+                        "-o", .path(tmpDir.join("build/Debug-android/tool"))
+                    ])
+                }
+
+                #expect(tester.fs.exists(projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix)").join("tool")))
+            }
+        }
+    }
 }


### PR DESCRIPTION
This adds support for the Android SDK that comes with the Swift for Windows installer and linking up the Swift bits with an Android NDK installed on the host system.