### PR TITLE
Add INVOKE_SSAF and EXTRACT_SUMMARIES build settings for Clang

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1016,6 +1016,8 @@ public final class BuiltinMacros {
     public static let REZ_PREFIX_FILE = BuiltinMacros.declarePathMacro("REZ_PREFIX_FILE")
     public static let REZ_SEARCH_PATHS = BuiltinMacros.declarePathListMacro("REZ_SEARCH_PATHS")
     public static let RUN_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("RUN_CLANG_STATIC_ANALYZER")
+    public static let INVOKE_SSAF = BuiltinMacros.declareBooleanMacro("INVOKE_SSAF")
+    public static let EXTRACT_SUMMARIES = BuiltinMacros.declareStringMacro("EXTRACT_SUMMARIES")
     public static let SWIFT_API_DIGESTER_MODE = BuiltinMacros.declareEnumMacro("SWIFT_API_DIGESTER_MODE") as EnumMacroDeclaration<SwiftAPIDigesterMode>
     public static let RUN_SWIFT_ABI_CHECKER_TOOL = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL")
     public static let RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER")
@@ -2226,6 +2228,8 @@ public final class BuiltinMacros {
         REZ_PREFIX_FILE,
         REZ_SEARCH_PATHS,
         RUN_CLANG_STATIC_ANALYZER,
+        INVOKE_SSAF,
+        EXTRACT_SUMMARIES,
         RUN_DOCUMENTATION_COMPILER,
         SKIP_BUILDING_DOCUMENTATION,
         RUN_SYMBOL_GRAPH_EXTRACT,

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1353,6 +1353,11 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             commandLine += ["-mllvm", "-cas-friendly-debug-info"]
         }
 
+        if cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true {
+            let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
+            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-tu-summary-file=\(outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".json").str)"]
+        }
+
         // If explicit modules are enabled we need to create the scan task first
         let extraInputs: [any PlannedNode]
         if action != nil {

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1355,7 +1355,9 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
         if cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true {
             let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
-            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-tu-summary-file=\(outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".json").str)"]
+            let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".json")
+            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-tu-summary-file=\(jsonPath.str)"]
+            extraOutputs.append(delegate.createNode(jsonPath))
         }
 
         // If explicit modules are enabled we need to create the scan task first

--- a/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
+++ b/Sources/SWBCore/ToolInfo/ClangToolInfo.swift
@@ -69,6 +69,7 @@ public struct DiscoveredClangToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
         case wSystemHeadersInModule = "Wsystem-headers-in-module"
         case extractAPISupportsCPlusPlus = "extract-api-supports-cpp"
         case deploymentTargetEnvironmentVariables = "deployment-target-environment-variables"
+        case invokeSsaf = "invoke-ssaf"
     }
     public var toolFeatures: ToolFeatures<FeatureFlag>
     public func hasFeature(_ feature: String) -> Bool {

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3468,6 +3468,16 @@
                     DefaultValue = NO;
                     Category = "SAPolicy";
             },
