### PR TITLE
Add build setting to control swiftinterface verification for installed headers

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1097,6 +1097,7 @@ public final class BuiltinMacros {
     public static let SWIFT_OPTIMIZATION_LEVEL = BuiltinMacros.declareStringMacro("SWIFT_OPTIMIZATION_LEVEL")
     public static let SWIFT_PACKAGE_NAME = BuiltinMacros.declareStringMacro("SWIFT_PACKAGE_NAME")
     public static let SWIFT_SDK_TOOLSETS = BuiltinMacros.declarePathListMacro("SWIFT_SDK_TOOLSETS")
+    public static let SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION = BuiltinMacros.declareBooleanMacro("SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION")
     public static let SWIFT_SYSTEM_INCLUDE_PATHS = BuiltinMacros.declarePathListMacro("SWIFT_SYSTEM_INCLUDE_PATHS")
     public static let PACKAGE_RESOURCE_BUNDLE_NAME = BuiltinMacros.declareStringMacro("PACKAGE_RESOURCE_BUNDLE_NAME")
     public static let PACKAGE_RESOURCE_TARGET_KIND = BuiltinMacros.declareEnumMacro("PACKAGE_RESOURCE_TARGET_KIND") as EnumMacroDeclaration<PackageResourceTargetKind>
@@ -2343,6 +2344,7 @@ public final class BuiltinMacros {
         SWIFT_OPTIMIZATION_LEVEL,
         SWIFT_PACKAGE_NAME,
         SWIFT_SDK_TOOLSETS,
+        SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION,
         SWIFT_SYSTEM_INCLUDE_PATHS,
         PACKAGE_RESOURCE_BUNDLE_NAME,
         PACKAGE_RESOURCE_TARGET_KIND,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1673,8 +1673,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 if SwiftCompilerSpec.shouldInstallGeneratedObjectiveCHeader(cbc.scope) {
                     // TODO: Remove -no-verify-emitted-module-interface once compiler
                     // .swiftinterface emission bugs are fixed (rdar://173707870, rdar://173796602).
-                    if moduleInterfaceFilePath != nil || privateModuleInterfaceFilePath != nil {
-                        args.append("-no-verify-emitted-module-interface")
+                    if cbc.scope.evaluate(BuiltinMacros.SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION) {
+                        if moduleInterfaceFilePath != nil || privateModuleInterfaceFilePath != nil {
+                            args.append("-no-verify-emitted-module-interface")
+                        }
                     }
 
                     if !cbc.scope.evaluate(BuiltinMacros.SWIFT_ALLOW_INSTALL_OBJC_HEADER) {

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -109,6 +109,11 @@
                 DefaultValue = YES;
             },
             {
+                Name = "SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
+            {
                 Name = "SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES";
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -1330,8 +1330,21 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     /// Check handling of multiple archs.
-    func testMultipleArchs(runDestination: RunDestinationInfo, archs: [String], excludedArchs: [String] = [], targetTripleSuffix: String, installObjcHeader: Bool = true, buildLibraryForDistribution: Bool = false, enableWMO: Bool = false) async throws {
+    func testMultipleArchs(runDestination: RunDestinationInfo, archs: [String], excludedArchs: [String] = [], targetTripleSuffix: String, installObjcHeader: Bool = true, buildLibraryForDistribution: Bool = false, enableWMO: Bool = false, skipInstalledHeaderInterfaceVerification: Bool? = true) async throws {
         let sdkroot = runDestination.sdk
+        var buildSettings: [String: String] = try await [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
+                        "SWIFT_OBJC_INTERFACE_HEADER_NAME": installObjcHeader ? "$(SWIFT_MODULE_NAME)-Swift.h" : "",
+                        "SWIFT_ALLOW_INSTALL_OBJC_HEADER": installObjcHeader ? "YES" : "NO",
+                        "TAPI_EXEC": tapiToolPath.str,
+                        "BUILD_LIBRARY_FOR_DISTRIBUTION": buildLibraryForDistribution ? "YES" : "NO",
+                        "SWIFT_WHOLE_MODULE_OPTIMIZATION": enableWMO ? "YES" : "NO",
+                    ]
+        if let skipInstalledHeaderInterfaceVerification {
+            buildSettings["SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION"] = skipInstalledHeaderInterfaceVerification ? "YES" : "NO"
+        }
         let testProject = try await TestProject(
             "aProject",
             groupTree: TestGroup(
@@ -1343,16 +1356,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             buildConfigurations: [
                 TestBuildConfiguration(
                     "Debug",
-                    buildSettings: [
-                        "GENERATE_INFOPLIST_FILE": "YES",
-                        "PRODUCT_NAME": "$(TARGET_NAME)",
-                        "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
-                        "SWIFT_OBJC_INTERFACE_HEADER_NAME": installObjcHeader ? "$(SWIFT_MODULE_NAME)-Swift.h" : "",
-                        "SWIFT_ALLOW_INSTALL_OBJC_HEADER": installObjcHeader ? "YES" : "NO",
-                        "TAPI_EXEC": tapiToolPath.str,
-                        "BUILD_LIBRARY_FOR_DISTRIBUTION": buildLibraryForDistribution ? "YES" : "NO",
-                        "SWIFT_WHOLE_MODULE_OPTIMIZATION": enableWMO ? "YES" : "NO",
-                    ]),
+                    buildSettings: buildSettings),
             ],
             targets: [
                 TestStandardTarget(
@@ -1424,7 +1428,11 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             results.checkTask(.matchRuleType("SwiftDriver Interface Verification"), .matchRuleItem(arch)) { task in
                                 results.checkTaskFollows(task, .matchRuleType("SwiftMergeGeneratedHeaders"))
                                 results.checkTaskFollows(task, .matchRuleType("SwiftDriver Compilation Requirements"), .matchRuleItem(arch))
-                                task.checkCommandLineContains(["-no-verify-emitted-module-interface"])
+                                if skipInstalledHeaderInterfaceVerification != false {
+                                    task.checkCommandLineContains(["-no-verify-emitted-module-interface"])
+                                } else {
+                                    task.checkCommandLineDoesNotContain("-no-verify-emitted-module-interface")
+                                }
                             }
                         } else {
                             results.checkTask(.matchRuleType("SwiftDriver Interface Verification"), .matchRuleItem(arch)) { task in
@@ -1468,6 +1476,29 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             enableWMO: enableWMO)
     }
 
+    @Test(.requireSDKs(.macOS), arguments: [true, false])
+    func swiftInterfaceVerificationNotSkippedWithInstalledHeader(enableWMO: Bool) async throws {
+        try await testMultipleArchs(
+            runDestination: .macOS,
+            archs: ["arm64", "arm64e"],
+            targetTripleSuffix: "-apple-macos",
+            installObjcHeader: true,
+            buildLibraryForDistribution: true,
+            enableWMO: enableWMO,
+            skipInstalledHeaderInterfaceVerification: false)
+    }
+
+    @Test(.requireSDKs(.macOS), arguments: [true, false])
+    func swiftInterfaceVerificationSkippedByDefault(enableWMO: Bool) async throws {
+        try await testMultipleArchs(
+            runDestination: .macOS,
+            archs: ["arm64", "arm64e"],
+            targetTripleSuffix: "-apple-macos",
+            installObjcHeader: true,
+            buildLibraryForDistribution: true,
+            enableWMO: enableWMO,
+            skipInstalledHeaderInterfaceVerification: nil)
+    }
 
     @Test(.requireSDKs(.iOS))
     func multipleArchs_iOS() async throws {


### PR DESCRIPTION
Gate the -no-verify-emitted-module-interface flag behind a new internal build setting SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION, defaulting to YES to preserve existing behavior. Setting it to NO allows .swiftinterface verification to run for frameworks that install a generated ObjC compatibility header.

rdar://174872349
