### PR TITLE
Fixup libfuzzer linker flags

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3030,8 +3030,7 @@
 				};
 				AdditionalLinkerArgs = {
 					YES = (
-						"-fsanitize=fuzzer",
-						"-fno-sanitize-coverage=pc-table"
+                        "$(LD_FUZZER)"
 					);
 					NO = ();
 				};

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -742,6 +742,20 @@
                 // Not visible in the build settings editor
             },
 
+            // Fuzzer
+            {
+                Name = LD_FUZZER;
+                DefaultValue = "$(LD_FUZZER_$(LINKER_DRIVER))";
+            },
+            {
+                Name = LD_FUZZER_clang;
+                DefaultValue = "-fsanitize=fuzzer";
+            },
+            {
+                Name = LD_FUZZER_swiftc;
+                DefaultValue = "-sanitize=fuzzer";
+            },
+
             {
                 Name = "LD_DEBUG_VARIANT";
                 Type = Boolean;

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1299,8 +1299,7 @@
                 };
                 AdditionalLinkerArgs = {
                     YES = (
-                        "-fsanitize=fuzzer",
-                        "-fno-sanitize-coverage=pc-table"
+                        "$(LD_FUZZER)"
                     );
                     NO = ();
                 };

--- a/Tests/SWBTaskConstructionTests/LinkerTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/LinkerTaskConstructionTests.swift
@@ -165,6 +165,16 @@ fileprivate struct LinkerTaskConstructionTests: CoreBasedTests {
                 linkerDriverUT: "swiftc",
                 expectedArgument: "-sanitize=thread",
             ),
+            (
+                buildSettingNameUT: "ENABLE_LIBFUZZER",
+                linkerDriverUT: "clang",
+                expectedArgument: "-fsanitize=fuzzer",
+            ),
+            (
+                buildSettingNameUT: "ENABLE_LIBFUZZER",
+                linkerDriverUT: "swiftc",
+                expectedArgument: "-sanitize=fuzzer",
+            ),
         ],
     )
     func ldSanitizerArgumentsAppearsOnCommandLine(


### PR DESCRIPTION
Ensure ENABLE_LIBFUZZER works with clang or swiftc as the linker driver

Fixes: #1231 