### PR TITLE
Rewrite TouchTool to use FSProxy instead of shell utilities

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -339,6 +339,7 @@ public protocol TaskActionCreationDelegate
     func createProcessProductProvisioningProfileTaskAction() -> any PlannedTaskAction
     func createRegisterExecutionPolicyExceptionTaskAction() -> any PlannedTaskAction
     func createSwiftHeaderToolTaskAction() -> any PlannedTaskAction
+    func createTouchTaskAction() -> any PlannedTaskAction
     func createValidateProductTaskAction() -> any PlannedTaskAction
     func createConstructStubExecutorInputFileListTaskAction() -> any PlannedTaskAction
     func createClangCompileTaskAction() -> any PlannedTaskAction

--- a/Sources/SWBCore/SpecImplementations/Tools/TouchTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TouchTool.swift
@@ -36,17 +36,9 @@ final class TouchToolSpec : CommandLineToolSpec, SpecIdentifierType, @unchecked 
             }
         }
 
-        let commandLine: [String]
-        if cbc.producer.hostOperatingSystem == .windows {
-            guard let commandShellPath = getEnvironmentVariable("ComSpec") else {
-                delegate.error("Can't determine path to cmd.exe because the ComSpec environment variable is not set")
-                return
-            }
-            commandLine = [commandShellPath, "/c", "copy", "/b", input.absolutePath.str, "+,,"]
-        } else {
-            commandLine = ["/usr/bin/touch", "-c", input.absolutePath.str]
-        }
+        // Use the builtin touch task action which works cross-platform via FSProxy
+        let commandLine = ["builtin-touch", input.absolutePath.str]
 
-        delegate.createTask(type: self, ruleInfo: ["Touch", input.absolutePath.str], commandLine: commandLine, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: [delegate.createNode(input.absolutePath)], outputs: outputs, mustPrecede: [], action: delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences), execDescription: resolveExecutionDescription(cbc, delegate, lookup: outputFileOverride), enableSandboxing: enableSandboxing)
+        delegate.createTask(type: self, ruleInfo: ["Touch", input.absolutePath.str], commandLine: commandLine, environment: EnvironmentBindings(), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: [delegate.createNode(input.absolutePath)], outputs: outputs, mustPrecede: [], action: delegate.taskActionCreationDelegate.createTouchTaskAction(), execDescription: resolveExecutionDescription(cbc, delegate, lookup: outputFileOverride), enableSandboxing: enableSandboxing)
     }
 }

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -873,6 +873,10 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return CreateBuildDirectoryTaskAction()
     }
 
+    func createTouchTaskAction() -> any PlannedTaskAction {
+        return TouchTaskAction()
+    }
+
     func createSwiftHeaderToolTaskAction() -> any PlannedTaskAction {
         return SwiftHeaderToolTaskAction()
     }

--- a/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
+++ b/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
@@ -59,6 +59,7 @@ public struct BuiltinTaskActionsExtension: TaskActionExtension {
             // 44: TestEntryPointGenerationTaskAction.self,
             45: SwiftCompilationVerificationTaskAction.self,
             46: GenerateEmbedInCodeAccessorTaskAction.self,
+            47: TouchTaskAction.self,
         ]
     }
 }

