### PR TITLE
Stop passing -add_ast_path / running modulewrap when compiler supports explicit modules based debug info

### DIFF
--- a/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
@@ -64,6 +64,8 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
         /// Whether the library should be found via the linker search path.
         public let useSearchPaths: Bool
 
+        public let isKnownToUseSwift: Bool
+
         /// The per-arch path to the corresponding Swift module file, if available.
         public let swiftModulePaths: [String: Path]
 
@@ -91,7 +93,7 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
 
         public let libPrefix: String?
 
-        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, swiftModulePaths: [String: Path], swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path], prefix: String? = nil, explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
+        public init(kind: Kind, path: Path, mode: Mode, useSearchPaths: Bool, isKnownToUseSwift: Bool, swiftModulePaths: [String: Path], swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path], prefix: String? = nil, explicitDependencies: [Path] = [], topLevelItemPath: Path? = nil, dsymPath: Path? = nil, xcframeworkSourcePath: Path? = nil, privacyFile: Path? = nil) {
             self.kind = kind
             self.path = path
             self.mode = mode
@@ -106,6 +108,7 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
             // Only use search paths when no prefix is required or when the prefix matches
             let hasValidPrefix = libPrefix.map { path.basename.hasPrefix($0) } ?? true
             self.useSearchPaths = hasValidPrefix && useSearchPaths
+            self.isKnownToUseSwift = isKnownToUseSwift
         }
     }
 

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -640,6 +640,7 @@ public struct DiscoveredSwiftCompilerToolSpecInfo: DiscoveredCommandLineToolSpec
         case compilationCaching = "compilation-caching"
         case Isystem = "Isystem"
         case apiDigesterXcc = "api-digester-Xcc"
+        case debugInfoExplicitDependency = "debug-info-explicit-dependency"
     }
     public var toolFeatures: ToolFeatures<FeatureFlag>
     public func hasFeature(_ flag: String) -> Bool {
@@ -959,12 +960,12 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         cbc.scope.evaluate(BuiltinMacros.COMPILER_WORKING_DIRECTORY).nilIfEmpty.map { Path($0) } ?? cbc.producer.defaultWorkingDirectory
     }
 
-    private func getExplicitModuleBlocklist(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any TaskGenerationDelegate) async ->  SwiftBlocklists.ExplicitModulesInfo? {
+    private func getExplicitModuleBlocklist(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async ->  SwiftBlocklists.ExplicitModulesInfo? {
         let specInfo = await (discoveredCommandLineToolSpecInfo(producer, scope, delegate) as? DiscoveredSwiftCompilerToolSpecInfo)
         return specInfo?.blocklists.explicitModules
     }
 
-    func swiftExplicitModuleBuildEnabled(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any TaskGenerationDelegate) async -> Bool {
+    public func swiftExplicitModuleBuildEnabled(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Bool {
         let buildSettingEnabled = scope.evaluate(BuiltinMacros.SWIFT_ENABLE_EXPLICIT_MODULES) == .enabled ||
                                   scope.evaluate(BuiltinMacros._EXPERIMENTAL_SWIFT_EXPLICIT_MODULES) == .enabled
 
@@ -1455,7 +1456,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             args += ["-emit-module", "-emit-module-path", moduleFilePath.str]
             moduleOutputPaths.append(moduleFilePath)
             let moduleLinkerArgsPath: Path?
-            if cbc.scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) {
+            if cbc.scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) &&
+                !toolSpecInfo.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue) {
                 let path = Path(moduleFilePath.appendingFileNameSuffix("-linker-args").withoutSuffix + ".resp")
                 moduleOutputPaths.append(path)
                 moduleLinkerArgsPath = path
@@ -2703,7 +2705,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR, lookup: lookup)
                 let moduleFilePath = moduleFileDir.join(moduleName + ".swiftmodule")
                 args += [["-Xlinker", "-add_ast_path", "-Xlinker", moduleFilePath.str]]
-                if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS, lookup: lookup) {
+                let toolInfo = await discoveredCommandLineToolSpecInfo(producer, scope, delegate)
+                if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS, lookup: lookup) &&
+                    toolInfo?.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue) != true {
                     args += [["@\(Path(moduleFilePath.appendingFileNameSuffix("-linker-args").withoutSuffix + ".resp").str)"]]
                 }
             }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -328,7 +328,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
     }
 
     /// Computes and returns a list of libraries to include when linking.
