### PR TITLE
Infer -library-level ipi for SKIP_INSTALL=YES targets

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1053,6 +1053,7 @@ public final class BuiltinMacros {
     public static let SWIFT_ENABLE_BATCH_MODE = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BATCH_MODE")
     public static let SWIFT_ENABLE_INCREMENTAL_COMPILATION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_COMPILATION")
     public static let SWIFT_ENABLE_INCREMENTAL_SCAN = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_SCAN")
+    public static let SWIFT_ENABLE_IPI_LIBRARY_LEVEL = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_IPI_LIBRARY_LEVEL")
     public static let SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES")
     public static let SWIFT_ENABLE_LIBRARY_EVOLUTION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LIBRARY_EVOLUTION")
     public static let SWIFT_ENABLE_BARE_SLASH_REGEX = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BARE_SLASH_REGEX")
@@ -2295,6 +2296,7 @@ public final class BuiltinMacros {
         SWIFT_ENABLE_BATCH_MODE,
         SWIFT_ENABLE_INCREMENTAL_COMPILATION,
         SWIFT_ENABLE_INCREMENTAL_SCAN,
+        SWIFT_ENABLE_IPI_LIBRARY_LEVEL,
         SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES,
         SWIFT_ENABLE_LIBRARY_EVOLUTION,
         SWIFT_USE_INTEGRATED_DRIVER,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2181,8 +2181,11 @@ private class SettingsBuilder: ProjectMatchLookup {
                 Path("/System/iOSSupport/usr/lib"),]
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
-            if table.contains(BuiltinMacros.SKIP_INSTALL) {
-                // Build-time / IPI module, the compiler doesn't know about this mode yet.
+            if scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
+                // Build-time / IPI module.
+                if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL) {
+                    table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "ipi")
+                }
             } else if privateInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
                 // SPI module.
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "spi")

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -114,6 +114,11 @@
                 DefaultValue = YES;
             },
             {
+                Name = "SWIFT_ENABLE_IPI_LIBRARY_LEVEL";
+                Type = Boolean;
+                DefaultValue = NO;
+            },
+            {
                 Name = "SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES";
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -3923,6 +3923,27 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                              buildSettings: ["INSTALL_PATH" : "/System/Library/Frameworks/MyFramework"]) { task in
             task.checkCommandLineDoesNotContain("-library-level")
         }
+
+        // Infer "ipi" from SKIP_INSTALL when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is YES.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["SKIP_INSTALL" : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "YES"]) { task in
+            task.checkCommandLineContains(["-library-level", "ipi"])
+        }
+
+        // Don't infer "ipi" from SKIP_INSTALL when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is NO (default).
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["SKIP_INSTALL" : "YES"]) { task in
+            task.checkCommandLineDoesNotContain("-library-level")
+        }
+
+        // Explicit SWIFT_LIBRARY_LEVEL takes precedence over SKIP_INSTALL.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["SKIP_INSTALL" : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "YES",
+                                                             "SWIFT_LIBRARY_LEVEL" : "spi"]) { task in
+            task.checkCommandLineContains(["-library-level", "spi"])
+        }
     }
 
     @Test(.skipHostOS(.macOS), .skipHostOS(.windows), .requireSDKs(.host))


### PR DESCRIPTION
Add SWIFT_ENABLE_IPI_LIBRARY_LEVEL build setting (default NO). When enabled, targets with SKIP_INSTALL=YES automatically get -library-level ipi passed to the compiler, enabling IPI import diagnostics. An explicit SWIFT_LIBRARY_LEVEL still takes precedence.

rdar://174947092