--- a/Sources/SWBTaskExecution/CMakeLists.txt
+++ b/Sources/SWBTaskExecution/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(SWBTaskExecution
   TaskActions/SwiftDriverTaskAction.swift
   TaskActions/SwiftHeaderToolTaskAction.swift
   TaskActions/TaskAction.swift
+  TaskActions/TouchTaskAction.swift
   TaskActions/ValidateDevelopmentAssetsTaskAction.swift
   TaskActions/ValidateProductTaskAction.swift
   TaskResult.swift

--- a/Sources/SWBTaskExecution/TaskActions/TouchTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/TouchTaskAction.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBCore
+public import SWBUtil
+
+/// Concrete implementation of task for touching a file or directory to update its modification timestamp.
+public final class TouchTaskAction: TaskAction {
+    public override class var toolIdentifier: String {
+        return "touch"
+    }
+
+    public override func performTaskAction(
+        _ task: any ExecutableTask,
+        dynamicExecutionDelegate: any DynamicTaskExecutionDelegate,
+        executionDelegate: any TaskExecutionDelegate,
+        clientDelegate: any TaskExecutionClientDelegate,
+        outputDelegate: any TaskOutputDelegate
+    ) async -> CommandResult {
+        let generator = task.commandLineAsStrings.makeIterator()
+        _ = generator.next() // consume program name "builtin-touch"
+
+        guard let pathString = generator.next() else {
+            outputDelegate.emitError("wrong number of arguments")
+            return .failed
+        }
+
+        let path = Path(pathString)
+        let fs = executionDelegate.fs
+
+        // Validate that the path exists
+        guard fs.exists(path) else {
+            outputDelegate.emitError("path does not exist: \(path.str)")
+            return .failed
+        }
+
+        // Touch the file/directory to update its modification timestamp
+        do {
+            try fs.touch(path)
+            return .succeeded
+        } catch {
+            outputDelegate.emitError("failed to touch \(path.str): \(error)")
+            return .failed
+        }
+    }
+}

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -148,6 +148,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return CreateBuildDirectoryTaskAction()
     }
 
+    package func createTouchTaskAction() -> any PlannedTaskAction {
+        return TouchTaskAction()
+    }
+
     package func createSwiftHeaderToolTaskAction() -> any PlannedTaskAction {
         return SwiftHeaderToolTaskAction()
     }

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -383,6 +383,10 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return CreateBuildDirectoryTaskAction()
     }
 
+    package func createTouchTaskAction() -> any PlannedTaskAction {
+        return TouchTaskAction()
+    }
+
     package func createSwiftHeaderToolTaskAction() -> any PlannedTaskAction {
         return SwiftHeaderToolTaskAction()
     }

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -250,6 +250,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
     func createLinkerTaskAction(expandResponseFiles: Bool, responseFileFormat: ResponseFileFormat, extractArchiveInputs: Bool) -> any PlannedTaskAction {
         return LinkerTaskAction(expandResponseFiles: expandResponseFiles, responseFileFormat: responseFileFormat, extractArchiveInputs: extractArchiveInputs)
     }
+
+    public func createTouchTaskAction() -> any PlannedTaskAction {
+        return TouchTaskAction()
+    }
 }
 
 extension CapturingTaskGenerationDelegate: CoreClientDelegate {

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1834,13 +1834,8 @@ import SWBMacro
         let task = try #require(delegate.shellTasks[safe: 0])
         #expect(task.ruleInfo == ["Touch", Path.root.join("tmp/input").str])
         #expect(task.execDescription == "Touch input")
-        if core.hostOperatingSystem == .windows {
-            let commandShellPath = try #require(getEnvironmentVariable("ComSpec"), "Can't determine path to cmd.exe because the ComSpec environment variable is not set")
-            task.checkCommandLine([commandShellPath, "/c", "copy", "/b", Path.root.join("tmp/input").str, "+,,"])
-        } else {
-            task.checkCommandLine(["/usr/bin/touch", "-c", Path.root.join("tmp/input").str])
-        }
-        #expect(task.execDescription == "Touch input")
+        // TouchTool now uses the builtin-touch action which works cross-platform via FSProxy.touch()
+        task.checkCommandLine(["builtin-touch", Path.root.join("tmp/input").str])
     }
 
     @Test

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -449,7 +449,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                 // There should be a product 'Touch' task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Touch")) { task in
                     task.checkRuleInfo(["Touch", "\(SRCROOT)/build/Debug/AppTarget.app"])
