### PR TITLE
Drop version from environment when constructing platform filters for Android triples

### DIFF
--- a/Sources/SWBCore/PlatformFiltering.swift
+++ b/Sources/SWBCore/PlatformFiltering.swift
@@ -18,11 +18,22 @@ extension PlatformFilter {
         let platformName = scope.evaluate(BuiltinMacros.PLATFORM_NAME)
         let os = (!scope.evaluate(BuiltinMacros.__USE_PLATFORM_NAME_FOR_FILTERS) ? scope.evaluate(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX).nilIfEmpty : nil) ?? platformName
 
-        // We always want developers to set platform filters for a device platform *and* its simulator counterpart as a *single* inseparable unit.
-        // To implicitly enforce this behavior (and avoid the need for Swift Build clients to replicate it individually) for any target platform
-        // whose *environment* is "simulator" we simply omit it, effectively treating the target the same as the corresponding device platform.
+        // FIXME: We should consider moving to directly using the triple for the whole computation here once we have more tests in place.
+        let triple = try? LLVMTriple(scope.evaluate(BuiltinMacros.SWIFT_TARGET_TRIPLE))
         let targetTripleSuffix = scope.evaluate(BuiltinMacros.LLVM_TARGET_TRIPLE_SUFFIX)
-        let env = targetTripleSuffix == "-simulator" ? "" : targetTripleSuffix
+        let env: String
+
+        if targetTripleSuffix == "-simulator" {
+            // We always want developers to set platform filters for a device platform *and* its simulator counterpart as a *single* inseparable unit.
+            // To implicitly enforce this behavior (and avoid the need for Swift Build clients to replicate it individually) for any target platform
+            // whose *environment* is "simulator" we simply omit it, effectively treating the target the same as the corresponding device platform.
+            env = ""
+        } else if let triple, let tripleEnv = triple.environment, tripleEnv != triple.environmentComponent {
+            // Remove the version number from the environment component where applicable (for example, with Android triples.
+            env = "-\(tripleEnv)"
+        } else {
+            env = targetTripleSuffix
+        }
 
         guard env.isEmpty || env.hasPrefix("-") else {
             // If LLVM_TARGET_TRIPLE_SUFFIX is set, it *must* begin with a dash.

--- a/Tests/SWBCoreTests/PlatformFilteringTests.swift
+++ b/Tests/SWBCoreTests/PlatformFilteringTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@_spi(Testing) import SWBCore
+@_spi(Testing) import SWBMacro
+
+@Suite
+struct PlatformFilteringTests {
+    private func createPlatformFilter(triple: String, swiftPlatformTargetPrefix: String, targetTripleSuffix: String = "") -> PlatformFilter? {
+        var table = MacroValueAssignmentTable(namespace: BuiltinMacros.namespace)
+        table.push(BuiltinMacros.SWIFT_TARGET_TRIPLE, literal: triple)
+        table.push(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX, literal: swiftPlatformTargetPrefix)
+        table.push(BuiltinMacros.LLVM_TARGET_TRIPLE_SUFFIX, literal: targetTripleSuffix)
+        let scope = MacroEvaluationScope(table: table)
+        return PlatformFilter(scope)
+    }
+
+    @Test
+    func androidFilters() {
+        do {
+            let filter = createPlatformFilter(triple: "aarch64-none-linux-android24", swiftPlatformTargetPrefix: "linux", targetTripleSuffix: "-android24")
+            let expected = PlatformFilter(platform: "linux", environment: "android")
+            #expect(filter == expected)
+        }
+
+        do {
+            let filter = createPlatformFilter(triple: "aarch64-none-linux-android", swiftPlatformTargetPrefix: "linux", targetTripleSuffix: "-android")
+            let expected = PlatformFilter(platform: "linux", environment: "android")
+            #expect(filter == expected)
+        }
+    }
+}


### PR DESCRIPTION
Android triples may contain version numbers in the environment field, which must be dropped for platform filter matching to work