### PR TITLE
Ensure stdout and stderr are drained concurrently to avoid deadlock

### DIFF
--- a/Sources/SWBUtil/Dispatch+Async.swift
+++ b/Sources/SWBUtil/Dispatch+Async.swift
@@ -79,7 +79,7 @@ extension DispatchFD {
 
     /// Returns an async stream which reads bytes from the specified file descriptor. Unlike `FileHandle.bytes`, it does not block the caller.
     @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public func dataStream() -> some AsyncSequence<SWBDispatchData, any Error> {
+    public func dataStream() -> AsyncThrowingStream<SWBDispatchData, any Error> {
         AsyncThrowingStream<SWBDispatchData, any Error> {
             while !Task.isCancelled {
                 let chunk = try await readChunk(upToLength: 4096)

--- a/Sources/SWBUtil/FileHandle+Async.swift
+++ b/Sources/SWBUtil/FileHandle+Async.swift
@@ -25,7 +25,7 @@ extension FileHandle {
 
     /// Replacement for `bytes` which uses DispatchIO to avoid blocking the caller.
     @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public func bytes() -> some AsyncSequence<SWBDispatchData, any Error> {
+    public func bytes() -> AsyncThrowingStream<SWBDispatchData, any Error> {
         DispatchFD(fileHandle: self).dataStream()
     }
 }

--- a/Sources/SWBUtil/Process+Async.swift
+++ b/Sources/SWBUtil/Process+Async.swift
@@ -45,21 +45,10 @@ extension Process {
     ///
     /// - note: This method will mutate the `standardOutput` or `standardError` property of the Process object, replacing any existing `Pipe` or `FileHandle` which may be set. It must be called before the process is started.
     @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> AsyncThrowingStream<SWBDispatchData, any Error> {        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
+    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> some AsyncSequence<SWBDispatchData, any Error> {
+        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
         self[keyPath: keyPath] = pipe
-        let fileHandle = pipe.fileHandleForReading
-        return AsyncThrowingStream { continuation in
-            Task {
-                do {
-                    for try await chunk in fileHandle.bytes() {
-                        continuation.yield(chunk)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-        }
+        return pipe.fileHandleForReading.bytes()
     }
 }
 

--- a/Sources/SWBUtil/Process+Async.swift
+++ b/Sources/SWBUtil/Process+Async.swift
@@ -45,10 +45,21 @@ extension Process {
     ///
     /// - note: This method will mutate the `standardOutput` or `standardError` property of the Process object, replacing any existing `Pipe` or `FileHandle` which may be set. It must be called before the process is started.
     @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> some AsyncSequence<SWBDispatchData, any Error> {
-        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
+    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> AsyncThrowingStream<SWBDispatchData, any Error> {        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
         self[keyPath: keyPath] = pipe
-        return pipe.fileHandleForReading.bytes()
+        let fileHandle = pipe.fileHandleForReading
+        return AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    for try await chunk in fileHandle.bytes() {
+                        continuation.yield(chunk)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/SWBUtil/Process+Async.swift
+++ b/Sources/SWBUtil/Process+Async.swift
@@ -45,21 +45,10 @@ extension Process {
     ///
     /// - note: This method will mutate the `standardOutput` or `standardError` property of the Process object, replacing any existing `Pipe` or `FileHandle` which may be set. It must be called before the process is started.
     @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> AsyncThrowingStream<SWBDispatchData, any Error> {        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
+    public func makeStream(for keyPath: ReferenceWritableKeyPath<Process, Pipe?>, using pipe: Pipe) -> AsyncThrowingStream<SWBDispatchData, any Error> {
+        precondition(!isRunning) // the pipe setters will raise `NSInvalidArgumentException` anyways
         self[keyPath: keyPath] = pipe
-        let fileHandle = pipe.fileHandleForReading
-        return AsyncThrowingStream { continuation in
-            Task {
-                do {
-                    for try await chunk in fileHandle.bytes() {
-                        continuation.yield(chunk)
-                    }
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-        }
+        return pipe.fileHandleForReading.bytes()
     }
 }
 

--- a/Sources/SWBUtil/Process.swift
+++ b/Sources/SWBUtil/Process.swift
@@ -94,9 +94,9 @@ extension Process {
                 let stderrStream = process.makeStream(for: \.standardErrorPipe, using: stderrPipe)
                 return (stdoutStream, stderrStream)
             } collect: { (stdoutStream, stderrStream) in
-                let stdoutData = try await stdoutStream.collect()
-                let stderrData = try await stderrStream.collect()
-                return (stdoutData: stdoutData, stderrData: stderrData)
+                async let stdoutData = stdoutStream.collect()
+                async let stderrData = stderrStream.collect()
+                return try await (stdoutData: stdoutData, stderrData: stderrData)
             }
             return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
         } else {
@@ -112,9 +112,9 @@ extension Process {
                 let stderrStream = process._makeStream(for: \.standardErrorPipe, using: stderrPipe)
                 return (stdoutStream, stderrStream)
             } collect: { (stdoutStream, stderrStream) in
-                let stdoutData = try await stdoutStream.collect()
-                let stderrData = try await stderrStream.collect()
-                return (stdoutData: stdoutData, stderrData: stderrData)
+                async let stdoutData = stdoutStream.collect()
+                async let stderrData = stderrStream.collect()
+                return try await (stdoutData: stdoutData, stderrData: stderrData)
             }
             return Processes.ExecutionResult(exitStatus: exitStatus, stdout: Data(output.stdoutData), stderr: Data(output.stderrData))
         }

--- a/Tests/SWBUtilTests/ProcessTests.swift
+++ b/Tests/SWBUtilTests/ProcessTests.swift
@@ -144,6 +144,18 @@ fileprivate struct ProcessTests {
         }
     }
 
+#if os(macOS)
+    @Test
+    func ensureFillingStderrBeforeWritingToStdoutDoesNotDeadlock() async throws {
+        let result = try await Process.getShellOutput(
+            "dd if=/dev/zero bs=131072 count=1 1>&2 2>/dev/null; echo done"
+        )
+        #expect(result.exitStatus == .exit(0))
+        #expect(result.stdout == Data("done\n".utf8))
+        #expect(result.stderr.count == 131072)
+    }
+#endif
+
     @Test
     func exitStatus() throws {
 #if !os(Windows)

--- a/Tests/SWBUtilTests/ProcessTests.swift
+++ b/Tests/SWBUtilTests/ProcessTests.swift
@@ -144,7 +144,7 @@ fileprivate struct ProcessTests {
         }
     }
 
-#if os(macOS)
+#if !os(Windows)
     @Test
     func ensureFillingStderrBeforeWritingToStdoutDoesNotDeadlock() async throws {
         let result = try await Process.getShellOutput(


### PR DESCRIPTION
The process that runs clang to check its version writes verbose (-v) output to stderr.  On some systems this can exceed the kernel buffer size.

Before this change the parent drained stdout and stderr sequentially, if the child filled the stderr pipe the child stalled waiting for the parent to drain it but the parent is waiting for stdout which would never arrive.
