### PR TITLE
Track dSYM bundle directory for stale file removal

### DIFF
--- a/Sources/SWBCore/PlannedTask.swift
+++ b/Sources/SWBCore/PlannedTask.swift
@@ -107,6 +107,9 @@ public protocol PlannedTask: AnyObject, CustomStringConvertible, Sendable, Plann
 
     /// The scope for stale file removal tracking of this task's outputs.
     var staleFileRemovalScope: StaleFileRemovalScope { get }
+
+    /// Additional paths to track for stale file removal beyond the task's declared outputs.
+    var additionalSFRPaths: [Path] { get }
 }
 
 /// Represents the priority of a task in relation to other tasks which may be ready to run at the same time.
@@ -170,6 +173,8 @@ public final class ConstructedTask: PlannedTask, Sendable {
 
     public let staleFileRemovalScope: StaleFileRemovalScope
 
+    public let additionalSFRPaths: [Path]
+
     /// Criteria for determining if this task should be included in the build plan.
     public let validityCriteria: (any TaskValidityCriteria)?
 
@@ -187,6 +192,7 @@ public final class ConstructedTask: PlannedTask, Sendable {
         self.priority = builder.priority
         self.repairViaOwnershipAnalysis = builder.repairViaOwnershipAnalysis
         self.staleFileRemovalScope = builder.staleFileRemovalScope
+        self.additionalSFRPaths = builder.additionalSFRPaths
         self.validityCriteria = builder.validityCriteria
     }
 
@@ -272,6 +278,8 @@ public final class GateTask: PlannedTask, Sendable {
     public var repairViaOwnershipAnalysis: Bool { false }
 
     public var staleFileRemovalScope: StaleFileRemovalScope { .target }
+
+    public var additionalSFRPaths: [Path] { [] }
 
     /// Gate tasks never have validity criteria.
     public var validityCriteria: (any TaskValidityCriteria)? { nil }

--- a/Sources/SWBCore/SpecImplementations/Tools/DsymutilTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/DsymutilTool.swift
@@ -58,6 +58,14 @@ public final class DsymutilToolSpec : GenericCommandLineToolSpec, SpecIdentifier
 
         let inputs: [any PlannedNode] = cbc.inputs.map({ delegate.createNode($0.absolutePath) }) + cbc.commandOrderingInputs
         let outputs: [any PlannedNode] = [delegate.createNode(output), orderingOutputNode] + cbc.commandOrderingOutputs
-        delegate.createTask(type: self, ruleInfo: ruleInfo, commandLine: commandLine, environment: environmentFromSpec(cbc, delegate), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs, outputs: outputs, action: nil, execDescription: resolveExecutionDescription(templateBuildContext, delegate), enableSandboxing: enableSandboxing)
+
+        var builder = PlannedTaskBuilder(type: self, ruleInfo: ruleInfo, commandLine: commandLine.map { .literal(ByteString(encodingAsUTF8: $0)) }, environment: environmentFromSpec(cbc, delegate), enableSandboxing: enableSandboxing)
+        builder.workingDirectory = cbc.producer.defaultWorkingDirectory
+        builder.inputs = inputs
+        builder.outputs = outputs
+        builder.execDescription = resolveExecutionDescription(templateBuildContext, delegate)
+        // Track the dSYM bundle for stale file removal so the entire bundle is cleaned up.
+        builder.additionalSFRPaths = [dsymBundle]
+        delegate.createTask(&builder)
     }
 }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -695,6 +695,9 @@ public struct PlannedTaskBuilder {
 
     public var staleFileRemovalScope: StaleFileRemovalScope = .target
 
+    /// Additional paths to track for stale file removal beyond the task's declared outputs.
+    public var additionalSFRPaths: [Path] = []
+
     public var validityCriteria: (any TaskValidityCriteria)?
 
     public init(type: any TaskTypeDescription, ruleInfo: [String], additionalSignatureData: String = "", commandLine: [CommandLineArgument], additionalOutput: [String] = [], environment: EnvironmentBindings = EnvironmentBindings(), inputs: [any PlannedNode] = [], outputs: [any PlannedNode] = [], mustPrecede: [any PlannedTask] = [], deps: DependencyDataStyle? = nil, additionalTaskOrderingOptions: TaskOrderingOptions = [], usesExecutionInputs: Bool = false, alwaysExecuteTask: Bool = false, showInLog: Bool = true, showCommandLineInLog: Bool = true, priority: TaskPriority = .unspecified, enableSandboxing: Bool = false, repairViaOwnershipAnalysis: Bool = false, validityCriteria: (any TaskValidityCriteria)? = nil) {

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -1080,6 +1080,7 @@ extension BuildDescription {
 
                 var outputs = outputPathsPerTarget[sfrTarget] ?? [Path]()
                 outputs.append(contentsOf: task.outputs.map { $0.path }.filter { !$0.str.isEmpty })
+                outputs.append(contentsOf: task.additionalSFRPaths)
                 outputPathsPerTarget[sfrTarget] = outputs
             }
 

--- a/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
@@ -301,4 +301,68 @@ fileprivate struct DsymGenerationBuildOperationTests: CoreBasedTests {
         }
     }
 
+    /// Test that when switching BUILD_VARIANTS from "normal asan" to "normal"
+    /// SFR does not remove the dSYM bundle.
+    @Test(.requireSDKs(.macOS))
+    func dSYMBundlePreservedWhenBuildVariantRemoved() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "SomeFiles", path: "Sources",
+                            children: [
+                                TestFile("main.c"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+                                ]),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "CoreFoo", type: .framework,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["main.c"])]),
+                        ])])
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/main.c")) { stream in
+                stream <<< "int foo = 42;"
+            }
+
+            let dsymBundlePath = SRCROOT.join("build/Debug/CoreFoo.framework.dSYM")
+
+            // Build with two variants so both produce DWARF binaries in the same dSYM bundle.
+            let multiVariantParams = BuildParameters(configuration: "Debug", overrides: [
+                "BUILD_VARIANTS": "normal asan",
+                "ENABLE_ADDRESS_SANITIZER": "YES",
+            ])
+            try await tester.checkBuild(parameters: multiVariantParams, runDestination: .macOS, persistent: true) { results in
+                results.consumeTasksMatchingRuleTypes()
+                results.checkTasks(.matchRuleType("GenerateDSYMFile")) { tasks in
+                    #expect(tasks.count >= 1)
+                }
+                results.checkNoErrors()
+            }
+            #expect(tester.fs.exists(dsymBundlePath), "dSYM bundle should exist after multi variant build")
+
+            // Switch to single variant. SFR should not remove the dSYM bundle.
+            let singleVariantParams = BuildParameters(configuration: "Debug", overrides: [
+                "BUILD_VARIANTS": "normal",
+            ])
+            try await tester.checkBuild(parameters: singleVariantParams, runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+            #expect(tester.fs.exists(dsymBundlePath), "dSYM bundle should still exist after switching to single variant")
+        }
+    }
+
 }

