### PR TITLE
Suppress warning about ignoring duplicate libraries in swiftbuild

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -271,7 +271,10 @@
                         "-Xlinker",
                         "-warn_duplicate_libraries",
                     );
-                    NO = ();
+                    NO = (
+                        "-Xlinker",
+                        "-no_warn_duplicate_libraries",
+                    );
                 };
             },
             {


### PR DESCRIPTION
Suppress warning about ignoring duplicate libraries in swiftbuild