### PR TITLE
Move swiftinterface verification to a separate task after merge-headers

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -345,6 +345,7 @@ public protocol TaskActionCreationDelegate
     func createSwiftDriverTaskAction() -> any PlannedTaskAction
     func createSwiftCompilationRequirementTaskAction() -> any PlannedTaskAction
     func createSwiftCompilationTaskAction() -> any PlannedTaskAction
+    func createSwiftCompilationVerificationTaskAction() -> any PlannedTaskAction
     func createProcessXCFrameworkTask() -> any PlannedTaskAction
     func createValidateDevelopmentAssetsTaskAction() -> any PlannedTaskAction
     func createSignatureCollectionTaskAction() -> any PlannedTaskAction

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1671,9 +1671,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 moduleOutputPaths.append(objcHeaderFilePath)
 
                 if SwiftCompilerSpec.shouldInstallGeneratedObjectiveCHeader(cbc.scope) {
-                    // Disable swiftinterface verification when installing a compatibility header.
-                    // This is a workaround until we can ensure that the verification phase
-                    // runs after the merge of the compatibility headers. rdar://99159525
+                    // TODO: Remove -no-verify-emitted-module-interface once compiler
+                    // .swiftinterface emission bugs are fixed (rdar://173707870, rdar://173796602).
                     if moduleInterfaceFilePath != nil || privateModuleInterfaceFilePath != nil {
                         args.append("-no-verify-emitted-module-interface")
                     }
@@ -2016,6 +2015,21 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 if case .compile = compilationMode {
                     // Unblocking compilation
                     delegate.createTask(type: self, dependencyData: eagerCompilationEnabled ? dependencyInfoPath.map(DependencyDataStyle.makefileIgnoringSubsequentOutputs) : nil, payload: payload, ruleInfo: ruleInfo("SwiftDriver Compilation", targetName), additionalSignatureData: additionalSignatureData, commandLine: ["builtin-Swift-Compilation", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: allInputsNodes, outputs: compilationOutputs, action: delegate.taskActionCreationDelegate.createSwiftCompilationTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Compile $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: true, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.blockedByTargetHeaders, .compilation], usesExecutionInputs: true, showInLog: true)
+
+                    // Compilation Verification — verifies emitted .swiftinterface files.
+                    // Scheduled after SwiftMergeGeneratedHeaders so the merged -Swift.h
+                    // is available at the installed framework path. rdar://100987466
+                    if moduleInterfaceFilePath != nil || privateModuleInterfaceFilePath != nil || packageModuleInterfaceFilePath != nil {
+                        let compilationVerificationFinishedNode = delegate.createNode(objectFileDir.join("\(targetName) Swift Compilation Verification Finished").appendingFileNameSuffix(compilationMode.moduleBaseNameSuffix))
+                        var verificationInputNodes = compilationRequirementOutputs.filter {
+                            $0.path.fileSuffix == ".swiftinterface"
+                        }
+                        if SwiftCompilerSpec.shouldInstallGeneratedObjectiveCHeader(cbc.scope) {
+                            let mergedHeaderPath = SwiftCompilerSpec.generatedObjectiveCHeaderOutputPath(cbc.scope)
+                            verificationInputNodes.append(delegate.createNode(mergedHeaderPath))
+                        }
+                        delegate.createTask(type: self, payload: payload, ruleInfo: ruleInfo("SwiftDriver Interface Verification", targetName), additionalSignatureData: additionalSignatureData, commandLine: ["builtin-Swift-Compilation-Verification", "--"] + args, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: verificationInputNodes, outputs: [compilationVerificationFinishedNode], action: delegate.taskActionCreationDelegate.createSwiftCompilationVerificationTaskAction(), execDescription: archSpecificExecutionDescription(cbc.scope.namespace.parseString("Verify module interface of $PRODUCT_NAME"), cbc, delegate), preparesForIndexing: false, enableSandboxing: enableSandboxing, additionalTaskOrderingOptions: [.blockedByTargetHeaders, .compilation], usesExecutionInputs: true, showInLog: true)
+                    }
                 }
 
             } else {

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -945,6 +945,10 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return SwiftCompilationTaskAction()
     }
 
