### PR TITLE
Clean up how environment is passed to llbuild

### DIFF
--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -482,7 +482,15 @@ final class ActiveBuild: ActiveBuildOperation {
     }
 
     private func createBuild(_ description: BuildDescription, priorBuildDescription: BuildDescription?) async -> BuildOperation? {
-        await operationDelegateQueue.sync {
+        let environment: [String: String]
+        do {
+            environment = try await self.workspaceContext.mergedBuildEnvironment(request: self.buildRequest)
+        } catch {
+            self.abortBuild(error)
+            return nil
+        }
+
+        return await operationDelegateQueue.sync {
             if self.state == .cancelled {
                 return nil
             }
@@ -492,7 +500,7 @@ final class ActiveBuild: ActiveBuildOperation {
 
             // Create the build operation.
             let clientDelegate = ClientExchangeDelegate(request: self.request, session: self.session)
-            let operation = self.request.buildService.buildManager.enqueue(request: self.buildRequest, buildRequestContext: self.buildRequestContext, workspaceContext: self.workspaceContext, description: description, operationDelegate: OperationDelegate(activeBuild: self), clientDelegate: clientDelegate, priorBuildDescription: priorBuildDescription)
+            let operation = self.request.buildService.buildManager.enqueue(request: self.buildRequest, buildRequestContext: self.buildRequestContext, workspaceContext: self.workspaceContext, environment: environment, description: description, operationDelegate: OperationDelegate(activeBuild: self), clientDelegate: clientDelegate, priorBuildDescription: priorBuildDescription)
             self.buildOperation = operation
             return operation
         }

--- a/Sources/SWBBuildService/BuildServiceEntryPoint.swift
+++ b/Sources/SWBBuildService/BuildServiceEntryPoint.swift
@@ -97,7 +97,7 @@ extension BuildService {
     fileprivate static func run(inputFD: FileDescriptor, outputFD: FileDescriptor, connectionMode: ServiceHostConnectionMode, pluginsDirectory: URL?, arguments: [String], pluginLoadingFinished: () throws -> Void) async throws {
         let pluginManager = try await { @PluginExtensionSystemActor () async throws in
             // Create the plugin manager and load plugins.
-            let pluginManager = MutablePluginManager(skipLoadingPluginIdentifiers: [])
+            let pluginManager = MutablePluginManager(pluginLoadingFilter: { _ in true })
 
             // Register plugin extension points.
             pluginManager.registerExtensionPoint(ServiceExtensionPoint())

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -263,7 +263,7 @@ private struct SetSessionSystemInfoMsg: MessageHandler {
 }
 
 private struct SetSessionUserInfoMsg: MessageHandler {
-    func handle(request: Request, message: SetSessionUserInfoRequest) async throws -> VoidResponse {
+    func handle(request: Request, message: SetSessionUserInfoRequest) throws -> VoidResponse {
         let session = try request.session(for: message)
         guard let workspaceContext = session.workspaceContext else {
             throw MsgParserError.missingWorkspaceContext
@@ -275,8 +275,7 @@ private struct SetSessionUserInfoMsg: MessageHandler {
         }
 
         // Update the workspace context.
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: workspaceContext.core.pluginManager, context: Context(hostOperatingSystem: workspaceContext.core.hostOperatingSystem, fs: workspaceContext.fs))
-        workspaceContext.updateUserInfo(try await UserInfo(user: message.user, group: message.group, uid: message.uid, gid: message.gid, home: Path(message.home), processEnvironment: message.processEnvironment, buildSystemEnvironment: message.buildSystemEnvironment).addingPlatformDefaults(from: env))
+        workspaceContext.updateUserInfo(UserInfo(user: message.user, group: message.group, uid: message.uid, gid: message.gid, home: Path(message.home), processEnvironment: message.processEnvironment, buildSystemEnvironment: message.buildSystemEnvironment))
 
         return VoidResponse()
     }

--- a/Sources/SWBBuildSystem/BuildManager.swift
+++ b/Sources/SWBBuildSystem/BuildManager.swift
@@ -43,7 +43,7 @@ package actor BuildManager {
     /// Enqueue a build operation.
     ///
     /// The build will not actually be initiated until it has been requested to start.
-    package nonisolated func enqueue(request: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, description: BuildDescription, operationDelegate: any BuildOperationDelegate, clientDelegate: any ClientDelegate, priorBuildDescription: BuildDescription?) -> BuildOperation {
+    package nonisolated func enqueue(request: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, environment: [String: String], description: BuildDescription, operationDelegate: any BuildOperationDelegate, clientDelegate: any ClientDelegate, priorBuildDescription: BuildDescription?) -> BuildOperation {
 
         let buildOnlyThesePaths: [Path]?
         switch request.buildCommand {
@@ -81,7 +81,7 @@ package actor BuildManager {
 
         let nodesToBuild = description.buildNodesToPrepareForIndex(buildRequest: request, buildRequestContext: buildRequestContext, workspaceContext: workspaceContext)
 
-        return BuildOperation(request, buildRequestContext, description, environment: workspaceContext.userInfo?.processEnvironment, operationDelegate, clientDelegate, cachedBuildSystems, persistent: true, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspaceContext.workspace, core: workspaceContext.core, userPreferences: workspaceContext.userPreferences, priorBuildDescription: priorBuildDescription)
+        return BuildOperation(request, buildRequestContext, description, environment: environment, operationDelegate, clientDelegate, cachedBuildSystems, persistent: true, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspaceContext.workspace, core: workspaceContext.core, userPreferences: workspaceContext.userPreferences, priorBuildDescription: priorBuildDescription)
     }
 
     package nonisolated func enqueueClean(request buildRequest: BuildRequest, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, style: BuildLocationStyle, operationDelegate: any BuildOperationDelegate, dependencyResolverDelegate: (any TargetDependencyResolverDelegate)?) -> CleanOperation {

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -131,6 +131,7 @@ package struct CommandLineDependencyInfo {
 }
 
 package protocol BuildSystemOperation: AnyObject, Sendable {
+    var environment: [String: String]? { get }
     var cachedBuildSystems: any BuildSystemCache { get }
     var request: BuildRequest { get }
     var requestContext: BuildRequestContext { get }
@@ -210,7 +211,7 @@ package final class BuildOperation: BuildSystemOperation {
     /// The build description.
     package let buildDescription: BuildDescription
 
-    /// The environment to operate with.
+    /// The merged build environment passed to the low-level build system, including extension point additions.
     package let environment: [String: String]?
 
     /// The operation delegate.
@@ -431,28 +432,8 @@ package final class BuildOperation: BuildSystemOperation {
             debuggingDataPath = nil
         }
 
-        var buildEnvironment: [String:String] = [:]
-
-        if let actualEnvironment = environment {
-            buildEnvironment.addContents(of: actualEnvironment)
-        }
-
-        do {
-            try await buildEnvironment.addContents(of: BuildOperationExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, fromEnvironment: buildEnvironment, parameters: request.parameters))
-        } catch {
-            self.buildOutputDelegate.error("unable to retrieve additional environment variables via the BuildOperationExtensionPoint.")
-        }
-
-        struct Context: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
-            var hostOperatingSystem: OperatingSystem
-            var fs: any FSProxy
-        }
-
-        do {
-            try await buildEnvironment.addContents(of: EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: Context(hostOperatingSystem: core.hostOperatingSystem, fs: fs)))
-        } catch {
-            self.buildOutputDelegate.error("unable to retrieve additional environment variables via the EnvironmentExtensionPoint.")
-        }
+        // The build environment given to llbuild should always be non-nil so that it never inherits the calling environment.
+        let buildEnvironment = self.environment ?? [:]
 
         // If we use a cached build system, be sure to release it on build completion.
         if userPreferences.enableBuildSystemCaching {
@@ -2570,5 +2551,34 @@ private func ==<K, V>(lhs: [K: V]?, rhs: [K: V]?) -> Bool {
 extension TaskIdentifier {
     init(command: Command) {
         self.init(rawValue: command.name)
+    }
+}
+
+extension WorkspaceContext {
+    package func mergedBuildEnvironment(request: BuildRequest) async throws -> [String: String] {
+        var buildEnvironment: [String: String] = [:]
+
+        if let actualEnvironment = userInfo?.processEnvironment {
+            buildEnvironment.addContents(of: actualEnvironment)
+        }
+
+        do {
+            try await buildEnvironment.addContents(of: BuildOperationExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, fromEnvironment: buildEnvironment, parameters: request.parameters))
+        } catch {
+            throw StubError.error("unable to retrieve additional environment variables via the BuildOperationExtensionPoint.")
+        }
+
+        struct Context: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
+            var hostOperatingSystem: OperatingSystem
+            var fs: any FSProxy
+        }
+
+        do {
+            try await buildEnvironment.addContents(of: EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: Context(hostOperatingSystem: core.hostOperatingSystem, fs: fs)))
+        } catch {
+            throw StubError.error("unable to retrieve additional environment variables via the EnvironmentExtensionPoint.")
+        }
+
+        return buildEnvironment
     }
 }

--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -49,6 +49,7 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
     }
 
     package let cachedBuildSystems: any BuildSystemCache
+    package let environment: [String: String]? = nil
 
     private let buildRequest: BuildRequest
     private let buildRequestContext: BuildRequestContext

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -33,7 +33,7 @@ final class GenericUnixPlugin: Sendable {
 
     func swiftTargetInfo(swiftExecutablePath: Path) async throws -> SwiftTargetInfo {
         let args = ["-print-target-info"]
-        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: swiftExecutablePath.str), arguments: args)
+        let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: swiftExecutablePath.str), arguments: args, environment: [:])
         guard executionResult.exitStatus.isSuccess else {
             throw RunProcessNonZeroExitError(args: [swiftExecutablePath.str] + args, workingDirectory: nil, environment: [:], status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
         }

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -910,7 +910,7 @@ package final class BuildDescriptionBuilder {
                 $0["inputs"] = inputs.map { $0.identifier }
                 $0["outputs"] = outputs.map { $0.identifier }
                 $0["args"] = commandLine
-                // FIXME: inherit-env defaults to true; we should pass false and inject the process environment explicitly, so that it is overridable for tests
+                // This defaults to true, we'll omit to to save space
                 // $0["inherit-env"] = "true"
                 if let environment {
                     $0["env"] = environment.bindings

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -1155,7 +1155,11 @@ package final class BuildOperationTester {
     /// The user information to supply when testing.
     ///
     /// The environment is configured so that the inferior build processes launched by the tester can find the libraries and frameworks required to launch individual tools (e.g., `ibtool`, `momc`). The relevant environment variables are defined in the individual Swift Build tests.
-    package var userInfo: UserInfo
+    package var userInfo: UserInfo {
+        didSet {
+            workspaceContext.updateUserInfo(userInfo)
+        }
+    }
 
     /// Convenience method for assigning the tester a `UserInfo` object configured for the current user.
     package class func userInfoForCurrentUser(sourceLocation: SourceLocation = #_sourceLocation) -> UserInfo? {
@@ -1197,10 +1201,18 @@ package final class BuildOperationTester {
     // FIXME: Make this the default
     package static let defaultSystemInfo = SystemInfo(operatingSystemVersion: Version(99, 98, 97), productBuildVersion: "99A98", nativeArchitecture: Architecture.host.stringValue ?? "undefined_arch")
     /// The system information to supply when testing.
-    package var systemInfo: SystemInfo
+    package var systemInfo: SystemInfo {
+        didSet {
+            workspaceContext.updateSystemInfo(systemInfo)
+        }
+    }
 
     /// The user preferences to supply when testing.
-    package var userPreferences = UserPreferences.defaultForTesting
+    package var userPreferences = UserPreferences.defaultForTesting {
+        didSet {
+            workspaceContext.updateUserPreferences(userPreferences)
+        }
+    }
 
     private struct EnvironmentVariablesExtensionContext: EnvironmentExtensionAdditionalEnvironmentVariablesContext {
         var hostOperatingSystem: OperatingSystem
@@ -1221,8 +1233,7 @@ package final class BuildOperationTester {
         self.clientDelegate = clientDelegate ?? MockTestClientDelegate()
         self.continueBuildingAfterErrors = continueBuildingAfterErrors
         self.systemInfo = systemInfo
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: EnvironmentVariablesExtensionContext(hostOperatingSystem: core.hostOperatingSystem, fs: fs))
-        self.userInfo = try await Self.defaultUserInfo.addingPlatformDefaults(from: env)
+        self.userInfo = try Self.defaultUserInfo
     }
 
     /// Convenience initializer for single project workspace tests.
@@ -1239,8 +1250,7 @@ package final class BuildOperationTester {
         self.clientDelegate = clientDelegate ?? MockTestClientDelegate()
         self.continueBuildingAfterErrors = continueBuildingAfterErrors
         self.systemInfo = systemInfo
-        let env = try await EnvironmentExtensionPoint.additionalEnvironmentVariables(pluginManager: core.pluginManager, context: EnvironmentVariablesExtensionContext(hostOperatingSystem: core.hostOperatingSystem, fs: fs))
-        self.userInfo = try await Self.defaultUserInfo.addingPlatformDefaults(from: env)
+        self.userInfo = try Self.defaultUserInfo
     }
 
     package var workspace: Workspace {
@@ -1474,7 +1484,9 @@ package final class BuildOperationTester {
                     priorBuildDescription = nil
                 }
 
-                operation = BuildOperation(operationBuildRequest, buildRequestContext, results.buildDescription, environment: userInfo.processEnvironment, delegate, results.clientDelegate, cachedBuildSystems, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspace, core: core, userPreferences: userPreferences, priorBuildDescription: priorBuildDescription)
+                let environment = try await workspaceContext.mergedBuildEnvironment(request: operationBuildRequest)
+
+                operation = BuildOperation(operationBuildRequest, buildRequestContext, results.buildDescription, environment: environment, delegate, results.clientDelegate, cachedBuildSystems, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, nodesToBuild: nodesToBuild, workspace: workspace, core: core, userPreferences: userPreferences, priorBuildDescription: priorBuildDescription)
             }
 
             // Perform the build.
@@ -1880,6 +1892,11 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
         func handleTaskCompletion() {
             parser?.close(result: result)
 
+            // Capture the base environment given to the low-level build system, which it will merge with the task's environment in the engine.
+            // Note that the engine also internally adds some additional environment variables like LLBUILD_BUILD_ID, LLBUILD_LANE_ID,
+            // LLBUILD_TASK_ID, and optionally LLBUILD_CONTROL_FD, none of which will be reflected here.
+            let baseEnvironment = operation.environment ?? [:]
+
             // `updateResult` may be called multiple times, so use the latest value when the delegate is deallocated.
             delegate.queue.async { [self] in
                 if let result = _result {
@@ -1887,7 +1904,7 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
                     if !self.hadErrors {
                         switch result {
                         case let .exit(exitStatus, _) where !exitStatus.isSuccess && !exitStatus.wasCanceled:
-                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory, environment: .init(task.environment.bindingsDictionary), status: exitStatus, mergedOutput: output).description)"))))
+                            self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed. \(RunProcessNonZeroExitError(args: Array(task.commandLineAsStrings), workingDirectory: task.workingDirectory, environment: .init(baseEnvironment.addingContents(of: task.environment.bindingsDictionary)), status: exitStatus, mergedOutput: output).description)"))))
                         case .failedSetup:
                             self.delegate.events.append(.buildHadDiagnostic(Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Command \(task.ruleInfo[0]) failed setup."))))
                         case .exit, .skipped:

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -24,10 +24,10 @@ package protocol CoreBasedTests {
 
 extension CoreBasedTests {
     /// This will create a customized `Core` object using the specified parameters, providing a test with detailed control over the contents of the `Core` it uses.
-    package static func makeCore(skipLoadingPluginsNamed: Set<String> = [], registerExtraPlugins: @PluginExtensionSystemActor (MutablePluginManager) -> Void = { _ in }, simulatedInferiorProductsPath: Path? = nil, environment: [String: String] = [:], _ delegate: TestingCoreDelegate? = nil, configurationDelegate: TestingCoreConfigurationDelegate? = nil, developerPathOverride: Core.DeveloperPath? = nil, sourceLocation: SourceLocation = #_sourceLocation) async throws -> Core {
+    package static func makeCore(pluginLoadingFilter: @escaping (_ identifier: String) -> Bool = { _ in true}, registerExtraPlugins: @PluginExtensionSystemActor (MutablePluginManager) -> Void = { _ in }, simulatedInferiorProductsPath: Path? = nil, environment: [String: String] = [:], _ delegate: TestingCoreDelegate? = nil, configurationDelegate: TestingCoreConfigurationDelegate? = nil, developerPathOverride: Core.DeveloperPath? = nil, sourceLocation: SourceLocation = #_sourceLocation) async throws -> Core {
         let core: Result<Core, any Error>
         do {
-            let theCore = try await Core.createInitializedTestingCore(skipLoadingPluginsNamed: skipLoadingPluginsNamed, registerExtraPlugins: registerExtraPlugins, simulatedInferiorProductsPath: simulatedInferiorProductsPath, environment: environment, delegate: delegate, configurationDelegate: configurationDelegate, developerPathOverride: developerPathOverride)
+            let theCore = try await Core.createInitializedTestingCore(pluginLoadingFilter: pluginLoadingFilter, registerExtraPlugins: registerExtraPlugins, simulatedInferiorProductsPath: simulatedInferiorProductsPath, environment: environment, delegate: delegate, configurationDelegate: configurationDelegate, developerPathOverride: developerPathOverride)
             core = .success(theCore)
         } catch {
             core = .failure(error)

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -16,6 +16,7 @@ package import SWBUtil
 import SWBTaskConstruction
 import SWBTaskExecution
 import SWBServiceCore
+import Testing
 
 #if USE_STATIC_PLUGIN_INITIALIZATION
 private import SWBAndroidPlatform
@@ -41,13 +42,13 @@ extension Core {
             developerPath = .swiftToolchain(.root, xcodeDeveloperPath: nil)
         }
         let delegate = TestingCoreDelegate()
-        return await (try Core(delegate: delegate, hostOperatingSystem: hostOperatingSystem, pluginManager: MutablePluginManager(skipLoadingPluginIdentifiers: []).finalize(), developerPath: developerPath, resourceSearchPaths: [], inferiorProductsPath: nil, additionalContentPaths: [], environment: [:], buildServiceModTime: Date(), connectionMode: .inProcess), delegate.diagnostics)
+        return await (try Core(delegate: delegate, hostOperatingSystem: hostOperatingSystem, pluginManager: MutablePluginManager(pluginLoadingFilter: { _ in true }).finalize(), developerPath: developerPath, resourceSearchPaths: [], inferiorProductsPath: nil, additionalContentPaths: [], environment: [:], buildServiceModTime: Date(), connectionMode: .inProcess), delegate.diagnostics)
     }
 
     /// Get an initialized Core suitable for testing.
     ///
     /// This function requires there to be no errors during loading the core.
-    package static func createInitializedTestingCore(skipLoadingPluginsNamed: Set<String>, registerExtraPlugins: @PluginExtensionSystemActor (MutablePluginManager) -> Void, simulatedInferiorProductsPath: Path? = nil, environment: [String:String] = [:], delegate: TestingCoreDelegate? = nil, configurationDelegate: TestingCoreConfigurationDelegate? = nil, developerPathOverride: DeveloperPath? = nil) async throws -> Core {
+    package static func createInitializedTestingCore(pluginLoadingFilter: @escaping (_ identifier: String) -> Bool, registerExtraPlugins: @PluginExtensionSystemActor (MutablePluginManager) -> Void, simulatedInferiorProductsPath: Path? = nil, environment: [String:String] = [:], delegate inputDelegate: TestingCoreDelegate? = nil, configurationDelegate: TestingCoreConfigurationDelegate? = nil, developerPathOverride: DeveloperPath? = nil) async throws -> Core {
         // When this code is being loaded directly via unit tests, find the running Xcode path.
         //
         // This is a "well known" launch parameter set in Xcode's schemes.
@@ -117,7 +118,7 @@ extension Core {
             additionalContentPaths.append(simulatedInferiorProductsPath)
         }
 
-        let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: skipLoadingPluginsNamed)
+        let pluginManager = await MutablePluginManager(pluginLoadingFilter: pluginLoadingFilter)
 
         @PluginExtensionSystemActor func extraPluginRegistration(pluginManager: MutablePluginManager, pluginPaths: [Path]) {
             pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
@@ -161,7 +162,7 @@ extension Core {
             #endif
 
             if useStaticPluginInitialization {
-                for (infix, initializer) in staticPluginInitializers where !skipLoadingPluginsNamed.contains("com.apple.dt.SWB\(infix)PlatformPlugin") {
+                for (infix, initializer) in staticPluginInitializers where pluginLoadingFilter("com.apple.dt.SWB\(infix)PlatformPlugin") {
                     initializer(pluginManager)
                 }
             }
@@ -169,8 +170,15 @@ extension Core {
             registerExtraPlugins(pluginManager)
         }
 
-        let delegate = delegate ?? TestingCoreDelegate()
+        let delegate = inputDelegate ?? TestingCoreDelegate()
         guard let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: developerPath, inferiorProductsPath: inferiorProductsPath, extraPluginRegistration: extraPluginRegistration, additionalContentPaths: additionalContentPaths, environment: environment, buildServiceModTime: Date(), connectionMode: .inProcess) else {
+            // If we weren't passed a delgate, the caller couldn't possibly have emitted the diagnostics themselves (and CoreInitializationError deliberately doesn't include them in its error output).
+            if inputDelegate == nil {
+                // Emit one failure per error, which will be significantly easier to read.
+                for diagnostic in delegate.diagnostics {
+                    Issue.record(Comment(rawValue: diagnostic.formatLocalizedDescription(.debug)))
+                }
+            }
             throw CoreInitializationError(diagnostics: delegate.diagnostics)
         }
 

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -92,7 +92,7 @@ fileprivate func spawnTaskAndWait(_ launchPath: Path, _ arguments: [String]?, _ 
     stream <<< "\(String(decoding: output, as: UTF8.self))"
 
     if !exitStatus.isSuccess {
-        throw RunProcessNonZeroExitError(args: [launchPath.str] + (arguments ?? []), workingDirectory: workingDirPath, environment: environment ?? .init(), status: exitStatus, mergedOutput: ByteString(output))
+        throw RunProcessNonZeroExitError(args: [launchPath.str] + (arguments ?? []), workingDirectory: workingDirPath, environment: environment, status: exitStatus, mergedOutput: ByteString(output))
     }
 }
 

--- a/Sources/SWBUtil/PluginManager.swift
+++ b/Sources/SWBUtil/PluginManager.swift
@@ -54,13 +54,13 @@ import SWBLibc
 
     fileprivate var extensions: [Ref<any ExtensionPoint>: [any Sendable]] = [:]
 
-    private let skipLoadingPluginIdentifiers: Set<String>
+    private let pluginLoadingFilter: (_ identifier: String) -> Bool
 
     /// Create the plugin manager.
     ///
     /// Clients are expected to register all of the available extension points, then load the plugins.
-    public init(skipLoadingPluginIdentifiers: Set<String>) {
-        self.skipLoadingPluginIdentifiers = skipLoadingPluginIdentifiers
+    public init(pluginLoadingFilter: @escaping (_ identifier: String) -> Bool) {
+        self.pluginLoadingFilter = pluginLoadingFilter
     }
 
     public var pluginsByIdentifier: [String: any CommonPlugin] {
@@ -110,7 +110,7 @@ import SWBLibc
             return
         }
 
-        guard !skipLoadingPluginIdentifiers.contains(pluginIdentifier) else {
+        guard pluginLoadingFilter(pluginIdentifier) else {
             return
         }
 

--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -161,7 +161,9 @@ extension Process {
         if let currentDirectoryURL {
             process.currentDirectoryURL = currentDirectoryURL
         }
-        process.environment = environment.map { .init($0) } ?? nil
+        if let environment {
+            process.environment = .init(environment)
+        }
 
         if try currentDirectoryURL != nil && hasUnsafeWorkingDirectorySupport {
             throw try RunProcessLaunchError(process, context: "Foundation.Process working directory support is not thread-safe")
@@ -342,14 +344,14 @@ extension Processes.ExitStatus: CustomStringConvertible {
 public protocol RunProcessError: Sendable {
     var args: [String] { get }
     var workingDirectory: Path? { get }
-    var environment: Environment { get }
+    var environment: Environment? { get }
 }
 
 extension RunProcessError {
     fileprivate var commandIdentityPrefixString: String {
         let fullArgs: [String]
-        if !environment.isEmpty {
-            fullArgs = ["env"] + [String: String](environment).sorted(byKey: <).map { key, value in "\(key)=\(value)" } + args
+        if let environment {
+            fullArgs = ["env", "-i"] + [String: String](environment).sorted(byKey: <).map { key, value in "\(key)=\(value)" } + args
         } else {
             fullArgs = args
         }
@@ -370,10 +372,10 @@ extension RunProcessError {
 public struct RunProcessLaunchError: Error, RunProcessError {
     public let args: [String]
     public let workingDirectory: Path?
-    public let environment: Environment
+    public let environment: Environment?
     public let context: String
 
-    public init(args: [String], workingDirectory: Path?, environment: Environment, context: String) {
+    public init(args: [String], workingDirectory: Path?, environment: Environment?, context: String) {
         self.args = args
         self.workingDirectory = workingDirectory
         self.environment = environment
@@ -383,7 +385,7 @@ public struct RunProcessLaunchError: Error, RunProcessError {
     public init(_ process: Process, context: String) throws {
         self.args = ((process.executableURL?.path).map { [$0] } ?? []) + (process.arguments ?? [])
         self.workingDirectory = try process.currentDirectoryURL?.filePath
-        self.environment = process.environment.map { .init($0) } ?? .init()
+        self.environment = process.environment.map { .init($0) } ?? nil
         self.context = context
     }
 }
@@ -401,7 +403,7 @@ extension RunProcessLaunchError: CustomStringConvertible, LocalizedError {
 public struct RunProcessNonZeroExitError: Error, RunProcessError {
     public let args: [String]
     public let workingDirectory: Path?
-    public let environment: Environment
+    public let environment: Environment?
     public let status: Processes.ExitStatus
 
     public enum Output: Sendable {
@@ -411,15 +413,15 @@ public struct RunProcessNonZeroExitError: Error, RunProcessError {
 
     public let output: Output?
 
-    public init(args: [String], workingDirectory: Path?, environment: Environment, status: Processes.ExitStatus, mergedOutput: ByteString) {
+    public init(args: [String], workingDirectory: Path?, environment: Environment?, status: Processes.ExitStatus, mergedOutput: ByteString) {
         self.init(args: args, workingDirectory: workingDirectory, environment: environment, status: status, output: .merged(mergedOutput))
     }
 
-    public init(args: [String], workingDirectory: Path?, environment: Environment, status: Processes.ExitStatus, stdout: ByteString, stderr: ByteString) {
+    public init(args: [String], workingDirectory: Path?, environment: Environment?, status: Processes.ExitStatus, stdout: ByteString, stderr: ByteString) {
         self.init(args: args, workingDirectory: workingDirectory, environment: environment, status: status, output: .separate(stdout: stdout, stderr: stderr))
     }
 
-    public init(args: [String], workingDirectory: Path?, environment: Environment, status: Processes.ExitStatus, output: Output) {
+    public init(args: [String], workingDirectory: Path?, environment: Environment?, status: Processes.ExitStatus, output: Output) {
         self.args = args
         self.workingDirectory = workingDirectory
         self.environment = environment
@@ -430,7 +432,7 @@ public struct RunProcessNonZeroExitError: Error, RunProcessError {
     public init?(_ process: Process) throws {
         self.args = ((process.executableURL?.path).map { [$0] } ?? []) + (process.arguments ?? [])
         self.workingDirectory = try process.currentDirectoryURL?.filePath
-        self.environment = process.environment.map { .init($0) } ?? .init()
+        self.environment = process.environment.map { .init($0) } ?? nil
         self.status = try .init(process)
         self.output = nil
         if self.status.isSuccess {

--- a/Sources/SWBWindowsPlatform/VSInstallation.swift
+++ b/Sources/SWBWindowsPlatform/VSInstallation.swift
@@ -57,7 +57,7 @@ public struct VSInstallation: Decodable, Sendable {
         ]
         let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: vswhere.str), arguments: args)
         guard executionResult.exitStatus.isSuccess else {
-            throw RunProcessNonZeroExitError(args: [vswhere.str] + args, workingDirectory: nil, environment: [:], status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
+            throw RunProcessNonZeroExitError(args: [vswhere.str] + args, workingDirectory: nil, environment: nil, status: executionResult.exitStatus, stdout: ByteString(executionResult.stdout), stderr: ByteString(executionResult.stderr))
         }
         return try JSONDecoder().decode([VSInstallation].self, from: executionResult.stdout)
     }

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -19,10 +19,13 @@ import SwiftBuildTestSupport
 import SWBTaskExecution
 @_spi(Testing) import SWBUtil
 import SWBLibc
+import SWBLLBuild
 
 import class SWBBuildSystem.BuildOperation
 import class SWBTaskExecution.Task
 import SWBProtocol
+import Foundation
+import SWBServiceCore
 
 private final class MockTaskTypeDescription: TaskTypeDescription {
     init(isUnsafeToInterrupt: Bool = false) {
@@ -969,6 +972,114 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
             results.checkTask(.matchRuleType("echo")) { task in
                 #expect(task.additionalOutput == ["just some extra output"])
+            }
+        }
+    }
+
+    /// Tests that the effective build environment is clean from interference.
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/env"))
+    func buildEnvironment() async throws {
+        final class EnvTaskAction: TaskAction {
+            override init() {
+                super.init()
+            }
+
+            override class var toolIdentifier: String {
+                return "env-task"
+            }
+
+            override func computeInitialSignature() -> ByteString {
+                return ByteString(encodingAsUTF8: "")
+            }
+
+            /// Override base implementation, which expects signature to be constant for lifetime of the object.
+            override func getSignature(_ task: any ExecutableTask, executionDelegate: any TaskExecutionDelegate) -> ByteString {
+                return computeInitialSignature()
+            }
+
+            override func performTaskAction(_ task: any ExecutableTask, dynamicExecutionDelegate: any DynamicTaskExecutionDelegate, executionDelegate: any TaskExecutionDelegate, clientDelegate: any TaskExecutionClientDelegate, outputDelegate: any TaskOutputDelegate) async -> CommandResult {
+                final class TaskProcessDelegate: ProcessDelegate {
+                    let outputDelegate: any TaskOutputDelegate
+                    private(set) var executionError: String?
+                    private var _commandResult: CommandResult?
+                    private(set) var processStarted = false
+
+                    var commandResult: CommandResult? {
+                        guard processStarted else {
+                            return .cancelled
+                        }
+                        return _commandResult
+                    }
+
+                    init(outputDelegate: any TaskOutputDelegate) {
+                        self.outputDelegate = outputDelegate
+                    }
+
+                    package func processStarted(pid: llbuild_pid_t?) {
+                        processStarted = true
+                    }
+
+                    package func processHadError(error: String) {
+                        executionError = error
+                    }
+
+                    package func processHadOutput(output: [UInt8]) {
+                        outputDelegate.emitOutput(ByteString(output))
+                    }
+
+                    // Kept for compatibility with older versions of llbuild. Remove once rdar://97019909 is widely available.
+                    package func processHadOutput(output: String) {
+                        outputDelegate.emitOutput(ByteString(encodingAsUTF8: output))
+                    }
+
+                    package func processFinished(result: CommandExtendedResult) {
+                        // This may be updated by commandStarted in the case of certain failures,
+                        // so only update the exit status in output delegate if it is nil.
+                        if outputDelegate.result == nil {
+                            outputDelegate.updateResult(TaskResult(result))
+                        }
+                        self._commandResult = result.result
+                    }
+                }
+                let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
+                do {
+                    try await dynamicExecutionDelegate.spawn(commandLine: Array(task.commandLineAsStrings), environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, processDelegate: processDelegate)
+                } catch {
+                    outputDelegate.error(error.localizedDescription)
+                    return .failed
+                }
+                if let error = processDelegate.executionError {
+                    outputDelegate.error(error)
+                    return .failed
+                }
+                return processDelegate.commandResult ?? .failed
+            }
+
+            public override func serialize<T: Serializer>(to serializer: T) { fatalError("not used") }
+            public required init(from deserializer: any Deserializer) throws { fatalError("not used") }
+        }
+
+        let envTask = createTask(ruleInfo: ["env"], commandLine: ["/usr/bin/env"], additionalOutput: [], inputs: [], outputs: [MakePlannedVirtualNode("<ECHO>")], action: EnvTaskAction())
+
+        let core = try await Core.createInitializedTestingCore(pluginLoadingFilter: { _ in true }, registerExtraPlugins: { _ in })
+
+        // Execute a test build against the task set.
+        let tester = try await BuildOperationTester(core, [envTask], simulated: false)
+        tester.userInfo.processEnvironment = [:]
+        tester.userInfo.buildSystemEnvironment = [:]
+        #expect(tester.workspaceContext.userInfo?.processEnvironment == [:])
+        #expect(tester.workspaceContext.userInfo?.buildSystemEnvironment == [:])
+
+        try await tester.checkBuild(runDestination: .host) { results in
+            // Check that the delegate was passed build started and build ended events in the right place.
+            results.checkCapstoneEvents()
+
+            results.checkTask(.matchRuleType("env")) { task in
+                results.checkTaskOutput(task) { output in
+                    #expect(output.unsafeStringValue.split(separator: "\n").map({ $0.split("=").0 }).sorted().filter { $0 != "VCToolsInstallDir" && !$0.hasPrefix("ANDROID_") && !$0.hasPrefix("QNX_") } == [
+                        "LLBUILD_BUILD_ID", "LLBUILD_CONTROL_FD", "LLBUILD_LANE_ID", "LLBUILD_TASK_ID"
+                    ])
+                }
             }
         }
     }

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -414,7 +414,7 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
                 """
             }
 
-            // FIXME: These two lines shouldn't be necessary. clang directly recognizes the same of this environment variable (coincidentally the same as our build setting). llbuild's shell tool has an `inherit-env` property which is true by default, and causes the _process_ environment of the build service to be propagated to build tasks like clang. Instead we should set `inherit-env` to false and merge `processEnvironment` from UserInfo into the task's environment, so that it is overridable from tests.
+            // FIXME: These two lines shouldn't be necessary. clang directly recognizes the same of this environment variable (coincidentally the same as our build setting). However, libclang_scanner_scan_dependencies is invoked in-process and doesn't currently have a means to propagate an environment dictionary, so it uses the calling process's.
             try POSIX.setenv("GCC_TREAT_WARNINGS_AS_ERRORS", "NO", 1)
             defer { try? POSIX.unsetenv("GCC_TREAT_WARNINGS_AS_ERRORS") }
 

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -302,7 +302,7 @@ import SWBServiceCore
     @Test
     func coreInvalidInferiorProductsPath() async throws {
         let delegate = TestingCoreDelegate()
-        let core = try await Core.createInitializedTestingCore(skipLoadingPluginsNamed: [], registerExtraPlugins: { _ in }, simulatedInferiorProductsPath: .root.join("invalid"), delegate: delegate)
+        let core = try await Core.createInitializedTestingCore(pluginLoadingFilter: { _ in true }, registerExtraPlugins: { _ in }, simulatedInferiorProductsPath: .root.join("invalid"), delegate: delegate)
 
         let ignoredPlatforms = Set(["Linux"].map { $0 + ".platform" })
 
@@ -332,7 +332,7 @@ import SWBServiceCore
             ]))
 
             let delegate = Delegate()
-            let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: [])
+            let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
             await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
             await pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
             let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: .swiftToolchain(tmpDirPath, xcodeDeveloperPath: nil), buildServiceModTime: Date(), connectionMode: .inProcess)
@@ -383,7 +383,7 @@ import SWBServiceCore
         try await withTemporaryDirectory { tmpDir in
             try localFS.createDirectory(tmpDir.join("Toolchains"))
             let delegate = Delegate()
-            let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: [])
+            let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
             await pluginManager.registerExtensionPoint(DeveloperDirectoryExtensionPoint())
             await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
             await pluginManager.registerExtensionPoint(ToolchainRegistryExtensionPoint())
@@ -430,7 +430,7 @@ import SWBServiceCore
 
     func testExternalToolchainPath(toolchainPath: Path, environmentOverrides: [String:String], expecting expectedPathStrings: [String], _ originalToolchainCount: Int) async throws {
         let delegate = Delegate()
-        let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: [])
+        let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
         await pluginManager.registerExtensionPoint(DeveloperDirectoryExtensionPoint())
         await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
         await pluginManager.registerExtensionPoint(ToolchainRegistryExtensionPoint())

--- a/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/IndexTargetDependencyResolverTests.swift
@@ -134,8 +134,6 @@ import SWBUtil
                     ])])
 
         let tester = try await BuildOperationTester(core, workspace, simulated: false)
-        let workspaceContext = WorkspaceContext(core: core, workspace: tester.workspace, processExecutionCache: .sharedForTesting)
-        workspaceContext.updateUserPreferences(.defaultForTesting)
         try await tester.checkIndexBuildGraph(targets: [macApp, macApp2, iosApp, iosApp2, fwkTarget_mac, fwkTarget_ios], workspaceOperation: true) { results in
             #expect(results.targets().map { results.targetNameAndPlatform($0) } == [
                 "FwkTarget_mac-macos", "macApp-macos", "macApp2-macos",
@@ -152,7 +150,7 @@ import SWBUtil
             try results.checkDependencies(of: fwkTarget_mac, are: [])
             try results.checkDependencies(of: .init(fwkTarget_ios, "iphoneos"), are: [])
             try results.checkDependencies(of: .init(fwkTarget_ios, "iphonesimulator"), are: [])
-            if workspaceContext.userPreferences.enableDebugActivityLogs {
+            if tester.workspaceContext.userPreferences.enableDebugActivityLogs {
                 results.delegate.checkDiagnostics([
                     "FwkTarget_mac rejected as an implicit dependency because its SUPPORTED_PLATFORMS (macosx) does not contain this target's platform (iphoneos). (in target 'iosApp' from project 'aProject')",
                     "FwkTarget_ios rejected as an implicit dependency because its SUPPORTED_PLATFORMS (iphoneos iphonesimulator) does not contain this target's platform (macosx). (in target 'macApp' from project 'aProject')",
@@ -262,8 +260,6 @@ import SWBUtil
                     ])])
 
         let tester = try await BuildOperationTester(core, workspace, simulated: false)
-        let workspaceContext = WorkspaceContext(core: core, workspace: tester.workspace, processExecutionCache: .sharedForTesting)
-        workspaceContext.updateUserPreferences(.defaultForTesting)
         try await tester.checkIndexBuildGraph(targets: [macApp, iosApp, watchKitApp, watchKitExt], workspaceOperation: true) { results in
             #expect(results.targets().map { results.targetNameAndPlatform($0) } == [
                 "macApp-macos", "iosApp-iphoneos", "iosApp-iphonesimulator",
@@ -274,7 +270,7 @@ import SWBUtil
             try results.checkDependencies(of: .init(iosApp, "iphonesimulator"), are: [])
             try results.checkDependencies(of: .init(watchKitApp, "watchos"), are: [.init(watchKitExt, "watchos")])
             try results.checkDependencies(of: .init(watchKitApp, "watchsimulator"), are: [.init(watchKitExt, "watchsimulator")])
-            if workspaceContext.userPreferences.enableDebugActivityLogs {
+            if tester.workspaceContext.userPreferences.enableDebugActivityLogs {
                 results.delegate.checkDiagnostics([
                     "Watchable WatchKit App rejected as an implicit dependency because its SUPPORTED_PLATFORMS (watchos watchsimulator) does not contain this target's platform (iphoneos). (in target 'iosApp' from project 'aProject')",
                     "Watchable WatchKit App rejected as an implicit dependency because its SUPPORTED_PLATFORMS (watchos watchsimulator) does not contain this target's platform (iphonesimulator). (in target 'iosApp' from project 'aProject')"
@@ -759,8 +755,6 @@ import SWBUtil
                     ])])
 
         let tester = try await BuildOperationTester(core, workspace, simulated: false)
-        let workspaceContext = WorkspaceContext(core: core, workspace: tester.workspace, processExecutionCache: .sharedForTesting)
-        workspaceContext.updateUserPreferences(.defaultForTesting)
         try await tester.checkIndexBuildGraph(targets: [catalystAppTarget1, catalystAppTarget2, catalystAppTarget3, osxAppTarget, osxAppTarget_iosmac, fwkTarget, fwkTarget_osx], workspaceOperation: true) { results in
             #expect(results.targets().map { results.targetNameAndPlatform($0) } == [
                 "FwkTarget-iphoneos", "catalystApp1-iphoneos", "FwkTarget-iphonesimulator", "catalystApp1-iphonesimulator", "FwkTarget-iosmac", "catalystApp1-iosmac", "catalystApp2-iphoneos", "catalystApp2-iphonesimulator", "catalystApp2-iosmac", "catalystApp3-iphoneos", "catalystApp3-iphonesimulator", "catalystApp3-iosmac", "FwkTarget_osx-macos", "catalystApp3-macos", "osxApp-macos", "osxApp_iosmac-iosmac", "FwkTarget_osx-iosmac",
@@ -779,7 +773,7 @@ import SWBUtil
             try results.checkDependencies(of: osxAppTarget, are: [.init(fwkTarget_osx, "macos")])
             try results.checkDependencies(of: osxAppTarget_iosmac, are: [.init(fwkTarget, "iosmac")])
 
-            if workspaceContext.userPreferences.enableDebugActivityLogs  {
+            if tester.workspaceContext.userPreferences.enableDebugActivityLogs  {
                 results.delegate.checkDiagnostics([
                     "FwkTarget rejected as an implicit dependency because its SUPPORTED_PLATFORMS (iphoneos iphonesimulator) does not contain this target's platform (macosx). (in target 'catalystApp3' from project 'aProject')",
                     "FwkTarget rejected as an implicit dependency because its SUPPORTED_PLATFORMS (iphoneos iphonesimulator) does not contain this target's platform (macosx). (in target 'osxApp' from project 'aProject')",

--- a/Tests/SWBCoreTests/PlatformRegistryTests.swift
+++ b/Tests/SWBCoreTests/PlatformRegistryTests.swift
@@ -32,7 +32,7 @@ import SWBMacro
         let pluginManager: any PluginManager
 
         init(pluginManager: any PluginManager) async {
-            self.specRegistry = await SpecRegistry(MutablePluginManager(skipLoadingPluginIdentifiers: []).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
+            self.specRegistry = await SpecRegistry(MutablePluginManager(pluginLoadingFilter: { _ in true }).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
             self.pluginManager = pluginManager
         }
 
@@ -69,7 +69,7 @@ import SWBMacro
                 }
             }
 
-            let delegate = await TestDataDelegate(pluginManager: MutablePluginManager(skipLoadingPluginIdentifiers: []).finalize())
+            let delegate = await TestDataDelegate(pluginManager: MutablePluginManager(pluginLoadingFilter: { _ in true }).finalize())
             let registry = await PlatformRegistry(delegate: delegate, searchPaths: [tmpDirPath], hostOperatingSystem: try ProcessInfo.processInfo.hostOperatingSystem(), fs: localFS)
             try await perform(registry, delegate)
         }

--- a/Tests/SWBCoreTests/SpecLoadingTests.swift
+++ b/Tests/SWBCoreTests/SpecLoadingTests.swift
@@ -67,7 +67,7 @@ import SWBMacro
 
         init(namespace: MacroNamespace? = nil) async {
             self.internalMacroNamespace = namespace ?? MacroNamespace(parent: BuiltinMacros.namespace, debugDescription: "spec loading tests")
-            specRegistry = await SpecRegistry(MutablePluginManager(skipLoadingPluginIdentifiers: []).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
+            specRegistry = await SpecRegistry(MutablePluginManager(pluginLoadingFilter: { _ in true }).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
         }
     }
 

--- a/Tests/SWBCoreTests/SpecParserTests.swift
+++ b/Tests/SWBCoreTests/SpecParserTests.swift
@@ -73,7 +73,7 @@ fileprivate final class MockSpecType: SpecType {
         }
 
         init() async {
-            specRegistry = await SpecRegistry(MutablePluginManager(skipLoadingPluginIdentifiers: []).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
+            specRegistry = await SpecRegistry(MutablePluginManager(pluginLoadingFilter: { _ in true }).finalize(), MockSpecRegistryDelegate(_diagnosticsEngine), [])
         }
     }
 

--- a/Tests/SWBCoreTests/SpecRegistryTests.swift
+++ b/Tests/SWBCoreTests/SpecRegistryTests.swift
@@ -46,7 +46,7 @@ import SWBUtil
             }
 
             // Ensure spec types are loaded.
-            let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: [])
+            let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
             await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
             await pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
 

--- a/Tests/SWBCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SWBCoreTests/ToolchainRegistryTests.swift
@@ -75,7 +75,7 @@ import SWBServiceCore
                 }
             }
 
-            let pluginManager = await MutablePluginManager(skipLoadingPluginIdentifiers: [])
+            let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
             await pluginManager.registerExtensionPoint(DeveloperDirectoryExtensionPoint())
             await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
             await pluginManager.registerExtensionPoint(ToolchainRegistryExtensionPoint())


### PR DESCRIPTION
Much of this came out of the investigation into another issue which turned out to be a dead end, but as a secondary effect, this centralizes and makes it easier to understand to full base environment that is given to the llbuild BuildSystem and merged with individual tasks' environment overrides. That's now in WorkspaceContext.mergedBuildEnvironment.

This fixed a number of issues, including where in some build operation tests we were not correctly replicating the full environment due to not considering all extension points that could add to it.

It also ensures that the error messages we print when a process failed to execute _actually_ show the environment they were invoked with. This was often missing. The only exception to this is the LLBUILD_ meta environment variables set internally by llbuild, which can't easily be propagated back without more changes Some of this was due to the aforementioned changes, and some of it was due to passing inconsistent arguments to Process.getOutput vs RunProcessNonZeroExitError. There are some additional opportunities for improvement there...

It updates some comments in the explicitModulesEnvironment() test and in the llbuild manifest construction related to #835, since the comments that were there turned out to be false.

Finally, a buildEnvironment() test was added which leverages `/usr/bin/env` to guarantee that llbuild invokes subprocesses with a clean environment controlled by the client APIs without inheriting anything from the process-level environment.