### PR TITLE
[6.4] Do not strip object libraries

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -241,6 +241,11 @@ package final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskP
         let phaseEndTask = self.phaseEndTask
 
         context.addDeferredProducer {
+            // Skip stripping for object libraries (.objlib), which are directories containing object files, not single binaries
+            if scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "objectlib" {
+                return []
+            }
+
             guard let inputPath = self.context.producedBinary(forVariant: scope.evaluate(BuiltinMacros.CURRENT_VARIANT)) else { return [] }
 
             let input = FileToBuild(context: self.context, absolutePath: inputPath)

--- a/Tests/SWBTaskConstructionTests/ObjectLibraryTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ObjectLibraryTaskConstructionTests.swift
@@ -30,23 +30,25 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                     TestFile("b.c"),
                 ]),
             buildConfigurations: [
-                TestBuildConfiguration("Debug", buildSettings: [
-                    "PRODUCT_NAME": "$(TARGET_NAME)",
-                    "SWIFT_EXEC": try await swiftCompilerPath.str,
-                    "SWIFT_VERSION": try await swiftVersion
-                ]),
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_EXEC": try await swiftCompilerPath.str,
+                        "SWIFT_VERSION": try await swiftVersion,
+                    ])
             ],
             targets: [
                 TestStandardTarget(
                     "Library",
                     type: .objectLibrary,
                     buildConfigurations: [
-                        TestBuildConfiguration("Debug", buildSettings: [:]),
+                        TestBuildConfiguration("Debug", buildSettings: [:])
                     ],
                     buildPhases: [
-                        TestSourcesBuildPhase(["a.c", "b.c"]),
+                        TestSourcesBuildPhase(["a.c", "b.c"])
                     ]
-                ),
+                )
             ])
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
@@ -61,7 +63,7 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                     .suffix("a.o"),
                     .suffix("b.o"),
                     "--output",
-                    .suffix("Library.objlib")
+                    .suffix("Library.objlib"),
                 ])
                 task.checkInputs([
                     .pathPattern(.suffix("a.o")),
@@ -73,6 +75,63 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                     .pathPattern(.suffix("Library.objlib"))
                 ])
             }
+        }
+    }
+
+    @Test(
+        .requireSDKs(.host),
+        arguments: [
+            true,
+            false,
+        ],
+    )
+    func objectLibraryDoesNotProductStipTaskWhenBinaryStripInstalledProductSetOrUnset(
+        isStrippingEnabled: Bool,
+    ) async throws {
+        let buildConfiguration = "Debug"
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("a.c"),
+                    TestFile("b.c"),
+                ],
+            ),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    buildConfiguration,
+                    buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_EXEC": try await swiftCompilerPath.str,
+                        "SWIFT_VERSION": try await swiftVersion,
+                        "DEPLOYMENT_POSTPROCESSING": "YES",
+                        "STRIP_INSTALLED_PRODUCT": (isStrippingEnabled ? "YES" : "NO"),
+                    ],
+                ),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Library",
+                    type: .objectLibrary,
+                    buildConfigurations: [
+                        TestBuildConfiguration(buildConfiguration, buildSettings: [:]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["a.c", "b.c"]),
+                    ],
+                ),
+            ],
+        )
+        let core = try await getCore()
+        let tester: TaskConstructionTester = try TaskConstructionTester(core, testProject)
+
+        await tester.checkBuild(
+            BuildParameters(configuration: buildConfiguration, overrides: [:]),
+            runDestination: .host
+        ) { results in
+            results.checkNoDiagnostics()
+            results.checkNoTask(.matchRuleType("Strip"))
         }
     }
 
@@ -96,8 +155,8 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                                 "CODE_SIGNING_ALLOWED": "NO",
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "SWIFT_VERSION": try await swiftVersion,
-                                "SWIFT_EXEC": try await swiftCompilerPath.str
-                            ]),
+                                "SWIFT_EXEC": try await swiftCompilerPath.str,
+                            ])
                     ],
                     targets: [
                         TestStandardTarget(
@@ -105,14 +164,14 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                             type: .commandLineTool,
                             buildPhases: [
                                 TestSourcesBuildPhase([
-                                    "b.swift",
+                                    "b.swift"
                                 ]),
                                 TestFrameworksBuildPhase([
                                     "Library.objlib"
-                                ])
+                                ]),
                             ],
                             dependencies: [
-                                "Library",
+                                "Library"
                             ]
                         ),
                         TestStandardTarget(
@@ -120,8 +179,8 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                             type: .objectLibrary,
                             buildPhases: [
                                 TestSourcesBuildPhase([
-                                    "a.swift",
-                                ]),
+                                    "a.swift"
+                                ])
                             ]
                         ),
                     ])
@@ -148,7 +207,7 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                     groupTree: TestGroup(
                         "Sources",
                         children: [
-                            TestFile("a.swift"),
+                            TestFile("a.swift")
                         ]),
                     buildConfigurations: [
                         TestBuildConfiguration(
@@ -157,8 +216,8 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                                 "CODE_SIGNING_ALLOWED": "NO",
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "SWIFT_VERSION": try await swiftVersion,
-                                "SWIFT_EXEC": try await swiftCompilerPath.str
-                            ]),
+                                "SWIFT_EXEC": try await swiftCompilerPath.str,
+                            ])
                     ],
                     targets: [
                         TestStandardTarget(
@@ -174,7 +233,7 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                                 TestSourcesBuildPhase([]),
                             ],
                             dependencies: [
-                                "Library",
+                                "Library"
                             ]
                         ),
                         TestStandardTarget(
@@ -182,8 +241,8 @@ fileprivate struct ObjectLibraryTaskConstructionTests: CoreBasedTests {
                             type: .objectLibrary,
                             buildPhases: [
                                 TestSourcesBuildPhase([
-                                    "a.swift",
-                                ]),
+                                    "a.swift"
+                                ])
                             ]
                         ),
                     ])


### PR DESCRIPTION
A feature is being added to swift package manager in swiftlang/swift-package-manager#10038 to not strip binaries in release mode.  However, some package product object libraries on some platforms.

This change excludes stripping object libraries.

Relates to swiftlang/swift-package-manager#10037