+    func createSwiftCompilationVerificationTaskAction() -> any PlannedTaskAction {
+        return SwiftCompilationVerificationTaskAction()
+    }
+
     func createProcessXCFrameworkTask() -> any PlannedTaskAction {
         return ProcessXCFrameworkTaskAction()
     }

--- a/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
+++ b/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
@@ -57,6 +57,7 @@ public struct BuiltinTaskActionsExtension: TaskActionExtension {
             42: ObjectLibraryAssemblerTaskAction.self,
             43: LinkerTaskAction.self,
             // 44: TestEntryPointGenerationTaskAction.self,
+            45: SwiftCompilationVerificationTaskAction.self,
         ]
     }
 }

--- a/Sources/SWBTaskExecution/CMakeLists.txt
+++ b/Sources/SWBTaskExecution/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(SWBTaskExecution
   TaskActions/SwiftCachingMaterializeKeyTaskAction.swift
   TaskActions/SwiftCachingOutputMaterializerTaskAction.swift
   TaskActions/SwiftCompilationTaskAction.swift
+  TaskActions/SwiftCompilationVerificationTaskAction.swift
   TaskActions/SwiftDriverCompilationRequirementTaskAction.swift
   TaskActions/SwiftDriverJobSchedulingTaskAction.swift
   TaskActions/SwiftDriverJobTaskAction.swift

--- a/Sources/SWBTaskExecution/TaskActions/SwiftCompilationVerificationTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftCompilationVerificationTaskAction.swift
@@ -10,33 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SWBUtil
-import SWBLibc
 public import SWBCore
-import enum SWBLLBuild.BuildValueKind
+import SWBLibc
+import SWBUtil
 
-public final class SwiftCompilationTaskAction: SwiftDriverJobSchedulingTaskAction {
+public final class SwiftCompilationVerificationTaskAction: SwiftDriverJobSchedulingTaskAction {
     public override class var toolIdentifier: String {
-        return "swift-driver-compilation"
+        "swift-driver-compilation-verification"
     }
 
     public override func primaryJobs(for plannedBuild: LibSwiftDriver.PlannedBuild, driverPayload: SwiftDriverPayload) -> ArraySlice<LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob> {
-        plannedBuild.compilationPlannedDriverJobs()
+        plannedBuild.verificationPlannedDriverJobs()
     }
 
     public override func untrackedPrimaryJobs(for plannedBuild: LibSwiftDriver.PlannedBuild, driverPayload: SwiftDriverPayload) -> ArraySlice<LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob> {
-        plannedBuild.compilationRequirementsPlannedDriverJobs()
-    }
-
-    public override func secondaryJobs(for plannedBuild: LibSwiftDriver.PlannedBuild, driverPayload: SwiftDriverPayload) -> ArraySlice<LibSwiftDriver.PlannedBuild.PlannedSwiftDriverJob> {
-        if driverPayload.eagerCompilationEnabled {
-            return plannedBuild.afterCompilationPlannedDriverJobs()
-        } else {
-            return []
-        }
-    }
-
-    public override func shouldReportSkippedJobs(driverPayload: SwiftDriverPayload) -> Bool {
-        driverPayload.eagerCompilationEnabled
+        []
     }
 }

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -220,6 +220,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return SwiftCompilationTaskAction()
     }
 
+    package func createSwiftCompilationVerificationTaskAction() -> any PlannedTaskAction {
+        return SwiftCompilationVerificationTaskAction()
+    }
+
     package func createProcessXCFrameworkTask() -> any PlannedTaskAction {
         return ProcessXCFrameworkTaskAction()
     }

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -455,6 +455,10 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return SwiftCompilationTaskAction()
     }
 
