### PR TITLE
Add explicit precompiled module cache pruning

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1148,6 +1148,10 @@ private class InProcessCommand: SWBLLBuild.ExternalCommand, SWBLLBuild.ExternalD
         self.adaptor = adaptor
     }
 
+    var outputs: [String] {
+        task.isDynamic ? task.outputPaths.map(\.str) : []
+    }
+
     func getSignature(_ command: Command) -> [UInt8] {
         let signature = action.getSignature(task, executionDelegate: adaptor.operation).bytes
         return signature
@@ -1535,6 +1539,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
             cleanupCompilationCache()
         }
         cleanupGlobalModuleCache()
+        pruneExplicitPrecompiledModules()
 
         await queue.sync {
             self.isCompleted = true
@@ -1636,6 +1641,64 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
                 emit(diagnostic: Diagnostic.init(behavior: .warning, location: .unknown, data: DiagnosticData("Failed to remove \(cachePath): \(error.localizedDescription)")), for: activity, signature: signature)
             }
             return .succeeded
+        }
+    }
+
+    /// Prune stale files from the explicit precompiled modules directories.
+    ///
+    /// When the compilation context changes new pcm variants with different context hashes
+    //  are created but old variants are never removed.
+    /// Uses the libclang clang_ModuleCache_prune API which removes stale .pcm files based on
+    /// access time. Uses CLANG_MODULES_PRUNE_AFTER and CLANG_MODULES_PRUNE_INTERVAL.
+    func pruneExplicitPrecompiledModules() {
+        var directories = Set<Path>()
+        var pruneAfter: TimeInterval = 604800  // 7 days default
+        var pruneInterval: TimeInterval = 86400 // 1 day default
+        var libclangPath: Path?
+        for target in operation.buildDescription.targetTaskCounts.keys {
+            let targetSettings = operation.requestContext.getCachedSettings(operation.request.parameters, target: target.target)
+            directories.insert(targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_EXPLICIT_MODULES_OUTPUT_PATH))
+            directories.insert(targetSettings.globalScope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH))
+            if let value = TimeInterval(targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_MODULES_PRUNE_AFTER)) {
+                pruneAfter = value
+            }
+            if let value = TimeInterval(targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_MODULES_PRUNE_INTERVAL)) {
+                pruneInterval = value
+            }
+            let path = targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_EXPLICIT_MODULES_LIBCLANG_PATH)
+            if !path.isEmpty {
+                libclangPath = Path(path)
+            }
+        }
+
+        guard pruneAfter > 0 else {
+            return
+        }
+        let existingDirectories = directories.filter { !$0.isEmpty && operation.fs.exists($0) }
+        guard !existingDirectories.isEmpty else {
+            return
+        }
+
+        guard let libclangPath,
+              let libclang = core.lookupLibclang(path: libclangPath).libclang,
+              libclang.supportsModuleCachePruning else {
+            return
+        }
+
+        for dirPath in existingDirectories {
+            let signatureCtx = InsecureHashContext()
+            signatureCtx.add(string: "PruneExplicitPrecompiledModules")
+            signatureCtx.add(string: dirPath.str)
+            let signature = signatureCtx.signature
+
+            withActivity(ruleInfo: "PruneExplicitPrecompiledModules \(dirPath.str)", executionDescription: "Prune stale explicit modules at \(dirPath.str)", signature: signature, target: nil, parentActivity: nil) { _ in
+                libclang.pruneModuleCache(
+                    path: dirPath.str,
+                    interval: Int(pruneInterval),
+                    expiration: Int(pruneAfter)
+                )
+                return .succeeded
+            }
         }
     }
 

--- a/Sources/SWBCSupport/CLibclang.cpp
+++ b/Sources/SWBCSupport/CLibclang.cpp
@@ -1321,6 +1321,13 @@ extern "C" {
          * Replaces currently installed error handler (if any).
          */
         void (*clang_install_aborting_llvm_fatal_error_handler)();
+
+        /**
+         * Prune module files in a module cache directory by access time.
+         */
+        void (*clang_ModuleCache_prune)(const char *Path,
+                                        time_t PruneInterval,
+                                        time_t PruneAfter);
     };
 }
 
