### PR TITLE
Introduce `SWIFT_DISABLE_HEADERMAPS` build setting

### DIFF
--- a/Sources/SWBApplePlatform/OpenCLCompiler.swift
+++ b/Sources/SWBApplePlatform/OpenCLCompiler.swift
@@ -52,7 +52,7 @@ final class OpenCLCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         let compilerVersionFlag = "-cl-std=" + scope.evaluate(BuiltinMacros.OPENCL_COMPILER_VERSION)
 
         let preprocessorDefinitionsFlags = scope.evaluate(BuiltinMacros.OPENCL_PREPROCESSOR_DEFINITIONS).map{ "-D" + $0 }
-        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, scope, usesModules: scope.evaluate(BuiltinMacros.CLANG_ENABLE_MODULES))
+        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, scope, usesModules: scope.evaluate(BuiltinMacros.CLANG_ENABLE_MODULES), forSwift: false)
         let headerSearchPathFlags = headerSearchPaths.searchPathArguments(for: self, scope: scope)
         let frameworkSearchPaths = GCCCompatibleCompilerSpecSupport.frameworkSearchPathArguments(cbc.producer, scope)
         let frameworkSearchPathFlags = frameworkSearchPaths.searchPathArguments(for: self, scope: scope)

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1082,6 +1082,7 @@ public final class BuiltinMacros {
     public static let SWIFT_INDEX_STORE_PATH = BuiltinMacros.declarePathMacro("SWIFT_INDEX_STORE_PATH")
     public static let SWIFT_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALL_OBJC_HEADER")
     public static let SWIFT_INSTALLAPI_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALLAPI_LAZY_TYPECHECK")
+    public static let SWIFT_DISABLE_HEADERMAPS = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_HEADERMAPS")
     public static let SWIFT_DISABLE_PARSE_AS_LIBRARY = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_PARSE_AS_LIBRARY")
     public static let SWIFT_LIBRARIES_ONLY = BuiltinMacros.declareBooleanMacro("SWIFT_LIBRARIES_ONLY")
     public static let SWIFT_LIBRARY_LEVEL = BuiltinMacros.declareStringMacro("SWIFT_LIBRARY_LEVEL")
@@ -2307,6 +2308,7 @@ public final class BuiltinMacros {
         _SWIFT_EXPLICIT_MODULES_ALLOW_CXX_INTEROP,
         _SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5,
         _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES,
+        SWIFT_DISABLE_HEADERMAPS,
         SWIFT_DISABLE_PARSE_AS_LIBRARY,
         SWIFT_ENABLE_BARE_SLASH_REGEX,
         SWIFT_ENABLE_EMIT_CONST_VALUES,

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -656,7 +656,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         }).map(\.asString)
 
         // Add the common header search paths.
-        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(producer, scope, usesModules: scope.evaluate(BuiltinMacros.CLANG_ENABLE_MODULES))
+        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(producer, scope, usesModules: scope.evaluate(BuiltinMacros.CLANG_ENABLE_MODULES), forSwift: false)
         commandLine += headerSearchPaths.searchPathArguments(for: self, scope: scope)
 
         // Add per-architecture flags (this is slated for deprecation, since there are now simpler ways to accomplish the same thing).

