### PR TITLE
Resolve relative derivedDataPath to absolute in swbuild build

### DIFF
--- a/Sources/SwiftBuild/ConsoleCommands/SWBServiceConsoleBuildCommand.swift
+++ b/Sources/SwiftBuild/ConsoleCommands/SWBServiceConsoleBuildCommand.swift
@@ -206,7 +206,7 @@ class SWBServiceConsoleBuildCommand: SWBServiceConsoleCommand {
             // arena info to both the request-global build parameters as well as the target-specific
             // build parameters, since they may have been deserialized from the build request file above,
             // overwriting the build parameters we set up earlier in this method.
-            if let path = derivedDataPath {
+            if let path = derivedDataPath?.makeAbsolute(relativeTo: Path(baseDirectory.pathString))?.normalize() ?? derivedDataPath {
                 request.setDerivedDataPath(path)
             }
 
@@ -337,7 +337,7 @@ class SWBServiceConsolePrepareForIndexCommand: SWBServiceConsoleCommand {
             request.continueBuildingAfterErrors = true
 
             // Override the arena, if requested.
-            if let path = derivedDataPath {
+            if let path = derivedDataPath?.makeAbsolute(relativeTo: Path(baseDirectory.pathString))?.normalize() ?? derivedDataPath {
                 request.setDerivedDataPath(path)
             }
 

--- a/Tests/SwiftBuildTests/ConsoleCommands/BuildCommandTests.swift
+++ b/Tests/SwiftBuildTests/ConsoleCommands/BuildCommandTests.swift
@@ -175,6 +175,31 @@ fileprivate struct BuildCommandTests {
         }
     }
 
+
+    @Test(.skipHostOS(.windows)) // PTY not supported on Windows
+    func buildCommandWithPIFRelativeDerivedDataPath() async throws {
+        let supportedPIFFileExtensions = ["json", "pif"]
+        for fileExtension in supportedPIFFileExtensions {
+            try await withTemporaryDirectory { tmp in
+                let pifPath = tmp.join("pif.\(fileExtension)")
+                try pif(basePath: tmp).propertyListItem.asJSONFragment().unsafeStringValue.write(to: URL(fileURLWithPath: pifPath.str), atomically: true, encoding: .utf8)
+
+
+                try await withCLIConnection(currentDirectory: tmp) { cli in
+                    try cli.send(command: commandSequenceCodec.encode(["build", pifPath.str, "--derivedDataPath", ".buildData", "--target", "aTarget"]))
+
+                    let reply = try await cli.getResponse()
+                    #expect(reply.contains(#"{"kind":"buildCompleted","result":"ok"}"#), Comment(rawValue: reply))
+
+                    try cli.send(command: "quit")
+                    _ = try await cli.getResponse()
+
+                    await #expect(try cli.exitStatus == .exit(0))
+                }
+            }
+        }
+    }
+
     @Test(arguments: [true, false])
     func buildCommandWithUserDefaults(enableDebugActivityLogs: Bool) async throws {
         try await withTemporaryDirectory { tmp in


### PR DESCRIPTION
## Summary

Resolve relative `--derivedDataPath` to an absolute path in `swbuild build` and `prepareForIndex` commands, consistent with how `containerPath` is already handled.

Resolves #944.

## Background

`swbuild build --derivedDataPath ./relative` fails because the relative path is passed through to the build pipeline without resolution. The `containerPath` parameter already resolves relative paths via `makeAbsolute(relativeTo:)` (with an explicit comment explaining why), but `derivedDataPath` was missing the same treatment.

## Changes

- Apply `makeAbsolute(relativeTo: baseDirectory) + normalize()` to `derivedDataPath` before calling `setDerivedDataPath`, in both `SWBServiceConsoleBuildCommand` and `SWBServiceConsolePrepareForIndexCommand`
- Add a test `buildCommandWithPIFRelativeDerivedDataPath` verifying that a relative `--derivedDataPath` produces a successful build

## Design discussion

I considered consolidating the absolute path conversion into a single step. Currently the flow is:

1. `makeAbsolute` + `normalize` → resolve relative path to absolute
2. `setDerivedDataPath(resolved)` → store in `arenaInfo` (generates 6 derived paths)
3. `AbsolutePath(validating:)` → read back from `arenaInfo` and validate

Step 3 re-validates a value we just resolved in step 1, which is redundant when `--derivedDataPath` is given. However, step 3 also covers the case where `derivedDataPath` comes from `--buildRequestFile` (without `--derivedDataPath`), so removing it would require splitting the logic into two explicit branches.

I opted for the minimal change (adding `makeAbsolute` before `setDerivedDataPath`) to keep the diff small and preserve the existing error handling. The redundant validation is harmless — it will always succeed for paths we resolved — but I wanted to flag this for reviewers.

Would it be worth refactoring the two-step conversion into a single unified path in a follow-up, or is the current approach preferred?

## Testing

- Added `buildCommandWithPIFRelativeDerivedDataPath` test