### PR TITLE
Copy experimentalWindowsDLL artifact bundle variants to the target build directory

### DIFF
--- a/Sources/SWBTaskConstruction/CMakeLists.txt
+++ b/Sources/SWBTaskConstruction/CMakeLists.txt
@@ -56,8 +56,10 @@ add_library(SWBTaskConstruction
   TaskProducers/WorkspaceTaskProducers/HeadermapVFSTaskProducer.swift
   TaskProducers/WorkspaceTaskProducers/IndexBuildVFSDirectoryRemapTaskProducer.swift
   TaskProducers/WorkspaceTaskProducers/PCHModuleMapTaskProducer.swift
+  TaskProducers/WorkspaceTaskProducers/WindowsDLLCopyTaskProducer.swift
   TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
   TaskProducerSandboxing.swift
+  WindowsDLLCopyContext.swift
   XCFrameworkContext.swift)
 set_target_properties(SWBTaskConstruction PROPERTIES
   Swift_LANGUAGE_VERSION 5)

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -65,6 +65,9 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
     /// Cache of parsed artifact bundle metadata.
     package let artifactBundleMetadataCache = Registry<Path, ArtifactBundleMetadata>()
 
+    /// Context for copying experimentalWindowsDLL artifact bundle variants to the build directory.
+    let windowsDLLCopyContext = WindowsDLLCopyContext()
+
     /// The information about XCFrameworks used throughout the task planning process.
     let xcframeworkContext: XCFrameworkContext
 

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
@@ -78,6 +78,7 @@ private struct WorkspaceProductPlanBuilder {
         var taskProducers: [any TaskProducer] = [
             CreateBuildDirectoryTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),
             XCFrameworkTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),