-    func computeLibraries(_ buildFilesContext: BuildFilesProcessingContext, _ scope: MacroEvaluationScope) -> [LinkerSpec.LibrarySpecifier] {
+    func computeLibraries(_ buildFilesContext: BuildFilesProcessingContext, _ scope: MacroEvaluationScope) async -> [LinkerSpec.LibrarySpecifier] {
         guard let frameworksPhase = frameworksBuildPhase else { return [] }
 
         // Compute the flattened list of build files after expanding package product targets.
@@ -337,7 +337,8 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         // Add libraries specifiers for each item in the phase.
         //
         // FIXME: Xcode uses the filtered references here, but our implementation isn't yet factored in a way we can do that.
-        return buildFiles.compactMap { buildFile -> LinkerSpec.LibrarySpecifier? in
+        var librarySpecifiers: [LinkerSpec.LibrarySpecifier] = []
+        for buildFile in buildFiles {
             // Resolve the buildable reference.
             let (_, settingsForRef, absolutePath, fileType): (Reference, Settings?, Path, FileTypeSpec)
 
@@ -347,10 +348,10 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     (_, settingsForRef, absolutePath, fileType) = try self.context.resolveBuildFileReference(buildFile)
                 } catch WorkspaceErrors.missingPackageProduct(let packageName) {
                     context.missingPackageProduct(packageName, buildFile, frameworksPhase)
-                    return nil
+                    continue
                 } catch {
                     context.error("Unable to resolve build file: \(buildFile) (\(error))")
-                    return nil
+                    continue
                 }
             case .namedReference(let name, let fileTypeIdentifier):
                 settingsForRef = nil
@@ -359,7 +360,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     fileType = type
                 } else {
                     context.error("Could not lookup file type '\(fileTypeIdentifier)'")
-                    return nil
+                    continue
                 }
             }
 
@@ -387,10 +388,12 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 producingTargetSettings = settings
             }
 
-            // For each target product reference, find the corresponding target and if it uses Swift, determine the path to the
-            // corresponding .swiftmodule file per arch, needed for debugging. Note that we can only determine these paths for
-            // targets which we are building from source, other kinds of product references will not provide the necessary
-            // information.
+            // For each target product reference, find the corresponding target and if:
+            // - it uses Swift
+            // - it is built from source
+            // - it _does not_ build using explicit modules or the compiler doesn't support explicit module based dependency info
+            // determine the path to the corresponding .swiftmodule file per arch, needed for debugging.
+            var isKnownToUseSwift = false
             var swiftModulePaths: [String: Path] = [:]
             var swiftModuleAdditionalLinkerArgResponseFilePaths: [String: Path] = [:]
             switch buildFile.buildableItem {
@@ -401,6 +404,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     let parameters = self.context.configuredTarget?.parameters ?? BuildParameters(configuration: nil)
                     let settings = self.context.settingsForProductReferenceTarget(referenceTarget, parameters: parameters)
                     if referenceTarget.usesSwift(context: self.context, settings: settings) {
+                        isKnownToUseSwift = true
                         var architectures = scope.evaluate(BuiltinMacros.ARCHS)
                         var processedArchitectures: Set<String> = []
                         while !architectures.isEmpty {
@@ -410,6 +414,12 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             }
                             processedArchitectures.insert(originalArch)
                             let scope = settings.globalScope.subscopeBindingArchAndTriple(arch: originalArch)
+                            let toolInfo = await context.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(context, scope, context.globalProductPlan.delegate)
+                            if await self.context.swiftCompilerSpec.swiftExplicitModuleBuildEnabled(self.context, scope, self.context.globalProductPlan.delegate) && toolInfo?.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue) == true {
+                                // When building with explicit modules, the driver/frontend will use -debug-module-path to record the information
+                                // necessary to find swiftmodules when debugging. Skip the redundant linker swiftmodule registration here.
+                                continue
+                            }
                             // Binding the architecture may change how we evaluate $(ARCHS). Ensure we process any new architectures.
                             for potentiallyNewArch in scope.evaluate(BuiltinMacros.ARCHS) {
                                 if !processedArchitectures.contains(potentiallyNewArch) {
@@ -434,6 +444,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             let moduleName = scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME)
                             let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR)
                             swiftModulePaths[arch] = moduleFileDir.join(moduleName + ".swiftmodule")
+                            let swiftInfo = await context.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(context, scope, context.globalProductPlan.delegate)
                             if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) {
                                 swiftModuleAdditionalLinkerArgResponseFilePaths[arch] = moduleFileDir.join("\(moduleName)-linker-args.resp")
                             }
