### PR TITLE
Update Package branch-based dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -498,7 +498,7 @@ if useLocalDependencies {
     }
 } else {
     /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-    let relatedDependenciesBranch = "main"
+    let relatedDependenciesBranch = "release/6.4.x"
 
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: relatedDependenciesBranch),


### PR DESCRIPTION
Update the Package.swift dependencies to have their branch dependency be `release/6.4.x`, to match the projects branch name.

Depends on: https://github.com/swiftlang/swift-driver/pull/2130