### PR TITLE
Fix test target compilation for WebAssembly

### DIFF
--- a/Sources/SWBApplePlatform/Specs/DarwinLibtool.xcspec
+++ b/Sources/SWBApplePlatform/Specs/DarwinLibtool.xcspec
@@ -23,6 +23,11 @@
                 DefaultValue = NO;
                 CommandLineFlag = "-no_warning_for_no_symbols";
             },
+            {
+                Name = ARCHIVER_SUPPORTS_SEARCH_PATHS;
+                Type = Boolean;
+                DefaultValue = YES;
+            },
         );
     },
 )

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -469,6 +469,7 @@ public final class BuiltinMacros {
     public static let APPLY_RULES_IN_COPY_HEADERS = BuiltinMacros.declareBooleanMacro("APPLY_RULES_IN_COPY_HEADERS")
     public static let APPLY_RULES_IN_INSTALLAPI = BuiltinMacros.declareBooleanMacro("APPLY_RULES_IN_INSTALLAPI")
     public static let AR = BuiltinMacros.declarePathMacro("AR")
+    public static let ARCHIVER_SUPPORTS_SEARCH_PATHS = BuiltinMacros.declareBooleanMacro("ARCHIVER_SUPPORTS_SEARCH_PATHS")
     public static let ARCHS_STANDARD = BuiltinMacros.declareStringListMacro("ARCHS_STANDARD")
     public static let ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = BuiltinMacros.declareStringListMacro("ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1")
     public static let ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = BuiltinMacros.declareStringListMacro("ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1")
@@ -847,6 +848,9 @@ public final class BuiltinMacros {
     public static let LD_RUNPATH_SEARCH_PATHS = BuiltinMacros.declareStringListMacro("LD_RUNPATH_SEARCH_PATHS")
     public static let LD_SDK_IMPORTS_FILE = BuiltinMacros.declarePathMacro("LD_SDK_IMPORTS_FILE")
     public static let LD_WARN_UNUSED_DYLIBS = BuiltinMacros.declareBooleanMacro("LD_WARN_UNUSED_DYLIBS")
+    public static let LD_WHOLE_ARCHIVE_PREFIX_FLAGS = BuiltinMacros.declareStringListMacro("LD_WHOLE_ARCHIVE_PREFIX_FLAGS")
+    public static let LD_WHOLE_ARCHIVE_PATH_PREFIX = BuiltinMacros.declareStringMacro("LD_WHOLE_ARCHIVE_PATH_PREFIX")
+    public static let LD_WHOLE_ARCHIVE_SUFFIX_FLAGS = BuiltinMacros.declareStringListMacro("LD_WHOLE_ARCHIVE_SUFFIX_FLAGS")
     public static let _LD_MULTIARCH = BuiltinMacros.declareBooleanMacro("_LD_MULTIARCH")
     public static let _LD_MULTIARCH_PREFIX_MAP = BuiltinMacros.declareStringListMacro("_LD_MULTIARCH_PREFIX_MAP")
     public static let _LD_ARCH = BuiltinMacros.declareStringMacro("_LD_ARCH")
@@ -1491,6 +1495,7 @@ public final class BuiltinMacros {
         APPLY_RULES_IN_COPY_HEADERS,
         APPLY_RULES_IN_INSTALLAPI,
         AR,
+        ARCHIVER_SUPPORTS_SEARCH_PATHS,
         ARCHS,
         ARCHS_STANDARD,
         ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1,
@@ -1994,6 +1999,9 @@ public final class BuiltinMacros {
         LD_SDK_IMPORTS_FILE,
         LD_SKIP_MERGEABLE_LIBRARY_BUNDLE_HOOK,
         LD_WARN_UNUSED_DYLIBS,
+        LD_WHOLE_ARCHIVE_PREFIX_FLAGS,
+        LD_WHOLE_ARCHIVE_PATH_PREFIX,
+        LD_WHOLE_ARCHIVE_SUFFIX_FLAGS,
         _LD_MULTIARCH,
         _LD_MULTIARCH_PREFIX_MAP,
         _LD_ARCH,

--- a/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/LinkerSpec.swift
@@ -50,6 +50,8 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
             case reexport_merge
             /// Link the library weakly.
             case weak
+            /// Force inclusion of all symbols from the archive when linking
+            case wholeArchive
         }
 
         /// The kind of library input.
@@ -133,6 +135,10 @@ open class LinkerSpec : CommandLineToolSpec, @unchecked Sendable {
 
     convenience required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         self.init(parser, basedOnSpec, isGeneric: false)
+    }
+
+    public func supportsSearchPaths(scope: MacroEvaluationScope) -> Bool {
+        true
     }
 
     override public func defaultRuleInfo(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [String] {

--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -521,11 +521,15 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
             inputPaths.append(fileListPath)
         }
 
-        // Add the library arguments.
-        let libraryArgs = LdLinkerSpec.computeLibraryArgs(libraries, scope: cbc.scope)
-        specialArgs += libraryArgs.args
-        if SWBFeatureFlag.enableLinkerInputsFromLibrarySpecifiers.value {
-            inputPaths += libraryArgs.inputs
+        do {
+            // Add the library arguments.
+            let libraryArgs = try LdLinkerSpec.computeLibraryArgs(libraries, scope: cbc.scope)
+            specialArgs += libraryArgs.args
+            if SWBFeatureFlag.enableLinkerInputsFromLibrarySpecifiers.value {
+                inputPaths += libraryArgs.inputs
+            }
+        } catch {
+            delegate.error(error)
         }
 
         // FIXME: When using LTO, keep an object file on the side to preserve debug info.
@@ -943,11 +947,15 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         var specialArgs = [String]()
         var inputPaths = cbc.inputs.map({ $0.absolutePath })
 
-        // Add the library arguments.
-        let libraryArgs = LdLinkerSpec.computeLibraryArgs(libraries, scope: cbc.scope)
-        specialArgs += libraryArgs.args
-        if SWBFeatureFlag.enableLinkerInputsFromLibrarySpecifiers.value {
-            inputPaths += libraryArgs.inputs
+        do {
+            // Add the library arguments.
+            let libraryArgs = try LdLinkerSpec.computeLibraryArgs(libraries, scope: cbc.scope)
+            specialArgs += libraryArgs.args
+            if SWBFeatureFlag.enableLinkerInputsFromLibrarySpecifiers.value {
+                inputPaths += libraryArgs.inputs
+            }
+        } catch {
+            delegate.error(error)
         }
 
         // Disable linker ad-hoc signing if we will be signing the product.  This is a performance optimization to eliminate redundant or unnecessary work.
@@ -1346,20 +1354,20 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
     /// Compute the list of command line arguments and inputs to pass to the linker, given a list of library specifiers.
     ///
     /// Note that `inputs` will only contain values for libraries which are being directly linked by absolute path rather than by using search paths.
-    private static func computeLibraryArgs(_ libraries: [LibrarySpecifier], scope: MacroEvaluationScope) -> (args: [String], inputs: [Path]) {
+    private static func computeLibraryArgs(_ libraries: [LibrarySpecifier], scope: MacroEvaluationScope) throws -> (args: [String], inputs: [Path]) {
         // Construct the library arguments.
-        return libraries.compactMap { specifier -> (args: [String], inputs: [Path]) in
+        return try libraries.compactMap { specifier -> (args: [String], inputs: [Path]) in
             switch specifier.kind {
             case .static, .dynamic, .textBased, .framework:
                 if specifier.useSearchPaths {
-                    return (specifier.searchPathFlagsForLd(), [])
+                    return (try specifier.searchPathFlagsForLd(scope: scope), [])
                 }
-                return (specifier.absolutePathFlagsForLd(), [specifier.path])
+                return (try specifier.absolutePathFlagsForLd(scope: scope), [specifier.path])
             case .object:
                 // Object files are added to linker inputs in the sources task producer.
                 return ([], [])
             case .objectLibrary:
-                let pathFlags = specifier.absolutePathFlagsForLd()
+                let pathFlags = try specifier.absolutePathFlagsForLd(scope: scope)
                 return (pathFlags, [specifier.path])
             }
         }.reduce(([], [])) { (lhs, rhs) in (lhs.args + rhs.args, lhs.inputs + rhs.inputs) }
@@ -1576,7 +1584,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 /// Extensions to `LinkerSpec.LibrarySpecifier` specific to the dynamic linker.
 fileprivate extension LinkerSpec.LibrarySpecifier {
 
-    func searchPathFlagsForLd() -> [String] {
+    func searchPathFlagsForLd(scope: MacroEvaluationScope) throws -> [String] {
         precondition(useSearchPaths)
         // Extract basename once to avoid redundant operations
         let basename = path.basename
@@ -1602,6 +1610,10 @@ fileprivate extension LinkerSpec.LibrarySpecifier {
         case (.static, .weak),
              (.textBased, .weak):
             return ["-weak-l" + strippedName]
+        case (.static, .wholeArchive):
+            return scope.evaluate(BuiltinMacros.LD_WHOLE_ARCHIVE_PREFIX_FLAGS) +
+            ["-l" + strippedName] +
+            scope.evaluate(BuiltinMacros.LD_WHOLE_ARCHIVE_SUFFIX_FLAGS)
         case (.static, _),
              (.textBased, _):
             // Other modes are not supported for these kinds.
@@ -1622,10 +1634,14 @@ fileprivate extension LinkerSpec.LibrarySpecifier {
         case (.objectLibrary, _):
             // Object libraries can't be found via search paths.
             return []
+        case (.framework, .wholeArchive):
+            throw StubError.error("frameworks do not support linking in 'whole archive' mode")
+        case (.dynamic, .wholeArchive):
+            throw StubError.error("dynamic libraries do not support linking in 'whole archive' mode")
         }
     }
 
-    func absolutePathFlagsForLd() -> [String] {
+    func absolutePathFlagsForLd(scope: MacroEvaluationScope) throws -> [String] {
         switch (kind, mode) {
         case (.dynamic, .normal):
             return [path.str]
@@ -1640,6 +1656,10 @@ fileprivate extension LinkerSpec.LibrarySpecifier {
         case (.static, .weak),
              (.textBased, .weak):
             return ["-weak_library", path.str]
+        case (.static, .wholeArchive):
+            return scope.evaluate(BuiltinMacros.LD_WHOLE_ARCHIVE_PREFIX_FLAGS) +
+            [scope.evaluate(BuiltinMacros.LD_WHOLE_ARCHIVE_PATH_PREFIX) + path.str] +
+            scope.evaluate(BuiltinMacros.LD_WHOLE_ARCHIVE_SUFFIX_FLAGS)
         case (.static, _),
              (.textBased, _):
             // Other modes are not supported for these kinds.
@@ -1660,6 +1680,10 @@ fileprivate extension LinkerSpec.LibrarySpecifier {
             return []
         case (.objectLibrary, _):
             return ["@\(path.join("args.resp").str)"]
+        case (.framework, .wholeArchive):
+            throw StubError.error("frameworks do not support linking in 'whole archive' mode")
+        case (.dynamic, .wholeArchive):
+            throw StubError.error("dynamic libraries do not support linking in 'whole archive' mode")
         }
     }
 }
@@ -1686,6 +1710,10 @@ public final class LibtoolLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @u
     public override func inputFileListContents(_ cbc: CommandBuildContext, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> ByteString {
         let format = cbc.scope.evaluate(BuiltinMacros.LIBTOOL_FILE_LIST_FORMAT, lookup: lookup)
         return ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: cbc.inputs.map { $0.absolutePath.strWithPosixSlashes }, format: format))
+    }
+
+    public override func supportsSearchPaths(scope: MacroEvaluationScope) -> Bool {
+        scope.evaluate(BuiltinMacros.ARCHIVER_SUPPORTS_SEARCH_PATHS)
     }
 
     static func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ delegate: any CoreClientTargetDiagnosticProducingDelegate, toolPath: Path) async throws -> DiscoveredLibtoolLinkerToolSpecInfo {

--- a/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
@@ -30,6 +30,7 @@
         Identifier = com.apple.product-type.bundle.unit-test;
         BasedOn = com.apple.product-type.library.dynamic;
         DefaultBuildProperties = {
+            ENABLE_TESTING_SEARCH_PATHS = YES;
             // Index store data is required to discover XCTest tests
             COMPILER_INDEX_STORE_ENABLE = YES;
             SWIFT_INDEX_STORE_ENABLE = YES;

--- a/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec
@@ -209,7 +209,18 @@
                     windowsShellQuotedNewlineSeparated,
                 );
                 DefaultValue = unixShellQuotedSpaceSeparated;
-            }
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_PREFIX_FLAGS;
+                Type = StringList;
+                // The input path must also be escaped with -Xlinker to ensure the relative ordering of these flags is preserved.
+                DefaultValue = "-Xlinker --whole-archive -Xlinker";
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_SUFFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "-Xlinker --no-whole-archive";
+            },
         );
     },
 )

--- a/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXLd.xcspec
@@ -169,6 +169,16 @@
                 );
                 IsInputDependency = Yes;
             },
+            {
+                Name = LD_WHOLE_ARCHIVE_PREFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "";
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_SUFFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "";
+            },
         );
     },
 )

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -328,7 +328,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
     }
 
     /// Computes and returns a list of libraries to include when linking.
-    func computeLibraries(_ buildFilesContext: BuildFilesProcessingContext, _ scope: MacroEvaluationScope) async -> [LinkerSpec.LibrarySpecifier] {
+    func computeLibraries(_ buildFilesContext: BuildFilesProcessingContext, _ scope: MacroEvaluationScope, allowSearchPaths: Bool) async -> [LinkerSpec.LibrarySpecifier] {
         guard let frameworksPhase = frameworksBuildPhase else { return [] }
 
         // Compute the flattened list of build files after expanding package product targets.
@@ -366,18 +366,22 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
             // Link using search paths unless the reference is in a different project, in which case we use a full path (to support legacy build locations, primarily).
             let useSearchPaths: Bool
-            switch buildFile.buildableItem {
-            case .reference:
-                useSearchPaths = true
-            case .targetProduct(guid: let guid):
-                if let referenceTarget = self.context.workspaceContext.workspace.target(for: guid) {
-                    let referenceProject = self.context.workspaceContext.workspace.project(for: referenceTarget)
-                    useSearchPaths = referenceProject === self.context.project
-                } else {
+            if allowSearchPaths {
+                switch buildFile.buildableItem {
+                case .reference:
+                    useSearchPaths = true
+                case .targetProduct(guid: let guid):
+                    if let referenceTarget = self.context.workspaceContext.workspace.target(for: guid) {
+                        let referenceProject = self.context.workspaceContext.workspace.project(for: referenceTarget)
+                        useSearchPaths = referenceProject === self.context.project
+                    } else {
+                        useSearchPaths = true
+                    }
+                case .namedReference:
                     useSearchPaths = true
                 }
-            case .namedReference:
-                useSearchPaths = true
+            } else {
+                useSearchPaths = false
             }
 
             /// If this `BuildFile` is being produced by a target, capture the effective `Settings` for it.  `TaskProducerContext.settingsForProductReferenceTarget()` will resolve this to the actual settings for the `ConfiguredTarget` in the target dependency graph (as opposed to an older approach of applying the current configured target's parameters to the other target, which won't work if there are context-dependent overrides).
@@ -510,10 +514,19 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             }
 
             if fileType.conformsTo(context.lookupFileType(identifier: "archive.ar")!) {
+                let mode: LinkerSpec.LibrarySpecifier.Mode
+                if buildFile.shouldLinkWeakly {
+                    mode = .weak
+                } else if context.productType?.conformsTo(identifier: "com.apple.product-type.tool.swiftpm-test-runner") == true {
+                    // Test runners should force load all archives they depend on to ensure they never drop test implementations.
+                    mode = .wholeArchive
+                } else {
+                    mode = .normal
+                }
                 librarySpecifiers.append(LinkerSpec.LibrarySpecifier(
                     kind: .static,
                     path: absolutePath,
-                    mode: buildFile.shouldLinkWeakly ? .weak : .normal,
+                    mode: mode,
                     useSearchPaths: useSearchPaths,
                     isKnownToUseSwift: isKnownToUseSwift,
                     swiftModulePaths: swiftModulePaths,
@@ -992,8 +1005,11 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
                 let previewsDylibInputs = previewsDylibForTestHost()
 
+                // Link the object files.
+                let linkerSpec = getLinkerToUse(scope)
+
                 // Compute the libraries that should be linked.
-                let librariesToLink = await computeLibraries(buildFilesContext, scope) + previewsDylibInputs
+                let librariesToLink = await computeLibraries(buildFilesContext, scope, allowSearchPaths: linkerSpec.supportsSearchPaths(scope: scope)) + previewsDylibInputs
                 allLinkedLibraries.append(contentsOf: librariesToLink)
 
                 // Insert the object files present in the framework build phase to the linker inputs.
@@ -1075,9 +1091,6 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
                     let canBeEagerlyLinkedAgainstUsingTBD = context.supportsEagerLinking(scope: scope)
                     shouldPrepareEagerLinkingTBD = shouldPrepareEagerLinkingTBD || canBeEagerlyLinkedAgainstUsingTBD
-
-                    // Link the object files.
-                    let linkerSpec = getLinkerToUse(scope)
 
                     var linkerOpts: TaskOrderingOptions = [.unsignedProductRequirement, .linking]
                     // The link task is a requirement for linking downstream tasks unless this target can be linked against using a TBD.

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -1065,6 +1065,17 @@
                 );
                 DefaultValue = unixShellQuotedSpaceSeparated;
             },
+            {
+                Name = LD_WHOLE_ARCHIVE_PREFIX_FLAGS;
+                Type = StringList;
+                // The input path must also be escaped with -Xlinker to ensure the relative ordering of these flags is preserved.
+                DefaultValue = "-Xlinker -force_load -Xlinker";
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_SUFFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "";
+            },
         );
     }
 )

--- a/Sources/SWBWebAssemblyPlatform/Specs/WebAssembly.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WebAssembly.xcspec
@@ -48,6 +48,21 @@
     {
         Domain = webassembly;
         Type = ProductType;
+        Identifier = com.apple.product-type.bundle.unit-test;
+        BasedOn = org.swift.product-type.common.object;
+        DefaultBuildProperties = {
+            ENABLE_TESTING_SEARCH_PATHS = YES;
+            // Index store data is required to discover XCTest tests
+            COMPILER_INDEX_STORE_ENABLE = YES;
+            SWIFT_INDEX_STORE_ENABLE = YES;
+            // Testability is needed to generate code to invoke discovered XCTest tests
+            SWIFT_ENABLE_TESTABILITY = YES;
+            GENERATE_TEST_ANCHOR = YES;
+        };
+    },
+    {
+        Domain = webassembly;
+        Type = ProductType;
         Identifier = com.apple.product-type.tool.swiftpm-test-runner;
         BasedOn = default:com.apple.product-type.tool.swiftpm-test-runner;
         DefaultBuildProperties = {

--- a/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsLd.xcspec
@@ -278,7 +278,21 @@
                 DefaultValue = "$(DEBUG_INFORMATION_FORMAT)";
                 Condition = "$(GCC_GENERATE_DEBUGGING_SYMBOLS) && $(ALTERNATE_LINKER) == lld-link";
             },
-
+            {
+                Name = LD_WHOLE_ARCHIVE_PREFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "";
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_PATH_PREFIX;
+                Type = String;
+                DefaultValue = "-wholearchive:";
+            },
+            {
+                Name = LD_WHOLE_ARCHIVE_SUFFIX_FLAGS;
+                Type = StringList;
+                DefaultValue = "";
+            },
         );
     },
 )

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1346,6 +1346,9 @@ import SWBMacro
             for useSearchPaths in [true, false] {
                 let searchPathString = useSearchPaths ? "search" : "abs"
                 for mode in LinkerSpec.LibrarySpecifier.Mode.allCases {
+                    guard mode != .wholeArchive else {
+                        continue
+                    }
                     let prefix: String?
                     let suffix = "_\(mode)_\(searchPathString)"
                     let filePath: Path

--- a/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/WebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -257,6 +257,159 @@ fileprivate struct WebAssemblyIntegrationTests: CoreBasedTests {
         }
     }
 
+    enum TestingFramework: String, CaseIterable, CustomStringConvertible, Sendable {
+        case swiftTesting
+        case xctest
+        case both
+
+        var description: String { rawValue }
+    }
+
+    @Test(.requireSDKs(.host), .requiresWebAssemblySwiftSDK, .skipXcodeToolchain, arguments: TestingFramework.allCases)
+    func unitTestWithGeneratedEntryPoint(framework: TestingFramework) async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: false) { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("library2.swift"),
+                        TestFile("test.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_VERSION": swiftVersion,
+                        "SDKROOT": "auto",
+                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                        "LINKER_DRIVER": "auto",
+                        "INDEX_DATA_STORE_DIR": "\(tmpDir.join("index").str)",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "UnitTestRunner",
+                        type: .swiftpmTestRunner,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug"),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(),
+                            TestFrameworksBuildPhase([
+                                TestBuildFile(.target("MyTests"))
+                            ])
+                        ],
+                        dependencies: ["MyTests"]
+                    ),
+                    TestStandardTarget(
+                        "MyTests",
+                        type: .unitTest,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [:])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["test.swift"]),
+                            TestFrameworksBuildPhase([
+                                TestBuildFile(.target("library")),
+                            ])
+                        ], dependencies: [
+                            "library"
+                        ],
+                        productReferenceName: "$(EXECUTABLE_NAME)"
+                    ),
+                    TestStandardTarget(
+                        "library",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "EXECUTABLE_PREFIX": "lib",
+                            ])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["library2.swift"]),
+                        ],
+                        productReferenceName: "$(EXECUTABLE_NAME)",
+                    )
+                ])
+            let core = try await Self.getSwiftSDKIntegrationTestingCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+            try localFS.createDirectory(tmpDir.join("index"))
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("library2.swift")) { stream in
+                stream <<< "public func foo() -> Int { 42 }\n"
+            }
+
+            let testSource: String
+            switch framework {
+            case .swiftTesting:
+                testSource = """
+                    import Testing
+                    import library
+                    @Suite struct MySuite {
+                        @Test func myTest() {
+                            #expect(foo() == 42)
+                        }
+                    }
+                """
+            case .xctest:
+                testSource = """
+                    import XCTest
+                    import library
+                    final class MYXCTests: XCTestCase {
+                        func testFoo() {
+                            XCTAssertEqual(foo(), 42)
+                        }
+                    }
+                """
+            case .both:
+                testSource = """
+                    import Testing
+                    import XCTest
+                    import library
+                    @Suite struct MySuite {
+                        @Test func myTest() {
+                            #expect(foo() == 42)
+                        }
+                    }
+
+                    final class MYXCTests: XCTestCase {
+                        func testFoo() {
+                            XCTAssertTrue(true)
+                        }
+                    }
+                """
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("test.swift")) { stream in
+                stream <<< testSource
+            }
+
+            let swiftSDK = try #require(await core.findWebAssemblySwiftSDK())
+            let destination = try RunDestinationInfo(sdkManifestPath: swiftSDK.manifestPath, triple: "wasm32-unknown-wasip1", targetArchitecture: "wasm32", supportedArchitectures: ["wasm32"], disableOnlyActiveArch: false, core: core)
+            try await tester.checkBuild(runDestination: destination, persistent: true) { results in
+                results.checkNoErrors()
+
+                let settings = results.buildRequestContext.getCachedSettings(results.buildRequest.parameters)
+                let wasmKitPath = try #require(try settings.executableSearchPaths.lookup(subject: .executable(basename: "wasmkit"), operatingSystem: ProcessInfo.processInfo.hostOperatingSystem()))
+                let executablePath = projectDir.join("build").join("Debug-webassembly").join("UnitTestRunner.wasm").str
+
+                if framework == .xctest || framework == .both {
+                    let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: wasmKitPath.str), arguments: ["run", "--dir", "/", executablePath])
+                    #expect(executionResult.exitStatus == .exit(0))
+                    #expect(String(decoding: executionResult.stdout, as: UTF8.self).contains("Executed 1 test"))
+                }
+                if framework == .swiftTesting || framework == .both {
+                    let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: wasmKitPath.str), arguments: ["run", "--dir", "/", executablePath, "--", "--testing-library", "swift-testing"])
+                    #expect(executionResult.exitStatus == .exit(0))
+                    #expect(String(decoding: executionResult.stderr, as: UTF8.self).contains("Test run with 1 test "))
+                }
+            }
+        }
+    }
+
     @Test(.requireSDKs(.host), .requiresEmbeddedWebAssemblySwiftSDK, .skipXcodeToolchain)
         func embeddedExecutable() async throws {
             try await withTemporaryDirectory { (tmpDir: Path) in


### PR DESCRIPTION
- Build test targets as static archives when targeting WebAssembly
- Ensure test runners use --whole-archive when incorporating static archives so we don't drop swift-testing tests
- Refactor handling of search paths vs direct inputs when constructing archiver arguments
- Fix an issue where the generic unix test product type wasn't setting ENABLE_TESTING_SEARCH_PATHS correctly