### PR TITLE
Respect INDEX_ENABLE_DATA_STORE=NO for Swift, Clang, and Metal index store options

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -42,6 +42,7 @@ extension ProjectModel {
             case GCC_C_LANGUAGE_STANDARD
             case GCC_OPTIMIZATION_LEVEL
             case GENERATE_PRELINK_OBJECT_FILE
+            case INDEX_ENABLE_DATA_STORE
             case INFOPLIST_FILE
             case IPHONEOS_DEPLOYMENT_TARGET
             case KEEP_PRIVATE_EXTERNS


### PR DESCRIPTION
The *_INDEX_STORE_ENABLE xcspec settings use INDEX_ENABLE_DATA_STORE as their DefaultValue, but if a PIF explicitly sets them to YES (as SwiftPM's new PIF builder does for package targets), the default is bypassed and INDEX_ENABLE_DATA_STORE=NO on the command line has no effect.

Add INDEX_ENABLE_DATA_STORE as a leading guard on the Condition for each setting, making it authoritative regardless of what the PIF provides.

rdar://174859173
