### PR TITLE
Don't filter args following -no_exported_symbols for preview dylibs

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -2043,11 +2043,6 @@ fileprivate func filterLinkerFlagsWhenUnderPreviewsDylib(_ flags: [String]) -> [
             // defining both at once) in order to remain compatible with Xcode versions both
             // before and after this change.
             newFlags.removeLast()
-            while let next = it.next() {
-                if next != "-Xlinker" {
-                    break
-                }
-            }
             continue
         }
         newFlags.append(flag)

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -1039,7 +1039,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                         "LD_ENVIRONMENT": "DYLD_X_PATH=/foo",
                         "OTHER_LDFLAGS": """
                             -Wl,-dyld_env,NOT=allowed_here -Xlinker -dyld_env -Xlinker NOR=this \
-                            -Wl,-no_exported_symbols -Xlinker -no_exported_symbols
+                            -Wl,-no_exported_symbols -Xlinker -no_exported_symbols -lDoNotRemove
                             """,
                         "LD_EXPORT_SYMBOLS": "NO",
                         "GENERATE_INFOPLIST_FILE": "YES",
@@ -1118,6 +1118,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                     task.checkCommandLineDoesNotContain("NOR=this")
                     task.checkCommandLineDoesNotContain("-Wl,-no_exported_symbols")
                     task.checkCommandLineDoesNotContain("-no_exported_symbols")
+                    task.checkCommandLineContains(["-lDoNotRemove"])
                 }
 
                 results.checkWarning(.equal("The OTHER_LDFLAGS build setting is not allowed to contain -dyld_env, use the dedicated LD_ENVIRONMENT build setting instead. (in target 'Tool' from project 'ProjectName')"))


### PR DESCRIPTION
-no_exported_symbols takes no argument, but there was some accidentally copy-pasted code here which assumed it did and attempted to filter it.