### PR TITLE
Add .compilationRequirement to BuildInstrumentsPackage tasks

### DIFF
--- a/Sources/SWBApplePlatform/InstrumentsPackageBuilderSpec.swift
+++ b/Sources/SWBApplePlatform/InstrumentsPackageBuilderSpec.swift
@@ -38,6 +38,6 @@ public final class InstrumentsPackageBuilderSpec: GenericCompilerSpec, SpecIdent
 
         let cbc = CommandBuildContext(producer: cbc.producer, scope: cbc.scope, inputs: cbc.inputs, isPreferredArch: cbc.isPreferredArch, outputs: cbc.outputs, commandOrderingInputs: cbc.commandOrderingInputs, commandOrderingOutputs: cbc.commandOrderingOutputs + orderingOutputs, buildPhaseInfo: cbc.buildPhaseInfo, resourcesDir: cbc.resourcesDir, tmpResourcesDir: cbc.tmpResourcesDir, unlocalizedResourcesDir: cbc.unlocalizedResourcesDir)
 
-        await super.constructTasks(cbc, delegate, specialArgs: [], dependencyData: dependencyData)
+        await super.constructTasks(cbc, delegate, specialArgs: [], dependencyData: dependencyData, additionalTaskOrderingOptions: [.compilationRequirement])
     }
 }

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -5074,6 +5074,61 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func instrumentsPackageDependencyOrdering() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = try await TestProject(
+                "aProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "Sources", children: [
+                        TestFile("Package.instrpkg"),
+                        TestFile("App.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            "SWIFT_VERSION": swiftVersion,
+                            "TAPI_EXEC": tapiToolPath.str,
+                            "SWIFT_USE_INTEGRATED_DRIVER": "YES",
+                        ]
+                    )],
+                targets: [
+                    TestStandardTarget(
+                        "InstrPkg",
+                        type: .instrumentsPackage,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["Package.instrpkg"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "App",
+                        type: .framework,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["App.swift"]),
+                        ],
+                        dependencies: ["InstrPkg"]
+                    ),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            let parameters = BuildParameters(configuration: "Debug")
+            let buildRequest = BuildRequest(parameters: parameters, buildTargets: tester.workspace.projects[0].targets.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }), continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: false, useDryRun: false)
+            try await tester.checkBuild(parameters, runDestination: .macOS, buildRequest: buildRequest) { results in
+                let instrTask = try #require(results.getTask(.matchTargetName("InstrPkg"), .matchRuleType("BuildInstrumentsPackage")))
+                let appCompilationReq = try #require(results.getTask(.matchTargetName("App"), .matchRuleType("SwiftDriver Compilation Requirements")))
+
+                results.checkTaskFollows(appCompilationReq, antecedent: instrTask)
+
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func instrumentsPackage() async throws {
         let testProject = TestProject(
             "aProject",


### PR DESCRIPTION
Ensures instruments packages are built before eager compilation opens the modulesReadyNode gate for dependent targets.

rdar://99503229