+            WindowsDLLCopyTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),
             SDKStatCacheTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),
             HeadermapVFSTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),
             PCHModuleMapTaskProducer(context: globalTaskProducerContext, targetContexts: targetContexts),

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/WindowsDLLCopyTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/WindowsDLLCopyTaskProducer.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SWBCore
+import SWBMacro
+import SWBUtil
+import Foundation
+
+/// Workspace-level task producer that copies `experimentalWindowsDLL` artifact bundle variants
+/// to each consuming target's build directory.
+///
+/// Following the same pattern as `XCFrameworkTaskProducer`, this producer runs in two phases:
+///
+/// 1. **prepare()** — iterates all target contexts *sequentially*, triple-matches DLL variants,
+///    and registers (source, destination) pairs in `GlobalProductPlan.windowsDLLCopyContext`.
+///    Because iteration is sequential, the first eligible target to register a destination always
+///    wins, making winner selection deterministic across incremental builds.
+///
+/// 2. **generateTasks()** — emits exactly one `Copy` task per registered destination.
+final class WindowsDLLCopyTaskProducer: StandardTaskProducer, TaskProducer {
+    private let targetContexts: [TaskProducerContext]
+
+    init(context globalContext: TaskProducerContext, targetContexts: [TaskProducerContext]) {
+        self.targetContexts = targetContexts
+        super.init(globalContext)
+    }
+
+    func prepare() {
+        targetContexts.forEach(prepare(context:))
+        context.globalProductPlan.windowsDLLCopyContext.freeze()
+    }
+
+    private func prepare(context: TaskProducerContext) {
+        let scope = context.settings.globalScope
+
+        // Collect artifact bundle build files, expanding package-product targets transitively
+        // (the same traversal used by XCFrameworkTaskProducer).
+        let artifactBundles = artifactBundleBuildFiles(for: context)
+
+        for (_, absolutePath, _) in artifactBundles {
+            let metadata: ArtifactBundleMetadata
+            do {
+                metadata = try context.globalProductPlan.artifactBundleMetadataCache
+                    .getOrInsert(absolutePath) {
+                        try ArtifactBundleMetadata.parse(at: absolutePath, fileSystem: context.fs)
+                    }
+            } catch {
+                context.error("failed to parse artifact bundle metadata for '\(absolutePath)': \(error.localizedDescription)")
+                continue
+            }
+
+            for (name, artifact) in metadata.artifacts {
+                guard artifact.type == .experimentalWindowsDLL else { continue }
+
+                // Triple matching is architecture-dependent, so evaluate per arch.
+                var foundMatch = false
+                for arch in scope.evaluate(BuiltinMacros.ARCHS) {
+                    let archScope = scope.subscopeBindingArchAndTriple(arch: arch)
+                    let triple = archScope.evaluate(BuiltinMacros.SWIFT_TARGET_TRIPLE)
+                    let targetBuildDir = archScope.evaluate(BuiltinMacros.TARGET_BUILD_DIR)
+
+                    for variant in artifact.variants {
+                        guard variant.supportedTriples == nil || variant.supportedTriples!.contains(where: {
+                            normalizedTriplesCompareDisregardingOSVersions($0, triple)
+                        }) else { continue }
+                        foundMatch = true
+                        let src = absolutePath.join(variant.path)
+                        let dst = targetBuildDir.join(src.basename)
+                        context.globalProductPlan.windowsDLLCopyContext.register(sourcePath: src, destinationPath: dst)
+                    }
+                }
+
+                if !foundMatch {
+                    context.warning("ignoring '\(name)' because the artifact bundle did not contain a matching variant", location: .path(absolutePath))
+                }
+            }
+        }
+    }
+
+    func generateTasks() async -> [any PlannedTask] {
+        let scope = context.settings.globalScope
+        var tasks: [any PlannedTask] = []
+        for req in context.globalProductPlan.windowsDLLCopyContext.copyRequirements {
+            await appendGeneratedTasks(&tasks) { delegate in
+                await context.copySpec.constructCopyTasks(
+                    CommandBuildContext(producer: context, scope: scope,
+                        inputs: [FileToBuild(context: context, absolutePath: req.sourcePath)],
+                        output: req.destinationPath),
+                    delegate, stripUnsignedBinaries: false)
+            }
+        }
+        return tasks
+    }
+
+    // MARK: - Helpers
+
+    /// Returns all artifact-bundle build files for a target, expanding package-product targets
+    /// transitively (mirrors the traversal in XCFrameworkTaskProducer).
+    private func artifactBundleBuildFiles(for context: TaskProducerContext) -> [(reference: Reference, absolutePath: Path, fileType: FileTypeSpec)] {
+        let currentPlatformFilter = PlatformFilter(context.settings.globalScope)
+
+        func buildFilesExpanding(phase: BuildPhaseWithBuildFiles) -> [BuildFile] {
+            var phases = [phase]
+            var enqueuedGUIDs: Set<String> = []
+            var result: [BuildFile] = []
+            while let current = phases.first {
+                phases.removeFirst()
+                for file in current.buildFiles {
+                    guard currentPlatformFilter.matches(file.platformFilters) else { continue }
+                    result.append(file)
+                    if case .targetProduct(let guid) = file.buildableItem,
+                       case let pkg as PackageProductTarget = context.workspaceContext.workspace.target(for: guid),
+                       let frameworksPhase = pkg.frameworksBuildPhase,
+                       !enqueuedGUIDs.contains(frameworksPhase.guid) {
+                        phases.append(frameworksPhase)
+                        enqueuedGUIDs.insert(frameworksPhase.guid)
+                    }
+                }
+            }
+            return result
+        }
+
+        let buildPhases: [BuildPhase]
+        switch context.configuredTarget?.target {
+        case let target as BuildPhaseTarget:
+            buildPhases = target.buildPhases
+        case let target as PackageProductTarget:
+            guard let phase = target.frameworksBuildPhase else { return [] }
+            buildPhases = [phase]
+        default:
+            return []
+        }
+
+        return buildPhases
+            .compactMap { $0 as? BuildPhaseWithBuildFiles }
+            .flatMap { buildFilesExpanding(phase: $0) }
+            .compactMap { buildFile -> (Reference, Path, FileTypeSpec)? in
+                guard currentPlatformFilter.matches(buildFile.platformFilters) else { return nil }
+                return try? context.resolveBuildFileReference(buildFile)
+            }
+            .filter { $0.2.conformsTo(identifier: "wrapper.artifactbundle") }
+    }
+}

