### PR TITLE
Add an option which can be used to allow index preparation to enable optimizations

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -773,6 +773,7 @@ public final class BuiltinMacros {
     public static let INDEX_DISABLE_SCRIPT_EXECUTION = BuiltinMacros.declareBooleanMacro("INDEX_DISABLE_SCRIPT_EXECUTION")
     public static let INDEX_DISABLE_VFS_DIRECTORY_REMAP = BuiltinMacros.declareBooleanMacro("INDEX_DISABLE_VFS_DIRECTORY_REMAP")
     public static let INDEX_ENABLE_BUILD_ARENA = BuiltinMacros.declareBooleanMacro("INDEX_ENABLE_BUILD_ARENA")
+    public static let INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE = BuiltinMacros.declareBooleanMacro("INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE")
     public static let INDEX_FORCE_SCRIPT_EXECUTION = BuiltinMacros.declareBooleanMacro("INDEX_FORCE_SCRIPT_EXECUTION")
     public static let INDEX_PREPARED_MODULE_CONTENT_MARKER_PATH = BuiltinMacros.declareStringMacro("INDEX_PREPARED_MODULE_CONTENT_MARKER_PATH")
     public static let INDEX_PREPARED_TARGET_MARKER_PATH = BuiltinMacros.declareStringMacro("INDEX_PREPARED_TARGET_MARKER_PATH")
@@ -1895,6 +1896,7 @@ public final class BuiltinMacros {
         INDEX_DISABLE_SCRIPT_EXECUTION,
         INDEX_DISABLE_VFS_DIRECTORY_REMAP,
         INDEX_ENABLE_BUILD_ARENA,
+        INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE,
         INDEX_FORCE_SCRIPT_EXECUTION,
         INDEX_PREPARED_MODULE_CONTENT_MARKER_PATH,
         INDEX_PREPARED_TARGET_MARKER_PATH,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3999,7 +3999,9 @@ private class SettingsBuilder: ProjectMatchLookup {
         // Generate Swift modules with a whole-module invocation. It is fast enough, since it is skipping function bodies, and we'll avoid the fragility problems of the `merge-modules` invocation (which is bound to be deprecated in the future).
         table.push(BuiltinMacros.SWIFT_COMPILATION_MODE, literal: "wholemodule")
         // We are not generating native code for the index build so this doesn't affect much, but make it clear to Swift that we don't need any SIL optimizations running.
-        table.push(BuiltinMacros.SWIFT_OPTIMIZATION_LEVEL, literal: "-Onone")
+        if createScope(sdkToUse: nil).evaluate(BuiltinMacros.INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE) {
+            table.push(BuiltinMacros.SWIFT_OPTIMIZATION_LEVEL, literal: "-Onone")
+        }
 
         // Ensure the index build uses the effective platform build directories and not install ones.
         // This is to avoid conflicts of outputs of a target configured for multiple platforms, and to avoid using same build directory outputs as a normal build.

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3546,6 +3546,11 @@ For more information on mergeable libraries, see [Configuring your project to us
                 Description = "Compress the index store, reducing its size on disk.";
             },
             {
+                Name = "INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
+            {
                 Name = TOOLCHAINS;
                 Type = StringList;
                 DefaultValue = "";

--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -111,6 +111,7 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
         updatedBuildRequest.parameters.action = "indexbuild"
         var overridesTable = buildRequest.parameters.overrides.commandLine ?? SWBSettingsTable()
         overridesTable.set(value: "YES", for: "ONLY_ACTIVE_ARCH")
+        overridesTable.set(value: "NO", for: "INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE")
         updatedBuildRequest.parameters.overrides.commandLine = overridesTable
         for targetIndex in updatedBuildRequest.configuredTargets.indices {
             updatedBuildRequest.configuredTargets[targetIndex].parameters?.action = "indexbuild"

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -606,6 +606,48 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func swiftIndexBuildWithoutOptimizationOverride() async throws {
+        let buildSettings: [String: String] = try await [
+            "GENERATE_INFOPLIST_FILE": "YES",
+            "CODE_SIGN_IDENTITY": "",
+            "PRODUCT_NAME": "$(TARGET_NAME)",
+            "ALWAYS_SEARCH_USER_PATHS": "NO",
+            "SWIFT_OPTIMIZATION_LEVEL": "-O",
+            "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
+            "SWIFT_EXEC": swiftCompilerPath.str,
+            "SWIFT_VERSION": swiftVersion,
+            "INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE": "NO",
+        ]
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [TestFile("main.swift")]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: buildSettings)
+            ],
+            targets: [
+                TestStandardTarget(
+                    "AppTarget",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: buildSettings)
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["main.swift"])
+                    ]),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+        try await tester.checkIndexBuild() { results in
+            results.checkTask(.matchTargetName("AppTarget"), .matchRuleItem("SwiftDriver Compilation Requirements")) { task in
+                task.checkCommandLineDoesNotContain("-Onone")
+                task.checkCommandLineContains(["-O"])
+            }
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func noIndexStorePathForGenerateSwiftModule() async throws {
         let buildSettings: [String: String] = try await [
             "GENERATE_INFOPLIST_FILE": "YES",


### PR DESCRIPTION
Historically index build disabled Swift optimizations, but SourceKit-LSP expects to receive compiler args with -O when setup to use the release configuration. Add a build setting to control the override and adopt it in SWBBuildServer.