### PR TITLE
Add XCBuild build setting evaluation operator for truncating to a 3 tuple version number

### DIFF
--- a/Sources/SWBMacro/MacroEvaluationProgram.swift
+++ b/Sources/SWBMacro/MacroEvaluationProgram.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
+internal import Foundation
 
 /// A “program” consisting of a sequence of instructions for building a macro evaluation result buffer.  Regular clients of macro evaluation don’t need to be aware of this class.
 final class MacroEvaluationProgram: Serializable, Sendable {
@@ -185,6 +186,7 @@ final class MacroEvaluationProgram: Serializable, Sendable {
         case suffix
         case standardizepath
         case not
+        case tripleversion
 
         /// Creates and returns a new retrieval operator with the given `name`.  Returns nil if the `name` is not a supported operator.
         init?(_ name: String) {
@@ -203,6 +205,7 @@ final class MacroEvaluationProgram: Serializable, Sendable {
             case "suffix": self = .suffix
             case "standardizepath": self = .standardizepath
             case "not": self = .not
+            case "tripleversion": self = .tripleversion
             default:
                 return nil
             }
@@ -245,6 +248,11 @@ final class MacroEvaluationProgram: Serializable, Sendable {
                 return Path(string).normalize(removeDotDotFromRelativePath: false).str
             case .not:
                 return string != "YES" ? "YES" : "NO"
+            case .tripleversion:
+                // Return up to the first three tuple of the version string
+                let components = string.components(separatedBy: ".")
+                let maxTuples = 3
+                return components.prefix(maxTuples).joined(separator: ".")
             }
         }
     }

--- a/Sources/SWBMacro/MacroEvaluationProgram.swift
+++ b/Sources/SWBMacro/MacroEvaluationProgram.swift
@@ -185,7 +185,7 @@ final class MacroEvaluationProgram: Serializable, Sendable {
         case suffix
         case standardizepath
         case not
-        case tripleversion
+        case truncatedversion
 
         /// Creates and returns a new retrieval operator with the given `name`.  Returns nil if the `name` is not a supported operator.
         init?(_ name: String) {
@@ -204,7 +204,7 @@ final class MacroEvaluationProgram: Serializable, Sendable {
             case "suffix": self = .suffix
             case "standardizepath": self = .standardizepath
             case "not": self = .not
-            case "tripleversion": self = .tripleversion
+            case "truncatedversion": self = .truncatedversion
             default:
                 return nil
             }
@@ -247,8 +247,7 @@ final class MacroEvaluationProgram: Serializable, Sendable {
                 return Path(string).normalize(removeDotDotFromRelativePath: false).str
             case .not:
                 return string != "YES" ? "YES" : "NO"
-            case .tripleversion:
-                // Return up to the first three tuple of the version string
+            case .truncatedversion:
                 let components = string.split(separator: ".", maxSplits: 3)
                 return components.prefix(3).joined(separator: ".")
             }

--- a/Sources/SWBMacro/MacroEvaluationProgram.swift
+++ b/Sources/SWBMacro/MacroEvaluationProgram.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
-internal import Foundation
 
 /// A “program” consisting of a sequence of instructions for building a macro evaluation result buffer.  Regular clients of macro evaluation don’t need to be aware of this class.
 final class MacroEvaluationProgram: Serializable, Sendable {
@@ -250,9 +249,8 @@ final class MacroEvaluationProgram: Serializable, Sendable {
                 return string != "YES" ? "YES" : "NO"
             case .tripleversion:
                 // Return up to the first three tuple of the version string
-                let components = string.components(separatedBy: ".")
-                let maxTuples = 3
-                return components.prefix(maxTuples).joined(separator: ".")
+                let components = string.split(separator: ".", maxSplits: 3)
+                return components.prefix(3).joined(separator: ".")
             }
         }
     }

--- a/Tests/SWBMacroTests/MacroEvaluationTests.swift
+++ b/Tests/SWBMacroTests/MacroEvaluationTests.swift
@@ -311,9 +311,9 @@ import SWBTestSupport
         let nonStandardRelPath = try namespace.declareStringMacro("NON_STANDARD_REL_PATH")
         let quoteString = try namespace.declareStringMacro("QUOTE_STRING")
         let bestBool = try namespace.declareBooleanMacro("BEST")
-        let quadVersion = try namespace.declareStringMacro("QUAD_VERSION")
-        let tripleVersion = try namespace.declareStringMacro("TRIPLE_VERSION")
-        let doubleVersion = try namespace.declareStringMacro("DOUBLE_VERSION")
+        let fourPartVersion = try namespace.declareStringMacro("FOUR_PART_VERSION")
+        let threePartVersion = try namespace.declareStringMacro("THREE_PART_VERSION")
+        let twoPartVersion = try namespace.declareStringMacro("TWO_PART_VERSION")
 
         // Push down some value assignments.
         table.push(simpleString, literal: "This")
@@ -324,9 +324,9 @@ import SWBTestSupport
         table.push(nonStandardRelPath, literal: "foo/../bar/./baz/")
         table.push(quoteString, literal: "foo bar \" ' \\")
         table.push(bestBool, literal: false)
-        table.push(quadVersion, literal: "1.2.3.4")
-        table.push(tripleVersion, literal: "1.2.3")
-        table.push(doubleVersion, literal: "1.2")
+        table.push(fourPartVersion, literal: "1.2.3.4")
+        table.push(threePartVersion, literal: "1.2.3")
+        table.push(twoPartVersion, literal: "1.2")
 
         // Create a macro evaluation scope for testing.
         let scope = MacroEvaluationScope(table: table)
@@ -347,9 +347,9 @@ import SWBTestSupport
         #expect(scope.evaluate(namespace.parseString("$(SIMPLE_STRING:lower)")) == "this")
         #expect(scope.evaluate(namespace.parseString("$(QUOTE_STRING:quote)")) == "foo\\ bar\\ \\\"\\ \\'\\ \\\\")
         #expect(scope.evaluate(namespace.parseString("$(BEST:not)")) == "YES")
-        #expect(scope.evaluate(namespace.parseString("$(QUAD_VERSION:tripleversion)")) == "1.2.3")
-        #expect(scope.evaluate(namespace.parseString("$(TRIPLE_VERSION:tripleversion)")) == "1.2.3")
-        #expect(scope.evaluate(namespace.parseString("$(DOUBLE_VERSION:tripleversion)")) == "1.2")
+        #expect(scope.evaluate(namespace.parseString("$(FOUR_PART_VERSION:truncatedversion)")) == "1.2.3")
+        #expect(scope.evaluate(namespace.parseString("$(THREE_PART_VERSION:truncatedversion)")) == "1.2.3")
+        #expect(scope.evaluate(namespace.parseString("$(TWO_PART_VERSION:truncatedversion)")) == "1.2")
     }
 
     @Test

--- a/Tests/SWBMacroTests/MacroEvaluationTests.swift
+++ b/Tests/SWBMacroTests/MacroEvaluationTests.swift
@@ -311,6 +311,9 @@ import SWBTestSupport
         let nonStandardRelPath = try namespace.declareStringMacro("NON_STANDARD_REL_PATH")
         let quoteString = try namespace.declareStringMacro("QUOTE_STRING")
         let bestBool = try namespace.declareBooleanMacro("BEST")
+        let quadVersion = try namespace.declareStringMacro("QUAD_VERSION")
+        let tripleVersion = try namespace.declareStringMacro("TRIPLE_VERSION")
+        let doubleVersion = try namespace.declareStringMacro("DOUBLE_VERSION")
 
         // Push down some value assignments.
         table.push(simpleString, literal: "This")
@@ -321,6 +324,9 @@ import SWBTestSupport
         table.push(nonStandardRelPath, literal: "foo/../bar/./baz/")
         table.push(quoteString, literal: "foo bar \" ' \\")
         table.push(bestBool, literal: false)
+        table.push(quadVersion, literal: "1.2.3.4")
+        table.push(tripleVersion, literal: "1.2.3")
+        table.push(doubleVersion, literal: "1.2")
 
         // Create a macro evaluation scope for testing.
         let scope = MacroEvaluationScope(table: table)
@@ -341,6 +347,9 @@ import SWBTestSupport
         #expect(scope.evaluate(namespace.parseString("$(SIMPLE_STRING:lower)")) == "this")
         #expect(scope.evaluate(namespace.parseString("$(QUOTE_STRING:quote)")) == "foo\\ bar\\ \\\"\\ \\'\\ \\\\")
         #expect(scope.evaluate(namespace.parseString("$(BEST:not)")) == "YES")
+        #expect(scope.evaluate(namespace.parseString("$(QUAD_VERSION:tripleversion)")) == "1.2.3")
+        #expect(scope.evaluate(namespace.parseString("$(TRIPLE_VERSION:tripleversion)")) == "1.2.3")
+        #expect(scope.evaluate(namespace.parseString("$(DOUBLE_VERSION:tripleversion)")) == "1.2")
     }
 
     @Test


