### PR TITLE
[6.4] Add buildTargetInfo API which exposes the effective platform name to clients

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -121,7 +121,7 @@ private struct BuildTargetInfoHandler: MessageHandler {
             throw StubError.error("service object is not of type BuildService")
         }
         let info = try await buildService.sharedCore(developerPath: message.developerPath).buildTargetInfo(triple: message.triple)
-        return BuildTargetInfoResponse(sdkName: info.sdkName, platformName: info.platformName, sdkVariant: info.sdkVariant, deploymentTargetSettingName: info.deploymentTargetSettingName, deploymentTarget: info.deploymentTarget)
+        return BuildTargetInfoResponse(sdkName: info.sdkName, platformName: info.platformName, buildProductsDirectorySuffix: info.buildProductsDirectorySuffix, sdkVariant: info.sdkVariant, deploymentTargetSettingName: info.deploymentTargetSettingName, deploymentTarget: info.deploymentTarget)
     }
 }
 
@@ -129,7 +129,7 @@ private struct SessionBuildTargetInfoHandler: MessageHandler {
     func handle(request: Request, message: SessionBuildTargetInfoRequest) async throws -> BuildTargetInfoResponse {
         let session = try request.session(for: message)
         let info = try session.core.buildTargetInfo(triple: message.triple)
-        return BuildTargetInfoResponse(sdkName: info.sdkName, platformName: info.platformName, sdkVariant: info.sdkVariant, deploymentTargetSettingName: info.deploymentTargetSettingName, deploymentTarget: info.deploymentTarget)
+        return BuildTargetInfoResponse(sdkName: info.sdkName, platformName: info.platformName, buildProductsDirectorySuffix: info.buildProductsDirectorySuffix, sdkVariant: info.sdkVariant, deploymentTargetSettingName: info.deploymentTargetSettingName, deploymentTarget: info.deploymentTarget)
     }
 }
 

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -627,7 +627,17 @@ public final class Core: Sendable {
         }
     }
 
