### PR TITLE
Add internal macro conditions for host and destination platforms

### DIFF
--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -93,6 +93,9 @@ public final class SDK: Sendable {
     /// The display name of the SDK.
     public let displayName: String
 
+    /// The name of the platform the SDK is for, if available.
+    public let platformName: String?
+
     /// The path of the SDK.
     public let path: Path
 
@@ -167,12 +170,13 @@ public final class SDK: Sendable {
     /// Note that this is technically "broken" for macOS, as the third version component in practice is more like a minor version, and macOS does not have true patch versions, but we'll respect the value in the SDK as-is for now.
     @_spi(Testing) public let maximumDeploymentTarget: Version?
 
-    init(_ canonicalName: String, canonicalNameComponents: CanonicalNameComponents?, _ aliases: Set<String>, _ cohortPlatforms: [String], _ displayName: String, _ path: Path, _ version: Version?, _ productBuildVersion: String?, _ defaultSettings: [String: PropertyListItem], _ overrideSettings: [String: PropertyListItem], _ variants: [String: SDKVariant], _ defaultDeploymentTarget: Version?, _ defaultVariant: SDKVariant?, _ searchPaths: (header: [Path], framework: [Path], library: [Path]), _ directoryMacros: [StringMacroDeclaration], _ isBaseSDK: Bool, _ fallbackSettingConditionValues: [String], _ toolchains: [String], _ versionMap: [String:[Version:Version]], _ maximumDeploymentTarget: Version?) {
+    init(_ canonicalName: String, canonicalNameComponents: CanonicalNameComponents?, _ aliases: Set<String>, _ cohortPlatforms: [String], _ displayName: String, platformName: String?, _ path: Path, _ version: Version?, _ productBuildVersion: String?, _ defaultSettings: [String: PropertyListItem], _ overrideSettings: [String: PropertyListItem], _ variants: [String: SDKVariant], _ defaultDeploymentTarget: Version?, _ defaultVariant: SDKVariant?, _ searchPaths: (header: [Path], framework: [Path], library: [Path]), _ directoryMacros: [StringMacroDeclaration], _ isBaseSDK: Bool, _ fallbackSettingConditionValues: [String], _ toolchains: [String], _ versionMap: [String:[Version:Version]], _ maximumDeploymentTarget: Version?) {
         self.canonicalName = canonicalName
         self.canonicalNameComponents = canonicalNameComponents
         self.aliases = aliases
         self.cohortPlatforms = cohortPlatforms
         self.displayName = displayName
+        self.platformName = platformName
         self.path = path
         self.version = version
         self.productBuildVersion = productBuildVersion
@@ -238,7 +242,7 @@ extension SDK {
         let buildVersionPlatformID: Int?
         if let id = sdkVariant?.buildVersionPlatformID {
             buildVersionPlatformID = id
-        } else if let platformName = defaultSettings[BuiltinMacros.PLATFORM_NAME.name]?.stringValue, let id = variant(for: platformName)?.buildVersionPlatformID {
+        } else if let platformName, let id = variant(for: platformName)?.buildVersionPlatformID {
             buildVersionPlatformID = id
         } else {
             buildVersionPlatformID = nil
@@ -921,7 +925,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
         }
 
         // Construct the SDK and add it to the registry.
-        let sdk = SDK(canonicalName, canonicalNameComponents: try? parseSDKName(canonicalName), aliases, cohortPlatforms, displayName, path, version, productBuildVersion, defaultSettings, overrideSettings, variants, defaultDeploymentTarget, defaultVariant, (headerSearchPaths, frameworkSearchPaths, librarySearchPaths), directoryMacros.elements, isBaseSDK, fallbackSettingConditionValues, toolchains, versionMap, maximumDeploymentTarget)
+        let sdk = SDK(canonicalName, canonicalNameComponents: try? parseSDKName(canonicalName), aliases, cohortPlatforms, displayName, platformName: defaultSettings["PLATFORM_NAME"]?.stringValue, path, version, productBuildVersion, defaultSettings, overrideSettings, variants, defaultDeploymentTarget, defaultVariant, (headerSearchPaths, frameworkSearchPaths, librarySearchPaths), directoryMacros.elements, isBaseSDK, fallbackSettingConditionValues, toolchains, versionMap, maximumDeploymentTarget)
         if let duplicate = sdksByCanonicalName[canonicalName] {
             delegate.error(path, "SDK '\(canonicalName)' already registered from \(duplicate.path.str)")
             return nil

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -25,9 +25,11 @@ public final class BuiltinMacros {
     public static let platformCondition = BuiltinMacros.declareConditionParameter("__platform_filter")
     public static let sdkBuildVersionCondition = BuiltinMacros.declareConditionParameter("_sdk_build_version")
     public static let targetNameCondition = BuiltinMacros.declareConditionParameter("target")
+    public static let hostPlatformCondition = BuiltinMacros.declareConditionParameter("__host_platform")
+    public static let destinationPlatformCondition = BuiltinMacros.declareConditionParameter("__destination_platform")
     public static let normalizedUnversionedTripleCondition = BuiltinMacros.declareConditionParameter("__normalized_unversioned_triple")
 
-    private static let allBuiltinConditionParameters = [archCondition, sdkCondition, variantCondition, configurationCondition, platformCondition, sdkBuildVersionCondition, targetNameCondition, normalizedUnversionedTripleCondition]
+    private static let allBuiltinConditionParameters = [archCondition, sdkCondition, variantCondition, configurationCondition, platformCondition, sdkBuildVersionCondition, targetNameCondition, hostPlatformCondition, destinationPlatformCondition, normalizedUnversionedTripleCondition]
 
     // MARK: Built-in Macro Definitions
 

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2003,6 +2003,24 @@ private class SettingsBuilder: ProjectMatchLookup {
             if let aBuildVersion = sdk.productBuildVersion {
                 conditionParameterValues[BuiltinMacros.sdkBuildVersionCondition] = [aBuildVersion]
             }
+
+            if let sdkPlatform = sdk.platformName,
+               let hostPlatform = try? workspaceContext.core.hostOperatingSystem.xcodePlatformName,
+               sdkPlatform == hostPlatform {
+                conditionParameterValues[BuiltinMacros.hostPlatformCondition] = ["YES"]
+            } else {
+                conditionParameterValues[BuiltinMacros.hostPlatformCondition] = ["NO"]
+            }
+
+            if let destination = parameters.activeRunDestination,
+               let destinationSDK = try? sdkRegistry.lookup(nameOrPath: destination.sdk, basePath: Path.root, activeRunDestination: destination),
+               let sdkPlatform = sdk.platformName,
+               let destinationPlatform = destinationSDK.platformName,
+               sdkPlatform == destinationPlatform {
+                conditionParameterValues[BuiltinMacros.destinationPlatformCondition] = ["YES"]
+            } else {
+                conditionParameterValues[BuiltinMacros.destinationPlatformCondition] = ["NO"]
+            }
         }
         return MacroEvaluationScope(table: table ?? _table, conditionParameterValues: conditionParameterValues)
     }

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -287,7 +287,7 @@ import SWBTestSupport
             #expect(settings.errors == [])
 
             // Verify that the global scope has the expected conditions (sdk and config).
-            #expect(Set(settings.globalScope.conditionParameterValues.keys) == Set([BuiltinMacros.sdkCondition, BuiltinMacros.targetNameCondition, BuiltinMacros.configurationCondition, BuiltinMacros.sdkBuildVersionCondition]))
+            #expect(Set(settings.globalScope.conditionParameterValues.keys) == Set([BuiltinMacros.sdkCondition, BuiltinMacros.targetNameCondition, BuiltinMacros.configurationCondition, BuiltinMacros.sdkBuildVersionCondition, BuiltinMacros.hostPlatformCondition, BuiltinMacros.destinationPlatformCondition]))
 
             // Verify that the target configuration was captured.  Notice that this is *not* the configuration the build parameters were configured with.
             #expect(settings.targetConfiguration?.name == "Config1")
@@ -1117,6 +1117,59 @@ import SWBTestSupport
             } else {
                 Issue.record("Errors creating settings: \(settings.errors)")
             }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS), .requireSDKs(.iOS))
+    func hostandDestinationPlatformConditions() async throws {
+        let core = try await getCore()
+        let workspace = try TestWorkspace(
+            "Workspace",
+            projects: [
+                TestProject(
+                    "aProject",
+                    groupTree: TestGroup(
+                        "SomeFiles", children: [TestFile("Mock.cpp")]),
+                    targets: [
+                        TestStandardTarget(
+                            "Target1",
+                            type: .dynamicLibrary,
+                            buildConfigurations: [
+                                TestBuildConfiguration(
+                                    "Debug",
+                                    buildSettings: [
+                                        "SDKROOT": "macosx",
+                                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                        "OTHER_SWIFT_FLAGS[__host_platform=YES]": "$(inherited) -DHOSTYES",
+                                        "OTHER_SWIFT_FLAGS[__host_platform=NO]": "$(inherited) -DHOSTNO",
+                                        "OTHER_SWIFT_FLAGS[__destination_platform=YES]": "$(inherited) -DDESTYES",
+                                        "OTHER_SWIFT_FLAGS[__destination_platform=NO]": "$(inherited) -DDESTNO",
+                                    ])
+                            ],
+                            buildPhases: [TestSourcesBuildPhase(["Mock.cpp"])])
+                    ])
+            ]).load(core)
+        let context = try await contextForTestData(workspace)
+        let buildRequestContext = BuildRequestContext(workspaceContext: context)
+        let project = context.workspace.projects[0]
+        let target = project.targets[0]
+
+        do {
+            let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .macOS)
+            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: project, target: target)
+            #expect(settings.errors == [])
+            #expect(settings.globalScope.conditionParameterValues[BuiltinMacros.hostPlatformCondition] == ["YES"])
+            #expect(settings.globalScope.conditionParameterValues[BuiltinMacros.destinationPlatformCondition] == ["YES"])
+            #expect(settings.globalScope.evaluate(BuiltinMacros.OTHER_SWIFT_FLAGS) == ["-DDESTYES", "-DHOSTYES"])
+        }
+
+        do {
+            let parameters = BuildParameters(action: .build, configuration: "Debug", activeRunDestination: .iOS)
+            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: project, target: target)
+            #expect(settings.errors == [])
+            #expect(settings.globalScope.conditionParameterValues[BuiltinMacros.hostPlatformCondition] == ["NO"])
+            #expect(settings.globalScope.conditionParameterValues[BuiltinMacros.destinationPlatformCondition] == ["YES"])
+            #expect(settings.globalScope.evaluate(BuiltinMacros.OTHER_SWIFT_FLAGS) == ["-DDESTYES", "-DHOSTNO"])
         }
     }
 

