### PR TITLE
Set Category for CLANG_ANALYZER_SECURITY_BUFFER_OVERFLOW_EXPERIMENTAL

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -4123,7 +4123,7 @@
                     );
                     NO = ();
                 };
-                // Category is hidden.
+                Category = SASecurityCheckers;
             },
             // Sanitizers should not be enabled while using the static analyzer.
             {


### PR DESCRIPTION
This setting wasn't showing up in the GUI because it had a hidden category.
rdar://176991801