### PR TITLE
Use Swift SDK manifest path as imposed SDKROOT during specialization

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -192,32 +192,6 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         }
     }
 
-    /// Resolve the SDKROOT value to impose on dependencies, given the build's parameters.
-    ///
-    /// Synthesized Swift SDKs (registered via `SDKRegistry.synthesizedSDK`) use the
-    /// SDK's manifest path as their canonical name — NOT the platform name. So when
-    /// imposing SDKROOT for specialization, falling back to `platform.sdkCanonicalName`
-    /// (e.g. `"webassembly"`) leaves the SDK lookup with no match and the build fails
-    /// with `error: unable to find sdk '<platform>'`. When the active run destination
-    /// is a Swift SDK targeting this same platform, we instead use its identifier
-    /// (`runDestination.sdk` = the manifest path) so the lookup hits the synthesized
-    /// SDK directly.
-    private func resolvedSdkRoot(for parameters: BuildParameters) -> String? {
-        guard let platform else { return nil }
-
-        if let runDestination = parameters.activeRunDestination,
-           case .swiftSDK = runDestination.buildTarget,
-           runDestination.platform == platform.name {
-            let identifier = runDestination.sdk
-            if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty {
-                return "\(identifier).\(canonicalNameSuffix)"
-            }
-            return identifier
-        }
-
-        return sdkRoot
-    }
-
     /// Check if a configured target can be used when this specialization is required.
     func isCompatible(with configuredTarget: ConfiguredTarget, settings: Settings, workspaceContext: WorkspaceContext) -> Bool {
         let toolchain = effectiveToolchainOverride(originalParameters: configuredTarget.parameters, workspaceContext: workspaceContext)

--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -192,6 +192,32 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
         }
     }
 
