### PR TITLE
Respect the run destination's choice of specific Windows SDKs

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -160,26 +160,35 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         (canonicalNameSuffix != nil ? " suffix: \(String(describing: canonicalNameSuffix))" : "")
     }
 
-    private func effectiveToolchainOverride(originalParameters: BuildParameters, workspaceContext: WorkspaceContext) -> [String]? {
-        guard let toolchain else { return nil }
-
-        // Check if the given toolchain is already the one that would be selected by default and do not impose it if that is the case.
-        let defaultToolchain = sdkRoot.map { try? workspaceContext.core.sdkRegistry.lookup($0, activeRunDestination: originalParameters.activeRunDestination)?.toolchains }
-        if (defaultToolchain??.first ?? ToolchainRegistry.defaultToolchainIdentifier) != toolchain.first {
-            return toolchain
+    private func effectiveSDKRootOverride(originalParameters: BuildParameters, workspaceContext: WorkspaceContext) -> String? {
+        if let platform {
+            let sdkNameBase: String?
+            if let runDestination = originalParameters.activeRunDestination,
+               let runDestinationSDK = try? workspaceContext.sdkRegistry.lookup(nameOrPath: runDestination.sdk, basePath: Path.root, activeRunDestination: runDestination),
+               Self.platform(forSDK: runDestinationSDK, workspaceContext: workspaceContext) === platform {
+                sdkNameBase = runDestinationSDK.canonicalName
+            } else {
+                sdkNameBase = platform.sdkCanonicalName
+            }
+            if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty {
+                return sdkNameBase.map { "\($0).\(canonicalNameSuffix)" }
+            } else {
+                return sdkNameBase
+            }
         } else {
             return nil
         }
     }
 
-    private var sdkRoot: String? {
-        guard let platform else { return nil }
-        let sdkRootPublic = platform.sdkCanonicalName
+    private func effectiveToolchainOverride(originalParameters: BuildParameters, workspaceContext: WorkspaceContext) -> [String]? {
+        guard let toolchain else { return nil }
 
-        if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty {
-            return sdkRootPublic.map { "\($0).\(canonicalNameSuffix)" }
+        // Check if the given toolchain is already the one that would be selected by default and do not impose it if that is the case.
+        let defaultToolchain = effectiveSDKRootOverride(originalParameters: originalParameters, workspaceContext: workspaceContext).map { try? workspaceContext.core.sdkRegistry.lookup($0, activeRunDestination: originalParameters.activeRunDestination)?.toolchains }
+        if (defaultToolchain??.first ?? ToolchainRegistry.defaultToolchainIdentifier) != toolchain.first {
+            return toolchain
         } else {
-            return sdkRootPublic
+            return nil
         }
     }
 
@@ -205,8 +214,9 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
     /// Compute a derived set of build parameters with the specialization imposed on them.
     func imposed(on parameters: BuildParameters, workspaceContext: WorkspaceContext) -> BuildParameters {
         var overrides = parameters.overrides
-        if let sdkRoot {
-            overrides["SDKROOT"] = sdkRoot
+
+        if let imposedSDKRoot = effectiveSDKRootOverride(originalParameters: parameters, workspaceContext: workspaceContext) {
+            overrides["SDKROOT"] = imposedSDKRoot
         }
         if let sdkVariant {
             overrides["SDK_VARIANT"] = sdkVariant.name
@@ -243,6 +253,13 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         self.diagnostics = diagnostics
     }
 
+    private static func platform(forSDK sdk: SDK, workspaceContext: WorkspaceContext) -> Platform? {
+        // This seems like an unfortunate way to get from the SDK to its platform.  But SettingsBuilder.computeBoundProperties() creates a scope to evaluate the PLATFORM_NAME defined in the SDK's default properties, so maybe there isn't a clearly better way.
+        return workspaceContext.core.platformRegistry.platforms.filter {
+            $0.sdks.contains(where: { $0.canonicalName == sdk.canonicalName })
+        }.only
+    }
+
     fileprivate init(workspaceContext: WorkspaceContext, buildRequestContext: BuildRequestContext, parameters: BuildParameters) {
         var diagnostics = [Diagnostic]()
         let platformName: String?
@@ -255,8 +272,7 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         else {
             overridingSdk = nil
         }
-        // This seems like an unfortunate way to get from the SDK to its platform.  But SettingsBuilder.computeBoundProperties() creates a scope to evaluate the PLATFORM_NAME defined in the SDK's default properties, so maybe there isn't a clearly better way.
-        if let overridingSdk, let overridingPlatform = workspaceContext.core.platformRegistry.platforms.filter({ $0.sdks.contains(where: { $0.canonicalName == overridingSdk.canonicalName }) }).first {
+        if let overridingSdk, let overridingPlatform = Self.platform(forSDK: overridingSdk, workspaceContext: workspaceContext) {
             platformName = overridingPlatform.name
         } else if let platform = parameters.activeRunDestination?.platform {
             platformName = platform

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3600,7 +3600,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         // If the target supports specialization and it already has an SDK, then we need to use that instead of attempting to override the SDK with the run destination information. This is very important in scenarios where the destination is Mac Catalyst, but the target is building for iphoneos. The target will be re-configured for macosx/iosmac.
         do {
             let scope = createScope(sdkToUse: nil)
-            let sdk = try sdkRegistry.lookup(scope.evaluate(BuiltinMacros.SDKROOT).str, activeRunDestination: nil)
+            let sdk = try sdkRegistry.lookup(nameOrPath: scope.evaluate(BuiltinMacros.SDKROOT).str, basePath: project?.sourceRoot ?? Path.root, activeRunDestination: nil)
             if Settings.targetPlatformSpecializationEnabled(scope: scope) && sdk != nil {
                 return
             }
@@ -3617,7 +3617,7 @@ private class SettingsBuilder: ProjectMatchLookup {
 
         let destinationSDK: SDK
         do {
-            if let sdk = try sdkRegistry.lookup(runDestination.sdk, activeRunDestination: runDestination) {
+            if let sdk = try sdkRegistry.lookup(nameOrPath: runDestination.sdk, basePath: project?.sourceRoot ?? Path.root, activeRunDestination: runDestination) {
                 destinationSDK = sdk
             } else {
                 self.errors.append("unable to resolve run destination SDK: '\(runDestination.sdk)'")
@@ -3706,7 +3706,7 @@ private class SettingsBuilder: ProjectMatchLookup {
 
                 requiredSDKCanonicalName = resolvedCandidates.compactMap { $0.1 }.first
             }
-            else if (destinationPlatformIsMacOS || destinationPlatformIsLinux || destinationPlatform.isSimulator || destinationUsesSwiftSDK) && targetPlatform === destinationPlatform {
+            else if targetPlatform === destinationPlatform {
                 // If the target specifies an SDK for the destination platform, don't override its choice of SDK.
             }
             else {

--- a/Sources/SWBTestSupport/Misc.swift
+++ b/Sources/SWBTestSupport/Misc.swift
@@ -106,7 +106,11 @@ package extension ConfiguredTarget {
         // Converts the sdkroot/sdkvariant info into a set of normalized values.
         func normalize(platform: String, variant: String?) -> String {
             // The suffix is not important in the discriminator as that can be verified via other means if necessary.
-            let platform = String(platform.split(separator: ".").first ?? "")
+            // Also strip any trailing version number.
+            var platform = String(platform.split(separator: ".").first ?? "")
+            while let last = platform.last, last.isNumber {
+                platform.removeLast()
+            }
 
             if let variant, platform == "macosx" { return variant }
             if platform == variant { return platform }

--- a/Sources/SWBWindowsPlatform/Plugin.swift
+++ b/Sources/SWBWindowsPlatform/Plugin.swift
@@ -148,36 +148,48 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
             return []
         }
 
-        let windowsSDKSettingsPlistPath = windowsPlatform.path.join("Developer").join("SDKs").join("Windows.sdk").join("SDKSettings.plist")
-        let windowsSDKSettingsPlist = try PropertyList.fromPath(windowsSDKSettingsPlistPath, fs: context.fs)
-        guard case let .plDict(dict) = windowsSDKSettingsPlist else {
-            throw StubError.error("Unexpected top-level property list type in \(windowsSDKSettingsPlistPath.str) (expected dictionary)")
-        }
-        let testingLibraryPath = windowsPlatform.path.join("Developer").join("Library")
-        let defaultProperties: [String: PropertyListItem] = [
-            "LD_DEPENDENCY_INFO_FILE": .plString(""),
-            "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
+        var additionalSDKs: [(path: Path, platform: SWBCore.Platform?, data: [String: PropertyListItem])] = []
+        for sdkDir in try context.fs.listdir(windowsPlatform.path.join("Developer").join("SDKs")) {
+            let windowsSDKSettingsPlistPath = windowsPlatform.path.join("Developer").join("SDKs").join(sdkDir).join("SDKSettings.plist")
+            let windowsSDKSettingsPlist = try PropertyList.fromPath(windowsSDKSettingsPlistPath, fs: context.fs)
+            guard case let .plDict(dict) = windowsSDKSettingsPlist else {
+                throw StubError.error("Unexpected top-level property list type in \(windowsSDKSettingsPlistPath.str) (expected dictionary)")
+            }
+            let testingLibraryPath = windowsPlatform.path.join("Developer").join("Library")
+            let defaultProperties: [String: PropertyListItem] = [
+                "LD_DEPENDENCY_INFO_FILE": .plString(""),
+                "PRELINK_DEPENDENCY_INFO_FILE": .plString(""),
 
-            "GENERATE_TEXT_BASED_STUBS": "NO",
-            "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
+                "GENERATE_TEXT_BASED_STUBS": "NO",
+                "GENERATE_INTERMEDIATE_TEXT_BASED_STUBS": "NO",
 
-            "LIBRARY_SEARCH_PATHS": "$(inherited) $(SDKROOT)/usr/lib/swift/windows/$(CURRENT_ARCH)",
-            "TEST_LIBRARY_SEARCH_PATHS": .plArray([
-                .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/"),
-                .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH)"),
-                .plString("\(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH)"),
-                .plString("\(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows"),
-            ]),
+                "LIBRARY_SEARCH_PATHS": "$(inherited) $(SDKROOT)/usr/lib/swift/windows/$(CURRENT_ARCH)",
+                "TEST_LIBRARY_SEARCH_PATHS": .plArray([
+                    .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/"),
+                    .plString("\(testingLibraryPath.strWithPosixSlashes)/Testing-$(SWIFT_TESTING_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH)"),
+                    .plString("\(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows/$(CURRENT_ARCH)"),
+                    .plString("\(testingLibraryPath.strWithPosixSlashes)/XCTest-$(XCTEST_VERSION)/usr/lib/swift/windows"),
+                ]),
 
-            "DEFAULT_USE_RUNTIME": "MD",
-        ]
-        .addingContents(of: dict["DefaultProperties"]?.dictValue ?? [:]) // allow the on-disk copy to override
+                "DEFAULT_USE_RUNTIME": "MD",
+            ].addingContents(of: dict["DefaultProperties"]?.dictValue ?? [:]) // allow the on-disk copy to override
 
-        return try [
-            (windowsSDKSettingsPlistPath.dirname, windowsPlatform, dict.merging([
+            let canonicalName: String
+            if case let .plString(providedCanonicalName) = dict["CanonicalName"] {
+                if sdkDir == "WindowsExperimental.sdk" && providedCanonicalName == "windows" {
+                    // Some versions of the Windows distribution report the same canonical name for Windows.SDK and WindowsExperimental.sdk.
+                    canonicalName = "windows-experimental"
+                } else {
+                    canonicalName = providedCanonicalName
+                }
+            } else {
+                canonicalName = "windows"
+            }
+
+            try additionalSDKs.append((windowsSDKSettingsPlistPath.dirname, windowsPlatform, dict.merging([
                 "Type": .plString("SDK"),
                 "Version": .plString(Version(ProcessInfo.processInfo.operatingSystemVersion).zeroTrimmed.description),
-                "CanonicalName": .plString("windows"),
+                "CanonicalName": .plString(canonicalName),
                 "IsBaseSDK": .plBool(true),
                 "DefaultProperties": .plDict([
                     "PLATFORM_NAME": .plString("windows"),
@@ -196,7 +208,8 @@ struct WindowsSDKRegistryExtension: SDKRegistryExtension {
                         "LLVMTargetTripleVendor": .plString("unknown"),
                     ])
                 ]),
-            ]) { old, new in new })
-        ]
+            ]) { old, new in new }))
+        }
+        return additionalSDKs
     }
 }

--- a/Tests/SWBCoreTests/DependencyScopingTests.swift
+++ b/Tests/SWBCoreTests/DependencyScopingTests.swift
@@ -582,9 +582,9 @@ import Foundation
         let t1Configured = buildGraph.allTargets[1]
         let t3ConfiguredTopLevel = buildGraph.allTargets[2]
         #expect(try buildGraph.dependencies(t1).map(\.target.name) == ["T3"])
-        #expect(t1Configured.parameters.overrides["SDKROOT"] == "iphoneos")
+        #expect(t1Configured.parameters.overrides["SDKROOT"] == "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)")
         #expect(t3ConfiguredAsDependencyOfT2.parameters.overrides["SDKROOT"] == "macosx")
-        #expect(t3ConfiguredTopLevel.parameters.overrides["SDKROOT"] == "iphoneos")
+        #expect(t3ConfiguredTopLevel.parameters.overrides["SDKROOT"] == "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)")
         delegate.checkNoDiagnostics()
     }
 

--- a/Tests/SWBCoreTests/MultiPlatformDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/MultiPlatformDependencyResolverTests.swift
@@ -365,7 +365,7 @@ extension SWBCore.Workspace {
         try validate(targets, buildGraph)
     }
 
-    func _testCoreScenario_macOSApp(useImplicitDependencies: Bool) async throws {
+    func _testCoreScenario_macOSApp(core: Core, useImplicitDependencies: Bool) async throws {
         try await _testCoreScenario(targetName: "macOS App", destination: .macOS, useImplicitDependencies: useImplicitDependencies) { target, graph in
 
             // NOTE: OS frameworks use arm64e, but! arm64e is not currently added to ARCHS by default for public SDKs.
@@ -381,7 +381,7 @@ extension SWBCore.Workspace {
 
             for dep in deps {
                 #expect(dep.parameters.overrides == [
-                    "SDKROOT": "macosx",
+                    "SDKROOT": "macosx\(core.loadSDK(.macOS).defaultDeploymentTarget)",
                     "SDK_VARIANT": "macos",
                     "SUPPORTS_MACCATALYST": "NO",
                 ])
@@ -391,15 +391,15 @@ extension SWBCore.Workspace {
 
     @Test(.requireSDKs(.macOS))
     func coreScenario_macOSApp_ExplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_macOSApp(useImplicitDependencies: false)
+        try await _testCoreScenario_macOSApp(core: getCore(), useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.macOS))
     func coreScenario_macOSApp_ImplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_macOSApp(useImplicitDependencies: true)
+        try await _testCoreScenario_macOSApp(core: getCore(), useImplicitDependencies: true)
     }
 
-    func _testCoreScenario_iOSApp(useImplicitDependencies: Bool) async throws {
+    func _testCoreScenario_iOSApp(core: Core, useImplicitDependencies: Bool) async throws {
         try await _testCoreScenario(targetName: "iOS App", destination: .iOS, useImplicitDependencies: useImplicitDependencies) { target, graph in
 
             let expectedDeps = [
@@ -414,7 +414,7 @@ extension SWBCore.Workspace {
 
             for dep in deps {
                 #expect(dep.parameters.overrides == [
-                    "SDKROOT": "iphoneos",
+                    "SDKROOT": "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)",
                     "SDK_VARIANT": "iphoneos",
                     "SUPPORTS_MACCATALYST": "NO",
                 ])
@@ -424,15 +424,15 @@ extension SWBCore.Workspace {
 
     @Test(.requireSDKs(.iOS))
     func coreScenario_iOSApp_ExplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_iOSApp(useImplicitDependencies: false)
+        try await _testCoreScenario_iOSApp(core: getCore(), useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.iOS))
     func coreScenario_iOSApp_ImplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_iOSApp(useImplicitDependencies: true)
+        try await _testCoreScenario_iOSApp(core: getCore(), useImplicitDependencies: true)
     }
 
-    func _testCoreScenario_macCatalystApp(useImplicitDependencies: Bool) async throws {
+    func _testCoreScenario_macCatalystApp(core: Core, useImplicitDependencies: Bool) async throws {
         try await _testCoreScenario(targetName: "macCatalyst App", destination: .macCatalyst, useImplicitDependencies: false) { target, graph in
 
             let expectedDeps = [
@@ -446,7 +446,7 @@ extension SWBCore.Workspace {
 
             for dep in deps {
                 #expect(dep.parameters.overrides == [
-                    "SDKROOT": "macosx",
+                    "SDKROOT": "macosx\(core.loadSDK(.macOS).defaultDeploymentTarget)",
                     "SDK_VARIANT": "iosmac",
                     "SUPPORTS_MACCATALYST": "YES",
                 ])
@@ -456,15 +456,15 @@ extension SWBCore.Workspace {
 
     @Test(.requireSDKs(.macOS))
     func coreScenario_macCatalystApp_ExplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_macCatalystApp(useImplicitDependencies: false)
+        try await _testCoreScenario_macCatalystApp(core: getCore(), useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.macOS))
     func coreScenario_macCatalystApp_ImplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_macCatalystApp(useImplicitDependencies: true)
+        try await _testCoreScenario_macCatalystApp(core: getCore(), useImplicitDependencies: true)
     }
 
-    func _testCoreScenario_watchApp(useImplicitDependencies: Bool) async throws {
+    func _testCoreScenario_watchApp(core: Core, useImplicitDependencies: Bool) async throws {
         try await _testCoreScenario(targetName: "Watchable", destination: .watchOS, useImplicitDependencies: false) { target, graph in
 
             let expectedDeps1 = [
@@ -490,7 +490,7 @@ extension SWBCore.Workspace {
                 }
                 else {
                     #expect(dep.parameters.overrides == [
-                        "SDKROOT": "watchos",
+                        "SDKROOT": "watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)",
                         "SDK_VARIANT": "watchos",
                         "SUPPORTS_MACCATALYST": "NO",
                     ])
@@ -501,15 +501,15 @@ extension SWBCore.Workspace {
 
     @Test(.requireSDKs(.watchOS))
     func coreScenario_watchApp_ExplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_watchApp(useImplicitDependencies: false)
+        try await _testCoreScenario_watchApp(core: getCore(), useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.watchOS))
     func coreScenario_watchApp_ImplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_watchApp(useImplicitDependencies: true)
+        try await _testCoreScenario_watchApp(core: getCore(), useImplicitDependencies: true)
     }
 
-    func _testCoreScenario_AllTopLevelTargets(destination: RunDestinationInfo?, useImplicitDependencies: Bool) async throws {
+    func _testCoreScenario_AllTopLevelTargets(core: Core, destination: RunDestinationInfo?, useImplicitDependencies: Bool) async throws {
         try await _testCoreScenario(targetNames: ["macOS App", "iOS App", "macCatalyst App", "Watchable"], destination: destination, useImplicitDependencies: useImplicitDependencies) { targets, graph in
 
             // Verify the macOS App target
@@ -528,7 +528,7 @@ extension SWBCore.Workspace {
 
                 for dep in deps {
                     #expect(dep.parameters.overrides == [
-                        "SDKROOT": "macosx",
+                        "SDKROOT": "\([.macOS, .macCatalyst].contains(destination) ? "macosx\(core.loadSDK(.macOS).defaultDeploymentTarget)" : "macosx")",
                         "SDK_VARIANT": "macos",
                         "SUPPORTS_MACCATALYST": "NO",
                     ].addingContents(of: destination == .macOS || destination == .macCatalyst ? [:] : ["SUPPORTED_PLATFORMS": "macosx"]))
@@ -551,7 +551,7 @@ extension SWBCore.Workspace {
 
                 for dep in deps {
                     #expect(dep.parameters.overrides == [
-                        "SDKROOT": "iphoneos",
+                        "SDKROOT": "\(destination == .iOS ? "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)" : "iphoneos")",
                         "SDK_VARIANT": "iphoneos",
                         "SUPPORTS_MACCATALYST": "NO",
                     ].addingContents(of: destination == .iOS ? [:] : ["SUPPORTED_PLATFORMS": "iphoneos iphonesimulator"]))
@@ -572,9 +572,21 @@ extension SWBCore.Workspace {
                 let deps = try graph.dependencies(target)
                 #expect(deps.map(\.nameAndPlatform).sorted() == expectedDeps)
 
+                let expectedSDKRoot: String
+                switch destination {
+                case .iOS:
+                    expectedSDKRoot = "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)"
+                case .macOS, nil:
+                    expectedSDKRoot = "iphoneos"
+                case .macCatalyst:
+                    expectedSDKRoot = "macosx\(core.loadSDK(.macOS).defaultDeploymentTarget)"
+                default:
+                    expectedSDKRoot = "macosx"
+                }
+
                 for dep in deps {
                     #expect(dep.parameters.overrides == [
-                        "SDKROOT": "\([.iOS, .macOS, nil].contains(destination) ? "iphoneos" : "macosx")",
+                        "SDKROOT": expectedSDKRoot,
                         "SDK_VARIANT": "\([.iOS, .macOS, nil].contains(destination) ? "iphoneos" : "iosmac")",
                     ]
                         .addingContents(of: [.iOS, .macCatalyst].contains(destination) ? [:] : ["SUPPORTED_PLATFORMS": "iphoneos iphonesimulator"])
@@ -627,27 +639,27 @@ extension SWBCore.Workspace {
 
     @Test(.requireSDKs(.macOS, .iOS, .watchOS))
     func coreScenario_AllTopLevelTargets_ExplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_AllTopLevelTargets(destination: nil, useImplicitDependencies: false)
+        try await _testCoreScenario_AllTopLevelTargets(core: getCore(), destination: nil, useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.macOS, .iOS, .watchOS))
     func coreScenario_AllTopLevelTargets_ImplicitDeps_PublicSDK() async throws {
-        try await _testCoreScenario_AllTopLevelTargets(destination: nil, useImplicitDependencies: true)
+        try await _testCoreScenario_AllTopLevelTargets(core: getCore(), destination: nil, useImplicitDependencies: true)
     }
 
     @Test(.requireSDKs(.macOS, .iOS, .watchOS))
     func coreScenario_AllTopLevelTargets_ExplicitDeps_PublicSDK_iOSDestination() async throws {
-        try await _testCoreScenario_AllTopLevelTargets(destination: .iOS, useImplicitDependencies: false)
+        try await _testCoreScenario_AllTopLevelTargets(core: getCore(), destination: .iOS, useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.macOS, .iOS, .watchOS))
     func coreScenario_AllTopLevelTargets_ExplicitDeps_PublicSDK_macOSDestination() async throws {
-        try await _testCoreScenario_AllTopLevelTargets(destination: .macOS, useImplicitDependencies: false)
+        try await _testCoreScenario_AllTopLevelTargets(core: getCore(), destination: .macOS, useImplicitDependencies: false)
     }
 
     @Test(.requireSDKs(.macOS, .iOS, .watchOS))
     func coreScenario_AllTopLevelTargets_ExplicitDeps_PublicSDK_macCatalystDestination() async throws {
-        try await _testCoreScenario_AllTopLevelTargets(destination: .macCatalyst, useImplicitDependencies: false)
+        try await _testCoreScenario_AllTopLevelTargets(core: getCore(), destination: .macCatalyst, useImplicitDependencies: false)
     }
 
     // Helper test method to verify that SUPPORTED_PLATFORMS properly filters potential dependencies.

--- a/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
@@ -383,6 +383,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
     }
 
     func validateBuildFor(_ targets: [SWBCore.Target], destination: RunDestinationInfo, tester: TaskConstructionTester, useImplicitDependencies: Bool, fs: any FSProxy, file: StaticString = #filePath, line: UInt = #line) async throws -> [RunDestinationInfo] {
+        let core = try await getCore()
 
         // Capture the various platforms that the test case validated; used by callers to validate the expected validation blocks are hit.
         var validated: [RunDestinationInfo] = []
@@ -419,15 +420,21 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
             // Ignore certain classes of tasks.
             results.consumeTasksMatchingRuleTypes(["CodeSign", "CreateBuildDirectory", "Gate", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "Copy", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate", "ValidateEmbeddedBinary", "WriteAuxiliaryFile"])
 
+            // When the run destination's SDK platform matches the dep's specialization platform, the SDKROOT includes the SDK version.
+            let iphoneosRoot = destination == .iOS ? "iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)" : "iphoneos"
+            let macosxRoot = [RunDestinationInfo.macOS, .macCatalyst].contains(destination) ? "macosx\(core.loadSDK(.macOS).defaultDeploymentTarget)" : "macosx"
+            let watchosRoot = destination == .watchOS ? "watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)" : "watchos"
+            let appletvosRoot = destination == .tvOS ? "appletvos\(core.loadSDK(.tvOS).defaultDeploymentTarget)" : "appletvos"
+
             if iphoneos {
                 validated.append(.iOS)
-                let sdkroot = (destination == .iOSSimulator) ? "iphonesimulator" : "iphoneos"
+                let sdkroot = (destination == .iOSSimulator) ? "iphonesimulator" : iphoneosRoot
 
                 results.checkTarget("iOS App") { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("CompileAssetCatalog")) { _ in }
                 }
 
-                results.checkTarget("Shared Framework", sdkroot: "iphoneos") { target in
+                results.checkTarget("Shared Framework", sdkroot: iphoneosRoot) { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                         validateTargetCompiledForPlatform("-apple-ios", tasks: tasks)
                     }
@@ -442,14 +449,14 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
             if watchos {
                 validated.append(.watchOS)
-                let sdkroot = destination == .watchOSSimulator ? "watchsimulator" : "watchos"
+                let sdkroot = destination == .watchOSSimulator ? "watchsimulator" : watchosRoot
 
                 // Check the shim app
                 results.checkTarget("Watchable") { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("CompileAssetCatalog")) { _ in }
                 }
 
-                results.checkTarget("Shared Framework", sdkroot: "watchos") { target in
+                results.checkTarget("Shared Framework", sdkroot: watchosRoot) { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                         validateTargetCompiledForPlatform("-apple-watchos", tasks: tasks)
                     }
@@ -471,13 +478,13 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver")) { _ in }
                     }
 
-                    results.checkTarget("Shared Framework", sdkroot: "macosx") { target in
+                    results.checkTarget("Shared Framework", sdkroot: macosxRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-macabi", tasks: tasks)
                         }
                     }
 
-                    results.checkTarget("SharedPkgTarget", sdkroot: "macosx") { target in
+                    results.checkTarget("SharedPkgTarget", sdkroot: macosxRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-macabi", tasks: tasks)
                         }
@@ -492,13 +499,13 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
                     // Since macCatalyst apps are really just iOS apps, if there is another iOS target, then the shared has already been consumed.
                     if !iphoneos {
-                        results.checkTarget("Shared Framework", sdkroot: "iphoneos") { target in
+                        results.checkTarget("Shared Framework", sdkroot: iphoneosRoot) { target in
                             results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                                 validateTargetCompiledForPlatform("-apple-ios", tasks: tasks)
                             }
                         }
 
-                        results.checkTarget("SharedPkgTarget", sdkroot: "iphoneos") { target in
+                        results.checkTarget("SharedPkgTarget", sdkroot: iphoneosRoot) { target in
                             results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                                 validateTargetCompiledForPlatform("-apple-ios", tasks: tasks)
                             }
@@ -524,13 +531,13 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
                     Issue.record("Unexpectedly building for macos for targets: \(targets.map({ $0.name }))")
                 }
 
-                results.checkTarget("Shared Framework", sdkroot: "macosx") { target in
+                results.checkTarget("Shared Framework", sdkroot: macosxRoot) { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                         validateTargetCompiledForPlatform("-apple-macos", tasks: tasks)
                     }
                 }
 
-                results.checkTarget("SharedPkgTarget", sdkroot: "macosx") { target in
+                results.checkTarget("SharedPkgTarget", sdkroot: macosxRoot) { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                         validateTargetCompiledForPlatform("-apple-macos", tasks: tasks)
                     }
@@ -539,7 +546,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
             if tvos {
                 validated.append(.tvOS)
-                let sdkroot = destination == .tvOSSimulator ? "appletvsimulator" : "appletvos"
+                let sdkroot = destination == .tvOSSimulator ? "appletvsimulator" : appletvosRoot
 
                 results.checkTarget("Shared Framework", sdkroot: sdkroot) { target in
                     results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
@@ -557,7 +564,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
             if shared {
                 if destination == .iOS {
                     validated.append(.iOS)
-                    results.checkTarget("Shared Framework", sdkroot: "iphoneos") { target in
+                    results.checkTarget("Shared Framework", sdkroot: iphoneosRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-apple-ios", tasks: tasks)
                         }
@@ -566,7 +573,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
                 if destination == .watchOS {
                     validated.append(.watchOS)
-                    results.checkTarget("Shared Framework", sdkroot: "watchos") { target in
+                    results.checkTarget("Shared Framework", sdkroot: watchosRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-apple-watchos", tasks: tasks)
                         }
@@ -575,7 +582,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
                 if destination == .macCatalyst {
                     validated.append(.macCatalyst)
-                    results.checkTarget("Shared Framework", sdkroot: "macosx") { target in
+                    results.checkTarget("Shared Framework", sdkroot: macosxRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-macabi", tasks: tasks)
                         }
@@ -584,7 +591,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
                 if destination == .macOS {
                     validated.append(.macOS)
-                    results.checkTarget("Shared Framework", sdkroot: "macosx") { target in
+                    results.checkTarget("Shared Framework", sdkroot: macosxRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-apple-macos", tasks: tasks)
                         }
@@ -593,7 +600,7 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
 
                 if destination == .tvOS {
                     validated.append(.tvOS)
-                    results.checkTarget("Shared Framework", sdkroot: "appletvos") { target in
+                    results.checkTarget("Shared Framework", sdkroot: appletvosRoot) { target in
                         results.checkTasks(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { tasks in
                             validateTargetCompiledForPlatform("-apple-tvos", tasks: tasks)
                         }


### PR DESCRIPTION
Part 1 of addressing https://github.com/swiftlang/swift-package-manager/issues/9939

- Ensure we load the full set of SDKs in the Windows platform
- Disambiguate the clashing canonical names of WindowsExperimental.sdk and Windows.sdk
- Ensure specialization of package targets doesn't replace the Windows SDK in the run destination with the default windows sdk

The specialization changes in particular deserve some scrutiny because they impact all platforms, not just windows.