--- a/Sources/SWBTaskConstruction/WindowsDLLCopyContext.swift
+++ b/Sources/SWBTaskConstruction/WindowsDLLCopyContext.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import SWBUtil
+import Synchronization
+
+/// Collects the set of Windows DLL copy operations needed across all targets in the workspace.
+///
+/// During the planning phase, `WindowsDLLCopyTaskProducer` iterates target contexts sequentially
+/// and calls `register(sourcePath:destinationPath:)` for each DLL variant that matches a target's
+/// triple. Because processing is sequential, the first target to register a given destination
+/// path always wins — providing deterministic task generation regardless of how many targets
+/// transitively reference the same artifact bundle.
+package final class WindowsDLLCopyContext: Sendable {
+    package struct CopyRequirement: Hashable, Sendable {
+        /// Absolute path to the DLL inside the artifact bundle.
+        package let sourcePath: Path
+        /// Destination path: `$(TARGET_BUILD_DIR)/dllname.dll`.
+        package let destinationPath: Path
+    }
+
+    private struct State: Sendable {
+        var requirements: [Path: CopyRequirement] = [:]
+        var frozen = false
+    }
+
+    private let state = SWBMutex(State())
+
+    package init() {}
+
+    /// Register a DLL copy requirement. The first call for a given `destinationPath` wins;
+    /// subsequent calls for the same destination are silently ignored.
+    func register(sourcePath: Path, destinationPath: Path) {
+        state.withLock { s in
+            precondition(!s.frozen)
+            if s.requirements[destinationPath] == nil {
+                s.requirements[destinationPath] = CopyRequirement(sourcePath: sourcePath, destinationPath: destinationPath)
+            }
+        }
+    }
+
+    func freeze() {
+        state.withLock { $0.frozen = true }
+    }
+
+    var copyRequirements: [CopyRequirement] {
+        state.withLock { s in
+            precondition(s.frozen)
+            return Array(s.requirements.values)
+        }
+    }
+}

