### PR TITLE
Skip test on Windows which relies on reliable atomic writes

### DIFF
--- a/Tests/SWBBuildSystemTests/ObjectLibraryBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/ObjectLibraryBuildOperationTests.swift
@@ -251,7 +251,7 @@ fileprivate struct ObjectLibraryBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "https://github.com/swiftlang/swift-foundation/issues/1507"))
     func consumingObjectLibraryIncrementalBuild() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(


### PR DESCRIPTION
This is failing in some Windows CI because swift-driver fails to write to files atomically due to https://github.com/swiftlang/swift-foundation/issues/1507