### PR TITLE
Fix prepareForIndex target resolution in --prepare option

### DIFF
--- a/Sources/SwiftBuild/ConsoleCommands/SWBServiceConsoleBuildCommand.swift
+++ b/Sources/SwiftBuild/ConsoleCommands/SWBServiceConsoleBuildCommand.swift
@@ -315,7 +315,7 @@ class SWBServiceConsolePrepareForIndexCommand: SWBServiceConsoleCommand {
 
                 if !prepareTargetNames.isEmpty {
                     do {
-                        prepareTargets = try workspaceInfo.configuredTargets(targetNames: configuredTargetNames, parameters: parameters, buildAllTargets: false).map(\.guid)
+                        prepareTargets = try workspaceInfo.configuredTargets(targetNames: prepareTargetNames, parameters: parameters, buildAllTargets: false).map(\.guid)
                     } catch {
                         return .failure(.failedCommandError(description: error.localizedDescription))
                     }


### PR DESCRIPTION
## Summary

Fix a bug in `SWBServiceConsolePrepareForIndexCommand` where the `--prepare` option was not correctly resolving target GUIDs for `buildOnlyTheseTargets`.

## Problem

When `prepareForIndex` was invoked with the `--prepare` option to specify which targets should be prepared, the code was incorrectly using the `--target` names (`configuredTargetNames`) instead of the `--prepare` names (`prepareTargetNames`) when resolving the target GUIDs.

This caused `prepareTargets` to contain the wrong set of targets, which meant `buildOnlyTheseTargets` was set based on `--target` input rather than `--prepare` input — resulting in **all targets being prepared** instead of just the ones specified via `--prepare`.

## Fix

Change `SWBServiceConsolePrepareForIndexCommand.swift` to use `prepareTargetNames` instead of `configuredTargetNames` when resolving target GUIDs for `buildOnlyTheseTargets`.

```diff
-  prepareTargets = try workspaceInfo.configuredTargets(targetNames: configuredTargetNames, parameters: parameters, buildAllTargets: false).map(\.guid)
+  prepareTargets = try workspaceInfo.configuredTargets(targetNames: prepareTargetNames, parameters: parameters, buildAllTargets: false).map(\.guid)
```

## Test plan
Additional automated test coverage is not added in this PR (the current minimal PIF in `BuildCommandTests` does not emit `preparedForIndex` messages because it lacks a `Sources` build phase; verifying emission requires either expanding the test PIF or switching to `BuildOperationTester`)
