### PR TITLE
Do not attempt to consume additional linker args when ebm is disabled due to Swift 4 usage

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -963,6 +963,21 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         return specInfo?.blocklists.explicitModules
     }
 
+    public func swiftShouldGenerateAdditionalLinkerArgsResponseFile(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Bool {
+        let toolSpecInfo: DiscoveredSwiftCompilerToolSpecInfo
+        do {
+            toolSpecInfo = try await discoveredCommandLineToolSpecInfo(producer, scope, delegate)
+        } catch {
+            delegate.error("Unable to discover `swiftc` command line tool info: \(error)")
+            return false
+        }
+        let responseFileSetting = scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS)
+        let explicitModulesEnabled = await swiftExplicitModuleBuildEnabled(producer, scope, delegate)
+        let compilerSupportsExplicitModulesBasedDebugInfo = toolSpecInfo.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue)
+
+        return responseFileSetting && explicitModulesEnabled && !compilerSupportsExplicitModulesBasedDebugInfo
+    }
+
     public func swiftExplicitModuleBuildEnabled(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> Bool {
         let buildSettingEnabled = scope.evaluate(BuiltinMacros.SWIFT_ENABLE_EXPLICIT_MODULES) == .enabled ||
                                   scope.evaluate(BuiltinMacros._EXPERIMENTAL_SWIFT_EXPLICIT_MODULES) == .enabled
@@ -1463,8 +1478,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             args += ["-emit-module", "-emit-module-path", moduleFilePath.str]
             moduleOutputPaths.append(moduleFilePath)
             let moduleLinkerArgsPath: Path?
-            if cbc.scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) &&
-                !toolSpecInfo.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue) {
+            if await self.swiftShouldGenerateAdditionalLinkerArgsResponseFile(cbc.producer, cbc.scope, delegate) {
                 let path = Path(moduleFilePath.appendingFileNameSuffix("-linker-args").withoutSuffix + ".resp")
                 moduleOutputPaths.append(path)
                 moduleLinkerArgsPath = path
@@ -2710,9 +2724,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR, lookup: lookup)
                 let moduleFilePath = moduleFileDir.join(moduleName + ".swiftmodule")
                 args += [["-Xlinker", "-add_ast_path", "-Xlinker", moduleFilePath.str]]
-                let toolInfo = await discoveredCommandLineToolSpecInfo(producer, scope, delegate)
-                if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS, lookup: lookup) &&
-                    toolInfo?.hasFeature(DiscoveredSwiftCompilerToolSpecInfo.FeatureFlag.debugInfoExplicitDependency.rawValue) != true {
+                if await self.swiftShouldGenerateAdditionalLinkerArgsResponseFile(producer, scope, delegate) {
                     args += [["@\(Path(moduleFilePath.appendingFileNameSuffix("-linker-args").withoutSuffix + ".resp").str)"]]
                 }
             }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -444,8 +444,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             let moduleName = scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME)
                             let moduleFileDir = scope.evaluate(BuiltinMacros.PER_ARCH_MODULE_FILE_DIR)
                             swiftModulePaths[arch] = moduleFileDir.join(moduleName + ".swiftmodule")
-                            let swiftInfo = await context.swiftCompilerSpec.discoveredCommandLineToolSpecInfo(context, scope, context.globalProductPlan.delegate)
-                            if scope.evaluate(BuiltinMacros.SWIFT_GENERATE_ADDITIONAL_LINKER_ARGS) {
+                            if await self.context.swiftCompilerSpec.swiftShouldGenerateAdditionalLinkerArgsResponseFile(self.context, scope, self.context.globalProductPlan.delegate) {
                                 swiftModuleAdditionalLinkerArgResponseFilePaths[arch] = moduleFileDir.join("\(moduleName)-linker-args.resp")
                             }
                         }

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -5443,4 +5443,85 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
             }
         }
     }
+
+    // Swift versions < 5 are notable because they disable explicit modules.
+    // This in turn impacts how we do things like registration of modules for
+    // debugging. This serves as a basic regression test to ensure we don't break
+    // these compiles.
+    @Test(.requireSDKs(.macOS))
+    func basicsSwift4_2() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = try TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            path: "Sources",
+                            children: [
+                                TestFile("file1.swift"),
+                                TestFile("file2.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "CODE_SIGNING_ALLOWED": "NO",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_VERSION": "4.2",
+                                    "SWIFT_USE_INTEGRATED_DRIVER": "YES",
+                                ])
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "TargetA",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "file1.swift",
+                                    ]),
+                                ]),
+                            TestStandardTarget(
+                                "TargetB",
+                                type: .dynamicLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "file2.swift",
+                                    ]),
+                                    TestFrameworksBuildPhase([TestBuildFile(.target("TargetA"))]),
+                                ],
+                                dependencies: ["TargetA"]),
+                        ])
+                ])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let parameters = BuildParameters(configuration: "Debug")
+            let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/file1.swift")) { file in
+                file <<<
+                    """
+                    public struct A {
+                        public init() {}
+                    }
+                    """
+            }
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/file2.swift")) { file in
+                file <<<
+                    """
+                    import TargetA
+                    public struct B {
+                        public init() { _ = A() }
+                    }
+                    """
+            }
+
+            try await tester.checkBuild(runDestination: .host, buildRequest: buildRequest, persistent: true) { results in
+                results.checkNoErrors()
+            }
+        }
+    }
 }


### PR DESCRIPTION
The code producing and consuming -linker-args.resp files used inconsistent criteria. When using a compiler which supported explicit module based debug info, but where explicit modules were disabled due to use of Swift 4 mode or a blocklist entry, we could end up attempting to consume a file which would not be produced. Centralize the logic for this in the Swift spec to ensure it's consistent, and add a basic regression test for compiles using g  the 4.2 language mode