### PR TITLE
Support swift build --experimental-xcframeworks-on-linux

### DIFF
--- a/Sources/SWBCore/XCFramework.swift
+++ b/Sources/SWBCore/XCFramework.swift
@@ -370,7 +370,7 @@ public struct XCFramework: Hashable, Sendable {
             return false
         }
         // SDK names from Info.plist.
-        let appleSDKNames: Set<String> = [
+        let sdkCanonicalNames = [
             "macosx",
             "iphoneos", "iphonesimulator",
             "appletvos", "appletvsimulator",
@@ -378,7 +378,7 @@ public struct XCFramework: Hashable, Sendable {
             "xros", "xrsimulator",
             "driverkit",
         ]
-        return !appleSDKNames.contains(platform)
+        return !sdkCanonicalNames.contains(platform)
     }
 
     /// Searches the `libraries` based on the current SDK being used.

--- a/Sources/SWBCore/XCFramework.swift
+++ b/Sources/SWBCore/XCFramework.swift
@@ -363,41 +363,42 @@ public struct XCFramework: Hashable, Sendable {
     /// The minimum XCFramework version required to support mergeable metadata.
     @_spi(Testing) public static let mergeableMetadataVersion = Version(1, 1)
 
+    static func hasPerArchSlices(_ platform: String) -> Bool {
+        return platform == "linux"
+    }
+
     /// Searches the `libraries` based on the current SDK being used.
-    public func findLibrary(sdk: SDK?, sdkVariant: SDKVariant?) -> XCFramework.Library? {
+    public func findLibrary(sdk: SDK?, sdkVariant: SDKVariant?, architectures: [String] = []) -> XCFramework.Library? {
         // Lookup the LC_BUILD_VERSION information as that it is how xcframeworks platform and variant values are defined.
         guard let platformName = sdkVariant?.llvmTargetTripleSys else {
             return nil
         }
-        return findLibrary(platform: platformName, platformVariant: sdkVariant?.llvmTargetTripleEnvironment ?? "")
+        return findLibrary(platform: platformName, platformVariant: sdkVariant?.llvmTargetTripleEnvironment ?? "", architectures: architectures)
     }
 
     /// Given a platform and the variant, attempt to find an library within the XCFramework that can be used.
     public func findLibrary(platform: String, platformVariant: String = "", architectures: [String] = []) -> XCFramework.Library? {
-        #if canImport(Darwin)
-        return self.libraries.filter { lib in
-            // Due to the fact that macro evaluation of empty settings returns empty strings, there is no meaningful distinction between nil and empty here.
-            lib.supportedPlatform == platform && (lib.platformVariant ?? "") == platformVariant
-        }.first
-        #else
-        // Linux ships per-arch XCFramework slices and typically omits SupportedPlatformVariant, so for
-        // that platform default archs to the host and allow a no-variant fallback.
-        let platformMatches = libraries.filter { $0.supportedPlatform == platform }
-        var effectiveArchs = architectures
-        if platform == "linux", effectiveArchs.isEmpty, let hostArch = Architecture.hostStringValue {
-            effectiveArchs = [hostArch]
+        guard Self.hasPerArchSlices(platform) else {
+            return self.libraries.filter { lib in
+                // Due to the fact that macro evaluation of empty settings returns empty strings, there is no meaningful distinction between nil and empty here.
+                lib.supportedPlatform == platform && (lib.platformVariant ?? "") == platformVariant
+            }.first
         }
-        let allowNoVariantFallback = platform == "linux" && !platformVariant.isEmpty
-        let variants = allowNoVariantFallback ? [platformVariant, ""] : [platformVariant]
+        // Linux ships per-arch XCFramework slices and typically omits SupportedPlatformVariant, so for
+        // that platform require exactly one target arch and allow a no-variant fallback.
+        guard architectures.count == 1 else { return nil }
+        let targetArch = architectures[0]
+        let variants: [String] = platformVariant.isEmpty ? [""] : [platformVariant, ""]
         for variant in variants {
-            if let match = platformMatches.first(where: {
-                ($0.platformVariant ?? "") == variant && effectiveArchs.allSatisfy($0.supportedArchitectures.contains)
+            if let match = libraries.first(where: {
+                $0.supportedPlatform == platform
+                    && ($0.platformVariant ?? "") == variant
+                    && $0.supportedArchitectures.contains(targetArch)
             }) {
                 return match
             }
         }
         return nil
-        #endif
     }
 }
 
@@ -409,7 +410,7 @@ extension XCFramework {
         let architectures: [String]
 
         // Per-arch slice platforms — sibling slices must not collide on `(platform, variant)` alone.
-        private var usesPerArchSlices: Bool { platform == "linux" }
+        private var usesPerArchSlices: Bool { XCFramework.hasPerArchSlices(platform) }
 
         func hash(into hasher: inout Hasher) {
             // identifier is only used for tracking the offending library

--- a/Sources/SWBCore/XCFramework.swift
+++ b/Sources/SWBCore/XCFramework.swift
@@ -363,8 +363,22 @@ public struct XCFramework: Hashable, Sendable {
     /// The minimum XCFramework version required to support mergeable metadata.
     @_spi(Testing) public static let mergeableMetadataVersion = Version(1, 1)
 
+    /// Whether the platform ships one slice per architecture (no fat binaries).
     static func hasPerArchSlices(_ platform: String) -> Bool {
-        return platform == "linux"
+        // Triple-sys spellings (e.g. "macos") — from findLibrary.
+        if BuildVersion.Platform(platform: platform, environment: nil) != nil {
+            return false
+        }
+        // SDK names from Info.plist.
+        let appleSDKNames: Set<String> = [
+            "macosx",
+            "iphoneos", "iphonesimulator",
+            "appletvos", "appletvsimulator",
+            "watchos", "watchsimulator",
+            "xros", "xrsimulator",
+            "driverkit",
+        ]
+        return !appleSDKNames.contains(platform)
     }
 
     /// Searches the `libraries` based on the current SDK being used.
@@ -384,10 +398,9 @@ public struct XCFramework: Hashable, Sendable {
                 lib.supportedPlatform == platform && (lib.platformVariant ?? "") == platformVariant
             }.first
         }
-        // Linux ships per-arch XCFramework slices and typically omits SupportedPlatformVariant, so for
-        // that platform require exactly one target arch and allow a no-variant fallback.
-        guard architectures.count == 1 else { return nil }
-        let targetArch = architectures[0]
+        // Non-Apple platforms ship per-arch XCFramework slices and typically omit SupportedPlatformVariant, so for
+        // those platforms, require exactly one target arch and allow a no-variant fallback.
+        guard let targetArch = architectures.only else { return nil }
         let variants: [String] = platformVariant.isEmpty ? [""] : [platformVariant, ""]
         for variant in variants {
             if let match = libraries.first(where: {
@@ -409,23 +422,17 @@ extension XCFramework {
         let platformVariant: String?
         let architectures: [String]
 
-        // Per-arch slice platforms — sibling slices must not collide on `(platform, variant)` alone.
-        private var usesPerArchSlices: Bool { XCFramework.hasPerArchSlices(platform) }
-
         func hash(into hasher: inout Hasher) {
             // identifier is only used for tracking the offending library
             hasher.combine(platform)
             hasher.combine(platformVariant)
-            if usesPerArchSlices {
-                hasher.combine(architectures)
-            }
+            hasher.combine(architectures)
         }
 
         static func == (lhs: LibraryKey, rhs: LibraryKey) -> Bool {
-            guard lhs.platform == rhs.platform, lhs.platformVariant == rhs.platformVariant else {
-                return false
-            }
-            return lhs.usesPerArchSlices ? (lhs.architectures == rhs.architectures) : true
+            return lhs.platform == rhs.platform
+                && lhs.platformVariant == rhs.platformVariant
+                && lhs.architectures == rhs.architectures
         }
     }
 
@@ -498,7 +505,12 @@ extension XCFramework {
                 throw XCFrameworkValidationError.headerPathNotSupported(libraryType: library.libraryType, libraryIdentifier: library.libraryIdentifier)
             }
 
-            let (added, oldMember) = libraryKeys.insert(LibraryKey(identifier: library.libraryIdentifier, platform: library.supportedPlatform, platformVariant: library.platformVariant, architectures: library.supportedArchitectures.sorted()))
+            // Per-arch platforms discriminate slices on arch; fat-binary platforms don't.
+            var keyArchitectures: [String] = []
+            if Self.hasPerArchSlices(library.supportedPlatform) {
+                keyArchitectures = library.supportedArchitectures.sorted()
+            }
+            let (added, oldMember) = libraryKeys.insert(LibraryKey(identifier: library.libraryIdentifier, platform: library.supportedPlatform, platformVariant: library.platformVariant, architectures: keyArchitectures))
             guard added == true else {
                 throw XCFrameworkValidationError.conflictingLibraryDefinitions(libraryIdentifier: oldMember.identifier, otherLibraryIdentifier: library.libraryIdentifier)
             }

--- a/Sources/SWBCore/XCFramework.swift
+++ b/Sources/SWBCore/XCFramework.swift
@@ -365,20 +365,7 @@ public struct XCFramework: Hashable, Sendable {
 
     /// Whether the platform ships one slice per architecture (no fat binaries).
     static func hasPerArchSlices(_ platform: String) -> Bool {
-        // Triple-sys spellings (e.g. "macos") — from findLibrary.
-        if BuildVersion.Platform(platform: platform, environment: nil) != nil {
-            return false
-        }
-        // SDK names from Info.plist.
-        let sdkCanonicalNames = [
-            "macosx",
-            "iphoneos", "iphonesimulator",
-            "appletvos", "appletvsimulator",
-            "watchos", "watchsimulator",
-            "xros", "xrsimulator",
-            "driverkit",
-        ]
-        return !sdkCanonicalNames.contains(platform)
+        return BuildVersion.Platform(platform: platform, environment: nil) == nil
     }
 
     /// Searches the `libraries` based on the current SDK being used.

--- a/Sources/SWBCore/XCFramework.swift
+++ b/Sources/SWBCore/XCFramework.swift
@@ -220,7 +220,7 @@ public struct XCFramework: Hashable, Sendable {
 
             switch ext {
             case "framework": self = .framework; break
-            case "dylib": self = .dynamicLibrary; break
+            case "dylib", "so": self = .dynamicLibrary; break
             case "a": self = .staticLibrary; break
             default: self = .unknown(fileExtension: ext)
             }
@@ -373,11 +373,31 @@ public struct XCFramework: Hashable, Sendable {
     }
 
     /// Given a platform and the variant, attempt to find an library within the XCFramework that can be used.
-    public func findLibrary(platform: String, platformVariant: String = "") -> XCFramework.Library? {
+    public func findLibrary(platform: String, platformVariant: String = "", architectures: [String] = []) -> XCFramework.Library? {
+        #if canImport(Darwin)
         return self.libraries.filter { lib in
             // Due to the fact that macro evaluation of empty settings returns empty strings, there is no meaningful distinction between nil and empty here.
             lib.supportedPlatform == platform && (lib.platformVariant ?? "") == platformVariant
         }.first
+        #else
+        // Linux ships per-arch XCFramework slices and typically omits SupportedPlatformVariant, so for
+        // that platform default archs to the host and allow a no-variant fallback.
+        let platformMatches = libraries.filter { $0.supportedPlatform == platform }
+        var effectiveArchs = architectures
+        if platform == "linux", effectiveArchs.isEmpty, let hostArch = Architecture.hostStringValue {
+            effectiveArchs = [hostArch]
+        }
+        let allowNoVariantFallback = platform == "linux" && !platformVariant.isEmpty
+        let variants = allowNoVariantFallback ? [platformVariant, ""] : [platformVariant]
+        for variant in variants {
+            if let match = platformMatches.first(where: {
+                ($0.platformVariant ?? "") == variant && effectiveArchs.allSatisfy($0.supportedArchitectures.contains)
+            }) {
+                return match
+            }
+        }
+        return nil
+        #endif
     }
 }
 
@@ -386,15 +406,25 @@ extension XCFramework {
         let identifier: String
         let platform: String
         let platformVariant: String?
+        let architectures: [String]
+
+        // Per-arch slice platforms — sibling slices must not collide on `(platform, variant)` alone.
+        private var usesPerArchSlices: Bool { platform == "linux" }
 
         func hash(into hasher: inout Hasher) {
             // identifier is only used for tracking the offending library
             hasher.combine(platform)
             hasher.combine(platformVariant)
+            if usesPerArchSlices {
+                hasher.combine(architectures)
+            }
         }
 
         static func == (lhs: LibraryKey, rhs: LibraryKey) -> Bool {
-            return lhs.platform == rhs.platform && lhs.platformVariant == rhs.platformVariant
+            guard lhs.platform == rhs.platform, lhs.platformVariant == rhs.platformVariant else {
+                return false
+            }
+            return lhs.usesPerArchSlices ? (lhs.architectures == rhs.architectures) : true
         }
     }
 
@@ -467,7 +497,7 @@ extension XCFramework {
                 throw XCFrameworkValidationError.headerPathNotSupported(libraryType: library.libraryType, libraryIdentifier: library.libraryIdentifier)
             }
 
-            let (added, oldMember) = libraryKeys.insert(LibraryKey(identifier: library.libraryIdentifier, platform: library.supportedPlatform, platformVariant: library.platformVariant))
+            let (added, oldMember) = libraryKeys.insert(LibraryKey(identifier: library.libraryIdentifier, platform: library.supportedPlatform, platformVariant: library.platformVariant, architectures: library.supportedArchitectures.sorted()))
             guard added == true else {
                 throw XCFrameworkValidationError.conflictingLibraryDefinitions(libraryIdentifier: oldMember.identifier, otherLibraryIdentifier: library.libraryIdentifier)
             }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -340,7 +340,7 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                 } catch {
                     context.error(error.localizedDescription)
                 }
-                if let xcFramework = xcFramework, let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) {
+                if let xcFramework = xcFramework, let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: scope.evaluate(BuiltinMacros.ARCHS)) {
                     // At this point we know this is an XCFramework which we're copying, and we've successfully resolved information about the relevant library in it that we're using.
                     // Now, if this library contains mergeable metadata then we *either* want to skip copying its binary (if we're merging it), *or* we want to strip mergeable metadata from it (if we're not merging it).
                     var shouldSkipCopyingBinary = false

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -584,7 +584,7 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
                         if let xcframework = try? context.globalProductPlan.planRequest.buildRequestContext.getCachedXCFramework(at: path) {
                             // Find a library in the XCFramework which is compatible with the current platform.
                             // Note that we don't validate supported architectures here because this code path only executes for non-frameworks build phases (like copy files), and it might actually be desirable in this case for an embedded framework to have a subset of the architectures of the current target.
-                            if let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) {
+                            if let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: scope.evaluate(BuiltinMacros.ARCHS)) {
                                 // FIXME: This should really be pulling the framework out of the debug location. However, due to the complexities of dealing with multiple actions that can produce these across various targets in the workspace, and attempting to order those correctly, this pulls the data from the xcframework itself. This is will only be a problem when/if we move to having incomplete xcframeworks that we can build up.
                                 // rdar://59753495 - Copy step for XCFrameworks should pull from the target directory, not the actual framework
                                 let libraryTargetPath = path.join(library.libraryIdentifier).join(library.libraryPath)

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -630,7 +630,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     continue
                 }
 
-                guard let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) else {
+                guard let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: scope.evaluate(BuiltinMacros.ARCHS)) else {
                     // Let the XCFrameworkTaskProducer log an error here
                     continue
                 }
@@ -1586,7 +1586,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             } catch {
                                 context.error(error.localizedDescription)
                             }
-                            if let xcFramework = xcFramework, let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) {
+                            if let xcFramework = xcFramework, let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: scope.evaluate(BuiltinMacros.ARCHS)) {
                                 var shouldCopyBinary = false
                                 if library.mergeableMetadata {
                                     // We know we're copying a library which was built mergeable. Now what we want to know if whether we're merging it, or one of our dependencies is.

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SwiftPackageCopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SwiftPackageCopyFilesTaskProducer.swift
@@ -86,7 +86,7 @@ final class SwiftPackageCopyFilesTaskProducer: CopyFilesTaskProducer {
 
         func shouldEmbedXCFramework(path xcframeworkPath: Path) throws -> Bool {
             let xcFramework = try XCFramework(path: xcframeworkPath, fs: context.fs)
-            guard let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) else { return false }
+            guard let library = xcFramework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: scope.evaluate(BuiltinMacros.ARCHS)) else { return false }
 
             switch library.libraryType {
             case .dynamicLibrary:

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
@@ -94,7 +94,7 @@ final class XCFrameworkTaskProducer: StandardTaskProducer, TaskProducer {
                     let xcframeworkPath = buildFile.absolutePath
                     let expectedSignature = (context.workspaceContext.workspace.lookupReference(for: buildFile.reference.guid) as? FileReference)?.expectedSignature
                     try context.globalProductPlan.xcframeworkContext.add(xcframeworkPath, for: configuredTarget, expectedSignature: expectedSignature) { xcframework in
-                        guard let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant) else {
+                        guard let library = xcframework.findLibrary(sdk: context.sdk, sdkVariant: context.sdkVariant, architectures: context.settings.globalScope.evaluate(BuiltinMacros.ARCHS)) else {
                             let platformDisplayName = context.sdk?.targetBuildVersionPlatform(sdkVariant: context.sdkVariant)?.displayName(infoLookup: context) ?? context.platform?.displayName ?? "No Platform"
                             context.error("While building for \(platformDisplayName), no library for this platform was found in '\(xcframeworkPath.str)'.", location: .path(xcframeworkPath))
                             return nil

--- a/Tests/SWBCoreTests/XCFrameworkTests.swift
+++ b/Tests/SWBCoreTests/XCFrameworkTests.swift
@@ -259,6 +259,42 @@ import SWBMacro
         #expect(xcframework.findLibrary(platform: "macos", platformVariant: "")?.libraryIdentifier == "lib1")
         #expect(xcframework.findLibrary(platform: "driverkit", platformVariant: "")?.libraryIdentifier == "lib5")
     }
+
+    #if !canImport(Darwin)
+    @Test
+    func findingLinuxLibraryFallsBackFromGNUVariantToNoVariant() throws {
+        let libraries: OrderedSet<XCFramework.Library> = [
+            XCFramework.Library(libraryIdentifier: "linux-x86_64", supportedPlatform: "linux", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("libtest.so"), binaryPath: Path("libtest.so"), headersPath: nil),
+        ]
+        let xcframework = try XCFramework(version: Version(1, 0), libraries: libraries)
+
+        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu")?.libraryIdentifier == "linux-x86_64")
+        #expect(xcframework.findLibrary(platform: "linux")?.libraryIdentifier == "linux-x86_64")
+    }
+
+    @Test
+    func findingLinuxLibraryPrefersMatchingArchitecture() throws {
+        let libraries: OrderedSet<XCFramework.Library> = [
+            XCFramework.Library(libraryIdentifier: "linux-aarch64", supportedPlatform: "linux", supportedArchitectures: ["aarch64"], platformVariant: nil, libraryPath: Path("libtest.so"), binaryPath: Path("libtest.so"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "linux-x86_64", supportedPlatform: "linux", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("libtest.so"), binaryPath: Path("libtest.so"), headersPath: nil),
+        ]
+        let xcframework = try XCFramework(version: Version(1, 0), libraries: libraries)
+
+        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu", architectures: ["aarch64"])?.libraryIdentifier == "linux-aarch64")
+        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu", architectures: ["x86_64"])?.libraryIdentifier == "linux-x86_64")
+    }
+
+    @Test
+    func findingLibraryReturnsNilForUnsupportedArchitecture() throws {
+        let libraries: OrderedSet<XCFramework.Library> = [
+            XCFramework.Library(libraryIdentifier: "linux-x86_64", supportedPlatform: "linux", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("libtest.so"), binaryPath: Path("libtest.so"), headersPath: nil),
+        ]
+        let xcframework = try XCFramework(version: Version(1, 0), libraries: libraries)
+
+        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu", architectures: ["aarch64"]) == nil)
+        #expect(xcframework.findLibrary(platform: "linux", architectures: ["aarch64"]) == nil)
+    }
+    #endif
 }
 
 @Suite fileprivate struct XCFrameworkInfoPlistv1ParsingTests {

--- a/Tests/SWBCoreTests/XCFrameworkTests.swift
+++ b/Tests/SWBCoreTests/XCFrameworkTests.swift
@@ -260,7 +260,6 @@ import SWBMacro
         #expect(xcframework.findLibrary(platform: "driverkit", platformVariant: "")?.libraryIdentifier == "lib5")
     }
 
-    #if !canImport(Darwin)
     @Test
     func findingLinuxLibraryFallsBackFromGNUVariantToNoVariant() throws {
         let libraries: OrderedSet<XCFramework.Library> = [
@@ -268,8 +267,8 @@ import SWBMacro
         ]
         let xcframework = try XCFramework(version: Version(1, 0), libraries: libraries)
 
-        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu")?.libraryIdentifier == "linux-x86_64")
-        #expect(xcframework.findLibrary(platform: "linux")?.libraryIdentifier == "linux-x86_64")
+        #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu", architectures: ["x86_64"])?.libraryIdentifier == "linux-x86_64")
+        #expect(xcframework.findLibrary(platform: "linux", architectures: ["x86_64"])?.libraryIdentifier == "linux-x86_64")
     }
 
     @Test
@@ -294,7 +293,6 @@ import SWBMacro
         #expect(xcframework.findLibrary(platform: "linux", platformVariant: "gnu", architectures: ["aarch64"]) == nil)
         #expect(xcframework.findLibrary(platform: "linux", architectures: ["aarch64"]) == nil)
     }
-    #endif
 }
 
 @Suite fileprivate struct XCFrameworkInfoPlistv1ParsingTests {


### PR DESCRIPTION
Allow use of `--experimental-xcframeworks-on-linux` flag as per https://github.com/swiftlang/swift-build/issues/1250

These changes allows us to compile our code base on Linux using `--build-system swiftbuild`.