### PR TITLE
Emit build error when resource files generate sources for target without a Compile Sources phase.

### DIFF
--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -193,7 +193,7 @@ struct ActoolInputFileGroupingStrategyExtension: InputFileGroupingStrategyExtens
         return ["actool": Factory()]
     }
 
-    func fileTypesCompilingToSwiftSources(scope: MacroEvaluationScope) -> [String] {
+    func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String] {
         guard scope.evaluate(BuiltinMacros.ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS) else {
             return []
         }
@@ -211,7 +211,7 @@ struct ImageScaleFactorsInputFileGroupingStrategyExtension: InputFileGroupingStr
         return ["image-scale-factors": Factory()]
     }
 
-    func fileTypesCompilingToSwiftSources(scope: MacroEvaluationScope) -> [String] {
+    func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String] {
         return []
     }
 }
@@ -226,7 +226,7 @@ struct LocalizationInputFileGroupingStrategyExtension: InputFileGroupingStrategy
         return ["region": Factory()]
     }
 
-    func fileTypesCompilingToSwiftSources(scope: MacroEvaluationScope) -> [String] {
+    func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String] {
         return []
     }
 }
@@ -241,7 +241,7 @@ struct XCStringsInputFileGroupingStrategyExtension: InputFileGroupingStrategyExt
         return ["xcstrings": Factory()]
     }
 
