### PR TITLE
Ensure embed-in-code accessor is regenerated when resources change

### DIFF
--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -133,6 +133,7 @@ add_library(SWBCore
   SpecImplementations/Tools/Gate.swift
   SpecImplementations/Tools/GCCCompatibleCompilerSupport.swift
   SpecImplementations/Tools/GenerateAppPlaygroundAssetCatalog.swift
+  SpecImplementations/Tools/GenerateEmbedInCodeAccessor.swift
   SpecImplementations/Tools/InfoPlistTool.swift
   SpecImplementations/Tools/LaunchServicesRegisterTool.swift
   SpecImplementations/Tools/LinkerTools.swift

--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -328,6 +328,7 @@ public protocol TaskActionCreationDelegate
     func createDeferredExecutionTaskAction() -> any PlannedTaskAction
     func createEmbedSwiftStdLibTaskAction() -> any PlannedTaskAction
     func createFileCopyTaskAction(_ context: FileCopyTaskActionContext) -> any PlannedTaskAction
+    func createGenerateEmbedInCodeAccessorTaskAction() -> any PlannedTaskAction
     func createGenericCachingTaskAction(enableCacheDebuggingRemarks: Bool, enableTaskSandboxEnforcement: Bool, sandboxDirectory: Path, extraSandboxSubdirectories: [Path], developerDirectory: Path, casOptions: CASOptions) -> any PlannedTaskAction
     func createInfoPlistProcessorTaskAction(_ contextPath: Path) -> any PlannedTaskAction
     func createMergeInfoPlistTaskAction() -> any PlannedTaskAction

--- a/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
+++ b/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
@@ -122,6 +122,7 @@ public struct BuiltinSpecsExtension: SpecificationsExtension {
             ConcatenateToolSpec.self,
             CreateAssetPackManifestToolSpec.self,
             CreateBuildDirectorySpec.self,
+            GenerateEmbedInCodeAccessorSpec.self,
             MergeInfoPlistSpec.self,
             ProcessSDKImportsSpec.self,
             ProcessXCFrameworkLibrarySpec.self,

--- a/Sources/SWBCore/SpecImplementations/Tools/GenerateEmbedInCodeAccessor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/GenerateEmbedInCodeAccessor.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+import SWBMacro
+
+/// Generates the `embedded_resources.swift` accessor for resources marked `embedInCode`.
+public final class GenerateEmbedInCodeAccessorSpec: CommandLineToolSpec, SpecImplementationType, @unchecked Sendable {
+    public static let identifier = "org.swift.build-tools.generate-embed-in-code-accessor"
+
+    public class func construct(registry: SpecRegistry, proxy: SpecProxy) -> Spec {
+        let execDescription = registry.internalMacroNamespace.parseString("Generate $(OutputFile:file)")
+        return GenerateEmbedInCodeAccessorSpec(registry, proxy, execDescription: execDescription, ruleInfoTemplate: [], commandLineTemplate: [])
+    }
+
+    public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) {
+        let outputNode = delegate.createNode(cbc.output)
+        let resourcePaths = cbc.inputs.map { $0.absolutePath }
+        let inputNodes = resourcePaths.map(delegate.createNode) + cbc.commandOrderingInputs
+        let action = delegate.taskActionCreationDelegate.createGenerateEmbedInCodeAccessorTaskAction()
+        let commandLine = ["builtin-generateEmbedInCodeAccessor", "--output", outputNode.path.str] + resourcePaths.map { $0.str }
+        delegate.createTask(
+            type: self,
+            ruleInfo: ["GenerateEmbedInCodeAccessor", outputNode.path.str],
+            commandLine: commandLine,
+            environment: EnvironmentBindings(),
+            workingDirectory: cbc.producer.defaultWorkingDirectory,
+            inputs: inputNodes,
+            outputs: [outputNode],
+            mustPrecede: [],
+            action: action,
+            execDescription: resolveExecutionDescription(cbc, delegate),
+            preparesForIndexing: true,
+            enableSandboxing: enableSandboxing,
+            additionalTaskOrderingOptions: [.immediate],
+            priority: .unblocksDownstreamTasks
+        )
+    }
+}

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1854,24 +1854,20 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             return nil
         }
 