@@ -1508,6 +1515,7 @@ struct LibclangWrapper {
         LOOKUP_OPTIONAL(clang_Driver_getExternalActionsForCommand_v0);
         LOOKUP_OPTIONAL(clang_Driver_ExternalActionList_dispose);
         LOOKUP_OPTIONAL(clang_install_aborting_llvm_fatal_error_handler);
+        LOOKUP_OPTIONAL(clang_ModuleCache_prune);
 #undef LOOKUP
 #undef LOOKUP_OPTIONAL
 #undef LOOKUP_OPTIONAL_DEPENDENCY_SCANNER_API
@@ -2518,6 +2526,16 @@ extern "C" {
         lib->fns.clang_disposeString(diagText);
         lib->fns.clang_experimental_cas_ReplayResult_dispose(cxReplayRes);
         return true;
+    }
+
+    bool libclang_has_module_cache_pruning_feature(libclang_t lib) {
+        return lib->wrapper->fns.clang_ModuleCache_prune != nullptr;
+    }
+
+    void libclang_prune_module_cache(libclang_t lib, const char *path, time_t prune_interval, time_t prune_after) {
+        if (!lib->wrapper->fns.clang_ModuleCache_prune)
+            return;
+        lib->wrapper->fns.clang_ModuleCache_prune(path, prune_interval, prune_after);
     }
 
 }

--- a/Sources/SWBCSupport/CLibclang.h
+++ b/Sources/SWBCSupport/CLibclang.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <time.h>
 
 #include "CSupportDefines.h"
 
