### PR TITLE
When imposing an sdk during specialization, ensure we don't apply a s…

### DIFF
--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -170,7 +170,7 @@ struct SpecializationParameters: Hashable, CustomStringConvertible {
             } else {
                 sdkNameBase = platform.sdkCanonicalName
             }
-            if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty {
+            if let canonicalNameSuffix, !canonicalNameSuffix.isEmpty, sdkNameBase?.hasSuffix(".\(canonicalNameSuffix)") != true {
                 return sdkNameBase.map { "\($0).\(canonicalNameSuffix)" }
             } else {
                 return sdkNameBase


### PR DESCRIPTION
…pecialized canonical name suffix twice

Small fix on top of https://github.com/swiftlang/swift-build/pull/1318/changes#diff-01206525e7218e8476d47b5585093d407ef6418e1e6aac147d0c44eb801f10a4. Ensure that if the run destination SDK matches the imposed platform, we are imposing an SDK suffix, and the run destination SDK already has that suffix, we don't append it a second time