-        let filePath = scope.evaluate(BuiltinMacros.DERIVED_SOURCES_DIR).join("embedded_resources.swift")
-
-        var content = "struct PackageResources {\n"
-
-        for file in resourceBuildFiles {
-            let (_, path, _) = try context.resolveBuildFileReference(file)
-
-            let variableName = path.basename.mangledToC99ExtendedIdentifier()
-            let fileContent = try Data(contentsOf: URL(fileURLWithPath: path.str)).map { String($0) }.joined(separator: ",")
-
-            content += "static let \(variableName): [UInt8] = [\(fileContent)]\n"
+        guard let spec = context.generateEmbedInCodeAccessorSpec else {
+            return nil
         }
 
-        content += "}"
+        let filePath = scope.evaluate(BuiltinMacros.DERIVED_SOURCES_DIR).join("embedded_resources.swift")
+
+        let resourceInputs = try resourceBuildFiles.map { file -> FileToBuild in
+            let (_, path, fileType) = try context.resolveBuildFileReference(file)
+            return FileToBuild(absolutePath: path, fileType: fileType)
+        }
 
         var tasks = [any PlannedTask]()
         await appendGeneratedTasks(&tasks) { delegate in
-            context.writeFileSpec.constructFileTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: [], output: filePath), delegate, contents: ByteString(encodingAsUTF8: content), permissions: nil, preparesForIndexing: true, additionalTaskOrderingOptions: [.immediate, .ignorePhaseOrdering])
+            spec.constructTasks(CommandBuildContext(producer: context, scope: context.settings.globalScope, inputs: resourceInputs, output: filePath), delegate)
         }
         return GeneratedSourceCodeResult(tasks: tasks, fileToBuild: filePath, fileToBuildFileType: context.lookupFileType(identifier: "sourcecode.swift")!)
     }

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -281,6 +281,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     let processXCFrameworkLibrarySpec: ProcessXCFrameworkLibrarySpec
     public let processSDKImportsSpec: ProcessSDKImportsSpec
     public let writeFileSpec: WriteFileSpec
+    private let _generateEmbedInCodeAccessorSpec: Result<GenerateEmbedInCodeAccessorSpec, any Error>
+    public var generateEmbedInCodeAccessorSpec: GenerateEmbedInCodeAccessorSpec? { return specForResult(_generateEmbedInCodeAccessorSpec) }
     private let _documentationCompilerSpec: Result<CommandLineToolSpec, any Error>
     var documentationCompilerSpec: CommandLineToolSpec? { return specForResult(_documentationCompilerSpec) }
     private let _tapiSymbolExtractorSpec: Result<TAPISymbolExtractor, any Error>
@@ -398,6 +400,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.processXCFrameworkLibrarySpec = try! workspaceContext.core.specRegistry.getSpec(ProcessXCFrameworkLibrarySpec.identifier, domain: domain, ofType: ProcessXCFrameworkLibrarySpec.self)
         self.processSDKImportsSpec = try! workspaceContext.core.specRegistry.getSpec(ProcessSDKImportsSpec.identifier, domain: domain, ofType: ProcessSDKImportsSpec.self)
         self.writeFileSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.write-file", domain: domain, ofType: WriteFileSpec.self)
+        self._generateEmbedInCodeAccessorSpec = Result { try workspaceContext.core.specRegistry.getSpec(GenerateEmbedInCodeAccessorSpec.identifier, domain: domain, ofType: GenerateEmbedInCodeAccessorSpec.self) }
         self._documentationCompilerSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation", domain: domain, ofType: CommandLineToolSpec.self) }
         self._tapiSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.objc-symbol-extract", domain: domain, ofType: TAPISymbolExtractor.self) }
         self._swiftSymbolExtractorSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.documentation.swift-symbol-extract", domain: domain, ofType: CommandLineToolSpec.self) }

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -849,6 +849,10 @@ extension BuildSystemTaskPlanningDelegate: TaskActionCreationDelegate {
         return ConcatenateTaskAction()
     }
 
+    func createGenerateEmbedInCodeAccessorTaskAction() -> any PlannedTaskAction {
+        return GenerateEmbedInCodeAccessorTaskAction()
+    }
+
     func createCopyPlistTaskAction() -> any PlannedTaskAction {
         return CopyPlistTaskAction()
     }

