### PR TITLE
Fix xcfilelist changes not invalidating build description

### DIFF
--- a/Sources/SWBTaskConstruction/ProductPlanning/BuildPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/BuildPlan.swift
@@ -195,9 +195,6 @@ package final class BuildPlan: StaleFileRemovalContext {
             return nil
         }
 
-        // Now that tasks have been generated, aggregate the invalidation paths
-        let invalidationPaths = Set(producersToEvaluate.flatMap { $0.producer.invalidationPaths })
-
         // Compute all of the deferred tasks (in parallel).
         delegate.updateProgress(statusMessage: messageShortening == .full ? "Planning deferred tasks" : "Constructing deferred tasks", showInLog: false)
         await TaskGroup.concurrentPerform(iterations: productPlanResultContexts.count, maximumParallelism: 10) { i in
@@ -220,6 +217,11 @@ package final class BuildPlan: StaleFileRemovalContext {
         if delegate.cancelled {
             return nil
         }
+
+        // Now that tasks have been generated, aggregate the invalidation paths.
+        // Collected from contexts since accessedPaths is shared across all
+        // producers within a context.
+        let invalidationPaths = Set(productPlanResultContexts.flatMap { $0.productPlan.taskProducerContext.accessedPaths })
 
         // Now we have a list of product plan result contexts, each of which contains a list of all planned tasks for each plan, as well as the information needed to validate them.
         // Since these contexts are independent of each other, we can in parallel have each one validate its tasks, and then serially add the tasks it ends up with to a final task array.

--- a/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/StandardTaskProducer.swift
@@ -19,13 +19,11 @@ open class StandardTaskProducer {
     package let context: TaskProducerContext
 
     /// Additional paths which invalidate the build description
-    package var invalidationPaths: [Path] { return Array(accessedPaths) }
-
-    private var accessedPaths = Set<Path>()
+    package var invalidationPaths: [Path] { return Array(context.accessedPaths) }
 
     /// Adds the accessed path to the list of paths which invalidate the build description.
     func access(path: Path) {
-        accessedPaths.insert(path)
+        context.access(path: path)
     }
 
     /// Reads the contents of the file at `path` and returns its contents as a byte string, and adds the path to the list of paths which invalidate the build description.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -111,7 +111,19 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     /// Whether a task planned by this producer has requested frontend command line emission.
     var emitFrontendCommandLines: Bool
 
+    /// Registers a path accessed during task construction.
+    func access(path: Path) {
+        state.withLock { $0.accessedPaths.insert(path) }
+    }
+
+    /// Paths accessed during task construction that invalidate the build description.
+    /// On the context so ephemeral producers are included.
+    var accessedPaths: Set<Path> {
+        state.withLock { $0.accessedPaths }
+    }
+
     private struct State: Sendable {
+        fileprivate var accessedPaths = Set<Path>()
         fileprivate var onDemandResourcesAssetPacks: [ODRTagSet: ODRAssetPackInfo] = [:]
         fileprivate var onDemandResourcesAssetPackSubPaths: [String: Set<String>] = [:]
 

--- a/Tests/SWBBuildSystemTests/CopyTests.swift
+++ b/Tests/SWBBuildSystemTests/CopyTests.swift
@@ -16,6 +16,7 @@ import SWBBuildSystem
 import SWBCore
 import SWBUtil
 import SWBTestSupport
+import SWBTaskExecution
 import SwiftBuildTestSupport
 
 @Suite
@@ -54,6 +55,62 @@ fileprivate struct CopyTests: CoreBasedTests {
             try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .host) { results in
                 results.checkNoDiagnostics()
                 try #expect(tester.fs.listdir(tmpDirPath.join("out").join("MyDirectory")) == ["file.txt"])
+            }
+        }
+    }
+
+    /// rdar://117046957: xcfilelists read by Custom Build Rules should be registered
+    /// as invalidation paths so changing them triggers a new build description.
+    @Test(.requireSDKs(.host), .skipHostOS(.windows))
+    func buildRuleXcfilelistTrackedAsInvalidationPath() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup("Sources", children: [
+                            TestFile("input.fake-custom"),
+                            TestFile("inputs.xcfilelist"),
+                        ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "App", type: .application,
+                                buildConfigurations: [TestBuildConfiguration("Debug")],
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["input.fake-custom"]),
+                                ],
+                                buildRules: [
+                                    TestBuildRule(
+                                        filePattern: "*.fake-custom",
+                                        script: "touch \"${SCRIPT_OUTPUT_FILE_0}\"",
+                                        inputFileLists: ["$(SRCROOT)/inputs.xcfilelist"],
+                                        outputs: ["$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE).out"]
+                                    ),
+                                ])])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            try tester.fs.createDirectory(SRCROOT, recursive: true)
+            try tester.fs.write(SRCROOT.join("input.fake-custom"), contents: "original\n")
+
+            try await tester.fs.writeFileContents(SRCROOT.join("inputs.xcfilelist")) { stream in
+                stream <<< ""
+            }
+
+            let xcfilelistPath = SRCROOT.join("inputs.xcfilelist")
+
+            try await tester.checkBuildDescription(BuildParameters(configuration: "Debug"), runDestination: .host) { results in
+                let invalidationPaths = results.buildDescription.invalidationPaths
+                #expect(invalidationPaths.contains(xcfilelistPath), "xcfilelist used by build rule should be an invalidation path, but invalidationPaths = \(invalidationPaths)")
             }
         }
     }


### PR DESCRIPTION
BuildRuleTaskProducer is created transiently and discarded after task generation so its accessedPaths were getting lost. Move accessedPaths to TaskProducerContext so all producers contribute to invalidation paths.

rdar://117046957