-                    task.checkCommandLine(["/usr/bin/touch", "-c", "\(SRCROOT)/build/Debug/AppTarget.app"])
+                    task.checkCommandLine(["builtin-touch", "\(SRCROOT)/build/Debug/AppTarget.app"])
                 }
 
                 results.checkTask(.matchTarget(target), .matchRuleType("RegisterExecutionPolicyException")) { task in

--- a/Tests/SWBTaskExecutionTests/TouchTaskActionTests.swift
+++ b/Tests/SWBTaskExecutionTests/TouchTaskActionTests.swift
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBUtil
+import SWBCore
+import SWBTaskExecution
+import SWBTestSupport
+
+#if compiler(<6.4)
+// Swift compiler versions prior to 6.4 ship with a Foundation implementation on Windows
+// that does not properly support setting timestamps on directories via touch operations.
+// This test is disabled on Windows for those compiler versions to avoid spurious failures.
+let enableTouchDirTest = (try? ProcessInfo.processInfo.hostOperatingSystem()) != .windows
+#else
+let enableTouchDirTest = true
+#endif
+
+@Suite
+fileprivate struct TouchTaskActionTests {
+
+    @Test(.enabled(if: enableTouchDirTest))
+    func touchDirectory() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let bundlePath = tmpDir.join("Test.bundle")
+            let fs = localFS
+
+            // Create a bundle directory
+            try fs.createDirectory(bundlePath, recursive: true)
+
+            // Get initial timestamp
+            let initialTimestamp = try fs.getFileTimestamp(bundlePath)
+
+            // wait for some time to pass
+            var newTime = time(nil)
+            while newTime <= initialTimestamp {
+                try await _Concurrency.Task.sleep(for: .seconds(1))
+                newTime = time(nil)
+            }
+
+            // Execute touch action
+            let executionDelegate = MockExecutionDelegate(fs: fs)
+            let action = TouchTaskAction()
+            let task = Task(forTarget: nil, ruleInfo: ["Touch", bundlePath.str], commandLine: ["builtin-touch", bundlePath.str], workingDirectory: tmpDir, outputs: [], action: action, execDescription: "Touch Test.bundle")
+
+            let outputDelegate = MockTaskOutputDelegate()
+            let result = await action.performTaskAction(
+                task,
+                dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+                executionDelegate: executionDelegate,
+                clientDelegate: MockTaskExecutionClientDelegate(),
+                outputDelegate: outputDelegate
+            )
+
+            // Verify success
+            #expect(result == .succeeded)
+            #expect(outputDelegate.errors.isEmpty)
+
+            // Verify timestamp was updated (touch sets it to current time)
+            let newTimestamp = try fs.getFileTimestamp(bundlePath)
+            #expect(newTimestamp > initialTimestamp, "Timestamp should have been updated to current time")
+        }
+    }
+
+    @Test
+    func touchFile() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let filePath = tmpDir.join("test.txt")
+            let fs = localFS
+
+            // Create a file
+            try fs.write(filePath, contents: "test content")
+
+            // Get initial timestamp
+            let initialTimestamp = try fs.getFileTimestamp(filePath)
+
+            // Execute touch action
+            let executionDelegate = MockExecutionDelegate(fs: fs)
+            let action = TouchTaskAction()
+            let task = Task(forTarget: nil, ruleInfo: ["Touch", filePath.str], commandLine: ["builtin-touch", filePath.str], workingDirectory: tmpDir, outputs: [], action: action, execDescription: "Touch test.txt")
+
+            let outputDelegate = MockTaskOutputDelegate()
+            let result = await action.performTaskAction(
+                task,
+                dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+                executionDelegate: executionDelegate,
+                clientDelegate: MockTaskExecutionClientDelegate(),
+                outputDelegate: outputDelegate
+            )
+
+            // Verify success
+            #expect(result == .succeeded)
+            #expect(outputDelegate.errors.isEmpty)
+
+            // Verify timestamp was updated (touch sets it to current time)
+            let newTimestamp = try fs.getFileTimestamp(filePath)
+            #expect(newTimestamp >= initialTimestamp, "Timestamp should have been updated to current time")
+        }
+    }
+
+    @Test
+    func touchNonexistentPath() async throws {
+        let fs = PseudoFS()
+        let nonexistentPath = Path.root.join("does-not-exist")
+
+        let executionDelegate = MockExecutionDelegate(fs: fs)
+        let action = TouchTaskAction()
+        let task = Task(forTarget: nil, ruleInfo: ["Touch", nonexistentPath.str], commandLine: ["builtin-touch", nonexistentPath.str], workingDirectory: .root, outputs: [], action: action, execDescription: "Touch does-not-exist")
+
+        let outputDelegate = MockTaskOutputDelegate()
+        let result = await action.performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        // Verify failure
+        #expect(result == .failed)
+        #expect(!outputDelegate.errors.isEmpty)
+        #expect(outputDelegate.errors.contains { $0.contains("does not exist") })
+    }
+
+    @Test
+    func touchWithMissingArguments() async throws {
+        let fs = PseudoFS()
+
+        let executionDelegate = MockExecutionDelegate(fs: fs)
+        let action = TouchTaskAction()
+        // Command line with only program name, no path argument
+        let task = Task(forTarget: nil, ruleInfo: ["Touch"], commandLine: ["builtin-touch"], workingDirectory: .root, outputs: [], action: action, execDescription: "Touch")
+
+        let outputDelegate = MockTaskOutputDelegate()
+        let result = await action.performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        // Verify failure
+        #expect(result == .failed)
+        #expect(!outputDelegate.errors.isEmpty)
+        #expect(outputDelegate.errors.contains { $0.contains("wrong number of arguments") })
+    }
+}

