### PR TITLE
Remove stale EagerLinkingTBDs across workspace switches

### DIFF
--- a/Sources/SWBCore/PlannedTask.swift
+++ b/Sources/SWBCore/PlannedTask.swift
@@ -51,6 +51,14 @@ extension TaskIdentifier {
     }
 }
 
+/// Determines which stale file removal command tracks a task's outputs.
+public enum StaleFileRemovalScope: Sendable {
+    /// Outputs are tracked by the per-target SFR command (default).
+    case target
+    /// Outputs are tracked by the workspace-wide SFR command.
+    case workspace
+}
+
 public protocol PlannedTaskInputsOutputs {
     var inputs: [any PlannedNode] { get }
     var outputs: [any PlannedNode] { get }
@@ -96,6 +104,9 @@ public protocol PlannedTask: AnyObject, CustomStringConvertible, Sendable, Plann
     var priority: TaskPriority { get }
 
     var repairViaOwnershipAnalysis: Bool { get }
+
+    /// The scope for stale file removal tracking of this task's outputs.
+    var staleFileRemovalScope: StaleFileRemovalScope { get }
 }
 
 /// Represents the priority of a task in relation to other tasks which may be ready to run at the same time.
@@ -157,6 +168,8 @@ public final class ConstructedTask: PlannedTask, Sendable {
 
     public let repairViaOwnershipAnalysis: Bool
 
+    public let staleFileRemovalScope: StaleFileRemovalScope
+
     /// Criteria for determining if this task should be included in the build plan.
     public let validityCriteria: (any TaskValidityCriteria)?
 
@@ -173,6 +186,7 @@ public final class ConstructedTask: PlannedTask, Sendable {
         self.alwaysExecuteTask = builder.alwaysExecuteTask
         self.priority = builder.priority
         self.repairViaOwnershipAnalysis = builder.repairViaOwnershipAnalysis
+        self.staleFileRemovalScope = builder.staleFileRemovalScope
         self.validityCriteria = builder.validityCriteria
     }
 
@@ -256,6 +270,8 @@ public final class GateTask: PlannedTask, Sendable {
     public var priority: TaskPriority { .gate }
 
     public var repairViaOwnershipAnalysis: Bool { false }
+
+    public var staleFileRemovalScope: StaleFileRemovalScope { .target }
 
     /// Gate tasks never have validity criteria.
     public var validityCriteria: (any TaskValidityCriteria)? { nil }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -693,6 +693,8 @@ public struct PlannedTaskBuilder {
 
     public var repairViaOwnershipAnalysis: Bool
 
+    public var staleFileRemovalScope: StaleFileRemovalScope = .target
+
     public var validityCriteria: (any TaskValidityCriteria)?
 
     public init(type: any TaskTypeDescription, ruleInfo: [String], additionalSignatureData: String = "", commandLine: [CommandLineArgument], additionalOutput: [String] = [], environment: EnvironmentBindings = EnvironmentBindings(), inputs: [any PlannedNode] = [], outputs: [any PlannedNode] = [], mustPrecede: [any PlannedTask] = [], deps: DependencyDataStyle? = nil, additionalTaskOrderingOptions: TaskOrderingOptions = [], usesExecutionInputs: Bool = false, alwaysExecuteTask: Bool = false, showInLog: Bool = true, showCommandLineInLog: Bool = true, priority: TaskPriority = .unspecified, enableSandboxing: Bool = false, repairViaOwnershipAnalysis: Bool = false, validityCriteria: (any TaskValidityCriteria)? = nil) {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -308,8 +308,8 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
     ///
     /// We override this to auto-attach tasks to the generated headers completion ordering gate.
     @discardableResult
-    package override func appendGeneratedTasks( _ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
-        return await super.appendGeneratedTasks(&tasks, options: options) { delegate in
+    package override func appendGeneratedTasks( _ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, staleFileRemovalScope: StaleFileRemovalScope = .target, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
+        return await super.appendGeneratedTasks(&tasks, options: options, staleFileRemovalScope: staleFileRemovalScope) { delegate in
             await body(SourcesPhaseBasedTaskGenerationDelegate(producer: self, userPreferences: context.workspaceContext.userPreferences, delegate: delegate))
         }
     }

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
@@ -162,8 +162,8 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
     }
 
     @discardableResult
-    override func appendGeneratedTasks( _ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
-        return await super.appendGeneratedTasks(&tasks, options: options) { delegate in
+    override func appendGeneratedTasks( _ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, staleFileRemovalScope: StaleFileRemovalScope = .target, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
+        return await super.appendGeneratedTasks(&tasks, options: options, staleFileRemovalScope: staleFileRemovalScope) { delegate in
             //
             await body(ModuleMapPhaseBasedTaskGenerationDelegate(delegate: delegate, copyHeadersCompletionTasks: copyHeadersCompletionTasks))
         }

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -38,6 +38,17 @@ enum InstallAPIDestination {
             return []
         }
     }
+
+    /// EagerLinkingTBDs are in a shared directory so their outputs should be
+    /// tracked by the workspace SFR.
+    var staleFileRemovalScope: StaleFileRemovalScope {
+        switch self {
+        case .eagerLinkingTBDDir:
+            return .workspace
+        case .builtProduct:
+            return .target
+        }
+    }
 }
 
 package final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskProducer {
@@ -794,7 +805,8 @@ func addCommonInstallAPITasks(_ producer: PhasedTaskProducer, _ scope: MacroEval
         dsymPath = producer.context.producedDSYM(forVariant: variant)
 
     }
-    let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, taskOptions: destination.correspondingTaskOrderingOptions, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
+    let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, taskOptions: destination.correspondingTaskOrderingOptions, staleFileRemovalScope: destination.staleFileRemovalScope, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
+
     let swiftTBDFiles = producer.context.generatedTBDFiles(forVariant: variant)
     await producer.context.tapiSpec.constructTAPITasks(CommandBuildContext(producer: producer.context, scope: scope, inputs: inputs, output: tapiOutputNode.path, commandOrderingInputs: dependencyInputs, commandOrderingOutputs: [tapiOrderingNode]), delegate, generatedTBDFiles: swiftTBDFiles, builtBinaryPath: builtBinaryPath, fileListPath: jsonPath, dsymPath: dsymPath)
 
@@ -816,7 +828,7 @@ extension FrameworkProductTypeSpec {
                 output = producer.context.createNode(scope.evaluate(BuiltinMacros.EAGER_LINKING_INTERMEDIATE_TBD_DIR).join(scope.evaluate(BuiltinMacros.WRAPPER_NAME)).join(fileName))
             }
 
-            await producer.appendGeneratedTasks(&tasks, options: destination.correspondingTaskOrderingOptions) { delegate in
+            await producer.appendGeneratedTasks(&tasks, options: destination.correspondingTaskOrderingOptions, staleFileRemovalScope: destination.staleFileRemovalScope) { delegate in
                 producer.context.symlinkSpec.constructSymlinkTask(CommandBuildContext(producer: producer.context, scope: scope, inputs: [], output: output.path), delegate, toPath: target, repairViaOwnershipAnalysis: true)
             }
         }
@@ -940,7 +952,7 @@ private extension FrameworkProductTypeSpec {
 
             let cbc = CommandBuildContext(producer: producer.context, scope: scope, inputs: [FileToBuild(context: producer.context, absolutePath: builtBinaryPath)], output: tapiOutputNode.path, commandOrderingOutputs: [tapiOrderingNode])
 
-            let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
+            let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, staleFileRemovalScope: destination.staleFileRemovalScope, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
             await producer.context.tapiStubifySpec.constructTasks(cbc, delegate)
             tasks += delegate.tasks
 
@@ -1058,7 +1070,7 @@ private extension LibraryProductTypeSpec {
             let cbc = CommandBuildContext(producer: producer.context, scope: scope, inputs: [FileToBuild(context: producer.context, absolutePath: builtBinaryPath)], output: tapiOutputNode.path, commandOrderingOutputs: [tapiOrderingNode])
 
             // Generate the text-based stub from the input binary.
-            let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
+            let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, staleFileRemovalScope: destination.staleFileRemovalScope, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
             await producer.context.tapiStubifySpec.constructTasks(cbc, delegate)
             return delegate.tasks
         }

--- a/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
@@ -60,10 +60,10 @@ open class StandardTaskProducer {
     ///
     /// By encouraging clients to go through this function for task generation based tasks, we also ensure that they will add their tasks somewhere and not forget to append them to the result.
     @discardableResult
-    package func appendGeneratedTasks(_ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
+    package func appendGeneratedTasks(_ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, staleFileRemovalScope: StaleFileRemovalScope = .target, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
         let options = options ?? defaultTaskOrderingOptions
 
-        let delegate = ProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options)
+        let delegate = ProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options, staleFileRemovalScope: staleFileRemovalScope)
         await body(delegate)
         tasks.append(contentsOf: delegate.tasks)
         return (tasks: delegate.tasks, outputs: delegate.outputs )
@@ -144,8 +144,8 @@ open class PhasedTaskProducer: StandardTaskProducer {
     ///
     /// We override this to auto-attach tasks to the phase ordering gates, and to return information from the delegate for reprocessing.
     @discardableResult
-    package override func appendGeneratedTasks(_ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
-        let (tasks, options, _) = await appendGeneratedTasks(&tasks, usePhasedOrdering: true, options: options, body: body)
+    package override func appendGeneratedTasks(_ tasks: inout [any PlannedTask], options: TaskOrderingOptions? = nil, staleFileRemovalScope: StaleFileRemovalScope = .target, body: (any TaskGenerationDelegate) async -> Void) async -> (tasks: [any PlannedTask], outputs: [FileToBuild]) {
+        let (tasks, options, _) = await appendGeneratedTasks(&tasks, usePhasedOrdering: true, options: options, staleFileRemovalScope: staleFileRemovalScope, body: body)
         return (tasks, options)
     }
 
@@ -156,14 +156,14 @@ open class PhasedTaskProducer: StandardTaskProducer {
     ///   - usePhasedOrdering: If true, the tasks are bound between the phase start and end, otherwise they will precede the target end task.
     /// - Returns: The generated tasks and outputs.
     @discardableResult
-    func appendGeneratedTasks<T>(_ tasks: inout [any PlannedTask], usePhasedOrdering: Bool, options: TaskOrderingOptions? = nil, body: (any TaskGenerationDelegate) async -> T) async -> (tasks: [any PlannedTask], outputs: [FileToBuild], result: T) {
+    func appendGeneratedTasks<T>(_ tasks: inout [any PlannedTask], usePhasedOrdering: Bool, options: TaskOrderingOptions? = nil, staleFileRemovalScope: StaleFileRemovalScope = .target, body: (any TaskGenerationDelegate) async -> T) async -> (tasks: [any PlannedTask], outputs: [FileToBuild], result: T) {
         let options = options ?? defaultTaskOrderingOptions
 
         let delegate: PhasedProducerBasedTaskGenerationDelegate
         if usePhasedOrdering {
-            delegate = PhasedProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
+            delegate = PhasedProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options, staleFileRemovalScope: staleFileRemovalScope, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
         } else {
-            delegate = PhasedProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options, phaseStartNodes: [], phaseEndTask: targetContext.targetEndTask)
+            delegate = PhasedProducerBasedTaskGenerationDelegate(producer: self, context: context, taskOptions: options, staleFileRemovalScope: staleFileRemovalScope, phaseStartNodes: [], phaseEndTask: targetContext.targetEndTask)
         }
         let result = await body(delegate)
         tasks.append(contentsOf: delegate.tasks)

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1558,13 +1558,15 @@ class ProducerBasedTaskGenerationDelegate: TaskGenerationDelegate {
     let producer: StandardTaskProducer
     let context: TaskProducerContext
     let taskOptions: TaskOrderingOptions
+    let staleFileRemovalScope: StaleFileRemovalScope
     var tasks: [any PlannedTask] = []
     var outputs: [FileToBuild] = []
 
-    init(producer: StandardTaskProducer, context: TaskProducerContext, taskOptions: TaskOrderingOptions = []) {
+    init(producer: StandardTaskProducer, context: TaskProducerContext, taskOptions: TaskOrderingOptions = [], staleFileRemovalScope: StaleFileRemovalScope = .target) {
         self.producer = producer
         self.context = context
         self.taskOptions = taskOptions
+        self.staleFileRemovalScope = staleFileRemovalScope
     }
 
     func diagnosticsEngine(for target: ConfiguredTarget?) -> DiagnosticProducingDelegateProtocolPrivate<DiagnosticsEngine> {
@@ -1651,6 +1653,7 @@ class ProducerBasedTaskGenerationDelegate: TaskGenerationDelegate {
     func createTask(_ builder: inout PlannedTaskBuilder) {
         // Associate the target.
         builder.forTarget = context.configuredTarget
+        builder.staleFileRemovalScope = staleFileRemovalScope
 
         let orderingOptions = self.taskOptions.union(builder.additionalTaskOrderingOptions)
         // A compilation or linking requirement should have a priority of at least `unblocksDownstreamTasks`
@@ -1712,10 +1715,10 @@ class PhasedProducerBasedTaskGenerationDelegate: ProducerBasedTaskGenerationDele
     let phaseStartNodes: [any PlannedNode]
     let phaseEndTask: any PlannedTask
 
-    init(producer: PhasedTaskProducer, context: TaskProducerContext, taskOptions: TaskOrderingOptions = [], phaseStartNodes: [any PlannedNode], phaseEndTask: any PlannedTask) {
+    init(producer: PhasedTaskProducer, context: TaskProducerContext, taskOptions: TaskOrderingOptions = [], staleFileRemovalScope: StaleFileRemovalScope = .target, phaseStartNodes: [any PlannedNode], phaseEndTask: any PlannedTask) {
         self.phaseStartNodes = phaseStartNodes
         self.phaseEndTask = phaseEndTask
-        super.init(producer: producer, context: context, taskOptions: taskOptions)
+        super.init(producer: producer, context: context, taskOptions: taskOptions, staleFileRemovalScope: staleFileRemovalScope)
     }
 
     override func createTask(_ builder: inout PlannedTaskBuilder) {

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -1065,9 +1065,11 @@ extension BuildDescription {
                     continue
                 }
 
-                var outputs = outputPathsPerTarget[target] ?? [Path]()
+                let sfrTarget = task.staleFileRemovalScope == .workspace ? nil : target
+
+                var outputs = outputPathsPerTarget[sfrTarget] ?? [Path]()
                 outputs.append(contentsOf: task.outputs.map { $0.path }.filter { !$0.str.isEmpty })
-                outputPathsPerTarget[target] = outputs
+                outputPathsPerTarget[sfrTarget] = outputs
             }
 
             // Diagnose dangling tasks which cannot be run.

--- a/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
+++ b/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
@@ -369,6 +369,446 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
             }
         }
     }
+
+    /// Test that stale EagerLinkingTBDs are removed when switching between workspaces
+    /// that share the same build output directory. rdar://109491531
+    @Test(.requireSDKs(.macOS))
+    func crossWorkspaceStaleEagerLinkingTBDRemoval() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let sharedBuildDir = tmpDirPath.join("SharedBuild")
+
+            let projectA = TestProject(
+                "ProjectA",
+                sourceRoot: tmpDirPath.join("ProjectA"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Fwk.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                        "SYMROOT": sharedBuildDir.join("Products").str,
+                        "DSTROOT": sharedBuildDir.join("Products").str,
+                    ])],
+                targets: [
+                    TestStandardTarget(
+                        "Fwk",
+                        type: .framework,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["Fwk.c"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "App",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                            TestFrameworksBuildPhase(["Fwk.framework"]),
+                        ],
+                        dependencies: ["Fwk"]
+                    ),
+                ])
+
+            let wsA = TestWorkspace(
+                "WorkspaceA",
+                sourceRoot: tmpDirPath.join("wsA"),
+                projects: [projectA])
+            let testerA = try await BuildOperationTester(getCore(), wsA, simulated: false)
+
+            try await testerA.fs.writeFileContents(tmpDirPath.join("ProjectA/Fwk.c")) { contents in
+                contents <<< "void fwk_func(void) {}\n"
+            }
+            try await testerA.fs.writeFileContents(tmpDirPath.join("ProjectA/App.c")) { contents in
+                contents <<< "extern void fwk_func(void);\nint main() { fwk_func(); return 0; }\n"
+            }
+
+            let eagerTBDDir = sharedBuildDir.join("Intermediates.noindex/EagerLinkingTBDs")
+            try await testerA.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            #expect(localFS.isDirectory(eagerTBDDir), "EagerLinkingTBDs directory should exist after workspace A build")
+            let tbdFilesAfterA = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) { return path }
+                return nil
+            }
+            #expect(!tbdFilesAfterA.isEmpty, "EagerLinkingTBDs should contain TBD files after workspace A build")
+
+            // Workspace B: static library, same build dir, different workspace.
+            // The workspace SFR key is stable across workspace switches, so
+            // llbuild's delta detects workspace A's TBDs as stale and removes them.
+            let projectB = TestProject(
+                "ProjectB",
+                sourceRoot: tmpDirPath.join("ProjectB"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Bar.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                        "SYMROOT": sharedBuildDir.join("Products").str,
+                        "DSTROOT": sharedBuildDir.join("Products").str,
+                    ])],
+                targets: [
+                    TestStandardTarget(
+                        "Bar",
+                        type: .staticLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["Bar.c"]),
+                        ]
+                    ),
+                ])
+
+            let wsB = TestWorkspace(
+                "WorkspaceB",
+                sourceRoot: tmpDirPath.join("wsB"),
+                projects: [projectB])
+            let testerB = try await BuildOperationTester(getCore(), wsB, simulated: false)
+
+            try await testerB.fs.writeFileContents(tmpDirPath.join("ProjectB/Bar.c")) { contents in
+                contents <<< "int bar(void) { return 0; }\n"
+            }
+
+            try await testerB.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            // Verify that stale EagerLinkingTBDs from workspace A were removed.
+            let tbdFilesAfterB = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) { return path }
+                return nil
+            }
+            #expect(tbdFilesAfterB.isEmpty, "Stale EagerLinkingTBDs from workspace A should be removed after workspace B build, but found: \(tbdFilesAfterB)")
+        }
+    }
+
+    /// Test that rebuilding the same workspace preserves its own EagerLinkingTBDs. rdar://109491531
+    @Test(.requireSDKs(.macOS))
+    func sameWorkspaceRebuildPreservesEagerLinkingTBDs() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let sharedBuildDir = tmpDirPath.join("SharedBuild")
+
+            let project = TestProject(
+                "ProjectA",
+                sourceRoot: tmpDirPath.join("ProjectA"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Fwk.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                        "SYMROOT": sharedBuildDir.join("Products").str,
+                        "DSTROOT": sharedBuildDir.join("Products").str,
+                    ])],
+                targets: [
+                    TestStandardTarget(
+                        "Fwk",
+                        type: .framework,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["Fwk.c"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "App",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                            TestFrameworksBuildPhase(["Fwk.framework"]),
+                        ],
+                        dependencies: ["Fwk"]
+                    ),
+                ])
+
+            let ws = TestWorkspace(
+                "WorkspaceA",
+                sourceRoot: tmpDirPath.join("wsA"),
+                projects: [project])
+            let tester = try await BuildOperationTester(getCore(), ws, simulated: false)
+
+            try await tester.fs.writeFileContents(tmpDirPath.join("ProjectA/Fwk.c")) { contents in
+                contents <<< "void fwk_func(void) {}\n"
+            }
+            try await tester.fs.writeFileContents(tmpDirPath.join("ProjectA/App.c")) { contents in
+                contents <<< "extern void fwk_func(void);\nint main() { fwk_func(); return 0; }\n"
+            }
+
+            let eagerTBDDir = sharedBuildDir.join("Intermediates.noindex/EagerLinkingTBDs")
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let tbdFilesAfterBuild1 = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) { return path }
+                return nil
+            }
+            #expect(!tbdFilesAfterBuild1.isEmpty, "EagerLinkingTBDs should exist after first build")
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let tbdFilesAfterBuild2 = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) { return path }
+                return nil
+            }
+            #expect(tbdFilesAfterBuild1 == tbdFilesAfterBuild2, "EagerLinkingTBDs should be preserved after rebuilding the same workspace")
+        }
+    }
+
+    /// Test that stale EagerLinkingTBDs from a dynamic framework are removed when
+    /// switching to a workspace where the same framework is static. rdar://165932649
+    @Test(.requireSDKs(.macOS))
+    func staleTBDRemovedWhenFrameworkSwitchesDynamicToStatic() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let sharedBuildDir = tmpDirPath.join("SharedBuild")
+
+            // Workspace A: SharedLib as dynamic framework (generates TBD).
+            let projectA = TestProject(
+                "ProjectA",
+                sourceRoot: tmpDirPath.join("ProjectA"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("SharedLib.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                        "SYMROOT": sharedBuildDir.join("Products").str,
+                        "DSTROOT": sharedBuildDir.join("Products").str,
+                    ])],
+                targets: [
+                    TestStandardTarget(
+                        "SharedLib",
+                        type: .framework,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["SharedLib.c"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "App",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                            TestFrameworksBuildPhase(["SharedLib.framework"]),
+                        ],
+                        dependencies: ["SharedLib"]
+                    ),
+                ])
+
+            let wsA = TestWorkspace(
+                "WorkspaceA",
+                sourceRoot: tmpDirPath.join("wsA"),
+                projects: [projectA])
+            let testerA = try await BuildOperationTester(getCore(), wsA, simulated: false)
+
+            try await testerA.fs.writeFileContents(tmpDirPath.join("ProjectA/SharedLib.c")) { contents in
+                contents <<< "void shared_func(void) {}\n"
+            }
+            try await testerA.fs.writeFileContents(tmpDirPath.join("ProjectA/App.c")) { contents in
+                contents <<< "extern void shared_func(void);\nint main() { shared_func(); return 0; }\n"
+            }
+
+            let eagerTBDDir = sharedBuildDir.join("Intermediates.noindex/EagerLinkingTBDs")
+            try await testerA.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let tbdFilesAfterA = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) && path.str.contains("SharedLib") { return path }
+                return nil
+            }
+            #expect(!tbdFilesAfterA.isEmpty, "SharedLib TBD should exist in EagerLinkingTBDs after workspace A (dynamic) build")
+
+            // Workspace B: SharedLib as static library, same build dir, different build.db.
+            // Stale TBD from workspace A should be removed.
+            let projectB = TestProject(
+                "ProjectB",
+                sourceRoot: tmpDirPath.join("ProjectB"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("SharedLib.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                        "SYMROOT": sharedBuildDir.join("Products").str,
+                        "DSTROOT": sharedBuildDir.join("Products").str,
+                    ])],
+                targets: [
+                    TestStandardTarget(
+                        "SharedLib",
+                        type: .staticLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["SharedLib.c"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "App",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                        ],
+                        dependencies: ["SharedLib"]
+                    ),
+                ])
+
+            let wsB = TestWorkspace(
+                "WorkspaceB",
+                sourceRoot: tmpDirPath.join("wsB"),
+                projects: [projectB])
+            let testerB = try await BuildOperationTester(getCore(), wsB, simulated: false)
+
+            try await testerB.fs.writeFileContents(tmpDirPath.join("ProjectB/SharedLib.c")) { contents in
+                contents <<< "int shared_func(void) { return 0; }\n"
+            }
+            try await testerB.fs.writeFileContents(tmpDirPath.join("ProjectB/App.c")) { contents in
+                contents <<< "extern int shared_func(void);\nint main() { return shared_func(); }\n"
+            }
+
+            try await testerB.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            // Verify the stale SharedLib TBD was removed.
+            let tbdFilesAfterB = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) && path.str.contains("SharedLib") { return path }
+                return nil
+            }
+            #expect(tbdFilesAfterB.isEmpty, "Stale SharedLib TBD from dynamic framework should be removed after switching to static library (rdar://165932649), but found: \(tbdFilesAfterB)")
+        }
+    }
+
+    /// Test that workspace SFR does not delete TBDs from other configurations.
+    @Test(.requireSDKs(.macOS))
+    func workspaceSFRDoesNotDeleteOtherConfigurations() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let sharedBuildDir = tmpDirPath.join("SharedBuild")
+
+            func sharedSettings() -> [String: String] {
+                return [
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "OBJROOT": sharedBuildDir.join("Intermediates.noindex").str,
+                    "SYMROOT": sharedBuildDir.join("Products").str,
+                    "DSTROOT": sharedBuildDir.join("Products").str,
+                ]
+            }
+
+            let fwkSource = tmpDirPath.join("SharedSrc/Fwk.c")
+            let appSource = tmpDirPath.join("SharedSrc/App.c")
+            try localFS.createDirectory(fwkSource.dirname, recursive: true)
+            try localFS.write(fwkSource, contents: ByteString(encodingAsUTF8: "void fwk_func(void) {}\n"))
+            try localFS.write(appSource, contents: ByteString(encodingAsUTF8: "extern void fwk_func(void);\nint main() { fwk_func(); return 0; }\n"))
+
+            // Workspace A: builds Debug configuration.
+            let projectA = TestProject(
+                "ProjectA",
+                sourceRoot: tmpDirPath.join("SharedSrc"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Fwk.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: sharedSettings())],
+                targets: [
+                    TestStandardTarget(
+                        "Fwk", type: .framework,
+                        buildPhases: [TestSourcesBuildPhase(["Fwk.c"])]
+                    ),
+                    TestStandardTarget(
+                        "App", type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                            TestFrameworksBuildPhase(["Fwk.framework"]),
+                        ],
+                        dependencies: ["Fwk"]
+                    ),
+                ])
+
+            let wsA = TestWorkspace("WorkspaceA", sourceRoot: tmpDirPath.join("wsA"), projects: [projectA])
+            let testerA = try await BuildOperationTester(getCore(), wsA, simulated: false)
+
+            try await testerA.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let eagerTBDDir = sharedBuildDir.join("Intermediates.noindex/EagerLinkingTBDs")
+            let debugTBDs = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) && path.str.contains("/Debug/") { return path }
+                return nil
+            }
+            #expect(!debugTBDs.isEmpty, "Debug EagerLinkingTBDs should exist after workspace A build")
+
+            // Workspace B: builds Release, same shared build dir, different build.db.
+            // Workspace SFR key includes the configuration, so Release SFR
+            // won't touch Debug TBDs.
+            let projectB = TestProject(
+                "ProjectB",
+                sourceRoot: tmpDirPath.join("SharedSrc"),
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Fwk.c"),
+                        TestFile("App.c"),
+                    ]),
+                buildConfigurations: [TestBuildConfiguration("Release", buildSettings: sharedSettings())],
+                targets: [
+                    TestStandardTarget(
+                        "Fwk", type: .framework,
+                        buildPhases: [TestSourcesBuildPhase(["Fwk.c"])]
+                    ),
+                    TestStandardTarget(
+                        "App", type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.c"]),
+                            TestFrameworksBuildPhase(["Fwk.framework"]),
+                        ],
+                        dependencies: ["Fwk"]
+                    ),
+                ])
+
+            let wsB = TestWorkspace("WorkspaceB", sourceRoot: tmpDirPath.join("wsB"), projects: [projectB])
+            let testerB = try await BuildOperationTester(getCore(), wsB, simulated: false)
+
+            try await testerB.checkBuild(parameters: BuildParameters(configuration: "Release"), runDestination: .macOS, persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            // Debug TBDs should survive — workspace B's SFR key is for Release.
+            let debugTBDsAfterRelease = try localFS.traverse(eagerTBDDir) { path -> Path? in
+                if !localFS.isDirectory(path) && path.str.contains("/Debug/") { return path }
+                return nil
+            }
+            #expect(!debugTBDsAfterRelease.isEmpty, "Debug EagerLinkingTBDs should survive after workspace B's Release build because workspace SFR key is configuration-specific")
+        }
+    }
 }
 
 fileprivate extension Array {


### PR DESCRIPTION
When switching between workspaces that share the same OBJROOT, llbuild's delta stale file removal fails because each workspace uses a different build.db with no previous state. This means stale TBDs in EagerLinkingTBDs/ can persist and cause link/runtime errors.

rdar://109491531
rdar://165932649