+    package func createSwiftCompilationVerificationTaskAction() -> any PlannedTaskAction {
+        return SwiftCompilationVerificationTaskAction()
+    }
+
     package func createProcessXCFrameworkTask() -> any PlannedTaskAction {
         return ProcessXCFrameworkTaskAction()
     }

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -585,8 +585,8 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
             try await tester.checkBuild(runDestination: .host, buildRequest: buildRequest, persistent: true) { results in
                 results.checkNoErrors()
 
-                results.checkTask(.matchTargetName("TargetA"), .matchRuleType("SwiftDriver Compilation")) { compileBucket in
-                    results.checkTaskRequested(compileBucket, .matchTargetName("TargetA"), .matchRuleType("SwiftVerifyEmittedModuleInterface"))
+                results.checkTask(.matchTargetName("TargetA"), .matchRuleType("SwiftDriver Interface Verification")) { verifyBucket in
+                    results.checkTaskRequested(verifyBucket, .matchTargetName("TargetA"), .matchRuleType("SwiftVerifyEmittedModuleInterface"))
                 }
             }
         }

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -215,6 +215,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return SwiftCompilationTaskAction()
     }
 
+    func createSwiftCompilationVerificationTaskAction() -> any PlannedTaskAction {
+        return SwiftCompilationVerificationTaskAction()
+    }
+
     public func createProcessXCFrameworkTask() -> any PlannedTaskAction {
         return ProcessXCFrameworkTaskAction()
     }

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -531,6 +531,9 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             // Ignore all Extract App Intents Metadata tasks.
             results.checkTasks(.matchRuleType("ExtractAppIntentsMetadata")) { _ in }
 
+            // Ignore all module interface verification tasks.
+            results.checkTasks(.matchRuleType("SwiftDriver Interface Verification")) { _ in }
+
             // There should be no other unmatched tasks.
             results.checkNoTask()
 
@@ -1174,6 +1177,9 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             results.checkTasks(.matchRuleType("SetOwnerAndGroup")) { _ in  }
             results.checkTasks(.matchRuleType("Strip")) { _ in  }
 
+            // Ignore all module interface verification tasks.
+            results.checkTasks(.matchRuleType("SwiftDriver Interface Verification")) { _ in }
+
             // Check there are no other tasks.
             results.checkNoTask()
 
