### PR TITLE
Route swift-driver incremental build diagnostics through the build message system

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1543,7 +1543,11 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
             // If the build failed, make sure we flush any pending incremental build records.
             // Usually, driver instances are cleaned up and write out their incremental build records when a target finishes building. However, this won't necessarily be the case if the build fails. Ensure we write out any pending records before tearing down the graph so we don't use a stale record on a subsequent build.
             if !buildSucceeded {
-                self.dynamicOperationContext.swiftModuleDependencyGraph.cleanUpForAllKeys()
+                self.dynamicOperationContext.swiftModuleDependencyGraph.cleanUpForAllKeys { [buildOutputDelegate = self.buildOutputDelegate] diagnostics in
+                    for diagnostic in diagnostics {
+                        buildOutputDelegate.emit(diagnostic)
+                    }
+                }
             }
 
             // Reset the DynamicOperationContext to free cached info from the finished build.
@@ -1720,7 +1724,11 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
         // First, give it a chance to write out incremental state
         let driverIdentifiers = operation.buildDescription.taskStore.tasksForTarget(target).compactMap { ($0.payload as? SwiftTaskPayload)?.driverPayload?.uniqueID }
         for identifier in Set(driverIdentifiers) {
-            dynamicOperationContext.swiftModuleDependencyGraph.cleanUp(key: identifier)
+            dynamicOperationContext.swiftModuleDependencyGraph.cleanUp(key: identifier) { [buildOutputDelegate] diagnostics in
+                for diagnostic in diagnostics {
+                    buildOutputDelegate.emit(diagnostic)
+                }
+            }
         }
     }
 

--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -252,20 +252,26 @@ public final class SwiftModuleDependencyGraph: SwiftGlobalExplicitDependencyGrap
     }
 
     /// Serialize incremental build state for the given key and removes its state from memory
