### PR TITLE
Fix free space test skip in PBXCPTests.largerFile

### DIFF
--- a/Tests/SWBTaskExecutionTests/PBXCpTests.swift
+++ b/Tests/SWBTaskExecutionTests/PBXCpTests.swift
@@ -453,8 +453,8 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             if let freeSpace = try fs.getFreeDiskSpace(tmp), freeSpace < requiredSpace {
                 withKnownIssue {
                     Issue.record("There is not enough free disk space to run this test (required: \(requiredSpace), free: \(freeSpace))")
-                    return
                 }
+                return
             }
 
             // Test copying a large file.


### PR DESCRIPTION
This has been failing intermittently for a little while in CI. Move the return out of the withKnownIssue closure to make sure we correctly early-exit the test when skipping it