### PR TITLE
Add DSYMUTIL_EMBED_RESOURCES build setting for embedding files into dSYM bundles

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -637,6 +637,7 @@ public final class BuiltinMacros {
     public static let DSYMUTIL_VARIANT_SUFFIX = BuiltinMacros.declareStringMacro("DSYMUTIL_VARIANT_SUFFIX")
     public static let DSYMUTIL_DSYM_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("DSYMUTIL_DSYM_SEARCH_PATHS")
     public static let DSYMUTIL_QUIET_OPERATION = BuiltinMacros.declareBooleanMacro("DSYMUTIL_QUIET_OPERATION")
+    public static let DSYMUTIL_EMBED_RESOURCES = BuiltinMacros.declareStringListMacro("DSYMUTIL_EMBED_RESOURCES")
     public static let DWARF_DSYM_FILE_NAME = BuiltinMacros.declareStringMacro("DWARF_DSYM_FILE_NAME")
     public static let DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT = BuiltinMacros.declareBooleanMacro("DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT")
     public static let DWARF_DSYM_FOLDER_PATH = BuiltinMacros.declarePathMacro("DWARF_DSYM_FOLDER_PATH")
@@ -1736,6 +1737,7 @@ public final class BuiltinMacros {
         DSYMUTIL_VARIANT_SUFFIX,
         DSYMUTIL_DSYM_SEARCH_PATHS,
         DSYMUTIL_QUIET_OPERATION,
+        DSYMUTIL_EMBED_RESOURCES,
         DT_TOOLCHAIN_DIR,
         DWARF_DSYM_FILE_NAME,
         DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT,

--- a/Sources/SWBCore/SpecImplementations/Tools/DsymutilTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/DsymutilTool.swift
@@ -56,7 +56,12 @@ public final class DsymutilToolSpec : GenericCommandLineToolSpec, SpecIdentifier
         // Create a virtual output node so any strip task can be ordered after this.
         let orderingOutputNode = delegate.createVirtualNode("GenerateDSYMFile \(output.str)")
 
-        let inputs: [any PlannedNode] = cbc.inputs.map({ delegate.createNode($0.absolutePath) }) + cbc.commandOrderingInputs
+        let embedResources = cbc.scope.evaluate(BuiltinMacros.DSYMUTIL_EMBED_RESOURCES)
+        let inputs: [any PlannedNode] = cbc.inputs.map({ delegate.createNode($0.absolutePath) }) + cbc.commandOrderingInputs + embedResources.compactMap { entry in
+            guard let src = entry.split(separator: "=", maxSplits: 1).first else { return nil }
+            let path = Path(String(src))
+            return delegate.createDirectoryTreeNode(path.isAbsolute ? path : cbc.scope.evaluate(BuiltinMacros.PROJECT_DIR).join(path))
+        }
         let outputs: [any PlannedNode] = [delegate.createNode(output), orderingOutputNode] + cbc.commandOrderingOutputs
 
         var builder = PlannedTaskBuilder(type: self, ruleInfo: ruleInfo, commandLine: commandLine.map { .literal(ByteString(encodingAsUTF8: $0)) }, environment: environmentFromSpec(cbc, delegate), enableSandboxing: enableSandboxing)

--- a/Sources/SWBUniversalPlatform/Specs/BuiltInCompilers.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/BuiltInCompilers.xcspec
@@ -68,6 +68,13 @@
                 DefaultValue = NO;
                 CommandLineFlag = "-q";
             },
+            {   Name = DSYMUTIL_EMBED_RESOURCES;
+                Type = StringList;
+                DefaultValue = "";
+                Category = BuildOptions;
+                Description = "A list of resources to embed into the dSYM bundle. Each entry has the form '<src-path>=<dst-path>' where the source path is a file or directory on disk and the destination path is relative to the bundle's Contents/Resources directory.";
+                CommandLineFlag = "--embed-resource";
+            },
         );
 
         CommandOutputParser = (

--- a/Tests/SWBTaskConstructionTests/DebugInformationTests.swift
+++ b/Tests/SWBTaskConstructionTests/DebugInformationTests.swift
@@ -418,4 +418,44 @@ fileprivate struct DebugInformationTests: CoreBasedTests {
             results.checkNoDiagnostics()
         }
     }
+
+    /// Test that DSYMUTIL_EMBED_RESOURCES generates --embed-resource flags and tracks sources as inputs.
+    @Test(.requireSDKs(.macOS))
+    func dsymutilEmbedResources() async throws {
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("main.c"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+                        "DSYMUTIL_EMBED_RESOURCES": "res/helper.py=Python/helper.py res/scripts=LLDB",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "CoreFoo", type: .framework,
+                    buildPhases: [
+                        TestSourcesBuildPhase(["main.c"])]),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .host) { results in
+            results.checkTask(.matchRuleType("GenerateDSYMFile")) { task in
+                task.checkCommandLineContains(["--embed-resource", "res/helper.py=Python/helper.py"])
+                task.checkCommandLineContains(["--embed-resource", "res/scripts=LLDB"])
+                task.checkInputs(contain: [.pathPattern(.suffix("res/helper.py"))])
+                task.checkInputs(contain: [.pathPattern(.suffix("res/scripts"))])
+            }
+
+            results.checkNoDiagnostics()
+        }
+    }
 }


### PR DESCRIPTION
Wires up dsymutil's new --embed-resource option to a new build setting. Resource source paths are tracked as directory tree inputs so that modifying an input triggers dsymutil to rerun.

rdar://50633614