### PR TITLE
Ensure Swift usage in object libraries is tracked correctly

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1030,7 +1030,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 let additionalLinkerOrderingInputs = librariesToLink.flatMap { $0.explicitDependencies.map(context.createNode) }
 
                 // If there is at least one object file that was built using Swift, ensure the Swift tool is present in the used tools to allow linker spec to add swift specific linker arguments.
-                if objectsInFrameworksPhase.contains(where: { $0.isKnownToUseSwift }), !usedTools.keys.contains(context.swiftCompilerSpec) {
+                if librariesToLink.filter({ $0.kind == .object || $0.kind == .objectLibrary }).contains(where: { $0.isKnownToUseSwift }), !usedTools.keys.contains(context.swiftCompilerSpec) {
                     usedTools[context.swiftCompilerSpec] = [context.lookupFileType(identifier: "compiled.mach-o.objfile")!]
                 }
 

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -2907,7 +2907,7 @@
                 AdditionalLinkerArgs = {
                     NO = ();
                     YES = (
-                        "-Xclang-linker", "-fprofile-instr-generate",
+                        "-profile-generate",
                     );
                 };
             },

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1179,7 +1179,7 @@
                 AdditionalLinkerArgs = {
                     NO = ();
                     YES = (
-                        "-Xclang-linker", "-fprofile-instr-generate",
+                        "-profile-generate",
                     );
                 };
             },

--- a/Tests/SWBBuildSystemTests/ObjectLibraryBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/ObjectLibraryBuildOperationTests.swift
@@ -388,4 +388,86 @@ fileprivate struct ObjectLibraryBuildOperationTests: CoreBasedTests {
             try await tester.checkNullBuild(runDestination: .host, persistent: true)
         }
     }
+
+    // Regression test for https://github.com/swiftlang/swift-build/issues/1353
+    @Test(.requireSDKs(.host))
+    func dynamicLibraryConsumingObjectLibraryWithCodeCoverage() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestPackageProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("a.swift"),
+                                TestFile("b.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "CODE_SIGNING_ALLOWED": "NO",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_VERSION": try await swiftVersion,
+                                    "LINKER_DRIVER": "auto",
+                                ]),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "Dylib",
+                                type: .dynamicLibrary,
+                                buildConfigurations: [
+                                    TestBuildConfiguration("Debug", buildSettings: [
+                                        "EXECUTABLE_PREFIX": "lib",
+                                        "EXECUTABLE_PREFIX[sdk=windows*]": "",
+                                    ])
+                                ],
+                                buildPhases: [
+                                    TestSourcesBuildPhase([]),
+                                    TestFrameworksBuildPhase([
+                                        "Library.objlib"
+                                    ])
+                                ],
+                                dependencies: [
+                                    "Library",
+                                ]
+                            ),
+                            TestStandardTarget(
+                                "Library",
+                                type: .objectLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "a.swift",
+                                        "b.swift",
+                                    ]),
+                                ]
+                            ),
+                        ])
+                ])
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/a.swift")) {
+                $0 <<< "public func foo() {}"
+            }
+
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/b.swift")) {
+                $0 <<< "public func bar() {}"
+            }
+
+            try await tester.checkBuild(runDestination: .host) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let coverageParameters = BuildParameters(configuration: "Debug", overrides: ["CLANG_COVERAGE_MAPPING": "YES"])
+            try await tester.checkBuild(parameters: coverageParameters, runDestination: .host) { results in
+                results.checkNoDiagnostics()
+                results.checkTask(.matchRuleType("Ld")) { task in
+                    task.checkCommandLineContains(["-profile-generate"])
+                }
+            }
+        }
+    }
 }

--- a/Tests/SWBTaskConstructionTests/CodeCoverageTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CodeCoverageTaskConstructionTests.swift
@@ -120,14 +120,14 @@ fileprivate struct CodeCoverageTaskConstructionTests: CoreBasedTests {
                 results.checkTarget("Target") { target in
                     // There should be one Ld task, which includes coverage options
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
-                        task.checkCommandLineContains(["-Xclang-linker", "-fprofile-instr-generate"])
+                        task.checkCommandLineContains(["-profile-generate"])
                     }
                 }
 
                 results.checkTarget("NoCoverageTarget") { target in
                     // There should be one Ld task, which includes coverage options
                     results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
-                        task.checkCommandLineContains(["-Xclang-linker", "-fprofile-instr-generate"])
+                        task.checkCommandLineContains(["-profile-generate"])
                     }
                 }
 


### PR DESCRIPTION
If a target consumes an object library built from swift sources, the swift spec should have an opportunity to inject additional linker arguments even if the target has no Swift sources of its own. We handled this correctly for relocatable objects, but not for object libraries.

Closes https://github.com/swiftlang/swift-build/issues/1353