### PR TITLE
Fix handling of static archive archiver inputs on non-Darwin/Windows

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -354,7 +354,7 @@ public protocol TaskActionCreationDelegate
     func createProcessSDKImportsTaskAction() -> any PlannedTaskAction
     func createValidateDependenciesTaskAction() -> any PlannedTaskAction
     func createObjectLibraryAssemblerTaskAction() -> any PlannedTaskAction
-    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) -> any PlannedTaskAction
+    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction
 }
 
 extension TaskActionCreationDelegate {

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -850,6 +850,7 @@ public final class BuiltinMacros {
     public static let LIBRARY_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("LIBRARY_SEARCH_PATHS")
     public static let LIBTOOL = BuiltinMacros.declarePathMacro("LIBTOOL")
     public static let LIBTOOL_DEPENDENCY_INFO_FILE = BuiltinMacros.declarePathMacro("LIBTOOL_DEPENDENCY_INFO_FILE")
+    public static let LIBTOOL_EXTRACT_ARCHIVE_INPUTS = BuiltinMacros.declareBooleanMacro("LIBTOOL_EXTRACT_ARCHIVE_INPUTS")
     public static let LIBTOOL_USE_RESPONSE_FILE = BuiltinMacros.declareBooleanMacro("LIBTOOL_USE_RESPONSE_FILE")
     public static let LINKER = BuiltinMacros.declareStringMacro("LINKER")
     public static let LINKER_DRIVER = BuiltinMacros.declareEnumMacro("LINKER_DRIVER") as EnumMacroDeclaration<LinkerDriverChoice>
@@ -1995,6 +1996,7 @@ public final class BuiltinMacros {
         LIBRARY_SEARCH_PATHS,
         LIBTOOL,
         LIBTOOL_DEPENDENCY_INFO_FILE,
+        LIBTOOL_EXTRACT_ARCHIVE_INPUTS,
         LIBTOOL_USE_RESPONSE_FILE,
         LINKER,
         LINK_OBJC_RUNTIME,

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -1473,7 +1473,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
     override public func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {
         let useResponseFile = cbc.scope.evaluate(BuiltinMacros.CLANG_USE_RESPONSE_FILE)
         let responseFileFormat = cbc.scope.evaluate(BuiltinMacros.LINKER_RESPONSE_FILE_FORMAT)
-        return delegate.taskActionCreationDelegate.createLinkerTaskAction(expandResponseFiles: !useResponseFile, responseFileFormat: responseFileFormat)
+        return delegate.taskActionCreationDelegate.createLinkerTaskAction(expandResponseFiles: !useResponseFile, responseFileFormat: responseFileFormat, extractArchiveInputs: false)
     }
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
@@ -1693,7 +1693,8 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
     override public func createTaskAction(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> (any PlannedTaskAction)? {
         let useResponseFile = cbc.scope.evaluate(BuiltinMacros.LIBTOOL_USE_RESPONSE_FILE)
         let responseFileFormat = cbc.scope.evaluate(BuiltinMacros.LINKER_RESPONSE_FILE_FORMAT)
-        return delegate.taskActionCreationDelegate.createLinkerTaskAction(expandResponseFiles: !useResponseFile, responseFileFormat: responseFileFormat)
+        let extractArchiveInputs = cbc.scope.evaluate(BuiltinMacros.LIBTOOL_EXTRACT_ARCHIVE_INPUTS)
+        return delegate.taskActionCreationDelegate.createLinkerTaskAction(expandResponseFiles: !useResponseFile || extractArchiveInputs, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
 
     override public func constructLinkerTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, libraries: [LibrarySpecifier], usedTools: [CommandLineToolSpec: Set<FileTypeSpec>]) async {

--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLibtool.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLibtool.xcspec
@@ -69,6 +69,11 @@
                 DefaultValue = YES;
             },
             {
+                Name = "LIBTOOL_EXTRACT_ARCHIVE_INPUTS";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
+            {
                 Name = "LIBTOOL_FILE_LIST_FORMAT";
                 Type = Enumeration;
                 Values = (

--- a/Sources/SWBQNXPlatform/Specs/QNXLibtool.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXLibtool.xcspec
@@ -68,6 +68,11 @@
                 Type = Boolean;
                 DefaultValue = YES;
             },
+            {
+                Name = "LIBTOOL_EXTRACT_ARCHIVE_INPUTS";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
             {   Name = ALL_OTHER_LIBTOOLFLAGS;
                 Type = StringList;
                 DefaultValue = "$(OTHER_LIBTOOLFLAGS) $(OTHER_LIBTOOLFLAGS_$(variant)) $(OTHER_LIBTOOLFLAGS_$(arch)) $(OTHER_LIBTOOLFLAGS_$(variant)_$(arch)) $(PRODUCT_SPECIFIC_LIBTOOLFLAGS)";

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -981,8 +981,8 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return ObjectLibraryAssemblerTaskAction()
     }
 
-    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) -> any PlannedTaskAction {
-        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat)
+    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction {
+        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
 }
 

--- a/Sources/SWBTaskExecution/TaskActions/LinkerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/LinkerTaskAction.swift
@@ -24,24 +24,33 @@ public final class LinkerTaskAction: TaskAction {
     private let expandResponseFiles: Bool
     private let responseFileFormat: ResponseFileFormat
 
-    public init(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) {
+    /// Whether static archive inputs should be extracted to their constituent
+    /// object files before invoking the archiver. Apple's libtool is capable of
+    /// directly merging static archives, but other tools like ar/llvm-ar/GNU libtool
+    /// are not.
+    private let extractArchiveInputs: Bool
+
+    public init(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) {
         self.expandResponseFiles = expandResponseFiles
         self.responseFileFormat = responseFileFormat
+        self.extractArchiveInputs = extractArchiveInputs
         super.init()
     }
 
     public override func serialize<T: Serializer>(to serializer: T) {
-        serializer.beginAggregate(3)
+        serializer.beginAggregate(4)
         serializer.serialize(expandResponseFiles)
         serializer.serialize(responseFileFormat)
+        serializer.serialize(extractArchiveInputs)
         super.serialize(to: serializer)
         serializer.endAggregate()
     }
 
     public required init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(3)
+        try deserializer.beginAggregate(4)
         self.expandResponseFiles = try deserializer.deserialize()
         self.responseFileFormat = try deserializer.deserialize()
+        self.extractArchiveInputs = try deserializer.deserialize()
         try super.init(from: deserializer)
     }
 
@@ -68,6 +77,106 @@ public final class LinkerTaskAction: TaskAction {
             }
         }
 
+        if extractArchiveInputs {
+            do {
+                return try await withTemporaryDirectory(fs: executionDelegate.fs) { tempDir in
+                    do {
+                        commandLine = try await extractStaticArchiveInputs(
+                            commandLine,
+                            tempDir: tempDir,
+                            task: task,
+                            dynamicExecutionDelegate: dynamicExecutionDelegate,
+                            executionDelegate: executionDelegate,
+                            outputDelegate: outputDelegate
+                        )
+                    }
+                    return await runArchiver(
+                        commandLine,
+                        task: task,
+                        dynamicExecutionDelegate: dynamicExecutionDelegate,
+                        executionDelegate: executionDelegate,
+                        outputDelegate: outputDelegate
+                    )
+                }
+            } catch {
+                outputDelegate.emitError("Failed to extract archive inputs: \(error.localizedDescription)")
+                return .failed
+            }
+        } else {
+            return await runArchiver(
+                commandLine,
+                task: task,
+                dynamicExecutionDelegate: dynamicExecutionDelegate,
+                executionDelegate: executionDelegate,
+                outputDelegate: outputDelegate
+            )
+        }
+    }
+
+    private func extractStaticArchiveInputs(
+        _ commandLine: [String],
+        tempDir: Path,
+        task: any ExecutableTask,
+        dynamicExecutionDelegate: any DynamicTaskExecutionDelegate,
+        executionDelegate: any TaskExecutionDelegate,
+        outputDelegate: any TaskOutputDelegate
+    ) async throws -> [String] {
+        guard !commandLine.isEmpty else { return commandLine }
+
+        let arPath = commandLine[0]
+        let outputPaths = Set(task.outputPaths.map(\.str))
+
+        var result = commandLine
+        var insertionOffset = 0
+        var archiveIndex = 0
+
+        for (originalIndex, arg) in commandLine.enumerated() {
+            // Extract objects from any static archive on the command line which isn't
+            // a task output.
+            guard arg.hasSuffix(".a"), !outputPaths.contains(arg) else { continue }
+
+            // Create a separate subdirectory of the temp dir for each archive we're
+            // extracting objects from.
+            let extractDir = tempDir.join(String(archiveIndex))
+            archiveIndex += 1
+            try executionDelegate.fs.createDirectory(extractDir)
+
+            let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
+            let success = try await dynamicExecutionDelegate.spawn(
+                commandLine: [arPath, "x", arg],
+                environment: task.environment.bindingsDictionary,
+                workingDirectory: extractDir,
+                processDelegate: processDelegate
+            )
+
+            if let error = processDelegate.executionError {
+                throw StubError.error(error)
+            }
+            guard success else {
+                throw StubError.error("Failed to extract static archive: \(arg)")
+            }
+
+            let extractedObjects = try executionDelegate.fs.listdir(extractDir)
+                .sorted()
+                .map { extractDir.join($0).str }
+
+            // Update the command line to replace each static archive with the objects we extracted from it.
+            let adjustedIndex = originalIndex + insertionOffset
+            result.remove(at: adjustedIndex)
+            result.insert(contentsOf: extractedObjects, at: adjustedIndex)
+            insertionOffset += extractedObjects.count - 1
+        }
+
+        return result
+    }
+
+    private func runArchiver(
+        _ commandLine: [String],
+        task: any ExecutableTask,
+        dynamicExecutionDelegate: any DynamicTaskExecutionDelegate,
+        executionDelegate: any TaskExecutionDelegate,
+        outputDelegate: any TaskOutputDelegate
+    ) async -> CommandResult {
         let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
         do {
             let success = try await dynamicExecutionDelegate.spawn(

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -256,7 +256,7 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return ObjectLibraryAssemblerTaskAction()
     }
 
-    package func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) -> any PlannedTaskAction {
-        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat)
+    package func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction {
+        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
 }

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -491,8 +491,8 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return ObjectLibraryAssemblerTaskAction()
     }
 
-    package func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) -> any PlannedTaskAction {
-        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat)
+    package func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction {
+        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
 }
 

--- a/Tests/SWBBuildSystemTests/StaticLibraryBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/StaticLibraryBuildOperationTests.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+import SWBCore
+import SWBTestSupport
+import SwiftBuildTestSupport
+@_spi(Testing) import SWBUtil
+
+@Suite
+fileprivate struct StaticLibraryBuildOperationTests: CoreBasedTests {
+    @Test(.requireSDKs(.host))
+    func staticLibraryLinkingStaticLibrary() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "ConsumerProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("lib.c"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "CODE_SIGNING_ALLOWED": "NO",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    // FIXME: Find a way to make these default
+                                    "EXECUTABLE_PREFIX": "lib",
+                                    "EXECUTABLE_PREFIX[sdk=windows*]": "",
+                                ]),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "Consumer",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["lib.c"]),
+                                    TestFrameworksBuildPhase([
+                                        TestBuildFile(.target("Dependency")),
+                                    ]),
+                                ],
+                                dependencies: ["Dependency"],
+                                productReferenceName: "$(EXECUTABLE_NAME)",
+                            ),
+                        ]
+                    ),
+                    TestProject(
+                        "DependencyProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("dep.c"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "CODE_SIGNING_ALLOWED": "NO",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    // FIXME: Find a way to make these default
+                                    "EXECUTABLE_PREFIX": "lib",
+                                    "EXECUTABLE_PREFIX[sdk=windows*]": "",
+                                ]),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "Dependency",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["dep.c"]),
+                                ],
+                                productReferenceName: "$(EXECUTABLE_NAME)",
+                            ),
+                        ]
+                    ),
+                ]
+            )
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/DependencyProject/dep.c")) {
+                $0 <<< "int dep_func(void) { return 42; }\n"
+            }
+
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/ConsumerProject/lib.c")) {
+                $0 <<< "int dep_func(void);\n"
+                $0 <<< "int lib_func(void) { return dep_func(); }\n"
+            }
+
+            try await tester.checkBuild(runDestination: .host) { results in
+                results.checkNoDiagnostics()
+                results.checkTaskExists(.matchTargetName("Dependency"), .matchRuleType("Libtool"))
+                results.checkTaskExists(.matchTargetName("Consumer"), .matchRuleType("Libtool"))
+            }
+        }
+    }
+}

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -251,8 +251,8 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return ObjectLibraryAssemblerTaskAction()
     }
 
-    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat) -> any PlannedTaskAction {
-        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat)
+    func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction {
+        return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
 }
 


### PR DESCRIPTION
The unix archiver is unable to merge static archives. Instead, we need to extract the individual objects from each input archive, then feed those to the final archiver invocation. This is implemented as a new step in the existing LinkerTaskAction.

Fixes an issue where building Swift toolchain components with --multiroot-data-file would fail on linux because we'd produce malformed archives for products of root packages depending on static libraries produced by other root packages