-    func fileTypesCompilingToSwiftSources(scope: MacroEvaluationScope) -> [String] {
+    func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String] {
         guard scope.evaluate(BuiltinMacros.STRING_CATALOG_GENERATE_SYMBOLS) else {
             return []
         }

--- a/Sources/SWBCore/Extensions/InputFileGroupingStrategyExtension.swift
+++ b/Sources/SWBCore/Extensions/InputFileGroupingStrategyExtension.swift
@@ -13,6 +13,28 @@
 public import SWBUtil
 public import SWBMacro
 
+/// Describes behavior when a source-generating file type is in the Resources phase
+/// but the target has no Compile Sources phase.
+public enum MissingSourcesPhaseBehavior: Sendable {
+    /// Silently keep the file in Resources
+    case keepInResources
+    /// Emit a build error because the generated source cannot be compiled
+    case error
+}
+
+/// Describes a file type that produces generated source code.
+public struct SourceGeneratingFileType: Sendable {
+    /// The file type identifier
+    public let identifier: String
+    /// What to do when the target has no Compile Sources phase
+    public let missingSourcesPhaseBehavior: MissingSourcesPhaseBehavior
+
+    public init(identifier: String, missingSourcesPhaseBehavior: MissingSourcesPhaseBehavior = .keepInResources) {
+        self.identifier = identifier
+        self.missingSourcesPhaseBehavior = missingSourcesPhaseBehavior
+    }
+}
+
 public struct InputFileGroupingStrategyExtensionPoint: ExtensionPoint, Sendable {
     public typealias ExtensionProtocol = InputFileGroupingStrategyExtension
 
@@ -23,5 +45,15 @@ public struct InputFileGroupingStrategyExtensionPoint: ExtensionPoint, Sendable 
 
 public protocol InputFileGroupingStrategyExtension: Sendable {
     func groupingStrategies() -> [String: any InputFileGroupingStrategyFactory]
-    func fileTypesCompilingToSwiftSources(scope: MacroEvaluationScope) -> [String]
+    func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String]
+    func sourceGeneratingFileTypes(scope: MacroEvaluationScope) -> [SourceGeneratingFileType]
+}
+
+// Default implementation so existing conformers don't break
+extension InputFileGroupingStrategyExtension {
+    public func sourceGeneratingFileTypes(scope: MacroEvaluationScope) -> [SourceGeneratingFileType] {
+        return fileTypesProducingGeneratedSources(scope: scope).map {
+            SourceGeneratingFileType(identifier: $0, missingSourcesPhaseBehavior: .keepInResources)
+        }
+    }
 }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -328,9 +328,18 @@ extension PluginManager {
     func fileTypesProducingGeneratedSources(scope: MacroEvaluationScope) -> [String] {
         var compileToSwiftFileTypes : [String] = []
         for groupingStragegyExtensions in extensions(of: InputFileGroupingStrategyExtensionPoint.self) {
-            compileToSwiftFileTypes.append(contentsOf: groupingStragegyExtensions.fileTypesCompilingToSwiftSources(scope: scope))
+            compileToSwiftFileTypes.append(contentsOf: groupingStragegyExtensions.fileTypesProducingGeneratedSources(scope: scope))
         }
         return compileToSwiftFileTypes
+    }
+
+    /// Returns source-generating file types with metadata about missing Sources phase behavior.
+    func sourceGeneratingFileTypes(scope: MacroEvaluationScope) -> [SourceGeneratingFileType] {
+        var result: [SourceGeneratingFileType] = []
+        for extension_ in extensions(of: InputFileGroupingStrategyExtensionPoint.self) {
+            result.append(contentsOf: extension_.sourceGeneratingFileTypes(scope: scope))
+        }
+        return result
     }
 }
 
@@ -787,12 +796,14 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
     /// Filters `buildFiles` down to only those files that are necessary inputs to source code generation.
     ///
     /// For example, this could include Asset Catalogs (and any of the files they subsume in their grouping strategy).
-    func sourceGenerationInputFiles(from buildFiles: [SWBCore.BuildFile], scope: MacroEvaluationScope) async -> [SWBCore.BuildFile] {
+    /// When `hasSourcesPhase` is false, file types that require a Sources phase will emit a build error.
+    func sourceGenerationInputFiles(from buildFiles: [SWBCore.BuildFile], scope: MacroEvaluationScope, hasSourcesPhase: Bool) async -> [SWBCore.BuildFile] {
         guard !buildFiles.isEmpty else {
             return []
         }
 
-        let fileIdentifiersGeneratingSources = context.workspaceContext.core.pluginManager.fileTypesProducingGeneratedSources(scope: scope)
+        let sourceGeneratingTypes = context.workspaceContext.core.pluginManager.sourceGeneratingFileTypes(scope: scope)
+        let fileIdentifiersGeneratingSources = sourceGeneratingTypes.map(\.identifier)
         guard !fileIdentifiersGeneratingSources.isEmpty else {
             return []
         }
@@ -809,6 +820,18 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
             guard fileIdentifiersGeneratingSources.contains(where: { identifier in fileRef.fileType.conformsTo(identifier: identifier) }) else {
                 ungroupedFiles.append(ftb)
                 continue
+            }
+
+            // Emit a build error if this file type requires a Sources phase but none exists.
+            if !hasSourcesPhase {
+                let shouldErrorForMissingSourcesPhase = sourceGeneratingTypes.contains(where: {
+                    $0.missingSourcesPhaseBehavior == .error && fileRef.fileType.conformsTo(identifier: $0.identifier)
+                })
+
+                if shouldErrorForMissingSourcesPhase {
+                    let targetName = context.configuredTarget?.target.name ?? "unknown"
+                    context.error("Target '\(targetName)' has '\(fileRef.fileType.identifier)' files that generate source code, but no 'Compile Sources' build phase. Add a 'Compile Sources' build phase to the target.")
+                }
             }
 
             if grouper == nil {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/ResourcesTaskProducer.swift
@@ -232,11 +232,20 @@ final class ResourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBa
         let sourceFiles = standardTarget?.sourcesBuildPhase?.buildFiles ?? []
         let resourceFiles = standardTarget?.resourcesBuildPhase?.buildFiles ?? []
 
-        guard !sourceFiles.isEmpty && !resourceFiles.isEmpty else {
+        guard !resourceFiles.isEmpty else {
             return []
         }
 
-        let files = await sourceGenerationInputFiles(from: resourceFiles, scope: scope)
+        // Call `sourceGenerationInputFiles` before the hasSourcesPhase guard.
+        // Some resource files generate sources that need compilation, and
+        // `sourceGenerationInputFiles` emits an error when hasSourcesPhase is false.
+        let hasSourcesPhase = !sourceFiles.isEmpty
+        let files = await sourceGenerationInputFiles(from: resourceFiles, scope: scope, hasSourcesPhase: hasSourcesPhase)
+
+        guard hasSourcesPhase else {
+            return []
+        }
+
         return Set(files.map({ Ref($0) }))
     }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -261,7 +261,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             return []
         }
 
-        return await sourceGenerationInputFiles(from: resourceFiles, scope: scope)
+        return await sourceGenerationInputFiles(from: resourceFiles, scope: scope, hasSourcesPhase: true)
     }
 
     override func additionalFilesToBuild(_ scope: MacroEvaluationScope) -> [FileToBuild] {


### PR DESCRIPTION
Problem:
* Targets with source-generating file types (e.g., `.xcstrings`) in the Resources phase but no Compile Sources phase silently dropped the generated sources, leading to confusing build failures or missing symbols at runtime.

Changes:
* Introduced `SourceGeneratingFileType` and `MissingSourcesPhaseBehavior` in `InputFileGroupingStrategyExtension.swift`.
  * Extension points can now declare whether a missing Sources phase should silently keep the file in Resources (`.keepInResources`) or emit a build error (`.error`).
* Renamed `fileTypesCompilingToSwiftSources` to `fileTypesProducingGeneratedSources` and threaded a `MacroEvaluationScope` through the call chain.
  * The scope is needed for extensions that conditionally produce sources based on build settings.
* In `ResourcesTaskProducer`, `sourceGenerationInputFiles` is now called even when there is no Sources phase.
  * This ensures file types opting into `.error` behavior produce a diagnostic instead of being silently ignored.
* Added a default implementation of `sourceGeneratingFileTypes` that bridges to `fileTypesProducingGeneratedSources` so existing conformers don't break.