-    public func cleanUpForAllKeys() {
+    public func cleanUpForAllKeys(diagnosticsHandler: (([SWBUtil.Diagnostic]) -> Void)?) {
         registryQueue.async {
             for driver in self.registry.values {
-                driver.writeIncrementalBuildInformation()
+                let diagnostics = driver.writeIncrementalBuildInformation()
+                if !diagnostics.isEmpty {
+                    diagnosticsHandler?(diagnostics)
+                }
             }
             self.registry.removeAll()
         }
     }
 
     /// Serialize incremental build state for the given key and removes its state from memory
-    public func cleanUp(key: String) {
+    public func cleanUp(key: String, diagnosticsHandler: (([SWBUtil.Diagnostic]) -> Void)?) {
         registryQueue.async {
             if let driver = self.registry.removeValue(forKey: key) {
-                driver.writeIncrementalBuildInformation()
+                let diagnostics = driver.writeIncrementalBuildInformation()
+                if !diagnostics.isEmpty {
+                    diagnosticsHandler?(diagnostics)
+                }
             }
         }
     }
@@ -613,13 +619,17 @@ public final class LibSwiftDriver {
         }
     }
 
-    /// Serialize this driver's incremental build state
-    public func writeIncrementalBuildInformation() {
+    /// Serializes incremental build state and returns any diagnostics emitted during serialization
+    /// (e.g. "next compile won't be incremental"). Uses a snapshot-delta of the accumulated
+    /// diagnostics engine so only diagnostics produced by this call are returned.
+    public func writeIncrementalBuildInformation() -> [SWBUtil.Diagnostic] {
+        let beforeCount = diagnosticsEngine.diagnostics.count
         driver.writeIncrementalBuildInformation(plannedBuild.driverTargetJobs)
+        return diagnosticsEngine.diagnostics.dropFirst(beforeCount).map { .build(from: $0) }
     }
 
     static func frontendCommandLine(compilerLocation: CompilerLocation, inputPath: Path, workingDirectory: Path, tempDirPath: Path, explicitModulesTempDirPath: Path, commandLine: [String], environment: [String: String], eagerCompilationEnabled: Bool, casOptions: CASOptions?) -> (commandLine: [String]?, diagnostics: [SWBUtil.Diagnostic]) {
-        let diagnosticsEngine = TSCBasic.DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
+        let diagnosticsEngine = TSCBasic.DiagnosticsEngine(handlers: [])
         do {
             let shim = try LibSwiftDriver(graph: nil, compilerLocation: compilerLocation, target: nil, workingDirectory: workingDirectory, tempDirPath: tempDirPath, explicitModulesTempDirPath: explicitModulesTempDirPath, commandLine: commandLine, environment: environment, eagerCompilationEnabled: eagerCompilationEnabled, diagnosticsEngine: diagnosticsEngine, casOptions: casOptions)
             let (success, diagnostics, jobs) = shim.run(dryRun: true)
@@ -649,7 +659,7 @@ public final class LibSwiftDriver {
     }
 
     fileprivate static func createAndPlan(for graph: SwiftModuleDependencyGraph, compilerLocation: CompilerLocation, target: ConfiguredTarget, workingDirectory: Path, tempDirPath: Path, explicitModulesTempDirPath: Path, commandLine: [String], environment: [String: String], eagerCompilationEnabled: Bool, casOptions: CASOptions?) -> (driver: LibSwiftDriver?, diagnostics: [SWBUtil.Diagnostic]) {
-        let diagnosticsEngine = TSCBasic.DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
+        let diagnosticsEngine = TSCBasic.DiagnosticsEngine(handlers: [])
 
         do {
             let shim = try LibSwiftDriver(graph: graph, compilerLocation: compilerLocation, target: target, workingDirectory: workingDirectory, tempDirPath: tempDirPath, explicitModulesTempDirPath: explicitModulesTempDirPath, commandLine: commandLine, environment: environment, eagerCompilationEnabled: eagerCompilationEnabled, diagnosticsEngine: diagnosticsEngine, casOptions: casOptions)

--- a/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CustomTaskBuildOperationTests.swift
@@ -104,6 +104,8 @@ fileprivate struct CustomTaskBuildOperationTests: CoreBasedTests {
 
             try await tester.checkBuild(parameters: parameters, runDestination: .host) { results in
                 results.checkWarning(.contains("this is a warning"))
+                // The swift-driver may emit this warning when it can't write incremental build state (e.g. permission issues in some CI environments).
+                results.checkWarning(.contains("next compile won't be incremental"), failIfNotFound: false)
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -266,6 +266,8 @@ fileprivate struct LinkerTests: CoreBasedTests {
                         #expect(installedLinkerPaths.map { $0.str }.contains(where: cleanedLinkerOutput.contains), "The default linker chosen by clang is not among the known installed linker paths: \(installedLinkerPaths.map { $0.str }.joined(separator: ", ")). The default linker is indicated by clang's output:\n\(cleanedLinkerOutput)")
                     }
                 }
+                // The swift-driver may emit this warning when it can't write incremental build state (e.g. permission issues in some CI environments).
+                results.checkWarning(.contains("next compile won't be incremental"), failIfNotFound: false)
                 results.checkNoDiagnostics()
             }
 


### PR DESCRIPTION
`writeIncrementalBuildInformation()` was emitting diagnostics (e.g. "warning: next compile won't be incremental") directly to stderr via `Driver.stderrDiagnosticsHandler`. In `inProcessStatic` mode (used by swift-package-manager), this bypasses the build message system entirely, causing warnings to appear on the wrong output stream with no way for the caller to intercept, deduplicate, or properly position them relative to progress output.

Changes:
- `LibSwiftDriver.writeIncrementalBuildInformation()` now captures diagnostics emitted during serialization using a snapshot-delta of the accumulated `diagnosticsEngine.diagnostics` array and returns them as `[SWBUtil.Diagnostic]` instead of writing to stderr.
- `DiagnosticsEngine` in `createAndPlan` and `frontendCommandLine` is created with an empty handler list instead of `[stderrDiagnosticsHandler]`. All diagnostics from those paths are already captured via `diagnosticsEngine.diagnostics` and returned to callers; the stderr handler was the source of double-writes.
- `SwiftModuleDependencyGraph.cleanUp(key:)` and `cleanUpForAllKeys()` gain an optional `diagnosticsHandler` callback (default `nil`, preserving backward compatibility at all existing call sites).
- `BuildOperation` wires up the handler at both call sites to emit cleanup diagnostics via `buildOutputDelegate.emit(_:)`, routing them through the same structured build output path as all other diagnostics.
