### PR TITLE
[6.4] Allow constructing a run destination from an in-memory representation of a Swift SDK

### DIFF
--- a/Sources/SWBCore/BuildRequestContext.swift
+++ b/Sources/SWBCore/BuildRequestContext.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SWBProtocol
+public import SWBProtocol
 public import SWBUtil
 public import SWBMacro
 import Foundation

--- a/Sources/SWBCore/CMakeLists.txt
+++ b/Sources/SWBCore/CMakeLists.txt
@@ -104,7 +104,6 @@ add_library(SWBCore
   ShellScript.swift
   SigningSupport.swift
   SwiftOutputParsing.swift
-  SwiftSDK.swift
   SpecImplementations/CommandLineToolSpec.swift
   SpecImplementations/CompilerSpec.swift
   Specs/CoreBuildSystem.xcspec

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -17,6 +17,7 @@ public import SWBUtil
 public import SWBCAS
 public import SWBServiceCore
 import SWBMacro
+import SWBProtocol
 
 /// Delegate protocol used to parameterize creation of a `Core` object and to report diagnostics.
 public protocol CoreDelegate: DiagnosticProducingDelegate, Sendable {
@@ -657,31 +658,47 @@ extension Core {
     public func performInitialization(for buildRequest: BuildRequest) throws {
         // Register the Swift SDK from the build request, if we had one.
         // This will add it to the SDKs-by-path map, which subsequent lookups will be able to retrieve from the registry.
-        if let destination = buildRequest.parameters.activeRunDestination, case let .swiftSDK(sdkManifestPath: sdkManifestPath, triple: triple) = destination.buildTarget {
-            guard let platform = platformRegistry.lookup(name: destination.platform) else {
-                throw StubError.error("unable to find platform for '\(destination.platform)'")
-            }
+        guard let destination = buildRequest.parameters.activeRunDestination else { return }
 
-            let llvmTriple = try LLVMTriple(triple)
+        let triple: String
+        switch destination.buildTarget {
+        case .toolchainSDK:
+            return
+        case let .swiftSDK(_, swiftSDKTriple), let .inMemorySwiftSDK(_, swiftSDKTriple):
+            triple = swiftSDKTriple
+        }
 
-            let platformExtensions = pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
+        guard let platform = platformRegistry.lookup(name: destination.platform) else {
+            throw StubError.error("unable to find platform for '\(destination.platform)'")
+        }
 
-            struct Context: PlatformInfoExtensionSwiftSDKAdditionalCustomPropertiesContext {
-                let hostOperatingSystem: OperatingSystem
-                let platform: Platform
-            }
-            let additionalContexts = try platformExtensions.compactMap({ try $0.swiftSDKAdditionalContext(context: Context(hostOperatingSystem: hostOperatingSystem, platform: platform)) })
-            if additionalContexts.count > 1 {
-                throw StubError.error("Conflicting additional Swift SDK context definitions for platform: \(platform.name)")
-            }
+        let llvmTriple = try LLVMTriple(triple)
+        let platformExtensions = pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
 
-            let deploymentTargetSettingNames = Set(platformExtensions.compactMap({ $0.deploymentTargetSettingName(triple: llvmTriple) }))
-            if deploymentTargetSettingNames.count > 1 {
-                throw StubError.error("conflicting deployment target setting names for triple '\(triple)': \(deploymentTargetSettingNames.sorted())")
-            }
+        struct Context: PlatformInfoExtensionSwiftSDKAdditionalCustomPropertiesContext {
+            let hostOperatingSystem: OperatingSystem
+            let platform: Platform
+        }
+        let additionalContexts = try platformExtensions.compactMap({ try $0.swiftSDKAdditionalContext(context: Context(hostOperatingSystem: hostOperatingSystem, platform: platform)) })
+        if additionalContexts.count > 1 {
+            throw StubError.error("Conflicting additional Swift SDK context definitions for platform: \(platform.name)")
+        }
 
+        let deploymentTargetSettingNames = Set(platformExtensions.compactMap({ $0.deploymentTargetSettingName(triple: llvmTriple) }))
+        if deploymentTargetSettingNames.count > 1 {
+            throw StubError.error("conflicting deployment target setting names for triple '\(triple)': \(deploymentTargetSettingNames.sorted())")
+        }
+
+        switch destination.buildTarget {
+        case .toolchainSDK:
+            return
+        case let .swiftSDK(sdkManifestPath, _):
             if try sdkRegistry.synthesizedSDK(platform: platform, sdkManifestPath: sdkManifestPath, triple: llvmTriple, additionalContext: additionalContexts.only, deploymentTargetSettingName: deploymentTargetSettingNames.only) == nil {
                 throw StubError.error("unable to synthesize SDK for Swift SDK at '\(sdkManifestPath)' and target triple '\(triple)'")
+            }
+        case let .inMemorySwiftSDK(swiftSDK, _):
+            if try sdkRegistry.synthesizedSDK(platform: platform, swiftSDK: swiftSDK, triple: llvmTriple, additionalContext: additionalContexts.only, deploymentTargetSettingName: deploymentTargetSettingNames.only) == nil {
+                throw StubError.error("unable to synthesize SDK for in-memory Swift SDK '\(swiftSDK.manifestPath.str)' and target triple '\(triple)'")
             }
         }
     }

--- a/Sources/SWBCore/RunDestinationInfo.swift
+++ b/Sources/SWBCore/RunDestinationInfo.swift
@@ -11,11 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 public import struct SWBProtocol.RunDestinationInfo
+public import struct SWBProtocol.SwiftSDK
 public import SWBUtil
 
 public enum BuildTarget: SerializableCodable, Hashable, Sendable {
     case toolchainSDK(sdk: String)
     case swiftSDK(sdkManifestPath: Path, triple: String)
+    case inMemorySwiftSDK(swiftSDK: SwiftSDK, triple: String)
 }
 
 /// Resolved run destination info with platform name and SDK variant derived from Core.
@@ -49,6 +51,11 @@ public struct RunDestinationInfo: SerializableCodable, Hashable, Sendable {
             let info = try core.buildTargetInfo(triple: triple)
             self.platform = info.platformName
             self.sdkVariant = info.sdkVariant
+        case let .inMemorySwiftSDK(swiftSDK, triple):
+            self.buildTarget = .inMemorySwiftSDK(swiftSDK: swiftSDK, triple: triple)
+            let info = try core.buildTargetInfo(triple: triple)
+            self.platform = info.platformName
+            self.sdkVariant = info.sdkVariant
         }
         self.targetArchitecture = payload.targetArchitecture
         self.supportedArchitectures = payload.supportedArchitectures
@@ -76,6 +83,8 @@ extension RunDestinationInfo {
             return sdk
         case let .swiftSDK(sdkManifestPath, _):
             return sdkManifestPath.str
+        case let .inMemorySwiftSDK(swiftSDK, _):
+            return swiftSDK.manifestPath.str
         }
     }
 

--- a/Sources/SWBCore/SDKRegistry.swift
+++ b/Sources/SWBCore/SDKRegistry.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
-import SWBProtocol
+public import SWBProtocol
 import class Foundation.ProcessInfo
 public import SWBMacro
 
@@ -1088,9 +1088,18 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
             return existing
         }
 
-        guard let swiftSDK = try SwiftSDK(identifier: sdkManifestPath.str, version: "1.0.0", path: sdkManifestPath, fs: localFS) else {
+        guard let swiftSDK = try SwiftSDK(manifestPath: sdkManifestPath, fs: localFS) else {
             // No Swift SDK exists at path or it has an incompatible schema version
             return nil
+        }
+
+        return try synthesizedSDK(platform: platform, swiftSDK: swiftSDK, triple: versionedTriple, additionalContext: additionalContext, deploymentTargetSettingName: deploymentTargetSettingName)
+    }
+
+    @discardableResult public func synthesizedSDK(platform: Platform, swiftSDK: SwiftSDK, triple versionedTriple: LLVMTriple, additionalContext: SwiftSDKAdditionalContext?, deploymentTargetSettingName: String?) throws -> SDK? {
+        // Don't allow re-registering the same SDK
+        if let existing = sdksByPath[swiftSDK.manifestPath] {
+            return existing
         }
 
         let defaultProperties: [String: PropertyListItem] = [
@@ -1108,7 +1117,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
         ]
 
         guard let tripleProperties = swiftSDK.targetTriples[versionedTriple.description] else {
-            throw StubError.error("Unsupported triple '\(versionedTriple)' in Swift SDK at path '\(sdkManifestPath)'. Supported triples include: \(swiftSDK.targetTriples.keys.sorted().joined(separator: ", "))")
+            throw StubError.error("Unsupported triple '\(versionedTriple)' in Swift SDK at path '\(swiftSDK.manifestPath)'. Supported triples include: \(swiftSDK.targetTriples.keys.sorted().joined(separator: ", "))")
         }
 
         do {
@@ -1141,8 +1150,11 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
 
             // TODO handle tripleProperties.toolSearchPaths
 
-            let headerSearchPaths: [PropertyListItem] = ["$(inherited)"] + (tripleProperties.includeSearchPaths ?? []).map( { PropertyListItem.plString($0) } )
-            let librarySearchPaths: [PropertyListItem] = ["$(inherited)"] + (tripleProperties.librarySearchPaths ?? []).map( { PropertyListItem.plString($0) } )
+            let includePaths: [PropertyListItem] = ["$(inherited)"] + (tripleProperties.includeSearchPaths ?? []).map { PropertyListItem.plString(swiftSDK.path.join($0).str)
+            }
+            let librarySearchPaths: [PropertyListItem] = ["$(inherited)"] + (tripleProperties.librarySearchPaths ?? []).map{
+                PropertyListItem.plString(swiftSDK.path.join($0).str)
+            }
 
             var toolsetAbsolutePaths: [PropertyListItem] = (tripleProperties.toolsetPaths ?? []).map { .plString(swiftSDK.path.join($0).str) }
             var sdkRootPath = sdkroot
@@ -1158,8 +1170,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
             let sdk = registerSDK(
                 sdkRootPath, sdkRootPath, platform, .plDict([
                 "Type": .plString("SDK"),
-                "Version": .plString(swiftSDK.version),
-                "CanonicalName": .plString(swiftSDK.identifier),
+                "CanonicalName": .plString(swiftSDK.manifestPath.str),
                 "Aliases": [],
                 "IsBaseSDK": .plBool(true),
                 "DefaultProperties": .plDict([
@@ -1171,7 +1182,8 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
 
                     // Default search paths
                     "LIBRARY_SEARCH_PATHS": .plArray(librarySearchPaths),
-                    "HEADER_SEARCH_PATHS": .plArray(headerSearchPaths),
+                    "HEADER_SEARCH_PATHS": .plArray(includePaths),
+                    "SWIFT_INCLUDE_PATHS": .plArray(includePaths),
 
                     // Resource directory settings
                     "SWIFT_RESOURCE_DIR_STATIC_STDLIB_NO": .plString(swiftResourceDir.str),
@@ -1192,7 +1204,7 @@ public final class SDKRegistry: SDKRegistryLookup, CustomStringConvertible, Send
 
             if let sdk {
                 try sdk.loadExtendedInfo(delegate.namespace)
-                sdksByPath[sdkManifestPath] = sdk
+                sdksByPath[swiftSDK.manifestPath] = sdk
                 return sdk
             } else {
                 // registerSDK should have already emitted an error to the delegate if it returned nil

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3689,9 +3689,10 @@ private class SettingsBuilder: ProjectMatchLookup {
         let destinationPlatformIsDevice = destinationPlatform.correspondingSimulatorPlatformName != nil && !destinationPlatformIsMacOS
         let destinationPlatformIsDeviceOrSimulator = destinationPlatformIsDevice || destinationPlatform.isSimulator
         let destinationUsesSwiftSDK: Bool
-        if case .swiftSDK = runDestination.buildTarget {
+        switch runDestination.buildTarget {
+        case .swiftSDK, .inMemorySwiftSDK:
             destinationUsesSwiftSDK = true
-        } else {
+        case .toolchainSDK:
             destinationUsesSwiftSDK = false
         }
 

--- a/Sources/SWBProtocol/CMakeLists.txt
+++ b/Sources/SWBProtocol/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(SWBProtocol
   PreviewMessages.swift
   ProjectDescriptorMessages.swift
   ProjectDescriptorTypes.swift
+  SwiftSDK.swift
   ProjectModel/BuildConfiguration.swift
   ProjectModel/BuildFile.swift
   ProjectModel/BuildPhase.swift

--- a/Sources/SWBProtocol/MessageSupport.swift
+++ b/Sources/SWBProtocol/MessageSupport.swift
@@ -389,7 +389,7 @@ public struct RunDestinationInfo: SerializableCodable, Hashable, Sendable {
             try container.encode(platform, forKey: .platform)
             try container.encode(sdk, forKey: .sdk)
             try container.encode(sdkVariant, forKey: .sdkVariant)
-        case .swiftSDK:
+        case .swiftSDK, .inMemorySwiftSDK:
             try container.encode(buildTarget, forKey: .buildTarget)
         }
 
@@ -403,6 +403,7 @@ public struct RunDestinationInfo: SerializableCodable, Hashable, Sendable {
 public enum BuildTarget: SerializableCodable, Hashable, Sendable {
     case toolchainSDK(platform: String, sdk: String, sdkVariant: String?)
     case swiftSDK(sdkManifestPath: Path, triple: String)
+    case inMemorySwiftSDK(swiftSDK: SwiftSDK, triple: String)
 }
 
 /// The arena info being sent in a Message.

--- a/Sources/SWBProtocol/SwiftSDK.swift
+++ b/Sources/SWBProtocol/SwiftSDK.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -16,15 +16,15 @@ import Foundation
 /// Represents a Swift SDK
 ///
 /// See https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md
-public struct SwiftSDK: Sendable {
+public struct SwiftSDK: Sendable, Hashable, Codable, SerializableCodable {
     @_spi(Testing) public struct SchemaVersionInfo: Codable {
         @_spi(Testing) public let schemaVersion: String
     }
 
-    public struct TripleProperties: Codable, Sendable {
+    public struct TripleProperties: Hashable, Codable, Sendable {
         /// The SDK root, that is, the directory given to the `-sdk` flag of the Swift compiler.
         /// This also doubles as the sysroot (`-sysroot` or `--sysroot`), but should really have its own dedicated property.
-        public var sdkRootPath: String
+        public var sdkRootPath: String?
         public var swiftResourcesPath: String?
         public var swiftStaticResourcesPath: String?
         public var clangResourcesPath: String? {
@@ -46,6 +46,15 @@ public struct SwiftSDK: Sendable {
         public var includeSearchPaths: [String]?
         public var librarySearchPaths: [String]?
         public var toolsetPaths: [String]?
+
+        public init(sdkRootPath: String?, swiftResourcesPath: String?, swiftStaticResourcesPath: String?, includeSearchPaths: [String]?, librarySearchPaths: [String]?, toolsetPaths: [String]?) {
+            self.sdkRootPath = sdkRootPath
+            self.swiftResourcesPath = swiftResourcesPath
+            self.swiftStaticResourcesPath = swiftStaticResourcesPath
+            self.includeSearchPaths = includeSearchPaths
+            self.librarySearchPaths = librarySearchPaths
+            self.toolsetPaths = toolsetPaths
+        }
 
         public func loadToolsets(sdk: SwiftSDK, fs: any FSProxy) throws -> [Toolset] {
             var toolsets: [Toolset] = []
@@ -113,25 +122,25 @@ public struct SwiftSDK: Sendable {
         }
     }
 
-    /// The identifier of the artifact bundle containing this SDK.
-    public let identifier: String
-    /// The version of the artifact bundle containing this SDK.
-    public let version: String
     /// The path to the SDK.
-    public let path: Path
+    public var path: Path {
+        manifestPath.dirname
+    }
     public let manifestPath: Path
     /// Target-specific properties for this SDK.
     public let targetTriples: [String: TripleProperties]
 
-    @_spi(Testing) public init?(identifier: String, version: String, path: Path, fs: any FSProxy) throws {
-        self.identifier = identifier
-        self.version = version
-        self.path = path.dirname
-        self.manifestPath = path
+    public init(manifestPath: Path, targetTriples: [String: TripleProperties]) {
+        self.manifestPath = manifestPath
+        self.targetTriples = targetTriples
+    }
 
-        guard fs.exists(path) else { return nil }
+    public init?(manifestPath: Path, fs: any FSProxy) throws {
+        self.manifestPath = manifestPath
 
-        let metadataData = try Data(fs.read(path))
+        guard fs.exists(manifestPath) else { return nil }
+
+        let metadataData = try Data(fs.read(manifestPath))
         let schema = try JSONDecoder().decode(SchemaVersionInfo.self, from: metadataData)
         guard schema.schemaVersion == "4.0" else { return nil }
 

--- a/Sources/SWBTestSupport/CoreBasedTests.swift
+++ b/Sources/SWBTestSupport/CoreBasedTests.swift
@@ -14,6 +14,7 @@ package import Testing
 
 import Foundation
 @_spi(Testing) package import SWBCore
+@_spi(Testing) package import struct SWBProtocol.SwiftSDK
 import enum SWBProtocol.ExternalToolResult
 import struct SWBProtocol.BuildOperationTaskEnded
 package import SWBUtil
@@ -470,9 +471,9 @@ extension Core {
         return try JSONDecoder().decode(SwiftPrintTargetInfo.self, from: result.stdout).swiftCompilerTag
     }
 
-    /// Finds a Swift SDK whose identifier suffix matches the given pattern.
+    /// Finds a Swift SDK whose artifact bundle identifier suffix matches the given pattern.
     ///
-    /// Swift SDK identifiers follow the pattern `<compilerTag>-<suffix>`. This method finds all installed
+    /// Swift SDK artifact bundle identifiers follow the pattern `<compilerTag>_<suffix>`. This method finds all installed
     /// Swift SDKs, strips the compiler tag prefix, and returns the unique SDK that matches, or `nil` if
     /// no SDK or more than one SDK matches.
     package func findSwiftSDK(_ pattern: StringPattern) async throws -> SwiftSDK? {
@@ -480,12 +481,12 @@ extension Core {
             return nil
         }
         let prefix = "\(compilerTag)_"
-        let sdks = try SwiftSDK.findSDKs(targetTriples: nil, fs: localFS, hostOperatingSystem: hostOperatingSystem)
-        let matchingSDKs = sdks.filter { sdk in
-            guard sdk.identifier.hasPrefix(prefix) else { return false }
-            let suffix = String(sdk.identifier.dropFirst(prefix.count))
+        let sdks = try SwiftSDK.findSDKsWithIdentifiers(targetTriples: nil, fs: localFS, hostOperatingSystem: hostOperatingSystem)
+        let matchingSDKs = sdks.filter { (identifier, sdk) in
+            guard identifier.hasPrefix(prefix) else { return false }
+            let suffix = String(identifier.dropFirst(prefix.count))
             return pattern ~= suffix
         }
-        return matchingSDKs.only
+        return matchingSDKs.only?.sdk
     }
 }

--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -12,6 +12,7 @@
 
 package import SWBCore
 package import SWBUtil
+package import struct SWBProtocol.SwiftSDK
 import Foundation
 
 /// This is a protocol to share the utilities in the below category between RunDestinationInfo in SWBProtocol.framework and SWBRunDestinationInfo in SwiftBuild.framework.
@@ -402,5 +403,10 @@ extension RunDestinationInfo: _RunDestinationInfo {
     package init(sdkManifestPath: Path, triple: String, targetArchitecture: String, supportedArchitectures: OrderedSet<String>, disableOnlyActiveArch: Bool, core: Core) throws {
         let buildTargetInfo = try core.buildTargetInfo(triple: triple)
         self.init(buildTarget: .swiftSDK(sdkManifestPath: sdkManifestPath, triple: triple), platform: buildTargetInfo.platformName, sdkVariant: buildTargetInfo.sdkVariant, targetArchitecture: targetArchitecture, supportedArchitectures: supportedArchitectures, disableOnlyActiveArch: disableOnlyActiveArch)
+    }
+
+    package init(swiftSDK: SwiftSDK, triple: String, targetArchitecture: String, supportedArchitectures: OrderedSet<String>, disableOnlyActiveArch: Bool, core: Core) throws {
+        let buildTargetInfo = try core.buildTargetInfo(triple: triple)
+        self.init(buildTarget: .inMemorySwiftSDK(swiftSDK: swiftSDK, triple: triple), platform: buildTargetInfo.platformName, sdkVariant: buildTargetInfo.sdkVariant, targetArchitecture: targetArchitecture, supportedArchitectures: supportedArchitectures, disableOnlyActiveArch: disableOnlyActiveArch)
     }
 }

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -127,9 +127,9 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    /// Skips a test case that requires a Swift SDK whose identifier suffix matches the given pattern.
+    /// Skips a test case that requires a Swift SDK whose artifact bundle identifier suffix matches the given pattern.
     ///
-    /// Swift SDK identifiers follow the pattern `<compilerTag>-<suffix>`. This trait finds all installed
+    /// Swift SDK artifact bundle identifiers follow the pattern `<compilerTag>_<suffix>`. This trait finds all installed
     /// Swift SDKs, strips the compiler tag prefix, and checks that exactly one SDK matches.
     package static func requireSwiftSDK(_ pattern: StringPattern, in core: (() async throws -> Core)? = nil) -> Self {
         if let core {

--- a/Sources/SWBTestSupport/SwiftSDK.swift
+++ b/Sources/SWBTestSupport/SwiftSDK.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 public import SWBUtil
+@_spi(Testing) public import SWBProtocol
 @_spi(Testing) public import SWBCore
 
 extension SwiftSDK {
@@ -33,22 +34,27 @@ extension SwiftSDK {
 
     /// Find Swift SDKs installed by SwiftPM.
     public static func findSDKs(targetTriples: [String]?, fs: any FSProxy, hostOperatingSystem: OperatingSystem) throws -> [SwiftSDK] {
+        try findSDKsWithIdentifiers(targetTriples: targetTriples, fs: fs, hostOperatingSystem: hostOperatingSystem).map(\.sdk)
+    }
+
+    /// Find Swift SDKs installed by SwiftPM, along with their artifact bundle identifiers.
+    static func findSDKsWithIdentifiers(targetTriples: [String]?, fs: any FSProxy, hostOperatingSystem: OperatingSystem) throws -> [(identifier: String, sdk: SwiftSDK)] {
         let swiftSDKsDirectory = try defaultSwiftSDKsDirectory(hostOperatingSystem: hostOperatingSystem)
         guard fs.exists(swiftSDKsDirectory) else {
             return []
         }
-        return try findSDKs(swiftSDKsDirectory: swiftSDKsDirectory, targetTriples: targetTriples, fs: fs)
+        return try findSDKsWithIdentifiers(swiftSDKsDirectory: swiftSDKsDirectory, targetTriples: targetTriples, fs: fs)
     }
 
-    private static func findSDKs(swiftSDKsDirectory: Path, targetTriples: [String]?, fs: any FSProxy) throws -> [SwiftSDK] {
-        var sdks: [SwiftSDK] = []
+    private static func findSDKsWithIdentifiers(swiftSDKsDirectory: Path, targetTriples: [String]?, fs: any FSProxy) throws -> [(identifier: String, sdk: SwiftSDK)] {
+        var sdks: [(identifier: String, sdk: SwiftSDK)] = []
         // Find .artifactbundle in the SDK directory (e.g. ~/Library/org.swift.swiftpm/swift-sdks)
         for artifactBundle in try fs.listdir(swiftSDKsDirectory) {
             guard artifactBundle.hasSuffix(".artifactbundle") else { continue }
             let artifactBundlePath = swiftSDKsDirectory.join(artifactBundle)
             guard fs.isDirectory(artifactBundlePath) else { continue }
 
-            sdks.append(contentsOf: (try? findSDKs(artifactBundle: artifactBundlePath, targetTriples: targetTriples, fs: fs)) ?? [])
+            sdks.append(contentsOf: (try? findSDKsWithIdentifiers(artifactBundle: artifactBundlePath, targetTriples: targetTriples, fs: fs)) ?? [])
         }
         return sdks
     }
@@ -70,6 +76,10 @@ extension SwiftSDK {
 
     /// Find Swift SDKs in an artifact bundle supporting one of the given targets.
     public static func findSDKs(artifactBundle: Path, targetTriples: [String]?, fs: any FSProxy) throws -> [SwiftSDK] {
+        try findSDKsWithIdentifiers(artifactBundle: artifactBundle, targetTriples: targetTriples, fs: fs).map(\.sdk)
+    }
+
+    static func findSDKsWithIdentifiers(artifactBundle: Path, targetTriples: [String]?, fs: any FSProxy) throws -> [(identifier: String, sdk: SwiftSDK)] {
         // Load info.json from the artifact bundle
         let infoPath = artifactBundle.join("info.json")
         guard try fs.isFile(infoPath) else { return [] }
@@ -84,7 +94,7 @@ extension SwiftSDK {
 
         let info = try JSONDecoder().decode(BundleInfo.self, from: infoData)
 
-        var sdks: [SwiftSDK] = []
+        var sdks: [(identifier: String, sdk: SwiftSDK)] = []
 
         for (identifier, artifact) in info.artifacts {
             for variant in artifact.variants {
@@ -100,12 +110,12 @@ extension SwiftSDK {
                 // FIXME: For now, we only support SDKs that are compatible with any host triple.
                 guard variant.supportedTriples?.isEmpty ?? true else { continue }
 
-                guard let sdk = try SwiftSDK(identifier: identifier, version: artifact.version, path: sdkPath, fs: fs) else { continue }
+                guard let sdk = try SwiftSDK(manifestPath: sdkPath, fs: fs) else { continue }
                 // Filter out SDKs that don't support any of the target triples.
                 if let targetTriples {
                     guard targetTriples.contains(where: { sdk.targetTriples[$0] != nil }) else { continue }
                 }
-                sdks.append(sdk)
+                sdks.append((identifier: identifier, sdk: sdk))
             }
         }
 

--- a/Sources/SwiftBuild/CMakeLists.txt
+++ b/Sources/SwiftBuild/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(SwiftBuild
   SWBBuildServiceConsole.swift
   SWBBuildServiceSession.swift
   SWBBuildTargetInfo.swift
+  SWBSwiftSDK.swift
   SWBChannel.swift
   SWBClientExchangeSupport.swift
   SWBConfiguredTargetIdentifier.swift

--- a/Sources/SwiftBuild/SWBBuildParameters.swift
+++ b/Sources/SwiftBuild/SWBBuildParameters.swift
@@ -46,6 +46,10 @@ public struct SWBRunDestinationInfo: Codable, Sendable {
         public static func swiftSDK(sdkManifestPath: String, triple: String) -> SWBBuildTarget {
             SWBBuildTarget(_internalBuildTarget: .swiftSDK(sdkManifestPath: sdkManifestPath, triple: triple))
         }
+
+        public static func swiftSDK(swiftSDK: SWBSwiftSDK, triple: String) -> SWBBuildTarget {
+            SWBBuildTarget(_internalBuildTarget: .inMemorySwiftSDK(swiftSDK: swiftSDK, triple: triple))
+        }
     }
 
     public var buildTarget: SWBBuildTarget
@@ -94,7 +98,7 @@ public struct SWBRunDestinationInfo: Codable, Sendable {
             try container.encode(platform, forKey: .platform)
             try container.encode(sdk, forKey: .sdk)
             try container.encode(sdkVariant, forKey: .sdkVariant)
-        case .swiftSDK:
+        case .swiftSDK, .inMemorySwiftSDK:
             try container.encode(buildTarget, forKey: .buildTarget)
         }
 
@@ -155,6 +159,7 @@ public struct SWBRunDestinationInfo: Codable, Sendable {
 enum InternalBuildTarget: Codable, Sendable {
     case toolchainSDK(platform: String, sdk: String, sdkVariant: String?)
     case swiftSDK(sdkManifestPath: String, triple: String)
+    case inMemorySwiftSDK(swiftSDK: SWBSwiftSDK, triple: String)
 
     private enum CodingKeys: String, CodingKey {
         // Selector
@@ -168,11 +173,15 @@ enum InternalBuildTarget: Codable, Sendable {
         // Swift SDK
         case sdkManifestPath
         case triple
+
+        // In-memory Swift SDK
+        case swiftSDK
     }
 
     private enum BuildTarget: String, Codable {
         case toolchainSDK
         case swiftSDK
+        case inMemorySwiftSDK
 
         init(_ buildTarget: InternalBuildTarget) {
             switch buildTarget {
@@ -180,6 +189,8 @@ enum InternalBuildTarget: Codable, Sendable {
                 self = .toolchainSDK
             case .swiftSDK:
                 self = .swiftSDK
+            case .inMemorySwiftSDK:
+                self = .inMemorySwiftSDK
             }
         }
     }
@@ -191,6 +202,8 @@ enum InternalBuildTarget: Codable, Sendable {
             self = try .toolchainSDK(platform: container.decode(String.self, forKey: .platform), sdk: container.decode(String.self, forKey: .sdk), sdkVariant: container.decode(String?.self, forKey: .sdkVariant))
         case .swiftSDK:
             self = try .swiftSDK(sdkManifestPath: container.decode(String.self, forKey: .sdkManifestPath), triple: container.decode(String.self, forKey: .triple))
+        case .inMemorySwiftSDK:
+            self = try .inMemorySwiftSDK(swiftSDK: container.decode(SWBSwiftSDK.self, forKey: .swiftSDK), triple: container.decode(String.self, forKey: .triple))
         }
     }
 
@@ -204,6 +217,9 @@ enum InternalBuildTarget: Codable, Sendable {
             try container.encode(sdkVariant, forKey: .sdkVariant)
         case let .swiftSDK(sdkManifestPath, triple):
             try container.encode(sdkManifestPath, forKey: .sdkManifestPath)
+            try container.encode(triple, forKey: .triple)
+        case let .inMemorySwiftSDK(swiftSDK, triple):
+            try container.encode(swiftSDK, forKey: .swiftSDK)
             try container.encode(triple, forKey: .triple)
         }
     }

--- a/Sources/SwiftBuild/SWBBuildServiceSession.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceSession.swift
@@ -850,6 +850,8 @@ fileprivate extension RunDestinationInfo {
             self.init(buildTarget: .toolchainSDK(platform: platform, sdk: sdk, sdkVariant: sdkVariant),  targetArchitecture: x.targetArchitecture, supportedArchitectures: OrderedSet(x.supportedArchitectures), disableOnlyActiveArch: x.disableOnlyActiveArch, hostTargetedPlatform: x.hostTargetedPlatform)
         case let .swiftSDK(sdkManifestPath: sdkManifestPath, triple: triple):
             self.init(buildTarget: .swiftSDK(sdkManifestPath: Path(sdkManifestPath), triple: triple),  targetArchitecture: x.targetArchitecture, supportedArchitectures: OrderedSet(x.supportedArchitectures), disableOnlyActiveArch: x.disableOnlyActiveArch, hostTargetedPlatform: x.hostTargetedPlatform)
+        case let .inMemorySwiftSDK(swiftSDK: swiftSDK, triple: triple):
+            self.init(buildTarget: .inMemorySwiftSDK(swiftSDK: .init(swiftSDK), triple: triple),  targetArchitecture: x.targetArchitecture, supportedArchitectures: OrderedSet(x.supportedArchitectures), disableOnlyActiveArch: x.disableOnlyActiveArch, hostTargetedPlatform: x.hostTargetedPlatform)
         }
     }
 }

--- a/Sources/SwiftBuild/SWBSwiftSDK.swift
+++ b/Sources/SwiftBuild/SWBSwiftSDK.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SWBProtocol
+import SWBUtil
+
+public struct SWBSwiftSDK: Codable, Sendable {
+    public struct TripleProperties: Codable, Sendable {
+        public var sdkRootPath: String?
+        public var swiftResourcesPath: String?
+        public var swiftStaticResourcesPath: String?
+        public var includeSearchPaths: [String]?
+        public var librarySearchPaths: [String]?
+        public var toolsetPaths: [String]?
+
+        public init(sdkRootPath: String?, swiftResourcesPath: String?, swiftStaticResourcesPath: String?, includeSearchPaths: [String]?, librarySearchPaths: [String]?, toolsetPaths: [String]?) {
+            self.sdkRootPath = sdkRootPath
+            self.swiftResourcesPath = swiftResourcesPath
+            self.swiftStaticResourcesPath = swiftStaticResourcesPath
+            self.includeSearchPaths = includeSearchPaths
+            self.librarySearchPaths = librarySearchPaths
+            self.toolsetPaths = toolsetPaths
+        }
+    }
+
+    public let manifestPath: String
+    public let targetTriples: [String: TripleProperties]
+
+    public init(manifestPath: String, targetTriples: [String: TripleProperties]) {
+        self.manifestPath = manifestPath
+        self.targetTriples = targetTriples
+    }
+}
+
+extension SWBProtocol.SwiftSDK {
+    init(_ other: SWBSwiftSDK) {
+        self.init(
+            manifestPath: Path(other.manifestPath),
+            targetTriples: other.targetTriples.mapValues(SWBProtocol.SwiftSDK.TripleProperties.init)
+        )
+    }
+}
+
+extension SWBProtocol.SwiftSDK.TripleProperties {
+    init(_ other: SWBSwiftSDK.TripleProperties) {
+        self.init(
+            sdkRootPath: other.sdkRootPath,
+            swiftResourcesPath: other.swiftResourcesPath,
+            swiftStaticResourcesPath: other.swiftStaticResourcesPath,
+            includeSearchPaths: other.includeSearchPaths,
+            librarySearchPaths: other.librarySearchPaths,
+            toolsetPaths: other.toolsetPaths
+        )
+    }
+}

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -17,6 +17,7 @@ import SWBTestSupport
 import SWBTaskExecution
 import SWBUtil
 import SWBCore
+import struct SWBProtocol.SwiftSDK
 import SWBMacro
 
 @Suite

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -23,6 +23,7 @@ import SWBBuildSystem
 import SWBCore
 import struct SWBProtocol.TargetDescription
 import struct SWBProtocol.TargetDependencyRelationship
+import struct SWBProtocol.SwiftSDK
 import SWBTestSupport
 import SWBTaskExecution
 @_spi(Testing) import SWBUtil

--- a/Tests/SWBGenericUnixPlatformTests/SwiftSDKTaskConstructionTests.swift
+++ b/Tests/SWBGenericUnixPlatformTests/SwiftSDKTaskConstructionTests.swift
@@ -138,4 +138,111 @@ fileprivate struct GenericUnixSwiftSDKTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.host))
+    func inMemoryStaticLinuxSwiftSDKRunDestination() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let clangCompilerPath = try await self.clangCompilerPath
+            let swiftCompilerPath = try await self.swiftCompilerPath
+            let swiftVersion = try await self.swiftVersion
+            let testProject = try await TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("SourceFile.c"),
+                        TestFile("SwiftFile.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MyLibrary",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "GENERATE_INFOPLIST_FILE": "YES",
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SDKROOT": "auto",
+                                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                                    "CLANG_ENABLE_MODULES": "YES",
+                                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                                    "SWIFT_VERSION": swiftVersion,
+                                                    "CC": clangCompilerPath.str,
+                                                    "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("SourceFile.c"),
+                                TestBuildFile("SwiftFile.swift"),
+                            ]),
+                        ]),
+                ])
+            let core = try await Self.makeCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            let sdkDir = tmpDir
+            try localFS.createDirectory(sdkDir)
+
+            try await localFS.writeFileContents(sdkDir.join("toolset.json"), waitForNewTimestamp: false, body: { stream in
+                stream.write("""
+                {
+                    "rootPath": "swift.xctoolchain/usr/bin",
+                    "swiftCompiler" : {
+                        "extraCLIOptions" : [
+                            "-static-executable",
+                            "-static-stdlib"
+                        ]
+                    },
+                    "schemaVersion": "1.0"
+                }
+                """)
+            })
+
+            let swiftSDK = SwiftSDK(
+                manifestPath: sdkDir.join("swift-sdk.json"),
+                targetTriples: [
+                    "x86_64-swift-linux-musl": .init(
+                        sdkRootPath: "musl-1.2.5.sdk/x86_64",
+                        swiftResourcesPath: "musl-1.2.5.sdk/x86_64/usr/lib/swift_static",
+                        swiftStaticResourcesPath: "musl-1.2.5.sdk/x86_64/usr/lib/swift_static",
+                        includeSearchPaths: ["include/path"],
+                        librarySearchPaths: ["library/path"],
+                        toolsetPaths: ["toolset.json"]
+                    )
+                ]
+            )
+
+            let sysroot = sdkDir.join("musl-1.2.5.sdk").join("x86_64")
+            let sdkroot = sdkDir.join("musl-1.2.5.sdk").join("x86_64")
+
+            let destination = try RunDestinationInfo(swiftSDK: swiftSDK, triple: "x86_64-swift-linux-musl", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false, core: core)
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
+            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
+                results.checkTask(.matchTargetName("MyLibrary"), .matchRuleType("CompileC")) { task in
+                    task.checkCommandLineContains([
+                        [clangCompilerPath.str],
+                        ["-target", "x86_64-swift-linux-musl"],
+                        ["--sysroot", sysroot.str],
+                        ["-I\(sdkDir.join("include/path").str)"]
+                    ].reduce([], +))
+                }
+
+                results.checkTask(.matchTargetName("MyLibrary"), .matchRuleType("SwiftDriver Compilation")) { task in
+                    task.checkCommandLineContains([
+                        ["-resource-dir", sdkDir.join("musl-1.2.5.sdk").join(
+                        "x86_64").join("usr").join("lib").join("swift_static").str],
+                        ["-static-stdlib"],
+                        ["-sdk", sdkroot.str],
+                        ["-sysroot", sysroot.str],
+                        ["-target", "x86_64-swift-linux-musl"],
+                        ["-I\(sdkDir.join("include/path").str)"]
+                    ].reduce([], +))
+                }
+
+                results.checkNoDiagnostics()
+            }
+        }
+    }
 }


### PR DESCRIPTION
I'd like to migrate SwiftPM over to this API, and only directly read Swift SDK metadata from disk for testing.

1. This allows SwiftPM to overlay options set via `swift sdk configure`
2. This allows SwiftPM to handle converting the various versions of the Swift SDK metadata format into a unified representation for the underlying build system.