--- a/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
@@ -185,6 +185,165 @@ fileprivate struct ArtifactBundleTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host))
+    func artifactBundleWithWindowsDLLs() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "aProject",
+                sourceRoot: tmpDir.join("srcroot"),
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("main.swift"),
+                        TestFile("MyDLLs.artifactbundle"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "CODE_SIGN_IDENTITY": "",
+                            "CODE_SIGNING_ALLOWED": "NO",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": swiftVersion,
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            // Force a Windows triple so the x86_64 variant is selected.
+                            "SWIFT_TARGET_TRIPLE": "x86_64-unknown-windows-msvc",
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Tool",
+                        type: .commandLineTool,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                            TestFrameworksBuildPhase(["MyDLLs.artifactbundle"]),
+                        ]
+                    )
+                ])
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            let fs = PseudoFS()
+            try fs.createDirectory(Path(SRCROOT).join("Sources"), recursive: true)
+            try fs.write(Path(SRCROOT).join("Sources/main.swift"), contents: "")
+
+            let artifactBundlePath = Path(SRCROOT).join("Sources/MyDLLs.artifactbundle")
+            try fs.createDirectory(artifactBundlePath.join("windows-x86_64"), recursive: true)
+            try fs.write(artifactBundlePath.join("windows-x86_64/foo.dll"), contents: "")
+            try fs.createDirectory(artifactBundlePath.join("windows-arm64"), recursive: true)
+            try fs.write(artifactBundlePath.join("windows-arm64/foo.dll"), contents: "")
+            let infoJSONContent = """
+            {
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "foo": {
+                  "type": "experimentalWindowsDLL",
+                  "version": "1.0.0",
+                  "variants": [
+                    {
+                      "path": "windows-x86_64/foo.dll",
+                      "supportedTriples": ["x86_64-unknown-windows-msvc"]
+                    },
+                    {
+                      "path": "windows-arm64/foo.dll",
+                      "supportedTriples": ["aarch64-unknown-windows-msvc"]
+                    }
+                  ]
+                }
+              }
+            }
+            """
+            try fs.write(artifactBundlePath.join("info.json"), contents: ByteString(encodingAsUTF8: infoJSONContent))
+
+            await tester.checkBuild(runDestination: .host, fs: fs) { results in
+                results.checkNoDiagnostics()
+
+                // The x86_64 variant should be copied; the arm64 variant should not.
+                results.checkTask(.matchRuleType("Copy"), .matchRuleItemBasename("foo.dll")) { task in
+                    task.checkCommandLineContains([
+                        Path("\(SRCROOT)/Sources/MyDLLs.artifactbundle/windows-x86_64/foo.dll").str
+                    ])
+                    task.checkCommandLineDoesNotContain(Path("\(SRCROOT)/Sources/MyDLLs.artifactbundle/windows-arm64/foo.dll").str)
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host))
+    func artifactBundleWithWindowsDLLsNoMatchWarning() async throws {
+        // When no variant matches the current triple a warning should be emitted and
+        // no copy task should be generated.
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "aProject",
+                sourceRoot: tmpDir.join("srcroot"),
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("main.swift"),
+                        TestFile("MyDLLs.artifactbundle"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: [
+                            "GENERATE_INFOPLIST_FILE": "YES",
+                            "CODE_SIGN_IDENTITY": "",
+                            "CODE_SIGNING_ALLOWED": "NO",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "SWIFT_VERSION": swiftVersion,
+                            "SWIFT_EXEC": swiftCompilerPath.str,
+                            // A triple that matches neither variant.
+                            "SWIFT_TARGET_TRIPLE": "riscv64-unknown-linux-gnu",
+                        ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Tool",
+                        type: .commandLineTool,
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                            TestFrameworksBuildPhase(["MyDLLs.artifactbundle"]),
+                        ]
+                    )
+                ])
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            let fs = PseudoFS()
+            try fs.createDirectory(Path(SRCROOT).join("Sources"), recursive: true)
+            try fs.write(Path(SRCROOT).join("Sources/main.swift"), contents: "")
+
+            let artifactBundlePath = Path(SRCROOT).join("Sources/MyDLLs.artifactbundle")
+            try fs.createDirectory(artifactBundlePath.join("windows-x86_64"), recursive: true)
+            try fs.write(artifactBundlePath.join("windows-x86_64/foo.dll"), contents: "")
+            let infoJSONContent = """
+            {
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "foo": {
+                  "type": "experimentalWindowsDLL",
+                  "version": "1.0.0",
+                  "variants": [
+                    {
+                      "path": "windows-x86_64/foo.dll",
+                      "supportedTriples": ["x86_64-unknown-windows-msvc"]
+                    }
+                  ]
+                }
+              }
+            }
+            """
+            try fs.write(artifactBundlePath.join("info.json"), contents: ByteString(encodingAsUTF8: infoJSONContent))
+
+            await tester.checkBuild(runDestination: .host, fs: fs) { results in
+                results.checkWarning(.contains("ignoring 'foo' because the artifact bundle did not contain a matching variant"))
+                results.checkNoTask(.matchRuleType("Copy"), .matchRuleItemBasename("foo.dll"))
+            }
+        }
+    }
+
     @Test(.requireSDKs(.macOS))
     func artifactBundleInfoPropagatesThroughPackageProductTarget() async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in


### PR DESCRIPTION
Artifact bundles with `experimentalWindowsDLL` entries now have their matching variant copied to `$(TARGET_BUILD_DIR)` alongside the built product, using a workspace-level producer that guarantees deterministic, duplicate-free task generation regardless of how many targets transitively reference the same bundle.

Architecture (mirrors XCFrameworkTaskProducer):

- WindowsDLLCopyContext (new) — holds a [destinationPath: CopyRequirement] map on GlobalProductPlan. First registration per destination wins.

- WindowsDLLCopyTaskProducer (new) — workspace-level producer registered alongside XCFrameworkTaskProducer in ProductPlanner. Its prepare() iterates target contexts *sequentially*, triple-matches DLL variants per arch, and registers (source, destination) pairs. Because iteration is sequential the winner is always the same target across incremental builds, eliminating the stale-file-removal warnings that a concurrent first-come-first-served approach would produce. generateTasks() emits one Copy task per registered destination.

Tests:
- artifactBundleWithWindowsDLLs: correct variant copied, non-matching skipped
- artifactBundleWithWindowsDLLsNoMatchWarning: warning + no copy when no variant matches