--- a/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
+++ b/Sources/SWBTaskExecution/BuiltinTaskActionsExtension.swift
@@ -58,6 +58,7 @@ public struct BuiltinTaskActionsExtension: TaskActionExtension {
             43: LinkerTaskAction.self,
             // 44: TestEntryPointGenerationTaskAction.self,
             45: SwiftCompilationVerificationTaskAction.self,
+            46: GenerateEmbedInCodeAccessorTaskAction.self,
         ]
     }
 }

--- a/Sources/SWBTaskExecution/CMakeLists.txt
+++ b/Sources/SWBTaskExecution/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(SWBTaskExecution
   TaskActions/DeferredExecutionTaskAction.swift
   TaskActions/EmbedSwiftStdLibTaskAction.swift
   TaskActions/FileCopyTaskAction.swift
+  TaskActions/GenerateEmbedInCodeAccessorTaskAction.swift
   TaskActions/GenericCachingTaskAction.swift
   TaskActions/InfoPlistProcessorTaskAction.swift
   TaskActions/LinkAssetCatalogTaskAction.swift

--- a/Sources/SWBTaskExecution/TaskActions/GenerateEmbedInCodeAccessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/GenerateEmbedInCodeAccessorTaskAction.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBCore
+import SWBLibc
+public import SWBUtil
+import ArgumentParser
+import Foundation
+
+/// Generates the `embedded_resources.swift` accessor for resources marked `embedInCode`.
+public final class GenerateEmbedInCodeAccessorTaskAction: TaskAction {
+    public override class var toolIdentifier: String {
+        return "generate-embed-in-code-accessor"
+    }
+
+    private struct Options: ParsableArguments {
+        @Option var output: Path
+        @Argument var inputs: [Path] = []
+    }
+
+    public override init() {
+        super.init()
+    }
+
+    public override func performTaskAction(
+        _ task: any ExecutableTask,
+        dynamicExecutionDelegate: any DynamicTaskExecutionDelegate,
+        executionDelegate: any TaskExecutionDelegate,
+        clientDelegate: any TaskExecutionClientDelegate,
+        outputDelegate: any TaskOutputDelegate
+    ) async -> CommandResult {
+        let options: Options
+        do {
+            options = try Options.parse(Array(task.commandLineAsStrings.dropFirst()))
+        } catch {
+            outputDelegate.emitError("\(error)")
+            return .failed
+        }
+
+        let fs = executionDelegate.fs
+        do {
+            var content = "struct PackageResources {\n"
+            for inputPath in options.inputs {
+                let variableName = inputPath.basename.mangledToC99ExtendedIdentifier()
+                let bytes = try fs.read(inputPath).bytes
+                let fileContent = bytes.map { String($0) }.joined(separator: ",")
+                content += "static let \(variableName): [UInt8] = [\(fileContent)]\n"
+            }
+            content += "}"
+            _ = try fs.writeIfChanged(options.output, contents: ByteString(encodingAsUTF8: content))
+        } catch {
+            outputDelegate.emitError("unable to write file '\(options.output.str)': \(error.localizedDescription)")
+            return .failed
+        }
+
+        return .succeeded
+    }
+
+    public override func serialize<T: Serializer>(to serializer: T) {
+        super.serialize(to: serializer)
+    }
+
+    public required init(from deserializer: any Deserializer) throws {
+        try super.init(from: deserializer)
+    }
+}

--- a/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
+++ b/Sources/SWBTestSupport/CapturingTaskGenerationDelegate.swift
@@ -124,6 +124,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return ConcatenateTaskAction()
     }
 
+    package func createGenerateEmbedInCodeAccessorTaskAction() -> any SWBCore.PlannedTaskAction {
+        return GenerateEmbedInCodeAccessorTaskAction()
+    }
+
     package func createCopyPlistTaskAction() -> any PlannedTaskAction {
         return CopyPlistTaskAction()
     }

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -359,6 +359,10 @@ extension TestTaskPlanningDelegate: TaskActionCreationDelegate {
         return ConcatenateTaskAction()
     }
 