@@ -172,6 +173,17 @@ CSUPPORT_EXPORT bool libclang_casdatabases_set_ondisk_size_limit(libclang_casdat
 ///
 /// \returns true if there was an error, false otherwise.
 CSUPPORT_EXPORT bool libclang_casdatabases_prune_ondisk_data(libclang_casdatabases_t, void (^error_callback)(const char *));
+
+/// Whether the libclang has module cache pruning support.
+CSUPPORT_EXPORT bool libclang_has_module_cache_pruning_feature(libclang_t lib);
+
+/// Prune module files in a module cache directory that haven't been accessed
+/// in a long time. Handles both flat layouts and two-level layouts.
+///
+/// \param path           Directory to prune (must exist).
+/// \param prune_interval Minimum seconds between prune operations.
+/// \param prune_after    Remove module files not accessed within this many seconds.
+CSUPPORT_EXPORT void libclang_prune_module_cache(libclang_t lib, const char *path, time_t prune_interval, time_t prune_after);
 
 /// A callback to get the name of a given output.
 ///

--- a/Sources/SWBCore/LibclangVendored/Libclang.swift
+++ b/Sources/SWBCore/LibclangVendored/Libclang.swift
@@ -110,6 +110,14 @@ public final class Libclang {
     public var supportsReproducerGeneration: Bool {
         libclang_has_reproducer_feature(lib)
     }
+
+    public var supportsModuleCachePruning: Bool {
+        libclang_has_module_cache_pruning_feature(lib)
+    }
+
+    public func pruneModuleCache(path: String, interval: Int, expiration: Int) {
+        libclang_prune_module_cache(lib, path, time_t(interval), time_t(expiration))
+    }
 }
 
 enum DependencyScanningError: Error {

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/PrecompileClangModuleDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/PrecompileClangModuleDynamicTaskSpec.swift
@@ -144,6 +144,8 @@ final class PrecompileClangModuleDynamicTaskSpec: DynamicTaskSpec {
             execDescription = "Compiling Clang module \(moduleName)"
         }
 
+        let pcmPath = Path(PrecompileClangModuleTaskKey.dependencyInfoPath.withoutSuffix + ".pcm")
+
         return Task(
             type: self,
             dependencyData: .makefile(Path(PrecompileClangModuleTaskKey.dependencyInfoPath.withoutSuffix + ".d")),
@@ -155,6 +157,7 @@ final class PrecompileClangModuleDynamicTaskSpec: DynamicTaskSpec {
             workingDirectory: dynamicTask.workingDirectory,
             showEnvironment: dynamicTask.showEnvironment,
             execDescription: execDescription,
+            outputPaths: [pcmPath],
             isDynamic: true
         )
     }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverJobDynamicTaskSpec.swift
@@ -149,6 +149,7 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
         let isUsingWholeModuleOptimization: Bool
         let compilerLocation: LibSwiftDriver.CompilerLocation
         let casOpts: CASOptions?
+        let taskOutputPaths: [Path]
         switch dynamicTask.taskKey {
         case .swiftDriverJob(let key):
             guard let job = try context.swiftModuleDependencyGraph.queryPlannedBuild(for: key.identifier).plannedTargetJob(for: key.driverJobKey)?.driverJob else {
@@ -185,6 +186,9 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
             isUsingWholeModuleOptimization = key.isUsingWholeModuleOptimization
             compilerLocation = key.compilerLocation
             casOpts = key.casOptions
+            // Not tracking outputs for regular driver jobs yet due to
+            // ObjC header duplicate producer issue (rdar://88393903).
+            taskOutputPaths = []
         case .swiftDriverExplicitDependencyJob(let key):
             guard let job = context.swiftModuleDependencyGraph.plannedExplicitDependencyBuildJob(for: key.driverJobKey)?.driverJob else {
                 throw StubError.error("Failed to lookup explicit modules Swift driver job \(key.driverJobKey)")
@@ -199,6 +203,7 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
             isUsingWholeModuleOptimization = false
             compilerLocation = key.compilerLocation
             casOpts = key.casOptions
+            taskOutputPaths = job.outputs
         default:
             fatalError("Unexpected dynamic task: \(dynamicTask)")
         }
@@ -219,6 +224,7 @@ final class SwiftDriverJobDynamicTaskSpec: DynamicTaskSpec {
                     showEnvironment: dynamicTask.showEnvironment,
                     execDescription: descriptionForLifecycle,
                     preparesForIndexing: true,
+                    outputPaths: taskOutputPaths,
                     showCommandLineInLog: false,
                     isDynamic: true
                 )

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -413,6 +413,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    package static var requireModuleCachePruning: Self {
+        enabled {
+            let libclang = try #require(try await ConditionTraitContext.shared.libclang)
+            return libclang.supportsModuleCachePruning
+        }
+    }
+
     package static var requireDependencyScannerPlusCaching: Self {
         disabled {
             let libclang = try #require(try await ConditionTraitContext.shared.libclang)

--- a/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
+++ b/Tests/SWBBuildSystemTests/StaleFileRemovalTests.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import class Foundation.ProcessInfo
+import struct Foundation.Date
+import struct Foundation.URL
+import struct Foundation.URLResourceValues
 
 import Testing
 
@@ -809,6 +812,350 @@ fileprivate struct StaleFileRemovalTests: CoreBasedTests {
             #expect(!debugTBDsAfterRelease.isEmpty, "Debug EagerLinkingTBDs should survive after workspace B's Release build because workspace SFR key is configuration-specific")
         }
     }
+
+    /// Test that stale pcm files in ExplicitPrecompiledModules directories are pruned after a build.
+    @Test(.requireSDKs(.macOS), .requireModuleCachePruning)
+    func pruneStaleExplicitPrecompiledModules() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let buildDir = tmpDirPath.join("build")
+
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("file.c"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "CLANG_ENABLE_MODULES": "YES",
+                                "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "CLANG_MODULES_PRUNE_AFTER": "345600",
+                                "CLANG_MODULES_PRUNE_INTERVAL": "1",
+                                "OBJROOT": buildDir.str,
+                                "SYMROOT": buildDir.str,
+                                "DSTROOT": buildDir.str,
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Library",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["file.c"]),
+                                ]),
+                        ])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
+                stream <<<
+                """
+                #include <stdio.h>
+                int something = 1;
+                """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let explicitModulesDir = buildDir.join("ExplicitPrecompiledModules")
+            let swiftExplicitModulesDir = buildDir.join("SwiftExplicitPrecompiledModules")
+
+            let staleDate = Date().addingTimeInterval(-500000) // ~5.8 days ago
+            let freshDate = Date().addingTimeInterval(-100000) // ~1.2 days ago
+
+            let stalePcm = explicitModulesDir.join("stale_module-DEADBEEF.pcm")
+            let freshPcm = explicitModulesDir.join("fresh_module-CAFEBABE.pcm")
+
+            try localFS.createDirectory(explicitModulesDir, recursive: true)
+            try localFS.write(stalePcm, contents: ByteString(encodingAsUTF8: "stale"))
+            try localFS.write(freshPcm, contents: ByteString(encodingAsUTF8: "fresh"))
+            try setAccessTime(stalePcm, to: staleDate)
+            try setAccessTime(freshPcm, to: freshDate)
+
+            let staleSwiftPcm = swiftExplicitModulesDir.join("stale_swift-DEADBEEF.pcm")
+            try localFS.createDirectory(swiftExplicitModulesDir, recursive: true)
+            try localFS.write(staleSwiftPcm, contents: ByteString(encodingAsUTF8: "stale_swift"))
+            try setAccessTime(staleSwiftPcm, to: staleDate)
+
+            // Backdate the modules.timestamp files so the prune interval check passes.
+            let oldTimestamp = Int(Date().addingTimeInterval(-100).timeIntervalSince1970)
+            for dir in [explicitModulesDir, swiftExplicitModulesDir] {
+                let timestampPath = dir.join("modules.timestamp")
+                if localFS.exists(timestampPath) {
+                    try localFS.setFileTimestamp(timestampPath, timestamp: oldTimestamp)
+                }
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            #expect(!localFS.exists(stalePcm), "Stale pcm in ExplicitPrecompiledModules should be pruned")
+            #expect(!localFS.exists(staleSwiftPcm), "Stale pcm in SwiftExplicitPrecompiledModules should be pruned")
+            #expect(localFS.exists(freshPcm), "Fresh pcm should survive pruning")
+        }
+    }
+
+    /// Test that pruning is throttled by CLANG_MODULES_PRUNE_INTERVAL.
+    @Test(.requireSDKs(.macOS), .requireModuleCachePruning)
+    func pruneExplicitPrecompiledModulesIntervalThrottling() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let buildDir = tmpDirPath.join("build")
+
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("file.c"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "CLANG_ENABLE_MODULES": "YES",
+                                "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "CLANG_MODULES_PRUNE_AFTER": "345600",
+                                "CLANG_MODULES_PRUNE_INTERVAL": "999999",
+                                "OBJROOT": buildDir.str,
+                                "SYMROOT": buildDir.str,
+                                "DSTROOT": buildDir.str,
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Library",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["file.c"]),
+                                ]),
+                        ])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
+                stream <<<
+                """
+                #include <stdio.h>
+                int something = 1;
+                """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let explicitModulesDir = buildDir.join("ExplicitPrecompiledModules")
+            let lastPrunedPath = explicitModulesDir.join("modules.timestamp")
+            #expect(localFS.exists(lastPrunedPath), "modules.timestamp should exist after first build")
+
+            let staleDate = Date().addingTimeInterval(-500000)
+            let stalePcm = explicitModulesDir.join("stale_module-DEADBEEF.pcm")
+            try localFS.write(stalePcm, contents: ByteString(encodingAsUTF8: "stale"))
+            try setAccessTime(stalePcm, to: staleDate)
+
+            // modules.timestamp is recent and interval is large, so pruning should be skipped.
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            #expect(localFS.exists(stalePcm), "Stale pcm should survive when pruning is throttled by interval")
+
+            // Backdate modules.timestamp so the interval has elapsed.
+            let oldTimestamp = Int(Date().addingTimeInterval(-1_000_001).timeIntervalSince1970)
+            try localFS.setFileTimestamp(lastPrunedPath, timestamp: oldTimestamp)
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            #expect(!localFS.exists(stalePcm), "Stale pcm should be pruned after interval elapses")
+        }
+    }
+
+    /// Test that deleting an explicit precompiled module triggers a rebuild on the next build.
+    @Test(.requireSDKs(.macOS), .requireModuleCachePruning)
+    func rebuildDeletedExplicitPrecompiledModule() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let buildDir = tmpDirPath.join("build")
+
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("file.c"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "CLANG_ENABLE_MODULES": "YES",
+                                "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "OBJROOT": buildDir.str,
+                                "SYMROOT": buildDir.str,
+                                "DSTROOT": buildDir.str,
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Library",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["file.c"]),
+                                ]),
+                        ])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.c")) { stream in
+                stream <<<
+                """
+                #include <stdio.h>
+                int something = 1;
+                """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let explicitModulesDir = buildDir.join("ExplicitPrecompiledModules")
+
+            let pcmFiles = try localFS.traverse(explicitModulesDir) { (path: Path) -> Path? in
+                if path.fileExtension == "pcm" { return path }
+                return nil
+            }
+            #expect(!pcmFiles.isEmpty, "Build should have produced at least one PCM")
+
+            for pcm in pcmFiles {
+                try localFS.remove(pcm)
+            }
+
+            // Should detect missing PCM outputs and rebuild them.
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let pcmFilesAfterRebuild = try localFS.traverse(explicitModulesDir) { (path: Path) -> Path? in
+                if path.fileExtension == "pcm" { return path }
+                return nil
+            }
+            #expect(!pcmFilesAfterRebuild.isEmpty, "PCMs should be rebuilt after deletion")
+        }
+    }
+
+    /// Test that deleting a Swift explicit precompiled module and then modifying a source file
+    /// results in a successful build. The Swift driver should rescan and rebuild the missing PCMs.
+    @Test(.requireSDKs(.macOS), .requireDependencyScanner)
+    func rebuildDeletedSwiftPCMAfterSourceChange() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let buildDir = tmpDirPath.join("build")
+
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("file.swift"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_VERSION": "5",
+                                "_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES": "YES",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "OBJROOT": buildDir.str,
+                                "SYMROOT": buildDir.str,
+                                "DSTROOT": buildDir.str,
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Library",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["file.swift"]),
+                                ]),
+                        ])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let sourceFile = testWorkspace.sourceRoot.join("aProject/file.swift")
+
+            try await tester.fs.writeFileContents(sourceFile) { stream in
+                stream <<<
+                """
+                import Foundation
+                public let something = 1
+                """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let swiftExplicitModulesDir = buildDir.join("SwiftExplicitPrecompiledModules")
+
+            let pcmFiles = try localFS.traverse(swiftExplicitModulesDir) { (path: Path) -> Path? in
+                if path.fileExtension == "pcm" { return path }
+                return nil
+            }
+            #expect(!pcmFiles.isEmpty, "Build should have produced at least one Swift explicit PCM")
+
+            // Delete all PCMs to simulate pruning.
+            for pcm in pcmFiles {
+                try localFS.remove(pcm)
+            }
+
+            try await tester.fs.writeFileContents(sourceFile) { stream in
+                stream <<<
+                """
+                import Foundation
+                public let something = 2
+                """
+            }
+
+            try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let pcmFilesAfterRebuild = try localFS.traverse(swiftExplicitModulesDir) { (path: Path) -> Path? in
+                if path.fileExtension == "pcm" { return path }
+                return nil
+            }
+            #expect(!pcmFilesAfterRebuild.isEmpty, "Swift explicit PCMs should be rebuilt after source change triggers recompile")
+        }
+    }
+}
+
+/// Set the access time (and modification time) of a file.
+private func setAccessTime(_ path: Path, to date: Date) throws {
+    var url = URL(fileURLWithPath: path.str)
+    var values = URLResourceValues()
+    values.contentAccessDate = date
+    values.contentModificationDate = date
+    try url.setResourceValues(values)
 }
 
 fileprivate extension Array {


### PR DESCRIPTION
Prune stale .pcm files from ExplicitPrecompiledModules/ and SwiftExplicitPrecompiledModules/ directories using the libclang clang_ModuleCache_prune API.

rdar://173786020
