### PR TITLE
[172848427] Rework plug-in initialization to support a new plug-in layout.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -290,7 +290,7 @@ let package = Package(
             swiftSettings: swiftSettings(languageMode: .v6)),
         .target(
             name: "SWBTestSupport",
-            dependencies: ["SwiftBuild", "SWBBuildSystem", "SWBCore", "SWBTaskConstruction", "SWBTaskExecution", "SWBUtil", "SWBLLBuild", "SWBMacro"],
+            dependencies: ["SwiftBuild", "SWBBuildService", "SWBBuildSystem", "SWBCore", "SWBTaskConstruction", "SWBTaskExecution", "SWBUtil", "SWBLLBuild", "SWBMacro"],
             swiftSettings: swiftSettings(languageMode: .v5)),
 
         // Tests

--- a/Sources/SWBBuildService/BuildServiceEntryPoint.swift
+++ b/Sources/SWBBuildService/BuildServiceEntryPoint.swift
@@ -76,7 +76,7 @@ extension BuildService {
         do {
             try await Service.main { inputFD, outputFD in
                 // Launch the Swift Build service.
-                try await BuildService.run(inputFD: inputFD, outputFD: outputFD, connectionMode: .outOfProcess, pluginsDirectory: Bundle.main.builtInPlugInsURL, arguments: arguments, pluginLoadingFinished: {
+                try await BuildService.run(inputFD: inputFD, outputFD: outputFD, connectionMode: .outOfProcess, arguments: arguments, pluginLoadingFinished: {
                     // Already using DYLD_IMAGE_SUFFIX, clear it to avoid propagating ASan to children.
                     // This must happen after plugin loading.
                     if let suffix = getEnvironmentVariable("DYLD_IMAGE_SUFFIX"), suffix == "_asan" {
@@ -94,7 +94,7 @@ extension BuildService {
     /// Common entry point to the build service for in-process and out-of-process connections.
     ///
     /// Called directly from the exported C entry point `swiftbuildServiceEntryPoint` for in-process connections, or from `BuildService.main()` (after some basic file descriptor setup) for out-of-process connections.
-    fileprivate static func run(inputFD: FileDescriptor, outputFD: FileDescriptor, connectionMode: ServiceHostConnectionMode, pluginsDirectory: URL?, arguments: [String], pluginLoadingFinished: () throws -> Void) async throws {
+    fileprivate static func run(inputFD: FileDescriptor, outputFD: FileDescriptor, connectionMode: ServiceHostConnectionMode, arguments: [String], pluginLoadingFinished: () throws -> Void) async throws {
         let pluginManager = try await { @PluginExtensionSystemActor () async throws in
             // Create the plugin manager and load plugins.
             let pluginManager = MutablePluginManager(pluginLoadingFilter: { _ in true })
@@ -150,7 +150,7 @@ extension BuildService {
                 staticPluginInitializers.forEach { $0(pluginManager) }
             } else {
                 // Otherwise, load the normal plugins.
-                if let pluginsDirectory {
+                if let pluginsDirectory = Bundle(for: BuildService.self).builtInPlugInsURL {
                     let pluginsPath = try pluginsDirectory.filePath
                     pluginManager.load(at: pluginsPath)
                     for subpath in (try? localFS.listdir(pluginsPath).sorted().map({ pluginsPath.join($0) })) ?? [] {
@@ -190,11 +190,11 @@ extension BuildService {
 ///
 /// This is exported as a C function for clients who wish to spawn the build service in-process, and which is used by the SwiftBuild client framework.
 @_cdecl("swiftbuildServiceEntryPoint")
-public func swiftbuildServiceEntryPoint(inputFD: Int32, outputFD: Int32, pluginsDirectory: URL?, completion: @Sendable @escaping ((any Error)?) -> Void) {
+public func swiftbuildServiceEntryPoint(inputFD: Int32, outputFD: Int32, completion: @Sendable @escaping ((any Error)?) -> Void) {
     _Concurrency.Task<Void, Never>.detached {
         let error: (any Error)?
         do {
-            try await BuildService.run(inputFD: FileDescriptor(rawValue: inputFD), outputFD: FileDescriptor(rawValue: outputFD), connectionMode: .inProcess, pluginsDirectory: pluginsDirectory, arguments: [buildServiceExecutableName()], pluginLoadingFinished: {})
+            try await BuildService.run(inputFD: FileDescriptor(rawValue: inputFD), outputFD: FileDescriptor(rawValue: outputFD), connectionMode: .inProcess, arguments: [buildServiceExecutableName()], pluginLoadingFinished: {})
             error = nil
         } catch let e {
             error = e

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -40,7 +40,7 @@ public final class Core: Sendable {
     /// Get a configured instance of the core.
     ///
     /// - returns: An initialized Core instance on which all discovery and loading will have been completed. If there are errors during that process, they will be logged to `stderr` and no instance will be returned. Otherwise, the initialized object is returned.
-    public static func getInitializedCore(_ delegate: any CoreDelegate, pluginManager: MutablePluginManager, developerPath: DeveloperPath? = nil, resourceSearchPaths: [Path] = [], inferiorProductsPath: Path? = nil, extraPluginRegistration: @PluginExtensionSystemActor (_ pluginManager: MutablePluginManager, _ pluginPaths: [Path]) -> Void = { _, _ in }, additionalContentPaths: [Path] = [], environment: [String:String] = [:], buildServiceModTime: Date, connectionMode: ServiceHostConnectionMode) async -> Core? {
+    public static func getInitializedCore(_ delegate: any CoreDelegate, pluginManager: MutablePluginManager, developerPath: DeveloperPath? = nil, resourceSearchPaths: [Path] = [], inferiorProductsPath: Path? = nil, additionalContentPaths: [Path] = [], environment: [String:String] = [:], buildServiceModTime: Date, connectionMode: ServiceHostConnectionMode) async -> Core? {
         // Enable macro expression interning during loading.
         return await MacroNamespace.withExpressionInterningEnabled { () -> Core? in
             let hostOperatingSystem: OperatingSystem
@@ -49,14 +49,6 @@ public final class Core: Sendable {
             } catch {
                 delegate.error("Could not determine host operating system: \(error)")
                 return nil
-            }
-
-            if useStaticPluginInitialization {
-                // In a package context, plugins are statically linked into the build system.
-                // Load specs from service plugins if requested since we don't have a Service in certain tests
-                // Here we don't have access to `core.pluginPaths` like we do in the call below,
-                // but it doesn't matter because `core.pluginPaths` will return an empty array when USE_STATIC_PLUGIN_INITIALIZATION is defined.
-                await extraPluginRegistration(pluginManager, [])
             }
 
             let resolvedDeveloperPath: DeveloperPath
@@ -79,12 +71,6 @@ public final class Core: Sendable {
             } catch {
                 delegate.error("Could not determine path to developer directory: \(error)")
                 return nil
-            }
-
-            if !useStaticPluginInitialization {
-                // In a package context, plugins are statically linked into the build system.
-                // Load specs from service plugins if requested since we don't have a Service in certain tests.
-                await extraPluginRegistration(pluginManager, Self.pluginPaths(inferiorProductsPath: inferiorProductsPath, developerPath: resolvedDeveloperPath))
             }
 
             let core: Core
@@ -314,55 +300,6 @@ public final class Core: Sendable {
     let _coreSettings = UnsafeDelayedInitializationSendableWrapper<CoreSettings>()
     @_spi(Testing) public var coreSettings: CoreSettings {
         _coreSettings.value
-    }
-
-    /// The list of plugin search paths.
-    private static func pluginPaths(inferiorProductsPath: Path?, developerPath: DeveloperPath) -> [Path] {
-        if useStaticPluginInitialization {
-            // In a package context, plugins are statically linked into the build system.
-            return []
-        }
-
-        var result = [Path]()
-
-        // If we are inferior, then search the built products directory first.
-        //
-        // FIXME: This is error prone, as it won't validate that any of these are installed in the expected location.
-        // FIXME: If we remove, move or rename something in the built Xcode, then this will still find the old item in the installed Xcode.
-        if let inferiorProductsPath {
-            result.append(inferiorProductsPath)
-        }
-
-        guard let coreFrameworkPath = try? Bundle(for: Self.self).bundleURL.filePath.dirname else {
-            return result
-        }
-
-        // Search paths relative to SWBCore itself.
-        do {
-            func appendInferior(_ path: Path) {
-                if !developerPath.path.dirname.isAncestor(of: path) {
-                    result.append(path)
-                }
-            }
-
-            // flat layout, when SWBCore is directly nested under BUILT_PRODUCTS_DIR
-            appendInferior(coreFrameworkPath)
-
-            // flat layout, when SWBCore is nested in SWBBuildServiceBundle in SwiftBuild.framework in BUILT_PRODUCTS_DIR
-            appendInferior(coreFrameworkPath.join("../../../../../../.."))
-        }
-
-        // In the superior or a hierarchical build, look for plugins in the build service bundle relative to SWBCore.framework.
-        let pluginPath = coreFrameworkPath.join("../PlugIns")
-        result.append(pluginPath)
-        for subdirectory in (try? localFS.listdir(pluginPath)) ?? [] {
-            let subdirectoryPath = pluginPath.join(subdirectory)
-            if localFS.isDirectory(subdirectoryPath) {
-                result.append(subdirectoryPath)
-            }
-        }
-
-        return result.map { $0.normalize() }
     }
 
     /// The list of toolchain search paths.

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -175,7 +175,7 @@ extension Core {
         if let buildServicePlugInsDirectory = Bundle(for: BuildService.self).builtInPlugInsURL {
             let path = Path(buildServicePlugInsDirectory.path(percentEncoded: false))
             pluginPaths.append(path)
-            
+
             pluginPaths += ((try? localFS.listdir(path)) ?? []).compactMap {
                 let subdirectoryPath = path.join($0)
                 if localFS.isDirectory(subdirectoryPath) {

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -173,7 +173,7 @@ extension Core {
 
         var pluginPaths: [Path] = []
         if let buildServicePlugInsDirectory = Bundle(for: BuildService.self).builtInPlugInsURL {
-            let path = Path(buildServicePlugInsDirectory.path(percentEncoded: false))
+            let path = try buildServicePlugInsDirectory.filePath
             pluginPaths.append(path)
 
             pluginPaths += ((try? localFS.listdir(path)) ?? []).compactMap {

--- a/Sources/SWBTestSupport/CoreTestSupport.swift
+++ b/Sources/SWBTestSupport/CoreTestSupport.swift
@@ -16,6 +16,7 @@ package import SWBUtil
 import SWBTaskConstruction
 import SWBTaskExecution
 import SWBServiceCore
+private import SWBBuildService
 import Testing
 
 #if USE_STATIC_PLUGIN_INITIALIZATION
@@ -170,8 +171,25 @@ extension Core {
             registerExtraPlugins(pluginManager)
         }
 
+        var pluginPaths: [Path] = []
+        if let buildServicePlugInsDirectory = Bundle(for: BuildService.self).builtInPlugInsURL {
+            let path = Path(buildServicePlugInsDirectory.path(percentEncoded: false))
+            pluginPaths.append(path)
+            
+            pluginPaths += ((try? localFS.listdir(path)) ?? []).compactMap {
+                let subdirectoryPath = path.join($0)
+                if localFS.isDirectory(subdirectoryPath) {
+                    return subdirectoryPath
+                } else {
+                    return nil
+                }
+            }
+        }
+
+        await extraPluginRegistration(pluginManager: pluginManager, pluginPaths: pluginPaths)
+
         let delegate = inputDelegate ?? TestingCoreDelegate()
-        guard let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: developerPath, inferiorProductsPath: inferiorProductsPath, extraPluginRegistration: extraPluginRegistration, additionalContentPaths: additionalContentPaths, environment: environment, buildServiceModTime: Date(), connectionMode: .inProcess) else {
+        guard let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: developerPath, inferiorProductsPath: inferiorProductsPath, additionalContentPaths: additionalContentPaths, environment: environment, buildServiceModTime: Date(), connectionMode: .inProcess) else {
             // If we weren't passed a delgate, the caller couldn't possibly have emitted the diagnostics themselves (and CoreInitializationError deliberately doesn't include them in its error output).
             if inputDelegate == nil {
                 // Emit one failure per error, which will be significantly easier to read.

--- a/Sources/SWBUtil/PluginManager.swift
+++ b/Sources/SWBUtil/PluginManager.swift
@@ -72,17 +72,16 @@ import SWBLibc
         // If we found a bundle, load it and look for a registration function.
         let name = path.basename
 
-        let pluginPath: Path
-        let executablePath: Path
-        let pluginIdentifier: String
-        switch path.fileSuffix {
-        case ".bundle":
-            pluginPath = path
-            let shallow = !localFS.exists(path.join("Contents"))
-            let executableBasePath = shallow
-                ? path.join(Path(name).basenameWithoutSuffix)
-                : path.join("Contents").join("MacOS").join(Path(name).basenameWithoutSuffix)
-            executablePath = {
+        func pluginInfo(forPluginAt path: Path,
+                        withShallowBundleTestDirectory shallowBundleTestDirectory: Path,
+                        deepExecutablesDirectory: Path,
+                        infoPlistFile: Path,
+        ) -> (Path, Path, String) {
+            let shallow = !localFS.exists(shallowBundleTestDirectory)
+
+            let executablesDirectory = shallow ? path : deepExecutablesDirectory
+            let executableBasePath = executablesDirectory.join(Path(name).basenameWithoutSuffix)
+            let executablePath = {
                 if let suffix = getEnvironmentVariable("DYLD_IMAGE_SUFFIX")?.nilIfEmpty {
                     let candidate = executableBasePath.appendingFileNameSuffix(suffix)
                     if localFS.exists(candidate) {
@@ -91,15 +90,26 @@ import SWBLibc
                 }
                 return executableBasePath
             }()
-            let infoPlistPath = shallow
-                ? path.join("Info.plist")
-                : path.join("Contents").join("Info.plist")
-            if let plist = try? PropertyList.fromPath(infoPlistPath, fs: localFS), let cfBundleIdentifier = plist.dictValue?["CFBundleIdentifier"]?.stringValue {
+
+            let pluginIdentifier: String
+            if let plist = try? PropertyList.fromPath(infoPlistFile, fs: localFS), let cfBundleIdentifier = plist.dictValue?["CFBundleIdentifier"]?.stringValue {
                 pluginIdentifier = cfBundleIdentifier
             }
             else {
                 pluginIdentifier = path.basename
             }
+
+            return (path, executablePath, pluginIdentifier)
+        }
+
+        let pluginPath: Path
+        let executablePath: Path
+        let pluginIdentifier: String
+        switch path.fileSuffix {
+        case ".bundle":
+            (pluginPath, executablePath, pluginIdentifier) = pluginInfo(forPluginAt: path, withShallowBundleTestDirectory: path.join("Contents"), deepExecutablesDirectory: path.join("Contents").join("MacOS"), infoPlistFile: path.join("Contents").join("Info.plist"))
+        case ".framework":
+            (pluginPath, executablePath, pluginIdentifier) = pluginInfo(forPluginAt: path, withShallowBundleTestDirectory: path.join("Versions"), deepExecutablesDirectory: path.join("Versions").join("Current"), infoPlistFile: path.join("Versions").join("Current").join("Resources").join("Info.plist"))
         default:
             return
         }

--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -571,7 +571,7 @@ extension SWBBuildServiceConnection {
 /// Method by which to launch the build service.
 public enum SWBBuildServiceConnectionMode: Sendable {
     /// Launch the build service in-process, statically with the provided swiftBuildServiceEntryPoint function.
-    case inProcessStatic(@Sendable (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void)
+    case inProcessStatic(@Sendable (Int32, Int32, @Sendable @escaping ((any Error)?) -> Void) -> Void)
 
     /// Launch the build service in-process.
     case inProcess
@@ -669,9 +669,9 @@ fileprivate final class InProcessStaticConnection: ConnectionTransport {
     private let serviceBundleURL: URL?
     private let done = WaitCondition()
     private let _state: LockedValue<SWBBuildServiceConnection.State> = .init(.running)
-    private let startFunc: @Sendable (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void
+    private let startFunc: @Sendable (Int32, Int32, @Sendable @escaping ((any Error)?) -> Void) -> Void
 
-    init(serviceBundleURL: URL?, stdinPipe: IOPipe, stdoutPipe: IOPipe, startFunc: @Sendable @escaping (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void) throws {
+    init(serviceBundleURL: URL?, stdinPipe: IOPipe, stdoutPipe: IOPipe, startFunc: @Sendable @escaping (Int32, Int32, @Sendable @escaping ((any Error)?) -> Void) -> Void) throws {
         self.serviceBundleURL = serviceBundleURL
         self.stdinPipe = stdinPipe
         self.stdoutPipe = stdoutPipe
@@ -697,22 +697,8 @@ fileprivate final class InProcessStaticConnection: ConnectionTransport {
 
         let inputFD = stdinPipe.readEnd.rawValue
         let outputFD = stdoutPipe.writeEnd.rawValue
-
-        let buildServiceLocation = SWBBuildServiceConnection.buildServiceLocation(for: .normal, overridingServiceBundleURL: serviceBundleURL)
-        let buildServicePlugInsDirectory: URL?
-        if let buildServiceLocation, let buildServiceBundle = buildServiceLocation.bundle {
-            buildServicePlugInsDirectory = buildServiceBundle.builtInPlugInsURL
-        } else if let buildServiceLocation: SWBBuildServiceConnection.BuildServiceLocation {
-            let path = SWBUtil.Path(buildServiceLocation.executable.path)
-            buildServicePlugInsDirectory = URL(fileURLWithPath: path.dirname.str, isDirectory: true)
-        } else {
-            // If the build service executable is unbundled, then try to find the build service entry point in this executable.
-            let path = try Library.locate(SWBBuildServiceConnection.self)
-            // If the build service executable is unbundled, assume that any plugins that may exist are next to our executable.
-            buildServicePlugInsDirectory = URL(fileURLWithPath: path.dirname.str, isDirectory: true)
-        }
         launched = true
-        self.startFunc(Int32(inputFD), Int32(outputFD), buildServicePlugInsDirectory, { [done, terminationHandler] error in
+        self.startFunc(Int32(inputFD), Int32(outputFD), { [done, terminationHandler] error in
             defer { done.signal() }
 
             #if !canImport(Darwin)
@@ -770,7 +756,6 @@ fileprivate final class InProcessConnection: ConnectionTransport {
         let buildServiceLocation = SWBBuildServiceConnection.buildServiceLocation(for: variant, overridingServiceBundleURL: serviceBundleURL)
 
         let handle: LibraryHandle
-        let buildServicePlugInsDirectory: URL?
         if let buildServiceLocation, let buildServiceBundle = buildServiceLocation.bundle {
             guard let buildServiceFrameworkURL = buildServiceBundle.privateFrameworksURL?.appendingPathComponent("SWBBuildService.framework", isDirectory: true) else {
                 throw StubError.error("cannot determine build service framework URL in build service bundle")
@@ -796,27 +781,21 @@ fileprivate final class InProcessConnection: ConnectionTransport {
             } catch {
                 throw StubError.error("unable to open build service framework executable at '\(buildServiceFrameworkExecutablePath.str)': \(error)")
             }
-
-            buildServicePlugInsDirectory = buildServiceBundle.builtInPlugInsURL
         } else if let buildServiceLocation {
             let path = SWBUtil.Path(buildServiceLocation.executable.path)
             handle = try Library.open(path)
-            buildServicePlugInsDirectory = URL(fileURLWithPath: path.dirname.str, isDirectory: true)
         } else {
             // If the build service executable is unbundled, then try to find the build service entry point in this executable.
             let path = try Library.locate(SWBBuildServiceConnection.self)
             handle = try Library.open(path)
-
-            // If the build service executable is unbundled, assume that any plugins that may exist are next to our executable.
-            buildServicePlugInsDirectory = URL(fileURLWithPath: path.dirname.str, isDirectory: true)
         }
 
         let entryPointName = "swiftbuildServiceEntryPoint"
         #if !canImport(Darwin)
         // Workaround for a compiler crash presumably related to Objective-C bridging on non-Darwin platforms (rdar://130826719&136043295)
-        typealias swiftbuildServiceEntryPoint_t = @convention(c) (Int32, Int32, URL?, @Sendable @escaping (Any) -> Void) -> Void
+        typealias swiftbuildServiceEntryPoint_t = @convention(c) (Int32, Int32, @Sendable @escaping (Any) -> Void) -> Void
         #else
-        typealias swiftbuildServiceEntryPoint_t = @convention(c) (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void
+        typealias swiftbuildServiceEntryPoint_t = @convention(c) (Int32, Int32, @Sendable @escaping ((any Error)?) -> Void) -> Void
         #endif
         guard let entryPointFunc: swiftbuildServiceEntryPoint_t = Library.lookup(handle, entryPointName) else {
             throw StubError.error("unable to find \(entryPointName) function in service executable")
@@ -827,7 +806,7 @@ fileprivate final class InProcessConnection: ConnectionTransport {
 
         // Launch the service, in process (on background queues).
         launched = true
-        entryPointFunc(Int32(inputFD), Int32(outputFD), buildServicePlugInsDirectory, { [done, terminationHandler] error in
+        entryPointFunc(Int32(inputFD), Int32(outputFD), { [done, terminationHandler] error in
             defer { done.signal() }
 
             #if !canImport(Darwin)


### PR DESCRIPTION
* Plug-ins are now allowed to be frameworks instead of bundles.
* Assume plug-ins are relative to the SWBBuildService library instead of the SWBBuildService bundle.
* In support of this, removed the `pluginsDirectory` parameter from the build service entry point.
* Also reworked the responsibility for plug-in registration in tests so it's part of CoreTestSupport.swift directly.

This is part of &lt;rdar://problem/172848427&gt;.