### PR DESCRIPTION
**Context and problem:**

XCBuild's build setting evaluation system supports operators that transform macro values inline (e.g. `$(VAR:upper)`, `$(VAR:standardizepath)`). However, there is currently no operator to truncate a version string to its first three components (major.minor.patch).

In Apple's build system, version numbers sometimes come in 4 or 5-tuple forms (e.g. `1.2.3.4`), but many contexts — such as bundle versions, SDK version constraints, or compatibility checks — require a standard 3-tuple semver format (`1.2.3`). Today, there's no way to perform this truncation directly within a build setting expression; you'd need to work around it with custom scripts or intermediate settings.

**What this change does:**

This adds a new `truncatedversion` build setting evaluation operator, so you can write `$(MY_VERSION:truncatedversion)` and it will return up to the first three dot-separated components of the version string. For example:

- `1.2.3.4` → `1.2.3`
- `1.2.3` → `1.2.3` (no change)
- `1.2` → `1.2` (shorter versions pass through unchanged)

This follows the same pattern as the existing operators (`upper`, `lower`, `suffix`, `standardizepath`, etc.) and includes tests covering the 4-tuple, 3-tuple, and 2-tuple cases.

**Usage Example**

```
PROJECT_VERSION = 100.4.0.0.1
PROJECT_SEMANTIC_VERSION = $(PROJECT_VERSION:truncatedversion)
// PROJECT_SEMANTIC_VERSION now 100.4.0

// for use with CFBundleVersion in Info.plist which "is a machine-readable string composed of one to three period-separated integers"
CURRENT_PROJECT_VERSION = $(PROJECT_SEMANTIC_VERSION)

// LC_LOAD_DYLIB is 32-bit: will truncate to three components in linker, but this avoids linker warning
DYLIB_CURRENT_VERSION = $(PROJECT_SEMANTIC_VERSION)
```