@@ -500,16 +511,17 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             }
 
             if fileType.conformsTo(context.lookupFileType(identifier: "archive.ar")!) {
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .static,
                     path: absolutePath,
                     mode: buildFile.shouldLinkWeakly ? .weak : .normal,
                     useSearchPaths: useSearchPaths,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: swiftModulePaths,
                     swiftModuleAdditionalLinkerArgResponseFilePaths: swiftModuleAdditionalLinkerArgResponseFilePaths,
                     prefix: fileType.prefix,
                     privacyFile: privacyFile
-                )
+                ))
             } else if fileType.conformsTo(context.lookupFileType(identifier: "compiled.mach-o.dylib")!) {
                 let adjustedAbsolutePath: Path
                 // On Windows, ensure import libraries (.lib) are used instead of DLLs.
@@ -518,27 +530,29 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 } else {
                     adjustedAbsolutePath = absolutePath
                 }
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .dynamic,
                     path: adjustedAbsolutePath,
                     mode: linkageModeForDylib(),
                     useSearchPaths: useSearchPaths,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: [:],
                     swiftModuleAdditionalLinkerArgResponseFilePaths: [:],
                     prefix: fileType.prefix,
                     privacyFile: privacyFile
-                )
+                ))
             } else if fileType.conformsTo(context.lookupFileType(identifier: "sourcecode.text-based-dylib-definition")!) {
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .textBased,
                     path: absolutePath,
                     mode: buildFile.shouldLinkWeakly ? .weak : .normal,
                     useSearchPaths: useSearchPaths,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: [:],
                     swiftModuleAdditionalLinkerArgResponseFilePaths: [:],
                     prefix: fileType.prefix,
                     privacyFile: privacyFile
-                )
+                ))
             } else if fileType.conformsTo(context.lookupFileType(identifier: "wrapper.framework")!) {
                 func kindFromSettings(_ settings: Settings) -> (kind: LinkerSpec.LibrarySpecifier.Kind, prefix: String?)? {
                     switch settings.globalScope.evaluate(BuiltinMacros.MACH_O_TYPE) {
@@ -578,50 +592,52 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     prefix = nil
                 }
 
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: kind,
                     path: path,
                     mode: linkageModeForDylib(),
                     useSearchPaths: useSearchPaths,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: [:],
                     swiftModuleAdditionalLinkerArgResponseFilePaths: [:],
                     prefix: prefix,
                     topLevelItemPath: topLevelItemPath,
                     dsymPath: dsymPath,
                     privacyFile: privacyFile
-                )
+                ))
             } else if fileType.conformsTo(context.lookupFileType(identifier: "compiled.mach-o.objfile")!) {
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .object,
                     path: absolutePath,
                     mode: buildFile.shouldLinkWeakly ? .weak : .normal,
                     useSearchPaths: false,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: swiftModulePaths,
                     swiftModuleAdditionalLinkerArgResponseFilePaths: swiftModuleAdditionalLinkerArgResponseFilePaths,
                     privacyFile: privacyFile
-                )
+                ))
             } else if fileType.conformsTo(context.lookupFileType(identifier: "wrapper.xcframework")!) {
                 // The XCFramework needs to be inspected here to determine what type of linkage is actually going to be done. This is more work than I'd like to do here, but there isn't really an alternative.
 
                 guard let xcframeworkPath = (try? context.resolveBuildFileReference(buildFile))?.absolutePath else {
                     // Even if a suitable library cannot be found for the build flavor being asked for, the actual reference to the xcframework should always be found. This is an internal model error if this occurs.
                     assertionFailure("unable to get the xcframeworkPath")
-                    return nil
+                    continue
                 }
 
                 guard let xcframework = try? context.globalProductPlan.planRequest.buildRequestContext.getCachedXCFramework(at: xcframeworkPath) else {
                     // Let the XCFrameworkTaskProducer log an errors here as this should only occur when an XCFramework is referenced on disk but is not actually present.
-                    return nil
+                    continue
                 }
 
                 guard let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) else {
                     // Let the XCFrameworkTaskProducer log an error here
-                    return nil
+                    continue
                 }
 
                 guard let target = context.configuredTarget, let outputFilePaths = context.globalProductPlan.xcframeworkContext.outputFiles(xcframeworkPath: xcframeworkPath, target: target) else {
                     // Let the XCFrameworkTaskProducer log an error here
-                    return nil
+                    continue
                 }
 
                 let outputPath = XCFramework.computeOutputDirectory(scope)
