### PR TITLE
Optimize SourcesTaskProducer by using direct identifier lookups

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -953,7 +953,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     }
 
                     if scope.evaluate(BuiltinMacros.GENERATE_TEST_ENTRY_POINT) {
-                        result.append((scope.evaluate(BuiltinMacros.GENERATED_TEST_ENTRY_POINT_PATH), context.lookupFileType(fileName: "sourcecode.swift")!,  /* shouldUsePrefixHeader */ false))
+                        result.append((scope.evaluate(BuiltinMacros.GENERATED_TEST_ENTRY_POINT_PATH), context.lookupFileType(identifier: "sourcecode.swift")!,  /* shouldUsePrefixHeader */ false))
                     }
 
                     return result
@@ -1861,7 +1861,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         await appendGeneratedTasks(&tasks) { delegate in
             context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: content), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
         }
-        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
+        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(identifier: "sourcecode.swift")!)
     }
 
     /// Generates a task for creating the `__BundleLookupHelper` class to enable `#bundle` support in mergeable libraries.
@@ -1895,7 +1895,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         await appendGeneratedTasks(&tasks) { delegate in
             context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: content), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
         }
-        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
+        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(identifier: "sourcecode.swift")!)
     }
 
     private func generateTestAnchor(_ scope: MacroEvaluationScope) async -> GeneratedSourceCodeResult? {
@@ -1911,7 +1911,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         await appendGeneratedTasks(&tasks) { delegate in
             context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: content), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
         }
-        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
+        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(identifier: "sourcecode.swift")!)
     }
 
     /// Generates a task for creating the resource bundle accessor for package targets.
@@ -2069,7 +2069,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         await appendGeneratedTasks(&tasks) { delegate in
             context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: contents), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
         }
-        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(fileName: "sourcecode.swift")!)
+        return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(identifier: "sourcecode.swift")!)
     }
 
     private func generateKernelExtensionModuleInfoFileTask(_ scope: MacroEvaluationScope, _ buildPhase: BuildPhaseWithBuildFiles) async -> (any PlannedTask)? {


### PR DESCRIPTION
## Motivation

When querying the sourcecode.swift spec in `SourcesTaskProducer`, the `context.lookupFileType(fileName: "sourcecode.swift")` overload was being used. This incorrectly triggers an O(N) linear scan across all registered `FileTypeSpec` objects to match the .swift extension. This only succeeded by coincidence because the spec identifier's suffix matches the valid file extension.

## Modifications:

Updated 5 call sites in `SourcesTaskProducer.swift `to use `context.lookupFileType(identifier: "sourcecode.swift")` instead of fileName:.

## Result:

Replaces the O(N) file extension scan with a direct O(1) proxy dictionary lookup, eliminating redundant iterations during task construction.