### PR TITLE
Stabilize custom task hash suffix calculation

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/CustomTaskProducer.swift
@@ -43,12 +43,7 @@ final class CustomTaskProducer: PhasedTaskProducer, TaskProducer {
                     md5Context.add(number: 0)
                 }
                 md5Context.add(number: 1)
-                for (key, value) in environment.bindingsDictionary {
-                    md5Context.add(string: key)
-                    md5Context.add(number: 0)
-                    md5Context.add(string: value)
-                    md5Context.add(number: 0)
-                }
+                environment.computeSignature(into: md5Context)
                 md5Context.add(number: 1)
                 md5Context.add(string: workingDirectory.str)
                 md5Context.add(number: 1)


### PR DESCRIPTION
The suffix of the custom task hash is based on the current environment variables and their values. This is done to force re-running the custom task whenever there is a change in the environment in case the change might cause different results in the custom task.

The md5 hash suffix for the custom task is calculated by iterating over the environment bindings dictionary. However, Swift dictionary iteration is intentionally randomized, and ordering affects the hash calculation. The same environment might produce different results.

Change the hashing of the environment to use a repeatable ordering to maintain hash stability.