+    /// Resolve the SDKROOT value to impose on dependencies, given the build's parameters.
+    ///
+    /// Synthesized Swift SDKs (registered via `SDKRegistry.synthesizedSDK`) use the
+    /// SDK's manifest path as their canonical name — NOT the platform name. So when
+    /// imposing SDKROOT for specialization, falling back to `platform.sdkCanonicalName`
+    /// (e.g. `"webassembly"`) leaves the SDK lookup with no match and the build fails
+    /// with `error: unable to find sdk '<platform>'`. When the active run destination
+    /// is a Swift SDK targeting this same platform, we instead use its identifier
+    /// (`runDestination.sdk` = the manifest path) so the lookup hits the synthesized
+    /// SDK directly.
+    private func resolvedSdkRoot(for parameters: BuildParameters) -> String? {
+        guard let platform else { return nil }
+
+        if let runDestination = parameters.activeRunDestination,
+           case .swiftSDK = runDestination.buildTarget,
+           runDestination.platform == platform.name {
+            let identifier = runDestination.sdk
+            if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty {
+                return "\(identifier).\(canonicalNameSuffix)"
+            }
+            return identifier
+        }
+
+        return sdkRoot
+    }
+
     /// Check if a configured target can be used when this specialization is required.
     func isCompatible(with configuredTarget: ConfiguredTarget, settings: Settings, workspaceContext: WorkspaceContext) -> Bool {
         let toolchain = effectiveToolchainOverride(originalParameters: configuredTarget.parameters, workspaceContext: workspaceContext)

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3714,7 +3714,15 @@ private class SettingsBuilder: ProjectMatchLookup {
             }
             else {
                 // The target specifies an SDK not for the destination platform, but claims to support the destination platform.
-                requiredSDKCanonicalName = getLatestSDKCanonicalName(for: destinationPlatform)
+                if destinationUsesSwiftSDK {
+                    // Synthesized Swift SDKs (e.g. wasm) are registered with the manifest path
+                    // as their canonical name, not the platform name. Pushing
+                    // platform.sdkCanonicalName (e.g. "webassembly") here would cause the
+                    // subsequent SDK lookup to fail with "unable to find sdk '<platform>'".
+                    requiredSDKCanonicalName = destinationSDK.canonicalName
+                } else {
+                    requiredSDKCanonicalName = getLatestSDKCanonicalName(for: destinationPlatform)
+                }
             }
         }
         else if destinationPlatformIsDeviceOrSimulator {

--- a/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
+++ b/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
@@ -130,14 +130,21 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
     /// Regression test: a wasm app target depending on a library with platform specialization
     /// must not fail with `unable to find sdk 'webassembly'`.
     ///
-    /// The failure is triggered by `SpecializationParameters.imposed(on:workspaceContext:)`
-    /// in `swift-build/Sources/SWBCore/DependencyResolution.swift`, which sets
-    /// `SDKROOT = platform.sdkCanonicalName` (= `"webassembly"`) on dependencies — and the
-    /// SDK registry has no SDK or alias by that canonical name when only a Swift SDK is
-    /// providing the wasm sysroot.
+    /// Two code paths in swift-build push `SDKROOT = platform.sdkCanonicalName` (= `"webassembly"`)
+    /// for Swift-SDK-backed builds, neither of which has a matching SDK in the registry when the
+    /// only wasm sysroot comes from a synthesized Swift SDK (whose canonical name is the manifest
+    /// path, not the platform name):
+    ///
+    /// 1. `SpecializationParameters.imposed(on:workspaceContext:)`
+    ///    in `swift-build/Sources/SWBCore/DependencyResolution.swift` — exercised by `MyLibrary`,
+    ///    which is reachable via specialization from `MyApp`.
+    /// 2. `addRunDestinationSettingsPlatformSDK` in
+    ///    `swift-build/Sources/SWBCore/Settings/Settings.swift` else branch — exercised by
+    ///    `MyMacOSLib`, whose configured SDK (`macosx`) does not match the destination platform
+    ///    (`webassembly`) but whose `SUPPORTED_PLATFORMS` still includes wasm.
     @Test(.requireSDKs(.host))
     func wasmSwiftSDKDependencySpecialization() async throws {
-        try await withTemporaryDirectory { tmpDir in
+        try await withTemporaryDirectory { (tmpDir: Path) in
             let clangCompilerPath = try await self.clangCompilerPath
             let swiftCompilerPath = try await self.swiftCompilerPath
             let swiftVersion = try await self.swiftVersion
@@ -148,6 +155,7 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
                     children: [
                         TestFile("App.swift"),
                         TestFile("Lib.swift"),
+                        TestFile("MacLib.swift"),
                     ]),
                 targets: [
                     TestStandardTarget(
@@ -170,8 +178,10 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
                         buildPhases: [
                             TestSourcesBuildPhase([TestBuildFile("App.swift")]),
                         ],
-                        dependencies: ["MyLibrary"]
+                        dependencies: ["MyLibrary", "MyMacOSLib"]
                     ),
+                    // Exercises DependencyResolution.swift `SpecializationParameters.imposed(on:)`:
+                    // gets specialized to wasm via the dependency from MyApp.
                     TestStandardTarget(
                         "MyLibrary",
                         type: .staticLibrary,
@@ -192,6 +202,31 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
                         ],
                         buildPhases: [
                             TestSourcesBuildPhase([TestBuildFile("Lib.swift")]),
+                        ]),
+                    // Exercises Settings.swift `addRunDestinationSettingsPlatformSDK` else branch:
+                    // configured SDK ("macosx") differs from destination platform ("webassembly")
+                    // but SUPPORTED_PLATFORMS includes wasm, so the SDK gets re-targeted.
+                    // No ALLOW_TARGET_PLATFORM_SPECIALIZATION here — that flag would short-circuit
+                    // the early-return guard at Settings.swift:3600 and skip the else branch.
+                    TestStandardTarget(
+                        "MyMacOSLib",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SDKROOT": "macosx",
+                                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                                    "CLANG_ENABLE_MODULES": "YES",
+                                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                                    "SWIFT_VERSION": swiftVersion,
+                                                    "CC": clangCompilerPath.str,
+                                                    "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MacLib.swift")]),
                         ]),
                 ])
             // Use a dedicated core for this test so the SDKs it registers do not impact other tests
