### PR TITLE
[6.4] Initialize toolchain consistently for Linux/FreeBSD/OpenBSD compared to other platforms

### DIFF
--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -282,8 +282,8 @@ public final class Core: Sendable {
             case .swiftToolchain(let path, xcodeDeveloperPath: let xcodeDeveloperPath):
                 if hostOperatingSystem == .windows {
                     toolchainPaths.append(.init(path: path.join("Toolchains"), strict: true, type: .toolchainsDirectoryPath, aliases: ["default"]))
-                } else if !path.isRoot {
-                    toolchainPaths.append(.init(path: path, strict: false, type: .toolchainPath))
+                } else {
+                    toolchainPaths.append(.init(path: path, strict: false, type: .toolchainPath, aliases: ["default"]))
                 }
                 if let xcodeDeveloperPath {
                     toolchainPaths.append(.init(path: xcodeDeveloperPath.join("Toolchains"), strict: xcodeDeveloperPath.str.hasSuffix(".app/Contents/Developer"), type: .toolchainsDirectoryPath))

--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -16,11 +16,10 @@ import Foundation
 
 public let initializePlugin: PluginInitializationFunction = { manager in
     let plugin = GenericUnixPlugin()
-    manager.register(GenericUnixDeveloperDirectoryExtension(), type: DeveloperDirectoryExtensionPoint.self)
+    manager.register(GenericUnixDeveloperDirectoryExtension(plugin: plugin), type: DeveloperDirectoryExtensionPoint.self)
     manager.register(GenericUnixPlatformSpecsExtension(), type: SpecificationsExtensionPoint.self)
     manager.register(GenericUnixPlatformInfoExtension(), type: PlatformInfoExtensionPoint.self)
     manager.register(GenericUnixSDKRegistryExtension(plugin: plugin), type: SDKRegistryExtensionPoint.self)
-    manager.register(GenericUnixToolchainRegistryExtension(plugin: plugin), type: ToolchainRegistryExtensionPoint.self)
 }
 
 final class GenericUnixPlugin: Sendable {
@@ -50,13 +49,35 @@ struct SwiftTargetInfo: Decodable {
 }
 
 struct GenericUnixDeveloperDirectoryExtension: DeveloperDirectoryExtension {
+    let plugin: GenericUnixPlugin
+
     func fallbackDeveloperDirectory(hostOperatingSystem: OperatingSystem) async throws -> Core.DeveloperPath? {
         if hostOperatingSystem == .windows || hostOperatingSystem == .macOS {
             // Handled by the Windows and Apple plugins
             return nil
         }
 
-        return .swiftToolchain(.root, xcodeDeveloperPath: nil)
+        let fs = localFS
+        guard let swift = plugin.swiftExecutablePath(fs: fs) else {
+            return nil
+        }
+
+        let realSwiftPath = try fs.realpath(swift).dirname.normalize()
+        let hasUsrBin = realSwiftPath.str.hasSuffix("/usr/bin")
+        let hasUsrLocalBin = realSwiftPath.str.hasSuffix("/usr/local/bin")
+        let path: Path
+        switch (hasUsrBin, hasUsrLocalBin) {
+        case (true, false):
+            path = realSwiftPath.dirname.dirname
+        case (false, true):
+            path = realSwiftPath.dirname.dirname.dirname
+        case (false, false):
+            throw StubError.error("Unexpected toolchain layout for Swift installation path: \(realSwiftPath)")
+        case (true, true):
+            preconditionFailure()
+        }
+
+        return .swiftToolchain(path, xcodeDeveloperPath: nil)
     }
 }
 
@@ -235,51 +256,6 @@ struct GenericUnixSDKRegistryExtension: SDKRegistryExtension {
                 ]),
             ])
         }.compactMap { $0 }