+            {   Name = INVOKE_SSAF;
+                    Type = Boolean;
+                    DefaultValue = NO;
+                    Category = "SAPolicy";
+            },
+            {   Name = EXTRACT_SUMMARIES;
+                    Type = String;
+                    DefaultValue = "";
+                    Category = "SAPolicy";
+            },
             // This entry exists for string expansion in 'RuleName'.
             {
                 Name = CLANG_STATIC_ANALYZER_MODE_ACTION_shallow;

--- a/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
+++ b/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
@@ -965,6 +965,9 @@ The restrictions on `offsetof` may be relaxed in a future version of the C++ sta
 "[RUN_CLANG_STATIC_ANALYZER]-name" = "Analyze During 'Build'";
 "[RUN_CLANG_STATIC_ANALYZER]-description" = "Activating this setting will cause Xcode to run the `Clang` static analysis tool on qualifying source files during every build.";
 
+"[INVOKE_SSAF]-name" = "Invoke Static Analyzer Framework";
+"[INVOKE_SSAF]-description" = "Activating this setting will cause the `Clang` static analysis tool to run on qualifying source files, equivalent to enabling `RUN_CLANG_STATIC_ANALYZER`.";
+
 "[CLANG_STATIC_ANALYZER_MODE]-name" = "Mode of Analysis for 'Build'";
 "[CLANG_STATIC_ANALYZER_MODE]-description" = "The depth the static analyzer uses during the Build action. Use `Deep` to exercise the full power of the analyzer. Use `Shallow` for faster analysis.";
 "[CLANG_STATIC_ANALYZER_MODE]-value-[shallow]" = "Shallow (faster)";

--- a/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
+++ b/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
@@ -966,7 +966,10 @@ The restrictions on `offsetof` may be relaxed in a future version of the C++ sta
 "[RUN_CLANG_STATIC_ANALYZER]-description" = "Activating this setting will cause Xcode to run the `Clang` static analysis tool on qualifying source files during every build.";
 
 "[INVOKE_SSAF]-name" = "Invoke Static Analyzer Framework";
-"[INVOKE_SSAF]-description" = "Activating this setting will cause the `Clang` static analysis tool to run on qualifying source files, equivalent to enabling `RUN_CLANG_STATIC_ANALYZER`.";
+"[INVOKE_SSAF]-description" = "When enabled, `Clang` is invoked with the Static Summary Analysis Framework (SSAF) flags `--ssaf-extract-summaries` and `--ssaf-tu-summary-file`, causing it to generate a per-translation-unit JSON summary file co-located with the object file. The type of summary extracted is controlled by `EXTRACT_SUMMARIES`.";
+
+"[EXTRACT_SUMMARIES]-name" = "Extract Summaries";
+"[EXTRACT_SUMMARIES]-description" = "Specifies the type of per-translation-unit summary for `Clang` to extract when `INVOKE_SSAF` is enabled. The value is passed verbatim to the `--ssaf-extract-summaries` flag (for example, `CallGraph`). Has no effect when `INVOKE_SSAF` is disabled.";
 
 "[CLANG_STATIC_ANALYZER_MODE]-name" = "Mode of Analysis for 'Build'";
 "[CLANG_STATIC_ANALYZER_MODE]-description" = "The depth the static analyzer uses during the Build action. Use `Deep` to exercise the full power of the analyzer. Use `Shallow` for faster analysis.";

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -16,8 +16,6 @@ import SWBCore
 import SWBTestSupport
 import SWBUtil
 
-import Foundation
-
 import SWBTaskExecution
 
 @Suite
@@ -403,41 +401,46 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
 
                     let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
-                    let jsonData = Data(jsonBytes.bytes)
-                    let parsed = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+                    let parsed = try #require(try PropertyList.fromJSONData(jsonBytes).dictValue)
 
                     // Build id -> USR lookup; entity IDs are assigned non-deterministically
-                    let idTable = parsed["id_table"] as! [[String: Any]]
+                    let idTable = try #require(parsed["id_table"]?.arrayValue)
                     var idToUSR: [Int: String] = [:]
                     for entry in idTable {
-                        let id = entry["id"] as! Int
-                        let nameInfo = entry["name"] as! [String: Any]
-                        idToUSR[id] = (nameInfo["usr"] as! String)
+                        let entryDict = try #require(entry.dictValue)
+                        let id = try #require(entryDict["id"]?.intValue)
+                        let nameInfo = try #require(entryDict["name"]?.dictValue)
+                        idToUSR[id] = try #require(nameInfo["usr"]?.stringValue)
                     }
 
                     // Resolve call graph by USR so comparisons are ID-order-independent
-                    let dataArr = parsed["data"] as! [[String: Any]]
-                    let callGraph = try #require(dataArr.first { ($0["summary_name"] as? String) == "CallGraph" })
-                    let summaryData = callGraph["summary_data"] as! [[String: Any]]
+                    let dataArr = try #require(parsed["data"]?.arrayValue)
+                    let callGraph = try #require(dataArr.first { $0.dictValue?["summary_name"]?.stringValue == "CallGraph" }?.dictValue)
+                    let summaryData = try #require(callGraph["summary_data"]?.arrayValue)
 
                     var prettyNameByUSR: [String: String] = [:]
                     var defLineByUSR: [String: Int] = [:]
                     var calleesByUSR: [String: [String]] = [:]
                     for entry in summaryData {
-                        let entityId = entry["entity_id"] as! Int
-                        let summary = entry["entity_summary"] as! [String: Any]
-                        let def = summary["def"] as! [String: Any]
-                        let callees = (summary["direct_callees"] as! [[String: Any]])
-                            .compactMap { idToUSR[$0["@"] as! Int] }
+                        let entryDict = try #require(entry.dictValue)
+                        let entityId = try #require(entryDict["entity_id"]?.intValue)
+                        let summary = try #require(entryDict["entity_summary"]?.dictValue)
+                        let def = try #require(summary["def"]?.dictValue)
+                        let callees = try #require(summary["direct_callees"]?.arrayValue)
+                            .compactMap { callee -> String? in
+                                guard let id = callee.dictValue?["@"]?.intValue else { return nil }
+                                return idToUSR[id]
+                            }
                             .sorted()
                         guard let usr = idToUSR[entityId] else { continue }
-                        prettyNameByUSR[usr] = (summary["pretty_name"] as! String)
-                        defLineByUSR[usr] = (def["line"] as! Int)
+                        prettyNameByUSR[usr] = try #require(summary["pretty_name"]?.stringValue)
+                        defLineByUSR[usr] = try #require(def["line"]?.intValue)
                         calleesByUSR[usr] = callees
                     }
 
-                    let tuNamespace = parsed["tu_namespace"] as! [String: Any]
-                    #expect((tuNamespace["name"] as! String).hasSuffix("/Test/aProject/File1.cpp"))
+                    let tuNamespace = try #require(parsed["tu_namespace"]?.dictValue)
+                    let tuName = try #require(tuNamespace["name"]?.stringValue)
+                    #expect(tuName.hasSuffix("/Test/aProject/File1.cpp"))
 
                     #expect(prettyNameByUSR["c:@F@foo#"] == "foo()")
                     #expect(defLineByUSR["c:@F@foo#"] == 1)

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -16,6 +16,8 @@ import SWBCore
 import SWBTestSupport
 import SWBUtil
 
+import Foundation
+
 import SWBTaskExecution
 
 @Suite
@@ -342,6 +344,178 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
 
             for dylib in legitimateDylibs {
                 #expect(tester.fs.exists(frameworksDir.join(dylib)), "Legitimate stdlib dylib \(dylib) should not have been removed")
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
+    func invokeSsafCommandLineFlags() async throws {
+        func makeTestWorkspace(_ tmpDirPath: Path, invokeSSAF: String, extractSummaries: String = "") -> TestWorkspace {
+            TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup("Sources", children: [TestFile("File1.cpp")]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "INVOKE_SSAF": invokeSSAF,
+                                "EXTRACT_SUMMARIES": extractSummaries,
+                                // Uncomment to test with a local build of clang
+                                // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
+                                "CODE_SIGNING_ALLOWED": "NO",
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Test",
+                                type: .dynamicLibrary,
+                                buildPhases: [TestSourcesBuildPhase(["File1.cpp"])])
+                        ])
+                ])
+        }
+
+        // INVOKE_SSAF=YES: both flags are present and the summary file path is co-located with
+        // the object file, sharing the same basename but with a .json extension.
+        try await withTemporaryDirectory { tmpDirPath in
+            let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "YES", extractSummaries: "CallGraph"), simulated: false)
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/File1.cpp")) {
+                $0 <<< "void foo() {}\n"
+                $0 <<< "\n"
+                $0 <<< "void bar() {\n"
+                $0 <<< "  foo();\n"
+                $0 <<< "}\n"
+                $0 <<< "\n"
+                $0 <<< "void baz() {}\n"
+                $0 <<< "\n"
+                $0 <<< "void test_call() {\n"
+                $0 <<< "  bar();\n"
+                $0 <<< "  baz();\n"
+                $0 <<< "}\n"
+            }
+            try await tester.checkBuild(runDestination: .host) { results in
+                try results.checkTask(.matchRuleType("CompileC")) { task throws in
+                    let objectPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".o") })
+                    let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".json").str
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
+                    task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
+
+                    let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
+                    let jsonData = Data(jsonBytes.bytes)
+                    let parsed = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
+
+                    // Build id -> USR lookup; entity IDs are assigned non-deterministically
+                    let idTable = parsed["id_table"] as! [[String: Any]]
+                    var idToUSR: [Int: String] = [:]
+                    for entry in idTable {
+                        let id = entry["id"] as! Int
+                        let nameInfo = entry["name"] as! [String: Any]
+                        idToUSR[id] = (nameInfo["usr"] as! String)
+                    }
+
+                    // Resolve call graph by USR so comparisons are ID-order-independent
+                    let dataArr = parsed["data"] as! [[String: Any]]
+                    let callGraph = try #require(dataArr.first { ($0["summary_name"] as? String) == "CallGraph" })
+                    let summaryData = callGraph["summary_data"] as! [[String: Any]]
+
+                    var prettyNameByUSR: [String: String] = [:]
+                    var defLineByUSR: [String: Int] = [:]
+                    var calleesByUSR: [String: [String]] = [:]
+                    for entry in summaryData {
+                        let entityId = entry["entity_id"] as! Int
+                        let summary = entry["entity_summary"] as! [String: Any]
+                        let def = summary["def"] as! [String: Any]
+                        let callees = (summary["direct_callees"] as! [[String: Any]])
+                            .compactMap { idToUSR[$0["@"] as! Int] }
+                            .sorted()
+                        guard let usr = idToUSR[entityId] else { continue }
+                        prettyNameByUSR[usr] = (summary["pretty_name"] as! String)
+                        defLineByUSR[usr] = (def["line"] as! Int)
+                        calleesByUSR[usr] = callees
+                    }
+
+                    let tuNamespace = parsed["tu_namespace"] as! [String: Any]
+                    #expect((tuNamespace["name"] as! String).hasSuffix("/Test/aProject/File1.cpp"))
+
+                    #expect(prettyNameByUSR["c:@F@foo#"] == "foo()")
+                    #expect(defLineByUSR["c:@F@foo#"] == 1)
+                    #expect(calleesByUSR["c:@F@foo#"] == [])
+
+                    #expect(prettyNameByUSR["c:@F@bar#"] == "bar()")
+                    #expect(defLineByUSR["c:@F@bar#"] == 3)
+                    #expect(calleesByUSR["c:@F@bar#"] == ["c:@F@foo#"])
+
+                    #expect(prettyNameByUSR["c:@F@baz#"] == "baz()")
+                    #expect(defLineByUSR["c:@F@baz#"] == 7)
+                    #expect(calleesByUSR["c:@F@baz#"] == [])
+
+                    #expect(prettyNameByUSR["c:@F@test_call#"] == "test_call()")
+                    #expect(defLineByUSR["c:@F@test_call#"] == 9)
+                    #expect(calleesByUSR["c:@F@test_call#"] == ["c:@F@bar#", "c:@F@baz#"])
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+
+        // INVOKE_SSAF=NO: neither SSAF flag is present.
+        try await withTemporaryDirectory { tmpDirPath in
+            let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "NO"), simulated: false)
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/File1.cpp")) {
+                $0 <<< "void foo() {}\n"
+                $0 <<< "\n"
+                $0 <<< "void bar() {\n"
+                $0 <<< "  foo();\n"
+                $0 <<< "}\n"
+                $0 <<< "\n"
+                $0 <<< "void baz() {}\n"
+                $0 <<< "\n"
+                $0 <<< "void test_call() {\n"
+                $0 <<< "  bar();\n"
+                $0 <<< "  baz();\n"
+                $0 <<< "}\n"
+            }
+            try await tester.checkBuild(runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-extract-summaries=")])
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host))
+    func extractSummariesValuePassedThrough() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup("Sources", children: [TestFile("File1.c")]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "INVOKE_SSAF": "YES",
+                                "EXTRACT_SUMMARIES": "codegen",
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Test",
+                                type: .dynamicLibrary,
+                                buildPhases: [TestSourcesBuildPhase(["File1.c"])])
+                        ])
+                ])
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: true)
+            try await tester.checkBuild(runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=codegen"])
+                }
+                results.checkNoDiagnostics()
             }
         }
     }

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -435,40 +435,6 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.host))
-    func extractSummariesValuePassedThrough() async throws {
-        try await withTemporaryDirectory { tmpDirPath in
-            let testWorkspace = TestWorkspace(
-                "Test",
-                sourceRoot: tmpDirPath.join("Test"),
-                projects: [
-                    TestProject(
-                        "aProject",
-                        groupTree: TestGroup("Sources", children: [TestFile("File1.c")]),
-                        buildConfigurations: [TestBuildConfiguration(
-                            "Debug",
-                            buildSettings: [
-                                "PRODUCT_NAME": "$(TARGET_NAME)",
-                                "INVOKE_SSAF": "YES",
-                                "EXTRACT_SUMMARIES": "codegen",
-                            ])],
-                        targets: [
-                            TestStandardTarget(
-                                "Test",
-                                type: .dynamicLibrary,
-                                buildPhases: [TestSourcesBuildPhase(["File1.c"])])
-                        ])
-                ])
-            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: true)
-            try await tester.checkBuild(runDestination: .host) { results in
-                results.checkTask(.matchRuleType("CompileC")) { task in
-                    task.checkCommandLineContains(["--ssaf-extract-summaries=codegen"])
-                }
-                results.checkNoDiagnostics()
-            }
-        }
-    }
-
-    @Test(.requireSDKs(.host))
     func avoidEmitModuleSourceInfo() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -401,62 +401,7 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
 
                     let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