@@ -1324,7 +1330,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     /// Check handling of multiple archs.
-    func testMultipleArchs(runDestination: RunDestinationInfo, archs: [String], excludedArchs: [String] = [], targetTripleSuffix: String) async throws {
+    func testMultipleArchs(runDestination: RunDestinationInfo, archs: [String], excludedArchs: [String] = [], targetTripleSuffix: String, installObjcHeader: Bool = true, buildLibraryForDistribution: Bool = false, enableWMO: Bool = false) async throws {
         let sdkroot = runDestination.sdk
         let testProject = try await TestProject(
             "aProject",
@@ -1341,8 +1347,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
-                        "SWIFT_ALLOW_INSTALL_OBJC_HEADER": "YES",
+                        "SWIFT_OBJC_INTERFACE_HEADER_NAME": installObjcHeader ? "$(SWIFT_MODULE_NAME)-Swift.h" : "",
+                        "SWIFT_ALLOW_INSTALL_OBJC_HEADER": installObjcHeader ? "YES" : "NO",
                         "TAPI_EXEC": tapiToolPath.str,
+                        "BUILD_LIBRARY_FOR_DISTRIBUTION": buildLibraryForDistribution ? "YES" : "NO",
+                        "SWIFT_WHOLE_MODULE_OPTIMIZATION": enableWMO ? "YES" : "NO",
                     ]),
             ],
             targets: [
@@ -1379,8 +1388,10 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         let fs = PseudoFS()
         try fs.createDirectory(Path("/Users/whoever/Library/MobileDevice/Provisioning Profiles"), recursive: true)
         try fs.write(Path("/Users/whoever/Library/MobileDevice/Provisioning Profiles/8db0e92c-592c-4f06-bfed-9d945841b78d.mobileprovision"), contents: "profile")
-
-        await tester.checkBuild(runDestination: runDestination, fs: fs) { results in
+        // Setting a correct path for macos
+        let frameworkModulesDir = sdkroot == "macosx" ? "Versions/A/Modules" : "Modules"
+        let frameworkHeadersDir = sdkroot == "macosx" ? "Versions/A/Headers" : "Headers"
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ONLY_ACTIVE_ARCH": "NO"]), runDestination: runDestination, fs: fs) { results in
             results.checkTarget("CoreFoo") { target in
                 // We should have one planning per arch.
                 for arch in archs {
@@ -1390,17 +1401,37 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
 
                 // We should have a Copy of the appropriate arch.
                 for arch in archs {
-                    results.checkTask(.matchRule(["Copy", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/Modules/CoreFoo.swiftmodule/\(arch)\(targetTripleSuffix).swiftmodule", "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(arch)/CoreFoo.swiftmodule"])) { _ in }
+                    results.checkTask(.matchRule(["Copy", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/\(frameworkModulesDir)/CoreFoo.swiftmodule/\(arch)\(targetTripleSuffix).swiftmodule", "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(arch)/CoreFoo.swiftmodule"])) { _ in }
                 }
 
                 // Check we only have one task for the Swift generated API header file.
+                if installObjcHeader {
                 if archs.count > 1 {
                     results.checkTask(.matchRuleType("SwiftMergeGeneratedHeaders"), .matchRuleItemBasename("CoreFoo-Swift.h")) { task in
-                        task.checkRuleInfo(["SwiftMergeGeneratedHeaders", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/Headers/CoreFoo-Swift.h"] + archs.sorted().map { arch in "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(arch)/CoreFoo-Swift.h" })
+                        task.checkRuleInfo(["SwiftMergeGeneratedHeaders", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/\(frameworkHeadersDir)/CoreFoo-Swift.h"] + archs.sorted().map { arch in "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(arch)/CoreFoo-Swift.h" })
                     }
                 } else {
                     results.checkTask(.matchRuleType("SwiftMergeGeneratedHeaders"), .matchRuleItemBasename("CoreFoo-Swift.h")) { task in
-                        task.checkRuleInfo(["SwiftMergeGeneratedHeaders", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/Headers/CoreFoo-Swift.h", "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(archs[0])/CoreFoo-Swift.h"])
+                        task.checkRuleInfo(["SwiftMergeGeneratedHeaders", "\(SRCROOT)/build/\(configurationDir(configuration: "Debug"))/CoreFoo.framework/\(frameworkHeadersDir)/CoreFoo-Swift.h", "\(SRCROOT)/build/aProject.build/\(configurationDir(configuration: "Debug"))/CoreFoo.build/Objects-normal/\(archs[0])/CoreFoo-Swift.h"])
+                    }
+                }
+                }
+
+                // Check that the Compilation Verification task follows MergeHeaders
+                if buildLibraryForDistribution {
+                    for arch in archs {
+                        if installObjcHeader {
+                            results.checkTask(.matchRuleType("SwiftDriver Interface Verification"), .matchRuleItem(arch)) { task in
+                                results.checkTaskFollows(task, .matchRuleType("SwiftMergeGeneratedHeaders"))
+                                results.checkTaskFollows(task, .matchRuleType("SwiftDriver Compilation Requirements"), .matchRuleItem(arch))
+                                task.checkCommandLineContains(["-no-verify-emitted-module-interface"])
+                            }
+                        } else {
+                            results.checkTask(.matchRuleType("SwiftDriver Interface Verification"), .matchRuleItem(arch)) { task in
+                                results.checkTaskFollows(task, .matchRuleType("SwiftDriver Compilation Requirements"), .matchRuleItem(arch))
+                                task.checkCommandLineDoesNotContain("-no-verify-emitted-module-interface")
+                            }
+                        }
                     }
                 }
             }
@@ -1414,6 +1445,29 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.macOS), arguments: [true, false])
+    func swiftInterfaceVerificationFollowsMergeHeaders(enableWMO: Bool) async throws {
+        try await testMultipleArchs(
+            runDestination: .macOS,
+            archs: ["arm64", "arm64e"],
+            targetTripleSuffix: "-apple-macos",
+            installObjcHeader: true,
+            buildLibraryForDistribution: true,
+            enableWMO: enableWMO)
+    }
+
+    @Test(.requireSDKs(.macOS), arguments: [true, false])
+    func swiftInterfaceVerificationWithoutMergeHeaders(enableWMO: Bool) async throws {
+        try await testMultipleArchs(
+            runDestination: .macOS,
+            archs: ["arm64", "arm64e"],
+            targetTripleSuffix: "-apple-macos",
+            installObjcHeader: false,
+            buildLibraryForDistribution: true,
+            enableWMO: enableWMO)
+    }
+
 
     @Test(.requireSDKs(.iOS))
     func multipleArchs_iOS() async throws {

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -6026,59 +6026,6 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
-    func installCompatibilityHeaderAndSwiftinterfaceVerification() async throws {
-        for installHeaderSetting in ["NO", "YES", nil] {
-            for buildForDistribution in ["NO", "YES", nil] {
-                var buildSettings = try await [
-                    "CODE_SIGN_IDENTITY": "",
-                    "SWIFT_EXEC": swiftCompilerPath.str,
-                    "SWIFT_VERSION": "5"
-                ]
-                if let installHeaderSetting {
-                    buildSettings["SWIFT_INSTALL_OBJC_HEADER"] = installHeaderSetting
-                }
-                if let buildForDistribution {
-                    buildSettings["BUILD_LIBRARY_FOR_DISTRIBUTION"] = buildForDistribution
-                }
-
-                let testProject = TestProject(
-                    "MyProject",
-                    sourceRoot: Path("/MyProject"),
-                    groupTree: TestGroup(
-                        "SomeFiles",
-                        path: "Sources",
-                        children: [TestFile("SourceFile1.swift")]),
-                    buildConfigurations: [
-                        TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: buildSettings)],
-                    targets: [
-                        TestStandardTarget(
-                            "MyFramework1",
-                            type: .framework,
-                            buildPhases: [
-                                TestSourcesBuildPhase(["SourceFile1.swift"])
-                            ]
-                        )
-                    ]
-                )
-
-                let tester = try await TaskConstructionTester(getCore(), testProject)
-                await tester.checkBuild(runDestination: .macOS) { results in
-                    results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
-                        if installHeaderSetting != "NO" && buildForDistribution == "YES" {
-                            task.checkCommandLineContains(["-no-verify-emitted-module-interface"])
-                        } else {
-                            task.checkCommandLineDoesNotContain("-no-verify-emitted-module-interface")
-                        }
-                    }
-                    results.checkNoDiagnostics()
-                }
-            }
-        }
-    }
-
     /// Tests that clang's PatternsOfFlagsNotAffectingPrecomps don't contribute to PCH hash.
     @Test(.requireSDKs(.macOS))
     func prefixHeaderHashIgnoresNeutralFlags() async throws {


### PR DESCRIPTION
Previously, swiftinterface verification ran as a secondary driver job inside SwiftDriver Compilation, with no dependency on SwiftMergeGeneratedHeaders. This meant verification could race with the merge step and use an incomplete module when the installed compatibility header was not yet present.

Introduce a third Swift driver task group VerifySwiftModuleInterface. This new group runs verification driver jobs via
SwiftCompilationVerificationTaskAction, scheduled as a separate static task rather than as secondary jobs of SwiftDriver Compilation.

The -no-verify-emitted-module-interface flag is preserved for now while compiler .swiftinterface emission bugs are being fixed (rdar://173707870, rdar://173796602). It will be removed once those are resolved.

rdar://100987466