+    package func createGenerateEmbedInCodeAccessorTaskAction() -> any PlannedTaskAction {
+        return GenerateEmbedInCodeAccessorTaskAction()
+    }
+
     package func createCopyPlistTaskAction() -> any PlannedTaskAction {
         return CopyPlistTaskAction()
     }

--- a/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PackageBuildOperationTests.swift
@@ -705,4 +705,65 @@ fileprivate struct PackageBuildOperationTests: CoreBasedTests {
         return tester
     }
 
+    @Test(.requireSDKs(.host))
+    func resourceEmbedInCodeIncrementalRebuild() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestPackageProject(
+                "aProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("main.swift"),
+                        TestFile("best.txt"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "SWIFT_VERSION": "5",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "GENERATE_EMBED_IN_CODE_ACCESSORS": "YES",
+                        "USE_HEADERMAP": "NO"]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "library",
+                        type: .staticLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                            TestCopyFilesBuildPhase([TestBuildFile(.file("best.txt"), resourceRule: .embedInCode)], destinationSubfolder: .builtProductsDir),
+                        ]
+                    ),
+                ]
+            )
+            let tester = try await BuildOperationTester(getCore(), testProject, simulated: false, fileSystem: localFS)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+            try await tester.fs.writeFileContents(projectDir.join("main.swift")) { stream in
+                stream.write("")
+            }
+            try await tester.fs.writeFileContents(projectDir.join("best.txt")) { stream in
+                stream.write("hello world")
+            }
+
+            try await tester.checkBuild(runDestination: .host, persistent: true) { results in
+                results.checkNoDiagnostics()
+                results.checkTaskExists(.matchRuleType("GenerateEmbedInCodeAccessor"), .matchRuleItemBasename("embedded_resources.swift"))
+                results.checkTaskExists(.matchRuleType("SwiftCompile"), .matchRuleItemPattern(.contains("embedded_resources.swift")))
+            }
+
+            try await tester.checkNullBuild(runDestination: .host, persistent: true)
+
+            try await tester.fs.writeFileContents(projectDir.join("best.txt"), waitForNewTimestamp: true) { stream in
+                stream.write("goodbye world")
+            }
+
+            // After changing the resource, we should regenerate and recompile the accessor.
+            try await tester.checkBuild(runDestination: .host, persistent: true) { results in
+                results.checkNoDiagnostics()
+                results.checkTaskExists(.matchRuleType("GenerateEmbedInCodeAccessor"), .matchRuleItemBasename("embedded_resources.swift"))
+                results.checkTaskExists(.matchRuleType("SwiftCompile"), .matchRuleItemPattern(.contains("embedded_resources.swift")))
+            }
+        }
+    }
+
 }

--- a/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
+++ b/Tests/SWBCorePerfTests/CommandLineSpecPerfTests.swift
@@ -119,6 +119,10 @@ extension CapturingTaskGenerationDelegate: TaskActionCreationDelegate {
         return ConcatenateTaskAction()
     }
 
+    public func createGenerateEmbedInCodeAccessorTaskAction() -> any PlannedTaskAction {
+        return GenerateEmbedInCodeAccessorTaskAction()
+    }
+
     public func createCopyPlistTaskAction() -> any PlannedTaskAction {
         return CopyPlistTaskAction()
     }

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -916,8 +916,9 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         await tester.checkBuild(runDestination: .macOS) { results in
             results.checkNoDiagnostics()
             results.checkTarget("tool") { target in
-                results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("embedded_resources.swift")) { task, contents in
-                    XCTAssertMatch(contents.unsafeStringValue, .contains("static let best_txt: [UInt8] ="))
+                results.checkTask(.matchTarget(target), .matchRuleType("GenerateEmbedInCodeAccessor"), .matchRuleItemBasename("embedded_resources.swift")) { task in
+                    task.checkInputs(contain: [.namePattern(.suffix("best.txt"))])
+                    task.checkOutputs(contain: [.namePattern(.suffix("embedded_resources.swift"))])
                 }
             }
         }


### PR DESCRIPTION
Previously the accessor content was being generated at build planning-time and written via an auxiliary file task action. Instead, add a new spec & task action which generate the accessor at task execution-time so we can properly invalidate it when the resources change.