### PR TITLE
Disable repairViaOwnershipAnalysis for EagerLinkingTBDs symlinks.

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -829,7 +829,10 @@ extension FrameworkProductTypeSpec {
             }
 
             await producer.appendGeneratedTasks(&tasks, options: destination.correspondingTaskOrderingOptions, staleFileRemovalScope: destination.staleFileRemovalScope) { delegate in
-                producer.context.symlinkSpec.constructSymlinkTask(CommandBuildContext(producer: producer.context, scope: scope, inputs: [], output: output.path), delegate, toPath: target, repairViaOwnershipAnalysis: true)
+                // Ownership analysis on EagerLinkingTBDs symlinks combined with .linkingRequirement
+                // ordering can cause dependency cycles. (rdar://130618458, rdar://143197276)
+                let repairViaOwnership = destination == .builtProduct
+                producer.context.symlinkSpec.constructSymlinkTask(CommandBuildContext(producer: producer.context, scope: scope, inputs: [], output: output.path), delegate, toPath: target, repairViaOwnershipAnalysis: repairViaOwnership)
             }
         }
     }

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -2692,4 +2692,42 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    /// rdar://130618458: EagerLinkingTBDs symlinks should not use repairViaOwnershipAnalysis
+    /// to avoid spurious dependency cycles.
+    @Test(.requireSDKs(.macOS))
+    func eagerLinkingTBDSymlinkOwnershipAnalysis() async throws {
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "Sources",
+                children: [
+                    TestFile("Fwk.c"),
+                    TestFile("Fwk.h"),
+                ]),
+            buildConfigurations: [TestBuildConfiguration(
+                "Debug",
+                buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "YES",
+                ])],
+            targets: [
+                TestStandardTarget(
+                    "Fwk", type: .framework,
+                    buildPhases: [
+                        TestHeadersBuildPhase([TestBuildFile("Fwk.h", headerVisibility: .public)]),
+                        TestSourcesBuildPhase(["Fwk.c"]),
+                    ]),
+            ])
+
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        await tester.checkBuild(runDestination: .macOS) { results in
+            results.checkTask(.matchRuleType("SymLink"), .matchRuleItemPattern(.contains("EagerLinkingTBDs"))) { task in
+                #expect(task.repairViaOwnershipAnalysis == false, "EagerLinkingTBDs symlink should not use repairViaOwnershipAnalysis")
+            }
+
+            results.checkNoDiagnostics()
+        }
+    }
 }


### PR DESCRIPTION
repairViaOwnershipAnalysis on EagerLinkingTBDs symlinks can cause intermittent dependency cycles in incremental builds.

rdar://130618458
rdar://143197276