@@ -648,7 +664,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 case let .unknown(fileExtension):
                     // An error of type this type should have already been manifested.
                     assertionFailure("unknown xcframework type: \(fileExtension)")
-                    return nil
+                    continue
                 }
 
                 let mode: LinkerSpec.LibrarySpecifier.Mode = {
@@ -664,18 +680,19 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }()
 
                 // NOTE: XCFrameworks are not currently being searched for the `PrivacyInfo.xcprivacy` files, instead, they searched by the inclusion of the item within the "Copy Phase".
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: libraryKind,
                     path: libraryTargetPath,
                     mode: mode,
                     useSearchPaths: useSearchPaths,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: [:],
                     swiftModuleAdditionalLinkerArgResponseFilePaths: [:],
                     prefix: prefix,
                     explicitDependencies: outputFilePaths,
                     xcframeworkSourcePath: xcframeworkPath,
                     privacyFile: nil
-                )
+                ))
             } else if fileType.conformsTo(identifier: "wrapper.artifactbundle") {
                 let metadata: ArtifactBundleMetadata
                 do {
@@ -684,7 +701,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                    }
                 } catch {
                     context.error("failed to parse artifact bundle metadata for '\(absolutePath)': \(error.localizedDescription)")
-                    return nil
+                    continue
                 }
                 for (name, artifact) in metadata.artifacts {
                     switch artifact.type {
@@ -702,15 +719,16 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                                 normalizedTriplesCompareDisregardingOSVersions($0, currentTripleString)
                             }) == true {
                                 foundMatch = true
-                                return LinkerSpec.LibrarySpecifier(
+                                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                                     kind: .static,
                                     path: absolutePath.join(variant.path),
                                     mode: .normal,
                                     useSearchPaths: false,
+                                    isKnownToUseSwift: isKnownToUseSwift,
                                     swiftModulePaths: [:],
                                     swiftModuleAdditionalLinkerArgResponseFilePaths: [:],
                                     privacyFile: privacyFile
-                                )
+                                ))
                             }
                         }
                         if !foundMatch {
@@ -718,21 +736,23 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                         }
                     }
                 }
-                return nil
+                continue
             } else if fileType.conformsTo(identifier: "compiled.object-library") {
-                return LinkerSpec.LibrarySpecifier(
+                librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .objectLibrary,
                     path: absolutePath,
                     mode: .normal,
                     useSearchPaths: false,
+                    isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: swiftModulePaths,
                     swiftModuleAdditionalLinkerArgResponseFilePaths: swiftModuleAdditionalLinkerArgResponseFilePaths,
-                )
+                ))
             } else {
                 // FIXME: Error handling.
-                return nil
+                continue
             }
         }
+        return librarySpecifiers
     }
 
     /// Record the inputs to 'prepare-for-index' target node, that were not already recorded so far.
@@ -969,7 +989,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 let previewsDylibInputs = previewsDylibForTestHost()
 
                 // Compute the libraries that should be linked.
-                let librariesToLink = computeLibraries(buildFilesContext, scope) + previewsDylibInputs
+                let librariesToLink = await computeLibraries(buildFilesContext, scope) + previewsDylibInputs
                 allLinkedLibraries.append(contentsOf: librariesToLink)
 
                 // Insert the object files present in the framework build phase to the linker inputs.