-    }
-}
-
-struct GenericUnixToolchainRegistryExtension: ToolchainRegistryExtension {
-    let plugin: GenericUnixPlugin
-
-    func additionalToolchains(context: any ToolchainRegistryExtensionAdditionalToolchainsContext) async throws -> [Toolchain] {
-        let operatingSystem = context.hostOperatingSystem
-        let fs = context.fs
-        guard operatingSystem.createFallbackSystemToolchain, let swift = plugin.swiftExecutablePath(fs: fs) else {
-            return []
-        }
-
-        let realSwiftPath = try fs.realpath(swift).dirname.normalize()
-        let hasUsrBin = realSwiftPath.str.hasSuffix("/usr/bin")
-        let hasUsrLocalBin = realSwiftPath.str.hasSuffix("/usr/local/bin")
-        let path: Path
-        switch (hasUsrBin, hasUsrLocalBin) {
-        case (true, false):
-            path = realSwiftPath.dirname.dirname
-        case (false, true):
-            path = realSwiftPath.dirname.dirname.dirname
-        case (false, false):
-            throw StubError.error("Unexpected toolchain layout for Swift installation path: \(realSwiftPath)")
-        case (true, true):
-            preconditionFailure()
-        }
-        let llvmDirectories = try Array(fs.listdir(Path("/usr/lib")).filter { $0.hasPrefix("llvm-") }.sorted().reversed())
-        let llvmDirectoriesLocal = try Array(fs.listdir(Path("/usr/local")).filter { $0.hasPrefix("llvm") }.sorted().reversed())
-        return [
-            Toolchain(
-                identifier: ToolchainRegistry.defaultToolchainIdentifier,
-                displayName: "Default",
-                version: Version(),
-                aliases: ["default"],
-                path: path,
-                frameworkPaths: [],
-                libraryPaths: llvmDirectories.map { "/usr/lib/\($0)/lib" } + llvmDirectoriesLocal.map { "/usr/local/\($0)/lib" } + ["/usr/lib64"],
-                defaultSettings: [:],
-                overrideSettings: [:],
-                defaultSettingsWhenPrimary: [:],
-                executableSearchPaths: realSwiftPath.dirname.relativeSubpath(from: path).map { [path.join($0).join("bin")] } ?? [],
-                testingLibraryPlatformNames: [],
-                fs: fs)
-        ]
     }
 }
 

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -67,12 +67,48 @@ package struct MockCommandProducer: CommandProducer, Sendable {
                 paths.append(path.join("usr").join("bin"))
                 paths.append(path.join("usr").join("local").join("bin"))
             case .swiftToolchain(let path, xcodeDeveloperPath: let xcodeDeveloperPath):
-                paths.append(path.join("usr").join("bin"))
-                paths.append(path.join("usr").join("local").join("bin"))
+                if core.hostOperatingSystem != .windows {
+                    paths.append(path.join("usr").join("bin"))
+                    paths.append(path.join("usr").join("local").join("bin"))
+                }
                 if let xcodeDeveloperPath {
                     paths.append(xcodeDeveloperPath.join("usr").join("bin"))
                     paths.append(xcodeDeveloperPath.join("usr").join("local").join("bin"))
                 }
+            }
+            switch core.hostOperatingSystem {
+            case .macOS:
+                paths.append(contentsOf: [
+                    .root.join("usr").join("bin"),
+                    .root.join("bin"),
+                    .root.join("usr").join("sbin"),
+                    .root.join("sbin"),
+                ])
+            case .linux:
+                paths.append(contentsOf: [
+                    .root.join("usr").join("sbin"),
+                    .root.join("usr").join("bin"),
+                    .root.join("sbin"),
+                    .root.join("bin"),
+                ])
+            case .freebsd:
+                paths.append(contentsOf: [
+                    .root.join("sbin"),
+                    .root.join("bin"),
+                    .root.join("usr").join("sbin"),
+                    .root.join("usr").join("bin"),
+                ])
+            case .openbsd:
+                paths.append(contentsOf: [
+                    .root.join("bin"),
+                    .root.join("sbin"),
+                    .root.join("usr").join("bin"),
+                    .root.join("usr").join("sbin"),
+                ])
+            case .android:
+                paths.append(.root.join("system").join("bin"))
+            case .iOS, .tvOS, .watchOS, .visionOS, .windows, .unknown:
+                break
             }
         }
         self.executableSearchPaths = StackedSearchPath(paths: [Path](paths), fs: fs)

--- a/Tests/SWBCoreTests/CoreTests.swift
+++ b/Tests/SWBCoreTests/CoreTests.swift
@@ -30,7 +30,12 @@ import SWBServiceCore
         case .windows:
             XCTAssertMatch(core.developerPath.path.str, .suffix("\\AppData\\Local\\Programs\\Swift"))
         default:
-            #expect(core.developerPath.path.str == "/")
+            let fs = localFS
+            let swift = try #require([
+                Environment.current["SWIFT_EXEC"].map(Path.init),
+                StackedSearchPath(environment: .current, fs: fs).lookup(Path("swift"))
+            ].compactMap { $0 }.first(where: fs.exists))
+            #expect(core.developerPath.path.isAncestor(of: swift))
         }
     }
 
@@ -335,11 +340,11 @@ import SWBServiceCore
             let pluginManager = await MutablePluginManager(pluginLoadingFilter: { _ in true })
             await pluginManager.registerExtensionPoint(SpecificationsExtensionPoint())
             await pluginManager.register(BuiltinSpecsExtension(), type: SpecificationsExtensionPoint.self)
-            let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: .swiftToolchain(tmpDirPath, xcodeDeveloperPath: nil), buildServiceModTime: Date(), connectionMode: .inProcess)
+            let core = await Core.getInitializedCore(delegate, pluginManager: pluginManager, developerPath: nil, buildServiceModTime: Date(), connectionMode: .inProcess)
             #expect(core == nil)
 
             let results = CoreDelegateResults(delegate.diagnostics)
-            results.checkError(.prefix("missing required default toolchain"))
+            results.checkError(.equal("Could not determine path to developer directory because no extensions provided a fallback value"))
             results.checkNoDiagnostics()
         }
     }


### PR DESCRIPTION
Currently toolchain initialization can fail on Linux in a cryptic manner if `swift` is not in the PATH