### PR TITLE
Specify -language-mode when building test libraries

### DIFF
--- a/Sources/SWBTestSupport/LibraryGeneration.swift
+++ b/Sources/SWBTestSupport/LibraryGeneration.swift
@@ -64,7 +64,7 @@ extension InstalledXcode {
         let linkerArgs = linkerOptions.map({ $0.args }).reduce([], +)
         if buildLibraryForDistribution {
             distributionArgs = ["-enable-library-evolution"]
-            _ = try await xcrun(["-sdk", platform.sdkName, "swiftc", "-target", target] + targetVariantArgs + distributionArgs as [String] + ["-emit-module-interface", "-emit-module-interface-path", swiftModuleDir.join("\(name).swiftinterface").str, "-c",  sourcePath.str], workingDirectory: workingDirectory)
+            _ = try await xcrun(["-sdk", platform.sdkName, "swiftc", "-target", target, "-swift-version", "5"] + targetVariantArgs + distributionArgs as [String] + ["-emit-module-interface", "-emit-module-interface-path", swiftModuleDir.join("\(name).swiftinterface").str, "-c",  sourcePath.str], workingDirectory: workingDirectory)
         } else {
             distributionArgs = []
         }


### PR DESCRIPTION
We want to enforce that swiftinterfaces always specify a language mode. Update some test code which wasn't doing this