### PR TITLE
[6.4 🍒] Skip DSTROOT during clean when DEPLOYMENT_LOCATION is off

### DIFF
--- a/Sources/SWBBuildSystem/CleanOperation.swift
+++ b/Sources/SWBBuildSystem/CleanOperation.swift
@@ -392,7 +392,14 @@ package final class CleanOperation: BuildSystemOperation, TargetDependencyResolv
 
 extension WorkspaceContext {
     func buildDirectories(settings: Settings) -> [Path] {
-        buildDirectoryMacros.map { settings.globalScope.evaluate($0) }
+        buildDirectoryMacros.compactMap { macro in
+            // Skip DSTROOT when DEPLOYMENT_LOCATION is off, matching
+            // CreateBuildDirectoryTaskProducer.prepare().
+            if macro == BuiltinMacros.DSTROOT && !settings.globalScope.evaluate(BuiltinMacros.DEPLOYMENT_LOCATION) {
+                return nil
+            }
+            return settings.globalScope.evaluate(macro)
+        }
     }
 
     func cacheDirectories(settings: Settings) -> [Path] {

--- a/Tests/SWBBuildSystemTests/CleanOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/CleanOperationTests.swift
@@ -151,6 +151,23 @@ fileprivate struct CleanOperationTests: CoreBasedTests {
         }
     }
 
+    /// DSTROOT should not be cleaned when DEPLOYMENT_LOCATION is off,
+    /// even if the directory exists on disk from another source.
+    @Test(.requireSDKs(.macOS))
+    func cleanSkipsDstrootWithoutDeploymentLocation() async throws {
+        try await withTestHarness { tester, tmpDirPath, dstRoot in
+            // Simulate an externally created DSTROOT directory
+            try tester.fs.createDirectory(dstRoot, recursive: true)
+            #expect(tester.fs.exists(dstRoot))
+
+            try await tester.checkBuild(runDestination: .macOS, buildCommand: .cleanBuildFolder(style: .regular), persistent: true) { results in
+                results.checkNoDiagnostics()
+            }
+
+            #expect(tester.fs.exists(dstRoot))
+        }
+    }
+
     @Test(.requireSDKs(.macOS))
     func cleanFrameworkInstall() async throws {
         try await withTestHarness(install: true) { tester, tmpDirPath, dstRoot in
@@ -305,7 +322,7 @@ fileprivate struct CleanOperationTests: CoreBasedTests {
 
     @Test(.requireSDKs(.macOS))
     func cleanBuildFolderContainingProject() async throws {
-        try await withTestHarness(useRootDstroot: true) { tester, tmpDirPath, _ in
+        try await withTestHarness(install: true, useRootDstroot: true) { tester, tmpDirPath, _ in
             let buildFolderPaths = [tmpDirPath]
 
             try await tester.checkBuild(runDestination: .macOS, persistent: true) { results in }


### PR DESCRIPTION
Explanation: Aligns clean with CreateBuildDirectoryTaskProducer, which already skips DSTROOT when DEPLOYMENT_LOCATION is off. 
Scope: Fixes case where build would error when DSTROOT was created outside of the build system.
Risk: Low
Original PR: https://github.com/swiftlang/swift-build/pull/1378
Testing: Added test to test suite and validated
Reviewers: @owenv 