### PR TITLE
BUILD_ONLY_KNOWN_LOCALIZATIONS hits single input assertion when there are multiple Asset Catalogs

### DIFF
--- a/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
+++ b/Sources/SWBApplePlatform/AssetCatalogCompiler.swift
@@ -182,7 +182,9 @@ public final class ActoolCompilerSpec : GenericCompilerSpec, SpecIdentifierType,
                     restrictedLocalizations.remove("Base") // Base is not a valid Asset Catalog locale
                     let restrictedLocalizations = restrictedLocalizations.sorted()
                     if !restrictedLocalizations.isEmpty {
-                        delegate.note("Asset Catalog will compile languages for known regions: \(restrictedLocalizations.joined(separator: ", "))", location: .path(cbc.input.absolutePath))
+                        for catalogPath in catalogInputPaths {
+                            delegate.note("Asset Catalog will compile languages for known regions: \(restrictedLocalizations.joined(separator: ", "))", location: .path(catalogPath))
+                        }
                     }
                     return cbc.scope.namespace.parseLiteralStringList(restrictedLocalizations)
                 }

--- a/Tests/SWBTaskConstructionTests/AssetCatalogTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AssetCatalogTaskConstructionTests.swift
@@ -486,6 +486,54 @@ fileprivate struct AssetCatalogTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func multipleAssetCatalogKnownLocalizationsFiltering() async throws {
+        let actoolPath = try await self.actoolPath
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestProject(
+                "AssetCatalogKnownRegionsTest",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup("Root", children: [
+                    TestFile("Assets.xcassets"),
+                    TestFile("MoreAssets.xcassets"),
+                ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ASSETCATALOG_EXEC": actoolPath.str,
+                        "BUILD_ONLY_KNOWN_LOCALIZATIONS": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget("App", type: .application,
+                                       buildPhases: [
+                                        TestResourcesBuildPhase([
+                                            "Assets.xcassets",
+                                            "MoreAssets.xcassets",
+                                        ])
+                                       ])
+                ],
+                knownLocalizations: ["en", "de", "Base"] // Only en and de should be compiled
+            )
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+
+            await tester.checkBuild(runDestination: .macOS) { results in
+
+                results.checkTask(
+                    .matchRuleType("CompileAssetCatalogVariant"),
+                    .matchRuleItem("thinned")
+                ) { task in
+                    task.checkCommandLineContains(["--include-language", "en"])
+                    task.checkCommandLineContains(["--include-language", "de"])
+                    task.checkCommandLineDoesNotContain("Base")
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func assetCatalogEmptyKnownLocalizations() async throws {
         let actoolPath = try await self.actoolPath
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
`cbc.input` has a precondition that there is only one input. That's not guaranteed to be the case with Asset Catalogs.

To fix, stop using `cbc.input` and handle multiple asset catalog paths.
