### PR TITLE
Apply earlier deterministic iteration fix to immutable plugin manager

### DIFF
--- a/Sources/SWBUtil/PluginManager.swift
+++ b/Sources/SWBUtil/PluginManager.swift
@@ -220,12 +220,16 @@ private final class ImmutablePluginManager: Sendable, PluginManager {
     }
 
     public func extensions<T: ExtensionPoint>(of extensionPoint: T.Type) -> [T.ExtensionProtocol] {
-        extensions.flatMap { key, value in
+        // Guarantee stability across process executions by sorting on the type description.
+        let collected: [any Sendable] = extensions.flatMap { key, value in
             if type(of: key.instance) == extensionPoint {
-                return value as! [T.ExtensionProtocol]
+                return value
             }
             return []
         }
+        return collected.sorted {
+            String(reflecting: type(of: $0)) < String(reflecting: type(of: $1))
+        } as! [T.ExtensionProtocol]
     }
 }
 

--- a/Tests/SWBUtilTests/PluginManagerTests.swift
+++ b/Tests/SWBUtilTests/PluginManagerTests.swift
@@ -61,4 +61,40 @@ import Testing
             }
         }
     }
+
+    @Test
+    @PluginExtensionSystemActor
+    func extensionsHaveStableOrderingAfterFreezing() async {
+        let allExtensions: [any TestExtensionProtocol] = [
+            ExtA(), ExtB(), ExtC(), ExtD(),
+            ExtE(), ExtF(), ExtG(), ExtH(),
+        ]
+
+        var firstResult: [String]?
+
+        for _ in 0..<10 {
+            let manager = MutablePluginManager(pluginLoadingFilter: { _ in true })
+            manager.registerExtensionPoint(TestExtensionPoint())
+
+            var shuffled = allExtensions
+            shuffled.shuffle()
+
+            for ext in shuffled {
+                manager.register(ext, type: TestExtensionPoint.self)
+            }
+
+            do {
+                let manager = manager.finalize()
+
+                let result = manager.extensions(of: TestExtensionPoint.self)
+                let descriptions = result.map { String(reflecting: type(of: $0)) }
+
+                if let firstResult {
+                    #expect(descriptions == firstResult)
+                } else {
+                    firstResult = descriptions
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Same as https://github.com/swiftlang/swift-build/pull/1260, but for querying extensions after the manager is finalized