### PR TITLE
Update platform versions in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,9 +75,9 @@ let package = Package(
     name: "SwiftBuild",
     defaultLocalization: "en",
     platforms: [
-        .macOS(.v14),
-        .iOS("17.0"),
-        .macCatalyst("17.0"),
+        .macOS(.v15),
+        .iOS(.v18),
+        .macCatalyst(.v18),
     ],
     products: [
         .executable(name: "swbuild", targets: ["swbuild"]),


### PR DESCRIPTION
We need to raise the minimum deployment target so that we can begin using macOS 15 APIs like Atomic and Mutex, and unblock SwiftSubprocess from potentially raising its minimum deployment target to macOS 15 accordingly, as we'll soon be taking it as a dependency.

This follows the sourcekit-lsp update in swiftlang/sourcekit-lsp#2636 and the swift-package-manager update in swiftlang/swift-package-manager#10043