-                    let parsed = try #require(try PropertyList.fromJSONData(jsonBytes).dictValue)
-
-                    // Build id -> USR lookup; entity IDs are assigned non-deterministically
-                    let idTable = try #require(parsed["id_table"]?.arrayValue)
-                    var idToUSR: [Int: String] = [:]
-                    for entry in idTable {
-                        let entryDict = try #require(entry.dictValue)
-                        let id = try #require(entryDict["id"]?.intValue)
-                        let nameInfo = try #require(entryDict["name"]?.dictValue)
-                        idToUSR[id] = try #require(nameInfo["usr"]?.stringValue)
-                    }
-
-                    // Resolve call graph by USR so comparisons are ID-order-independent
-                    let dataArr = try #require(parsed["data"]?.arrayValue)
-                    let callGraph = try #require(dataArr.first { $0.dictValue?["summary_name"]?.stringValue == "CallGraph" }?.dictValue)
-                    let summaryData = try #require(callGraph["summary_data"]?.arrayValue)
-
-                    var prettyNameByUSR: [String: String] = [:]
-                    var defLineByUSR: [String: Int] = [:]
-                    var calleesByUSR: [String: [String]] = [:]
-                    for entry in summaryData {
-                        let entryDict = try #require(entry.dictValue)
-                        let entityId = try #require(entryDict["entity_id"]?.intValue)
-                        let summary = try #require(entryDict["entity_summary"]?.dictValue)
-                        let def = try #require(summary["def"]?.dictValue)
-                        let callees = try #require(summary["direct_callees"]?.arrayValue)
-                            .compactMap { callee -> String? in
-                                guard let id = callee.dictValue?["@"]?.intValue else { return nil }
-                                return idToUSR[id]
-                            }
-                            .sorted()
-                        guard let usr = idToUSR[entityId] else { continue }
-                        prettyNameByUSR[usr] = try #require(summary["pretty_name"]?.stringValue)
-                        defLineByUSR[usr] = try #require(def["line"]?.intValue)
-                        calleesByUSR[usr] = callees
-                    }
-
-                    let tuNamespace = try #require(parsed["tu_namespace"]?.dictValue)
-                    let tuName = try #require(tuNamespace["name"]?.stringValue)
-                    #expect(tuName.hasSuffix("/Test/aProject/File1.cpp"))
-
-                    #expect(prettyNameByUSR["c:@F@foo#"] == "foo()")
-                    #expect(defLineByUSR["c:@F@foo#"] == 1)
-                    #expect(calleesByUSR["c:@F@foo#"] == [])
-
-                    #expect(prettyNameByUSR["c:@F@bar#"] == "bar()")
-                    #expect(defLineByUSR["c:@F@bar#"] == 3)
-                    #expect(calleesByUSR["c:@F@bar#"] == ["c:@F@foo#"])
-
-                    #expect(prettyNameByUSR["c:@F@baz#"] == "baz()")
-                    #expect(defLineByUSR["c:@F@baz#"] == 7)
-                    #expect(calleesByUSR["c:@F@baz#"] == [])
-
-                    #expect(prettyNameByUSR["c:@F@test_call#"] == "test_call()")
-                    #expect(defLineByUSR["c:@F@test_call#"] == 9)
-                    #expect(calleesByUSR["c:@F@test_call#"] == ["c:@F@bar#", "c:@F@baz#"])
+                    #expect(!jsonBytes.isEmpty)
                 }
                 results.checkNoDiagnostics()
             }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -442,4 +442,78 @@ fileprivate struct ClangTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.host))