@@ -990,7 +1010,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 let additionalLinkerOrderingInputs = librariesToLink.flatMap { $0.explicitDependencies.map(context.createNode) }
 
                 // If there is at least one object file that was built using Swift, ensure the Swift tool is present in the used tools to allow linker spec to add swift specific linker arguments.
-                if objectsInFrameworksPhase.contains(where: { !$0.swiftModulePaths.isEmpty }), !usedTools.keys.contains(context.swiftCompilerSpec) {
+                if objectsInFrameworksPhase.contains(where: { $0.isKnownToUseSwift }), !usedTools.keys.contains(context.swiftCompilerSpec) {
                     usedTools[context.swiftCompilerSpec] = [context.lookupFileType(identifier: "compiled.mach-o.objfile")!]
                 }
 
@@ -1087,6 +1107,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                                 path: outputPreviewDylib,
                                 mode: .normal,
                                 useSearchPaths: false,
+                                isKnownToUseSwift: false,
                                 swiftModulePaths: [:],
                                 swiftModuleAdditionalLinkerArgResponseFilePaths: [:]
                             )
@@ -2198,6 +2219,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             path: fullPath,
             mode: .normal,
             useSearchPaths: false,
+            isKnownToUseSwift: false,
             swiftModulePaths: [:],
             swiftModuleAdditionalLinkerArgResponseFilePaths: [:]
         )]

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1369,7 +1369,7 @@ import SWBMacro
                         prefix = nil
                         continue
                     }
-                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:], prefix: prefix))
+                    result.append(LinkerSpec.LibrarySpecifier(kind: kind, path: filePath, mode: mode, useSearchPaths: useSearchPaths, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:], prefix: prefix))
                 }
             }
             return result
@@ -1379,7 +1379,7 @@ import SWBMacro
             libraries.append(contentsOf: generateLibrarySpecifiers(kind: kind))
         }
         // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
-        libraries.append(LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]))
+        libraries.append(LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]))
 
         await linkerSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 
@@ -1596,28 +1596,28 @@ import SWBMacro
         let mockFileType = try core.specRegistry.getSpec("file", ofType: FileTypeSpec.self)
         let cbc = CommandBuildContext(producer: producer, scope: mockScope, inputs: [FileToBuild(absolutePath: Path.root.join("tmp/obj/normal/x86_64/file1.o"), fileType: mockFileType)], output: Path.root.join("tmp/obj/normal/x86_64/output"))
         let libraries = [
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo1.a"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo2.a"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo3.a"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo4.a"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo1.a"), mode: .normal, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo2.a"), mode: .weak, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo3.a"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .static, path: Path.root.join("usr/lib/libfoo4.a"), mode: .weak, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar1.dylib"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar2.dylib"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar3.dylib"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar4.dylib"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar1.dylib"), mode: .normal, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar2.dylib"), mode: .weak, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar3.dylib"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .dynamic, path: Path.root.join("usr/lib/libbar4.dylib"), mode: .weak, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz1.tbd"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz2.tbd"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz3.tbd"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz4.tbd"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz1.tbd"), mode: .normal, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz2.tbd"), mode: .weak, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz3.tbd"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .textBased, path: Path.root.join("usr/lib/libbaz4.tbd"), mode: .weak, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo1.framework"), mode: .normal, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo2.framework"), mode: .weak, useSearchPaths: true, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo3.framework"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
-            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo4.framework"), mode: .weak, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo1.framework"), mode: .normal, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo2.framework"), mode: .weak, useSearchPaths: true, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo3.framework"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .framework, path: Path.root.join("tmp/Foo4.framework"), mode: .weak, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
 
             // This is a no-op because object files get added in the SourcesTaskProducer, but we want to confirm that this is the case.
-            LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
+            LinkerSpec.LibrarySpecifier(kind: .object, path: Path.root.join("tmp/Bar.o"), mode: .normal, useSearchPaths: false, isKnownToUseSwift: false, swiftModulePaths: [:], swiftModuleAdditionalLinkerArgResponseFilePaths: [:]),
         ]
         await librarianSpec.constructLinkerTasks(cbc, delegate, libraries: libraries, usedTools: [:])
 


### PR DESCRIPTION
Reapply the change to drop use of -add_ast_path when the compiler is capable of using explicit modules based debug info