### PR TITLE
Preliminary OpenBSD support with swiftpm.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -328,7 +328,11 @@ let package = Package(
             resources: [
                 .copy("TestData")
             ],
-            swiftSettings: swiftSettings(languageMode: .v5)), // Temporarily downgraded from Swift 6 mode due to a source break in 1/31/26 nightly snapshot (rdar://169461269)
+            swiftSettings: swiftSettings(languageMode: .v5), // Temporarily downgraded from Swift 6 mode due to a source break in 1/31/26 nightly snapshot (rdar://169461269)
+            linkerSettings: [
+                // required for openpty.
+                .linkedLibrary("util", .when(platforms: [.openbsd])),
+            ]),
         .testTarget(
             name: "SWBProjectModelTests",
             dependencies: ["SWBProjectModel"],

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -124,6 +124,8 @@ func _deploymentTargetSettingName(os: String) -> String? {
     switch os {
     case "freebsd":
         return "FREEBSD_DEPLOYMENT_TARGET"
+    case "openbsd":
+        return "OPENBSD_DEPLOYMENT_TARGET"
     default:
         return nil
     }
@@ -157,14 +159,20 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
 
                     "AR": "llvm-ar",
                 ]
+            case .openbsd:
+                defaultProperties = [
+                    "GENERATE_TEXT_BASED_STUBS": "NO",
+                    "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
+                    "AR": "ar",
+                ]
             default:
                 defaultProperties = [:]
             }
 
             let shouldUseLLD = {
                 switch operatingSystem {
-                case .freebsd:
-                    // FreeBSD is always LLVM-based.
+                case .freebsd, .openbsd:
+                    // FreeBSD and OpenBSD are always LLVM-based.
                     return true
                 case .linux:
                     // Amazon Linux 2 has a gold linker bug see: https://sourceware.org/bugzilla/show_bug.cgi?id=23016.
@@ -190,9 +198,9 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
                 tripleEnvironment = ""
             }
 
+            let realTripleVersion = try Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description
             let deploymentTargetSettings: [String: PropertyListItem]
             if let deploymentTargetSettingName = _deploymentTargetSettingName(os: tripleSystem) {
-                let realTripleVersion = try Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description
                 deploymentTargetSettings = [
                     "DeploymentTargetSettingName": .plString(deploymentTargetSettingName),
                     "DefaultDeploymentTarget": .plString(realTripleVersion),
@@ -205,7 +213,7 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
 
             return try (.root, platform, [
                 "Type": .plString("SDK"),
-                "Version": .plString(Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description),
+                "Version": .plString(realTripleVersion),
                 "CanonicalName": .plString(operatingSystem.xcodePlatformName),
                 "IsBaseSDK": .plBool(true),
                 "DefaultProperties": .plDict([

--- a/Sources/SWBUtil/Architecture.swift
+++ b/Sources/SWBUtil/Architecture.swift
@@ -99,7 +99,7 @@ public struct Architecture: Sendable {
                 return withUnsafeBytes(of: &buf.machine) { buf in
                     let data = Data(buf)
                     let value = String(decoding: data[0...(data.lastIndex(where: { $0 != 0 }) ?? 0)], as: UTF8.self)
-                    #if os(FreeBSD)
+                    #if os(FreeBSD) || os(OpenBSD)
                     switch value {
                     case "amd64":
                         return "x86_64"

--- a/Tests/SWBBuildServiceTests/BuildServiceTests.swift
+++ b/Tests/SWBBuildServiceTests/BuildServiceTests.swift
@@ -78,7 +78,7 @@ fileprivate struct BuildServiceTests: CoreBasedTests {
         .init(triple: "x86_64-unknown-freebsd14", platformName: "freebsd", sdkVariant: nil, deploymentTargetSettingName: "FREEBSD_DEPLOYMENT_TARGET", deploymentTarget: "14"),
 
         // OpenBSD
-        .init(triple: "x86_64-unknown-openbsd", platformName: "openbsd", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "x86_64-unknown-openbsd7.8", platformName: "openbsd", sdkVariant: nil, deploymentTargetSettingName: "OPENBSD_DEPLOYMENT_TARGET", deploymentTarget: "7.8"),
 
         // QNX
         .init(triple: "aarch64-unknown-nto-qnx", platformName: "qnx", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),

--- a/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
@@ -155,6 +155,7 @@ extension CoreBasedTests {
                     // Not actually recognized by clang
                     "ANDROID_DEPLOYMENT_TARGET",
                     "FREEBSD_DEPLOYMENT_TARGET",
+                    "OPENBSD_DEPLOYMENT_TARGET",
                     "QNX_DEPLOYMENT_TARGET",
                 ])
                 let suffix = "_DEPLOYMENT_TARGET"


### PR DESCRIPTION
Here, we require manually set ar otherwise swb tries to call ar-lld,
which does not exist. Additionally, since the swift-build tests call
openpty, linking with libutil is required for the tests to build and run.

There was reticence to ensure that swiftmodule names are versioned with a
preference for unversioning triples for the platform, which landed on the
compiler side in https://github.com/swiftlang/swift/pull/88224.

Lastly, there are some other changes still required to improve swb here,
and address unit tests failing for the platform, but this should be the
minimal set.