--- a/Tests/SwiftBuildTests/DeferredExecutionTests.swift
+++ b/Tests/SwiftBuildTests/DeferredExecutionTests.swift
@@ -77,23 +77,21 @@ fileprivate struct DeferredExecutionTests: CoreBasedTests {
 
             let testWorkspace = TestWorkspace("aWorkspace", sourceRoot: tmpDir, projects: [testProject])
 
-            try await withConfirmations(invert: !isOn) { assetCatalogExpectation, codeSignExpectation, clangExpectation, swiftExpectation, linkerExpectation, touchExpectation, derqExpectation in
+            try await withConfirmations(invert: !isOn) { assetCatalogExpectation, codeSignExpectation, clangExpectation, swiftExpectation, linkerExpectation, derqExpectation in
                 final class MockBuildOperationDelegate: SWBPlanningOperationDelegate {
                     let assetCatalogExpectation: Confirmation
                     let codeSignExpectation: Confirmation
                     let clangExpectation: Confirmation
                     let swiftExpectation: Confirmation
                     let linkerExpectation: Confirmation
-                    let touchExpectation: Confirmation
                     let derqExpectation: Confirmation
 
-                    init(assetCatalogExpectation: Confirmation, codeSignExpectation: Confirmation, clangExpectation: Confirmation, swiftExpectation: Confirmation, linkerExpectation: Confirmation, touchExpectation: Confirmation, derqExpectation: Confirmation) {
+                    init(assetCatalogExpectation: Confirmation, codeSignExpectation: Confirmation, clangExpectation: Confirmation, swiftExpectation: Confirmation, linkerExpectation: Confirmation, derqExpectation: Confirmation) {
                         self.assetCatalogExpectation = assetCatalogExpectation
                         self.codeSignExpectation = codeSignExpectation
                         self.clangExpectation = clangExpectation
                         self.swiftExpectation = swiftExpectation
                         self.linkerExpectation = linkerExpectation
-                        self.touchExpectation = touchExpectation
                         self.derqExpectation = derqExpectation
                     }
 
@@ -138,13 +136,6 @@ fileprivate struct DeferredExecutionTests: CoreBasedTests {
                             break
                         case "swift-frontend":
                             swiftExpectation.confirm()
-                        case "touch":
-                            defer { touchExpectation.confirm() }
-
-                            let target = try #require(commandLine.last.map(Path.init))
-                            try localFS.touch(target)
-
-                            return .result(status: .exit(0), stdout: Data(), stderr: Data())
                         case "derq":
                             defer { derqExpectation.confirm() }
                             return .result(status: .exit(0), stdout: Data(), stderr: Data())
@@ -158,7 +149,7 @@ fileprivate struct DeferredExecutionTests: CoreBasedTests {
                 }
 
                 try await withTester(testWorkspace, fs: fs, userPreferences: UserPreferences.defaultForTesting.with(allowsExternalToolExecution: isOn)) { tester in
-                    try await tester.checkBuild(SWBBuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES", "CODE_SIGNING_ALLOWED": "YES", "CODE_SIGN_IDENTITY": "-"]), delegate: MockBuildOperationDelegate(assetCatalogExpectation: assetCatalogExpectation, codeSignExpectation: codeSignExpectation, clangExpectation: clangExpectation, swiftExpectation: swiftExpectation, linkerExpectation: linkerExpectation, touchExpectation: touchExpectation, derqExpectation: derqExpectation)) { results in
+                    try await tester.checkBuild(SWBBuildParameters(configuration: "Debug", activeRunDestination: .macOS, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES", "CODE_SIGNING_ALLOWED": "YES", "CODE_SIGN_IDENTITY": "-"]), delegate: MockBuildOperationDelegate(assetCatalogExpectation: assetCatalogExpectation, codeSignExpectation: codeSignExpectation, clangExpectation: clangExpectation, swiftExpectation: swiftExpectation, linkerExpectation: linkerExpectation, derqExpectation: derqExpectation)) { results in
                         results.checkNoFailedTasks()
                         results.checkNoDiagnostics()
                     }
@@ -181,7 +172,7 @@ fileprivate struct DeferredExecutionTests: CoreBasedTests {
     }
 }
 
-fileprivate func withConfirmations(invert: Bool, _ body: (_ assetCatalogExpectation: Confirmation, _ codeSignExpectation: Confirmation, _ clangExpectation: Confirmation, _ swiftExpectation: Confirmation, _ linkerExpectation: Confirmation, _ touchExpectation: Confirmation, _ derqExpectation: Confirmation) async throws -> Void) async rethrows {
+fileprivate func withConfirmations(invert: Bool, _ body: (_ assetCatalogExpectation: Confirmation, _ codeSignExpectation: Confirmation, _ clangExpectation: Confirmation, _ swiftExpectation: Confirmation, _ linkerExpectation: Confirmation, _ derqExpectation: Confirmation) async throws -> Void) async rethrows {
     let expectedCount = invert ? 0 : 1
     let swiftExpectedCount = invert ? 0 : 2
     try await confirmation("Asset catalog deferred execution requested", expectedCount: expectedCount) { assetCatalogExpectation in
@@ -189,10 +180,8 @@ fileprivate func withConfirmations(invert: Bool, _ body: (_ assetCatalogExpectat
             try await confirmation("Clang deferred execution requested", expectedCount: expectedCount) { clangExpectation in
                 try await confirmation("Swift deferred execution requested", expectedCount: swiftExpectedCount) { swiftExpectation in
                     try await confirmation("Linker deferred execution requested", expectedCount: expectedCount) { linkerExpectation in
-                        try await confirmation("Touch deferred execution requested", expectedCount: expectedCount) { touchExpectation in
-                            try await confirmation("derq deferred execution requested", expectedCount: expectedCount) { derqExpectation in
-                                try await body(assetCatalogExpectation, codeSignExpectation, clangExpectation, swiftExpectation, linkerExpectation, touchExpectation, derqExpectation)
-                            }
+                        try await confirmation("derq deferred execution requested", expectedCount: expectedCount) { derqExpectation in
+                            try await body(assetCatalogExpectation, codeSignExpectation, clangExpectation, swiftExpectation, linkerExpectation, derqExpectation)
                         }
                     }
                 }


### PR DESCRIPTION
Replace platform-specific shell commands with a cross-platform builtin task action using FSProxy.touch().

This fixes a bug on Windows where the `copy /b +,,` trick failed for directories, attempting to copy contents instead of updating timestamps.

The new TouchTaskAction uses FileManager.setAttributes() internally via FSProxy, providing consistent cross-platform behavior with better error handling and no external dependencies.

depends on: https://github.com/swiftlang/swift-foundation/pull/1855