### PR TITLE
Update dependencyValidationWithSymlinks() to account for a change in the dependencies file emitted by clang.

### DIFF
--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -127,7 +127,7 @@ extension CoreBasedTests {
         }
     }
 
-    private var clangInfo: DiscoveredClangToolSpecInfo {
+    package var clangInfo: DiscoveredClangToolSpecInfo {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
             let clang = try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "clang"), "couldn't find clang in default toolchain")
@@ -135,7 +135,7 @@ extension CoreBasedTests {
         }
     }
 
-    private var clangPlusPlusInfo: DiscoveredClangToolSpecInfo {
+    package var clangPlusPlusInfo: DiscoveredClangToolSpecInfo {
         get async throws {
             let (core, defaultToolchain) = try await coreAndToolchain()
             let clang = try #require(defaultToolchain.executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "clang++"), "couldn't find clang in default toolchain")

--- a/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/DependencyValidationTests.swift
@@ -220,7 +220,8 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
                 "SYMROOT": tmpDir.join("SYMROOT").str,
                 "VALIDATE_DEPENDENCIES": "YES_ERROR",
             ])
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testWorkspace, simulated: false)
 
             try tester.fs.createDirectory(tmpDir.join("aProject/Sources"), recursive: true)
             try await tester.fs.writeFileContents(tmpDir.join("aProject/Sources/test.c")) {
@@ -240,10 +241,11 @@ fileprivate struct DependencyValidationTests: CoreBasedTests {
                 let testDependencies = try tester.fs.read(tmpDir.join("OBJROOT").join("aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/test.d"))
                 #expect(testDependencies.unsafeStringValue.split(separator: "\n") == [
                     "dependencies: \\",
+                    try await clangInfo.clangVersion >= Version(2100, 3) ? "  \(core.loadSDK(.macOS).path.str)/SDKSettings.json \\" : nil,
                     "  \(tmpDir.str)/aProject/Sources/test.c \\",
                     "  \(tmpDir.str)/SYMROOT/Debug/Framework.framework/Headers/Framework.h \\",
                     "  \(tmpDir.str)/SYMROOT/Debug/Framework.framework/Headers/test.h"
-                ])
+                ].compactMap { $0 })
 
                 // Even though the Makefile dependencies point to symlinks for the headers, we should resolve them and still find the producer tasks.
                 results.checkNoDiagnostics()


### PR DESCRIPTION
rdar://172974439