--- a/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
@@ -96,6 +96,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "Apple Development",
+                        "OTHER_SWIFT_FLAGS[__host_platform=YES]": "$(inherited) -DHOST_YES",
+                        "OTHER_SWIFT_FLAGS[__host_platform=NO]": "$(inherited) -DHOST_NO",
+                        "OTHER_SWIFT_FLAGS[__destination_platform=YES]": "$(inherited) -DDEST_YES",
+                        "OTHER_SWIFT_FLAGS[__destination_platform=NO]": "$(inherited) -DDEST_NO",
                     ]),
             ],
             targets: [
@@ -145,12 +149,20 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                 results.checkTasks(.matchTarget(frameworkTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                     for compileTask in compileTasks {
                         compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                        compileTask.checkCommandLineContains(["-DHOST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                        compileTask.checkCommandLineContains(["-DDEST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DDEST_NO")
                     }
                 }
             }
             results.checkTarget("HostTool") { hostTarget in
                 results.checkTask(.matchTarget(hostTarget), .matchRuleType("SwiftDriver Compilation")) { compileTask in
                     compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                    compileTask.checkCommandLineContains(["-DHOST_YES"])
+                    compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                    compileTask.checkCommandLineContains(["-DDEST_YES"])
+                    compileTask.checkCommandLineDoesNotContain("-DDEST_NO")
                 }
             }
 
@@ -159,6 +171,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                 results.checkTasks(.matchTarget(dependencyTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                     for compileTask in compileTasks {
                         compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                        compileTask.checkCommandLineContains(["-DHOST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                        compileTask.checkCommandLineContains(["-DDEST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DDEST_NO")
                     }
                 }
             }
@@ -166,10 +182,16 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
 
         await tester.checkBuild(runDestination: .anyiOSDevice, targetName: "Framework", fs: fs) { results in
             results.checkNoDiagnostics()
+            // Building for iOS on macOS: Framework builds for iOS (non-host, matches destination),
+            // HostTool and HostToolDependency build for macOS (host, does not match destination).
             results.checkTarget("Framework") { frameworkTarget in
                 results.checkTasks(.matchTarget(frameworkTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                     for compileTask in compileTasks {
                         compileTask.checkCommandLineMatches(["-target", .contains("ios")])
+                        compileTask.checkCommandLineContains(["-DHOST_NO"])
+                        compileTask.checkCommandLineDoesNotContain("-DHOST_YES")
+                        compileTask.checkCommandLineContains(["-DDEST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DDEST_NO")
                     }
                 }
             }
@@ -178,6 +200,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
             results.checkTarget("HostTool") { hostTarget in
                 results.checkTask(.matchTarget(hostTarget), .matchRuleType("SwiftDriver Compilation")) { compileTask in
                     compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                    compileTask.checkCommandLineContains(["-DHOST_YES"])
+                    compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                    compileTask.checkCommandLineContains(["-DDEST_NO"])
+                    compileTask.checkCommandLineDoesNotContain("-DDEST_YES")
                 }
             }
 
@@ -186,6 +212,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                 results.checkTasks(.matchTarget(dependencyTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                     for compileTask in compileTasks {
                         compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                        compileTask.checkCommandLineContains(["-DHOST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                        compileTask.checkCommandLineContains(["-DDEST_NO"])
+                        compileTask.checkCommandLineDoesNotContain("-DDEST_YES")
                     }
                 }
             }
@@ -212,6 +242,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                             "GENERATE_INFOPLIST_FILE": "YES",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CODE_SIGN_IDENTITY": "Apple Development",
+                            "OTHER_SWIFT_FLAGS[__host_platform=YES]": "$(inherited) -DHOST_YES",
+                            "OTHER_SWIFT_FLAGS[__host_platform=NO]": "$(inherited) -DHOST_NO",
+                            "OTHER_SWIFT_FLAGS[__destination_platform=YES]": "$(inherited) -DDEST_YES",
+                            "OTHER_SWIFT_FLAGS[__destination_platform=NO]": "$(inherited) -DDEST_NO",
                         ]),
                 ],
                 targets: [
@@ -300,6 +334,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                     results.checkTasks(.matchTarget(frameworkTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                         for compileTask in compileTasks {
                             compileTask.checkCommandLineMatches(["-target", .contains("linux-musl")])
+                            compileTask.checkCommandLineContains(["-DHOST_NO"])
+                            compileTask.checkCommandLineDoesNotContain("-DHOST_YES")
+                            compileTask.checkCommandLineContains(["-DDEST_YES"])
+                            compileTask.checkCommandLineDoesNotContain("-DDEST_NO")
                         }
                     }
                 }
@@ -308,6 +346,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                 results.checkTarget("HostTool") { hostTarget in
                     results.checkTask(.matchTarget(hostTarget), .matchRuleType("SwiftDriver Compilation")) { compileTask in
                         compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                        compileTask.checkCommandLineContains(["-DHOST_YES"])
+                        compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                        compileTask.checkCommandLineContains(["-DDEST_NO"])
+                        compileTask.checkCommandLineDoesNotContain("-DDEST_YES")
                     }
                 }
 
@@ -316,6 +358,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                     results.checkTasks(.matchTarget(dependencyTarget), .matchRuleType("SwiftDriver Compilation")) { compileTasks in
                         for compileTask in compileTasks {
                             compileTask.checkCommandLineMatches(["-target", .contains("macos")])
+                            compileTask.checkCommandLineContains(["-DHOST_YES"])
+                            compileTask.checkCommandLineDoesNotContain("-DHOST_NO")
+                            compileTask.checkCommandLineContains(["-DDEST_NO"])
+                            compileTask.checkCommandLineDoesNotContain("-DDEST_YES")
                         }
                     }
                 }


### PR DESCRIPTION
These will be used by SwiftPM internally to correctly modify extra flags forwarded via -Xswiftc, command plugins, etc. These are not meant to be user facing, and only work correctly if a run destination is used (which is always the case when driving the build system via SwiftPM / when using packages.