+    func invokeSsafOptions() async throws {
+        func getTestProject(invokeSSAF: String, extractSummaries: String = "") -> TestProject {
+            TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.c"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "INVOKE_SSAF": invokeSSAF,
+                            "EXTRACT_SUMMARIES": extractSummaries,
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Test",
+                        type: .dynamicLibrary,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["File1.c"]),
+                        ]
+                    ),
+                ])
+        }
+
+        let core = try await getCore()
+
+        // When INVOKE_SSAF is YES, the extract-summaries value and a .json summary file path are added.
+        // The summary file is co-located with the object file: same directory, same basename, .json extension.
+        do {
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "analysis"))
+            await tester.checkBuild(runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=analysis"])
+                    if let objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") }) {
+                        let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".json").str
+                        task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
+                    } else {
+                        Issue.record("No .o output found in CompileC task outputs")
+                    }
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+
+        // When INVOKE_SSAF is NO, neither ssaf flag is present.
+        do {
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "NO"))
+            await tester.checkBuild(runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-extract-summaries=")])
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+
+        // The value of EXTRACT_SUMMARIES is passed through verbatim to --ssaf-extract-summaries.
+        do {
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph"))
+            await tester.checkBuild(runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { task in
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
 }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -443,7 +443,7 @@ fileprivate struct ClangTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
     func invokeSsafOptions() async throws {
         func getTestProject(invokeSSAF: String, extractSummaries: String = "") -> TestProject {
             TestProject(
@@ -460,6 +460,8 @@ fileprivate struct ClangTests: CoreBasedTests {
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "INVOKE_SSAF": invokeSSAF,
                             "EXTRACT_SUMMARIES": extractSummaries,
+                            // Uncomment to test with a local build of clang
+                            // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
                         ]),
                 ],
                 targets: [
@@ -478,10 +480,10 @@ fileprivate struct ClangTests: CoreBasedTests {
         // When INVOKE_SSAF is YES, the extract-summaries value and a .json summary file path are added.
         // The summary file is co-located with the object file: same directory, same basename, .json extension.
         do {
-            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "analysis"))
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph"))
             await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC")) { task in
-                    task.checkCommandLineContains(["--ssaf-extract-summaries=analysis"])
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
                     if let objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") }) {
                         let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".json").str
                         task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])


### PR DESCRIPTION
Introduces two new build settings:
  - INVOKE_SSAF (Boolean): when enabled alongside clang's `invoke-ssaf` feature flag, passes `--ssaf-extract-summaries` and `--ssaf-tu-summary-file` to the compiler, writing a per-TU JSON summary co-located with the object file.
  - EXTRACT_SUMMARIES (String): controls which summaries to extract; its value is forwarded verbatim to `--ssaf-extract-summaries`.

SWBTaskConstructionTests cover the YES/NO flag combinations and that the EXTRACT_SUMMARIES value is passed through. SwiftBuildOperationTests verify that the summary json file generated for CallGraph analysis on a test file has the correct summary.
