### PR TITLE
Don't try to copy codesigning xattrs on non-Darwin platforms

### DIFF
--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -205,12 +205,14 @@ let code_sign_attributes = [
 ]
 
 fileprivate func copyCodesignAttr(_ srcPath: Path, _ dstPath: Path) throws {
+    #if canImport(Darwin)
     let ext_attrs = try localFS.listExtendedAttributes(srcPath)
     for attr in ext_attrs {
         if code_sign_attributes.contains(attr) {
             try copyXattr(srcPath, dstPath, attr)
         }
     }
+    #endif
     return
 }
 


### PR DESCRIPTION
When the `swift-build` build system is in use and the underlying filesystem does not support extended attributes (either due to actual lack of support or because the `no_xattr` `mount(8)` flag is set), builds fail because `PbxCp`'s attempt to copy codesigning attributes requests a list of xattrs and `ENOTSUP (95)` is returned from `listxattr(2)`. As a straightforward fix, this PR elides the attempt to copy codesigning xattrs on non-Darwin platforms, and leaves the larger issue of supporting `no_xattr` filesystems in general as a future improvement. This problem appears most visibly when using bind mounts with Docker Desktop for Mac, due to the VirtioFS driver sometimes creating mounts with the `no_xattr` flag (it is not clear whether this affects all configurations or only some; clearing the flag via `mount -o remount,...` results in everything working as expected, so it appears to be a bug).