-    public func buildTargetInfo(triple: String) throws -> (sdkName: String, platformName: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
+    package static func effectivePlatformName(platformName: String, archComponent: String) -> String {
+        // `archComponent` is currently unused, but will be used to disambiguate build directories for platforms that
+        // don't support universal binaries once this API is adopted.
+        if platformName == "macosx" {
+            return ""
+        } else {
+            return "-\(platformName)"
+        }
+    }
+
+    public func buildTargetInfo(triple: String) throws -> (sdkName: String, platformName: String, buildProductsDirectorySuffix: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
         let llvmTriple = try LLVMTriple(triple)
 
         let platformExtensions = pluginManager.extensions(of: PlatformInfoExtensionPoint.self)
@@ -636,6 +646,8 @@ public final class Core: Sendable {
         guard let platformName = platformNames.only else {
             throw StubError.error("unable to find a single platform name for triple '\(triple)'. results: \(platformNames)")
         }
+
+        let buildProductsDirectorySuffix = Self.effectivePlatformName(platformName: platformName, archComponent: llvmTriple.arch)
 
         let sdkVariants = Set(platformExtensions.compactMap({ $0.sdkVariant(triple: llvmTriple) }))
         if sdkVariants.count > 1 {
@@ -649,7 +661,7 @@ public final class Core: Sendable {
 
         let deploymentTarget: String? = try llvmTriple.version.map { "\($0)" }
 
-        return (sdkName: platformName, platformName: platformName, sdkVariant: sdkVariants.only, deploymentTargetSettingName: deploymentTargetSettingNames.only, deploymentTarget: deploymentTarget)
+        return (sdkName: platformName, platformName: platformName, buildProductsDirectorySuffix: buildProductsDirectorySuffix, sdkVariant: sdkVariants.only, deploymentTargetSettingName: deploymentTargetSettingNames.only, deploymentTarget: deploymentTarget)
     }
 }
 

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2528,11 +2528,9 @@ private class SettingsBuilder: ProjectMatchLookup {
             platformTable.push(BuiltinMacros.PLATFORM_FAMILY_NAME, literal: platform.familyName)
             platformTable.push(BuiltinMacros.PLATFORM_DISPLAY_NAME, literal: platform.displayName)
             platformTable.push(BuiltinMacros.PLATFORM_DIR, literal: platform.path.str)
-            if isMacOS {
-                platformTable.push(BuiltinMacros.EFFECTIVE_PLATFORM_NAME, literal: "")
-            } else {
-                platformTable.push(BuiltinMacros.EFFECTIVE_PLATFORM_NAME, literal: "-\(platform.name)")
-            }
+
+            platformTable.push(BuiltinMacros.EFFECTIVE_PLATFORM_NAME, BuiltinMacros.namespace.parseString(Core.effectivePlatformName(platformName: platform.name, archComponent: "$(CURRENT_ARCH)")))
+
             if platform.name.hasSuffix("simulator") {
                 platformTable.push(BuiltinMacros.EFFECTIVE_PLATFORM_SUFFIX, literal: "simulator")
             } else {

--- a/Sources/SWBProtocol/Message.swift
+++ b/Sources/SWBProtocol/Message.swift
@@ -433,13 +433,15 @@ public struct BuildTargetInfoResponse: Message, Equatable, SerializableCodable {
 
     public let sdkName: String
     public let platformName: String
+    public let buildProductsDirectorySuffix: String
     public let sdkVariant: String?
     public let deploymentTargetSettingName: String?
     public let deploymentTarget: String?
 
-    public init(sdkName: String, platformName: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
+    public init(sdkName: String, platformName: String, buildProductsDirectorySuffix: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
         self.sdkName = sdkName
         self.platformName = platformName
+        self.buildProductsDirectorySuffix = buildProductsDirectorySuffix
         self.sdkVariant = sdkVariant
         self.deploymentTargetSettingName = deploymentTargetSettingName
         self.deploymentTarget = deploymentTarget

--- a/Sources/SwiftBuild/SWBBuildTargetInfo.swift
+++ b/Sources/SwiftBuild/SWBBuildTargetInfo.swift
@@ -15,13 +15,15 @@ import SWBProtocol
 public struct SWBBuildTargetInfo: Sendable, Equatable {
     public let sdkName: String
     public let platformName: String
+    public let buildProductsDirectorySuffix: String
     public let sdkVariant: String?
     public let deploymentTargetSettingName: String?
     public let deploymentTarget: String?
 
-    public init(sdkName: String, platformName: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
+    public init(sdkName: String, platformName: String, buildProductsDirectorySuffix: String, sdkVariant: String?, deploymentTargetSettingName: String?, deploymentTarget: String?) {
         self.sdkName = sdkName
         self.platformName = platformName
+        self.buildProductsDirectorySuffix = buildProductsDirectorySuffix
         self.sdkVariant = sdkVariant
         self.deploymentTargetSettingName = deploymentTargetSettingName
         self.deploymentTarget = deploymentTarget
@@ -30,6 +32,7 @@ public struct SWBBuildTargetInfo: Sendable, Equatable {
     init(_ response: BuildTargetInfoResponse) {
         self.sdkName = response.sdkName
         self.platformName = response.platformName
+        self.buildProductsDirectorySuffix = response.buildProductsDirectorySuffix
         self.sdkVariant = response.sdkVariant
         self.deploymentTargetSettingName = response.deploymentTargetSettingName
         self.deploymentTarget = response.deploymentTarget

--- a/Tests/SWBBuildServiceTests/BuildServiceTests.swift
+++ b/Tests/SWBBuildServiceTests/BuildServiceTests.swift
@@ -54,47 +54,47 @@ fileprivate struct BuildServiceTests: CoreBasedTests {
 
     @Test(arguments: [
         // Apple platforms
-        .init(triple: "arm64-apple-macos15.0", platformName: "macosx", sdkVariant: nil, deploymentTargetSettingName: "MACOSX_DEPLOYMENT_TARGET", deploymentTarget: "15.0"),
-        .init(triple: "arm64-apple-ios18.0", platformName: "iphoneos", sdkVariant: nil, deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
-        .init(triple: "arm64-apple-ios18.0-simulator", platformName: "iphonesimulator", sdkVariant: nil, deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
-        .init(triple: "arm64-apple-ios17.0-macabi", platformName: "macosx", sdkVariant: "iosmac", deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "17.0"),
-        .init(triple: "arm64-apple-tvos18.0", platformName: "appletvos", sdkVariant: nil, deploymentTargetSettingName: "TVOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
-        .init(triple: "arm64-apple-tvos18.0-simulator", platformName: "appletvsimulator", sdkVariant: nil, deploymentTargetSettingName: "TVOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
-        .init(triple: "arm64-apple-watchos11.0", platformName: "watchos", sdkVariant: nil, deploymentTargetSettingName: "WATCHOS_DEPLOYMENT_TARGET", deploymentTarget: "11.0"),
-        .init(triple: "arm64-apple-watchos11.0-simulator", platformName: "watchsimulator", sdkVariant: nil, deploymentTargetSettingName: "WATCHOS_DEPLOYMENT_TARGET", deploymentTarget: "11.0"),
-        .init(triple: "arm64-apple-xros2.0", platformName: "xros", sdkVariant: nil, deploymentTargetSettingName: "XROS_DEPLOYMENT_TARGET", deploymentTarget: "2.0"),
-        .init(triple: "arm64-apple-xros2.0-simulator", platformName: "xrsimulator", sdkVariant: nil, deploymentTargetSettingName: "XROS_DEPLOYMENT_TARGET", deploymentTarget: "2.0"),
-        .init(triple: "arm64-apple-driverkit24.0", platformName: "driverkit", sdkVariant: nil, deploymentTargetSettingName: "DRIVERKIT_DEPLOYMENT_TARGET", deploymentTarget: "24.0"),
+        .init(triple: "arm64-apple-macos15.0", platformName: "macosx", buildProductsDirectorySuffix: "", sdkVariant: nil, deploymentTargetSettingName: "MACOSX_DEPLOYMENT_TARGET", deploymentTarget: "15.0"),
+        .init(triple: "arm64-apple-ios18.0", platformName: "iphoneos", buildProductsDirectorySuffix: "-iphoneos", sdkVariant: nil, deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
+        .init(triple: "arm64-apple-ios18.0-simulator", platformName: "iphonesimulator", buildProductsDirectorySuffix: "-iphonesimulator", sdkVariant: nil, deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
+        .init(triple: "arm64-apple-ios17.0-macabi", platformName: "macosx", buildProductsDirectorySuffix: "", sdkVariant: "iosmac", deploymentTargetSettingName: "IPHONEOS_DEPLOYMENT_TARGET", deploymentTarget: "17.0"),
+        .init(triple: "arm64-apple-tvos18.0", platformName: "appletvos", buildProductsDirectorySuffix: "-appletvos", sdkVariant: nil, deploymentTargetSettingName: "TVOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
+        .init(triple: "arm64-apple-tvos18.0-simulator", platformName: "appletvsimulator", buildProductsDirectorySuffix: "-appletvsimulator", sdkVariant: nil, deploymentTargetSettingName: "TVOS_DEPLOYMENT_TARGET", deploymentTarget: "18.0"),
+        .init(triple: "arm64-apple-watchos11.0", platformName: "watchos", buildProductsDirectorySuffix: "-watchos", sdkVariant: nil, deploymentTargetSettingName: "WATCHOS_DEPLOYMENT_TARGET", deploymentTarget: "11.0"),
+        .init(triple: "arm64-apple-watchos11.0-simulator", platformName: "watchsimulator", buildProductsDirectorySuffix: "-watchsimulator", sdkVariant: nil, deploymentTargetSettingName: "WATCHOS_DEPLOYMENT_TARGET", deploymentTarget: "11.0"),
+        .init(triple: "arm64-apple-xros2.0", platformName: "xros", buildProductsDirectorySuffix: "-xros", sdkVariant: nil, deploymentTargetSettingName: "XROS_DEPLOYMENT_TARGET", deploymentTarget: "2.0"),
+        .init(triple: "arm64-apple-xros2.0-simulator", platformName: "xrsimulator", buildProductsDirectorySuffix: "-xrsimulator", sdkVariant: nil, deploymentTargetSettingName: "XROS_DEPLOYMENT_TARGET", deploymentTarget: "2.0"),
+        .init(triple: "arm64-apple-driverkit24.0", platformName: "driverkit", buildProductsDirectorySuffix: "-driverkit", sdkVariant: nil, deploymentTargetSettingName: "DRIVERKIT_DEPLOYMENT_TARGET", deploymentTarget: "24.0"),
 
         // Linux
-        .init(triple: "aarch64-unknown-linux-gnu", platformName: "linux", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
-        .init(triple: "x86_64-unknown-linux-musl", platformName: "linux", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "aarch64-unknown-linux-gnu", platformName: "linux", buildProductsDirectorySuffix: "-linux", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "x86_64-unknown-linux-musl", platformName: "linux", buildProductsDirectorySuffix: "-linux", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
 
         // Android
-        .init(triple: "aarch64-unknown-linux-android24", platformName: "android", sdkVariant: nil, deploymentTargetSettingName: "ANDROID_DEPLOYMENT_TARGET", deploymentTarget: "24"),
-        .init(triple: "armv7-unknown-linux-androideabi24", platformName: "android", sdkVariant: nil, deploymentTargetSettingName: "ANDROID_DEPLOYMENT_TARGET", deploymentTarget: "24"),
+        .init(triple: "aarch64-unknown-linux-android24", platformName: "android", buildProductsDirectorySuffix: "-android", sdkVariant: nil, deploymentTargetSettingName: "ANDROID_DEPLOYMENT_TARGET", deploymentTarget: "24"),
+        .init(triple: "armv7-unknown-linux-androideabi24", platformName: "android", buildProductsDirectorySuffix: "-android", sdkVariant: nil, deploymentTargetSettingName: "ANDROID_DEPLOYMENT_TARGET", deploymentTarget: "24"),
 
         // FreeBSD
-        .init(triple: "x86_64-unknown-freebsd14", platformName: "freebsd", sdkVariant: nil, deploymentTargetSettingName: "FREEBSD_DEPLOYMENT_TARGET", deploymentTarget: "14"),
+        .init(triple: "x86_64-unknown-freebsd14", platformName: "freebsd", buildProductsDirectorySuffix: "-freebsd", sdkVariant: nil, deploymentTargetSettingName: "FREEBSD_DEPLOYMENT_TARGET", deploymentTarget: "14"),
 
         // OpenBSD
-        .init(triple: "x86_64-unknown-openbsd7.8", platformName: "openbsd", sdkVariant: nil, deploymentTargetSettingName: "OPENBSD_DEPLOYMENT_TARGET", deploymentTarget: "7.8"),
+        .init(triple: "x86_64-unknown-openbsd7.8", platformName: "openbsd", buildProductsDirectorySuffix: "-openbsd", sdkVariant: nil, deploymentTargetSettingName: "OPENBSD_DEPLOYMENT_TARGET", deploymentTarget: "7.8"),
 
         // QNX
-        .init(triple: "aarch64-unknown-nto-qnx", platformName: "qnx", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "aarch64-unknown-nto-qnx", platformName: "qnx", buildProductsDirectorySuffix: "-qnx", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
 
         // Windows
-        .init(triple: "x86_64-unknown-windows-msvc", platformName: "windows", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "x86_64-unknown-windows-msvc", platformName: "windows", buildProductsDirectorySuffix: "-windows", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
 
         // WebAssembly
-        .init(triple: "wasm32-unknown-wasi", platformName: "webassembly", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "wasm32-unknown-wasi", platformName: "webassembly", buildProductsDirectorySuffix: "-webassembly", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
 
         // Bare metal
-        .init(triple: "aarch64-none-none-elf", platformName: "none", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "aarch64-none-none-elf", platformName: "none", buildProductsDirectorySuffix: "-none", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
     ] as [BuildTargetInfoExpectation])
     func buildTargetInfo(_ expectation: BuildTargetInfoExpectation) async throws {
         let info = try await withBuildSession { try await $0.buildTargetInfo(triple: expectation.triple) }
-        #expect(info == SWBBuildTargetInfo(sdkName: expectation.platformName, platformName: expectation.platformName, sdkVariant: expectation.sdkVariant, deploymentTargetSettingName: expectation.deploymentTargetSettingName, deploymentTarget: expectation.deploymentTarget))
+        #expect(info == SWBBuildTargetInfo(sdkName: expectation.platformName, platformName: expectation.platformName, buildProductsDirectorySuffix: expectation.buildProductsDirectorySuffix, sdkVariant: expectation.sdkVariant, deploymentTargetSettingName: expectation.deploymentTargetSettingName, deploymentTarget: expectation.deploymentTarget))
     }
 
     @Test func buildTargetInfoUnrecognizedTriple() async throws {
@@ -107,6 +107,7 @@ fileprivate struct BuildServiceTests: CoreBasedTests {
 fileprivate struct BuildTargetInfoExpectation: Sendable, CustomTestStringConvertible {
     let triple: String
     let platformName: String
+    let buildProductsDirectorySuffix: String
     let sdkVariant: String?
     let deploymentTargetSettingName: String?
     let deploymentTarget: String?


### PR DESCRIPTION
Expose API on build target info for EFFECTIVE_PLATFORM_NAME / the build products directory suffix. This ensures SwiftPM doesn't need to duplicate the same logic, allowing us to more easily change it to better accommodate platforms which don't support universal binaries (https://github.com/swiftlang/swift-build/issues/1363)