--- a/Sources/SWBCore/SpecImplementations/Tools/GCCCompatibleCompilerSupport.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/GCCCompatibleCompilerSupport.swift
@@ -210,7 +210,7 @@ extension SearchPathCommandLineBuilder
 package struct GCCCompatibleCompilerSpecSupport
 {
     /// Constructs and returns common header search path entries for LLVM-based compiler specs.  Also returns any input paths (to headermap or VFS files) which users of these search paths should depend on.
-    package static func headerSearchPathArguments(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, usesModules: Bool) -> SearchPaths
+    package static func headerSearchPathArguments(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, usesModules: Bool, forSwift: Bool) -> SearchPaths
     {
         let searchPathBuilder = SearchPathBuilder()
 
@@ -218,7 +218,7 @@ package struct GCCCompatibleCompilerSpecSupport
         let alwaysSearchUserPaths = scope.evaluate(BuiltinMacros.ALWAYS_SEARCH_USER_PATHS)
 
         // Add the arguments for the headermap files, if any.
-        if scope.evaluate(BuiltinMacros.USE_HEADERMAP)
+        if scope.evaluate(BuiltinMacros.USE_HEADERMAP) && !(forSwift && scope.evaluate(BuiltinMacros.SWIFT_DISABLE_HEADERMAPS))
         {
             // Swift Build does not support "traditional" (single-file) headermaps.  Use of separate headermaps has been the default for new projects for years, and use of the VFS (when clang modules are enabled) requires separate headermaps.
             // If the target is configured to use a traditional headermap, then we the HeadermapTaskProducer emits a warning about that, and we use separate headermaps anyway.

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftABIGenerationTool.swift
@@ -67,7 +67,7 @@ func computeSharedAPIDigesterFlags(cbc: CommandBuildContext, toolSpecInfo: Disco
         commandLine += ["-I", searchPath]
     }
     if toolSpecInfo.toolFeatures.has(.apiDigesterXcc) {
-        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true)
+        let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true, forSwift: true)
         let commonHeaderSearchArgs = headerSearchPaths.searchPathArguments(for: cbc.producer.swiftCompilerSpec, scope: cbc.scope)
         for option in commonHeaderSearchArgs {
             commandLine.append(contentsOf: ["-Xcc", option])

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1646,7 +1646,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             }
 
             // Add the common header search options.  The swift driver expects that we prefix each option with '-Xcc' to pass it to clang.
-            let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true)
+            let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true, forSwift: true)
             let commonHeaderSearchArgs = headerSearchPaths.searchPathArguments(for: self, scope: cbc.scope)
             for option in commonHeaderSearchArgs {
                 args.append(contentsOf: ["-Xcc", option])

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftSymbolExtractor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftSymbolExtractor.swift
@@ -75,7 +75,7 @@ final class SwiftSymbolExtractor: GenericCompilerSpec, GCCCompatibleCompilerComm
             // We do this to also include header maps.
             switch macro {
             case BuiltinMacros.SYMBOL_GRAPH_EXTRACTOR_SEARCH_PATHS:
-                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true)
+                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: true, forSwift: true)
                 let frameworkSearchPaths = GCCCompatibleCompilerSpecSupport.frameworkSearchPathArguments(cbc.producer, cbc.scope)
                 let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(cbc.producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
 

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
@@ -292,7 +292,7 @@ final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompil
             case BuiltinMacros.TAPI_EXTRACT_API_SDKDB_OUTPUT_PATH:
                 return cbc.scope.namespace.parseLiteralString(symbolGraphFile.str)
             case BuiltinMacros.TAPI_EXTRACT_API_SEARCH_PATHS:
-                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES))
+                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES), forSwift: false)
                 let frameworkSearchPaths = GCCCompatibleCompilerSpecSupport.frameworkSearchPathArguments(cbc.producer, cbc.scope)
                 let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(cbc.producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
 
@@ -383,7 +383,7 @@ final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompil
             // Override TAPI_EXTRACT_API_SEARCH_PATHS to construct all search paths (user headers, headers, system headers, frameworks, system frameworks, etc.)
             // We do this to also include header maps and VFS overlays.
             if macro == BuiltinMacros.TAPI_EXTRACT_API_SEARCH_PATHS {
-                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES))
+                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES), forSwift: false)
                 let frameworkSearchPaths = GCCCompatibleCompilerSpecSupport.frameworkSearchPathArguments(cbc.producer, cbc.scope)
                 let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(cbc.producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
 

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
@@ -44,7 +44,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
         let innerLookup: ((MacroDeclaration) -> MacroExpression?) = { macro in
             switch macro {
             case BuiltinMacros.TAPI_HEADER_SEARCH_PATHS:
-                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES))
+                let headerSearchPaths = GCCCompatibleCompilerSpecSupport.headerSearchPathArguments(cbc.producer, cbc.scope, usesModules: cbc.scope.evaluate(BuiltinMacros.TAPI_ENABLE_MODULES), forSwift: false)
                 let frameworkSearchPaths = GCCCompatibleCompilerSpecSupport.frameworkSearchPathArguments(cbc.producer, cbc.scope)
                 let sparseSDKSearchPaths = GCCCompatibleCompilerSpecSupport.sparseSDKSearchPathArguments(cbc.producer.sparseSDKs, headerSearchPaths.headerSearchPaths, frameworkSearchPaths.frameworkSearchPaths)
 

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -2730,6 +2730,68 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func swiftDisabledHeadermaps() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("bar.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "CODE_SIGN_IDENTITY": "",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_EXEC": swiftCompilerPath.str,
+                        "SWIFT_VERSION": swiftVersion,
+                        "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                        "SWIFT_DISABLE_HEADERMAPS": "YES",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "FwkTarget",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "DEFINES_MODULE": "YES",
+                            ]
+                        ),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["bar.swift"]),
+                    ]),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        let fs = PseudoFS()
+
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
+            results.checkTarget("FwkTarget") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineNoMatch([.suffix("-generated-files.hmap")])
+                    task.checkCommandLineNoMatch([.suffix("-own-target-headers.hmap")])
+                    task.checkCommandLineNoMatch([.suffix("-all-non-framework-target-headers.hmap")])
+                    task.checkCommandLineNoMatch([.suffix("all-product-headers.yaml")])
+                    task.checkCommandLineNoMatch([.suffix("-project-headers.hmap")])
+
+                    task.checkNoInputs(contain: [
+                        .namePattern(.suffix(".hmap")),
+                        .namePattern(.suffix("all-product-headers.yaml"))
+                    ])
+                }
+            }
+
+            // Check there are no diagnostics.
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func generateIndexingInfo() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
This allows opting-in for disabling headermaps for Swift targets only, as an easier transition path compared to disabling headermaps for the whole project.