### PR TITLE
Fix stale checker name in Clang.xcspec

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -4120,11 +4120,7 @@
                 CommandLineArgs = {
                     YES = (
                         "-Xclang", "-analyzer-checker",
-                        "-Xclang", "core.experimental.Overflow",
-                        "-Xclang", "-analyzer-checker",
-                        "-Xclang", "security.experimental.ArrayBoundV2",
-                        "-Xclang", "-analyzer-max-loop",
-                        "-Xclang", "100"
+                        "-Xclang", "security.ArrayBound"
                     );
                     NO = ();
                 };


### PR DESCRIPTION
Turns out the `CLANG_ANALYZER_SECURITY_BUFFER_OVERFLOW_EXPERIMENTAL` was broken since 2012. The mentioned checker is now called `security.ArrayBound` in clang-21 and above.

Interestingly, both `core.experimental.Overflow` and `security.experimental.ArrayBoundV2` used to refer to the same checker and in the early days unknown checker names didn't trigger an error.
Likely the original author figured that this is more backward-compatible, thus used both spellings.
Here I drop both of these and substitute them with the proper checker name.

I also drop the `analyzer-max-loop` because that's unlikely to change much, and would make this option more focused and aligned with the name of the option.
No users were using this option anyway because it was broken for years.

Read the radar for the details.
rdar://175499030