### PR TITLE
[6.4] Ensure object library contents don't collide on case-insensitive file systems

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
@@ -43,7 +43,8 @@ public final class ObjectLibraryAssemblerTaskAction: TaskAction {
 
             // Process each input to determine its destination name
             for input in options.inputs {
-                let basename = input.basename
+                // Always use lowercase basenames to avoid collisions on case-insenitive filesystems
+                let basename = input.basename.lowercased()
                 let count = basenameCount[basename, default: 0]
                 basenameCount[basename] = count + 1
 

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -20,6 +20,54 @@ import SWBTaskExecution
 
 @Suite
 fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
+    @Test(.requireSDKs(.host))
+    func caseInsensitiveObjectLibraryCollision() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("objlib.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ARCHS": "$(ARCHS_STANDARD)",
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "$(HOST_PLATFORM)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                        "SWIFT_VERSION": swiftVersion,
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Objlib",
+                        type: .objectLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug"),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["objlib.swift"]),
+                        ]
+                    ),
+                ])
+            let tester = try await BuildOperationTester(getCore(), testProject, simulated: false)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("objlib.swift")) { stream in
+                stream <<< "func foo() {}"
+            }
+
+            try await tester.checkBuild(runDestination: .host) { results in
+                // The source and modulewrap objects should not collide when assembling the object library.
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
     /// Test that building a project with module-only architectures and generated Objective-C headers still generates the headers for the module-only architectures.
     @Test(.requireSDKs(.watchOS))
     func swiftModuleOnlyArchsWithGeneratedObjectiveCHeaders() async throws {


### PR DESCRIPTION
Resolves an issue building swift-argument-parser on windows, where object libraries build from source files would collide with the module wrap output in a batch mode compile.

Closes https://github.com/swiftlang/swift-build/issues/1313 / https://github.com/apple/swift-argument-parser/issues/896