@@ -225,10 +260,42 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
                 """)
             })
 
+            let sysroot = sdkManifestDir.join("WASI.sdk")
+            let sdkroot = sdkManifestDir.join("WASI.sdk")
+
             let destination = try RunDestinationInfo(sdkManifestPath: sdkManifestPath, triple: "wasm32-unknown-wasip1", targetArchitecture: "wasm32", supportedArchitectures: ["wasm32"], disableOnlyActiveArch: false, core: core)
             let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
-            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
-                // The bug surfaces as an error literally containing "unable to find sdk 'webassembly'".
+
+            // Path 1: build MyApp — exercises DependencyResolution.swift `SpecializationParameters.imposed(on:)`
+            // because MyLibrary is reached via dependency from MyApp, which pre-imposes SDKROOT.
+            // Without the DependencyResolution fix, MyLibrary's specialized configuration would
+            // fail with `unable to find sdk 'webassembly'`.
+            await tester.checkBuild(parameters, runDestination: nil, targetName: "MyApp", fs: localFS) { results in
+                results.checkTask(.matchTargetName("MyLibrary"), .matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContains([
+                        ["-static-stdlib"],
+                        ["-sdk", sdkroot.str],
+                        ["-sysroot", sysroot.str],
+                        ["-target", "wasm32-unknown-wasip1"],
+                    ].reduce([], +))
+                }
+
+                results.checkNoErrors()
+            }
+
+            // Path 2: build MyMacOSLib standalone — exercises Settings.swift `addRunDestinationSettingsPlatformSDK`
+            // else branch because no dependency imposes SDKROOT, and the target's own SDK ("macosx")
+            // doesn't match the destination platform ("webassembly"). Without the Settings.swift fix,
+            // this branch would push SDKROOT="webassembly" and the lookup would fail.
+            await tester.checkBuild(parameters, runDestination: nil, targetName: "MyMacOSLib", fs: localFS) { results in
+                results.checkTask(.matchTargetName("MyMacOSLib"), .matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContains([
+                        ["-sdk", sdkroot.str],
+                        ["-sysroot", sysroot.str],
+                        ["-target", "wasm32-unknown-wasip1"],
+                    ].reduce([], +))
+                }
+
                 results.checkNoErrors()
             }
         }

--- a/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
+++ b/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
@@ -126,4 +126,111 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
             }
         }
     }
+
+    /// Regression test: a wasm app target depending on a library with platform specialization
+    /// must not fail with `unable to find sdk 'webassembly'`.
+    ///
+    /// The failure is triggered by `SpecializationParameters.imposed(on:workspaceContext:)`
+    /// in `swift-build/Sources/SWBCore/DependencyResolution.swift`, which sets
+    /// `SDKROOT = platform.sdkCanonicalName` (= `"webassembly"`) on dependencies — and the
+    /// SDK registry has no SDK or alias by that canonical name when only a Swift SDK is
+    /// providing the wasm sysroot.
+    @Test(.requireSDKs(.host))
+    func wasmSwiftSDKDependencySpecialization() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let clangCompilerPath = try await self.clangCompilerPath
+            let swiftCompilerPath = try await self.swiftCompilerPath
+            let swiftVersion = try await self.swiftVersion
+            let testProject = try await TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("App.swift"),
+                        TestFile("Lib.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MyApp",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SDKROOT": "auto",
+                                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                                    "CLANG_ENABLE_MODULES": "YES",
+                                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                                    "SWIFT_VERSION": swiftVersion,
+                                                    "CC": clangCompilerPath.str,
+                                                    "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("App.swift")]),
+                        ],
+                        dependencies: ["MyLibrary"]
+                    ),
+                    TestStandardTarget(
+                        "MyLibrary",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SDKROOT": "auto",
+                                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                                    "ALLOW_TARGET_PLATFORM_SPECIALIZATION": "YES",
+                                                    "CLANG_ENABLE_MODULES": "YES",
+                                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                                    "SWIFT_VERSION": swiftVersion,
+                                                    "CC": clangCompilerPath.str,
+                                                    "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("Lib.swift")]),
+                        ]),
+                ])
+            // Use a dedicated core for this test so the SDKs it registers do not impact other tests
+            let core = try await Self.makeCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            let sdkManifestContents = """
+            {
+                "schemaVersion" : "4.0",
+                "targetTriples" : {
+                    "wasm32-unknown-wasip1" : {
+                        "sdkRootPath" : "WASI.sdk",
+                        "swiftResourcesPath" : "swift.xctoolchain/usr/lib/swift_static",
+                        "swiftStaticResourcesPath" : "swift.xctoolchain/usr/lib/swift_static",
+                        "toolsetPaths" : [ "toolset.json" ]
+                    }
+                }
+            }
+            """
+            let sdkManifestDir = tmpDir
+            try localFS.createDirectory(sdkManifestDir)
+            let sdkManifestPath = sdkManifestDir.join("swift-sdk.json")
+            try await localFS.writeFileContents(sdkManifestPath, waitForNewTimestamp: false, body: { $0.write(sdkManifestContents) })
+            try await localFS.writeFileContents(sdkManifestDir.join("toolset.json"), waitForNewTimestamp: false, body: { stream in
+                stream.write("""
+                {
+                    "rootPath" : "swift.xctoolchain/usr/bin",
+                    "schemaVersion" : "1.0",
+                    "swiftCompiler" : { "extraCLIOptions" : [ "-static-stdlib" ] }
+                }
+                """)
+            })
+
+            let destination = try RunDestinationInfo(sdkManifestPath: sdkManifestPath, triple: "wasm32-unknown-wasip1", targetArchitecture: "wasm32", supportedArchitectures: ["wasm32"], disableOnlyActiveArch: false, core: core)
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
+            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
+                // The bug surfaces as an error literally containing "unable to find sdk 'webassembly'".
+                results.checkNoErrors()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Synthesized Swift SDKs (registered via `SDKRegistry.synthesizedSDK`) use the SDK's manifest path as their canonical name and not the platform name. When imposing `SDKROOT` for specialization, falling back to `platform.sdkCanonicalName` e.g. `"webassembly"`) leaves the SDK lookup with no match and the build fails with `error: unable to find sdk '<platform>'`. When the active run destination is a Swift SDK targeting this same platform, we instead use its identifier (`runDestination.sdk` = the manifest path) so the lookup hits the synthesized SDK directly.

Resolves https://github.com/swiftlang/swift-build/issues/1325.