--- a/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/DsymGenerationBuildOperationTests.swift
@@ -228,4 +228,77 @@ fileprivate struct DsymGenerationBuildOperationTests: CoreBasedTests {
         }
     }
 
+    /// Test that switching DEBUG_INFORMATION_FORMAT between dwarf-with-dsym and dwarf
+    /// correctly generates/removes the dSYM bundle via stale file removal and switching
+    /// back to dwarf-with-dsym generates a valid dSYM. Regression test for rdar://19063463.
+    @Test(.requireSDKs(.macOS))
+    func dSYMBundleCleanupOnDebugInfoFormatChange() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "SomeFiles", path: "Sources",
+                            children: [
+                                TestFile("main.c"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                ]),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "CoreFoo", type: .framework,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["main.c"])]),
+                        ])])
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/main.c")) { stream in
+                stream <<< "int foo = 42;"
+            }
+
+            let dsymBundlePath = SRCROOT.join("build/Debug/CoreFoo.framework.dSYM")
+            let dsymDwarfPath = dsymBundlePath.join("Contents/Resources/DWARF/CoreFoo")
+
+            // Build with dwarf-with-dsym. dSYM bundle should be created.
+            let dsymParams = BuildParameters(configuration: "Debug", overrides: [
+                "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+            ])
+            try await tester.checkBuild(parameters: dsymParams, runDestination: .macOS, persistent: true) { results in
+                results.consumeTasksMatchingRuleTypes()
+                results.checkTask(.matchRuleType("GenerateDSYMFile")) { _ in }
+                results.checkNoErrors()
+            }
+            #expect(tester.fs.exists(dsymBundlePath), "dSYM bundle should exist after dwarf-with-dsym build")
+            #expect(tester.fs.exists(dsymDwarfPath), "DWARF binary should exist inside dSYM bundle")
+
+            // Rebuild with dwarf. SFR should remove the entire dSYM bundle.
+            let dwarfParams = BuildParameters(configuration: "Debug", overrides: [
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+            ])
+            try await tester.checkBuild(parameters: dwarfParams, runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+            #expect(!tester.fs.exists(dsymDwarfPath), "DWARF binary should be removed after switching to dwarf")
+            #expect(!tester.fs.exists(dsymBundlePath), "dSYM bundle should be fully removed after switching to dwarf")
+
+            // Switch back to dwarf-with-dsym. dSYM should be regenerated with valid content.
+            try await tester.checkBuild(parameters: dsymParams, runDestination: .macOS, persistent: true) { results in
+                results.consumeTasksMatchingRuleTypes()
+                results.checkTask(.matchRuleType("GenerateDSYMFile")) { _ in }
+                results.checkNoErrors()
+            }
+            #expect(tester.fs.exists(dsymBundlePath), "dSYM bundle should be regenerated after switching back to dwarf-with-dsym")
+            #expect(tester.fs.exists(dsymDwarfPath), "DWARF binary should exist in regenerated dSYM bundle")
+        }
+    }
+
 }


### PR DESCRIPTION
SFR only tracked the DWARF binary inside the dSYM bundle, leaving the dSYM directory and skeleton behind when switching DEBUG_INFORMATION_FORMAT from dwarf-with-dsym to dwarf.

Add additionalSFRPaths to PlannedTask so tasks can register paths for SFR tracking that aren't formal task outputs and use it to register the dSYM bundle directory.

rdar://19063463