### PR TITLE
[6.4] Replace all references to LockedValue with SWBMutex

### DIFF
--- a/Sources/SWBBuildService/BuildOperationMessages.swift
+++ b/Sources/SWBBuildService/BuildOperationMessages.swift
@@ -64,7 +64,7 @@ final class ActiveBuild: ActiveBuildOperation {
         }
 
         fileprivate unowned let activeBuild: ActiveBuild
-        var _cancelled: LockedValue<Bool> = .init(false)
+        let _cancelled: SWBMutex<Bool> = .init(false)
         var cancelled: Bool {
             _cancelled.withLock { $0 }
         }
@@ -612,7 +612,7 @@ private final class ObjectIDMapping<T> {
         }
     }
 
-    private var state: LockedValue<State> = .init(State())
+    private let state: SWBMutex<State> = .init(State())
 
     func takeID() -> Int {
         return state.withLock { state in
@@ -1036,7 +1036,7 @@ final class OperationDelegate: BuildOperationDelegate {
     }
 
     fileprivate unowned let activeBuild: ActiveBuild
-    private var activeTargets = LockedValue<[ConfiguredTarget.GUID: TargetInfo]>([:])
+    private let activeTargets = SWBMutex<[ConfiguredTarget.GUID: TargetInfo]>([:])
     fileprivate var activeTasks: ObjectIDMapping<any ExecutableTask> {
         activeBuild.activeTasks
     }

--- a/Sources/SWBBuildService/BuildService.swift
+++ b/Sources/SWBBuildService/BuildService.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 import SWBBuildSystem
 import SWBCore
 import SWBLibc
@@ -50,7 +51,7 @@ open class BuildService: Service, @unchecked Sendable {
     /// The map of registered sessions.
     var sessionMap = Dictionary<String, Session>()
 
-    private var lastBuildOperationID = LockedValue<Int>(0)
+    private let lastBuildOperationID = SWBMutex<Int>(0)
 
     /// The shared build manager.
     let buildManager = BuildManager()

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -19,6 +19,7 @@ import SWBTaskExecution
 package import SWBUtil
 import SWBMacro
 import Foundation
+import Synchronization
 
 // MARK: Core Dump Commands
 
@@ -532,7 +533,7 @@ private struct BuildCancelRequestMsg: MessageHandler {
 }
 
 package class InfoOperation {
-    private var isCancelled: LockedValue<Bool> = .init(false)
+    private let isCancelled: SWBMutex<Bool> = .init(false)
     package var cancelled: Bool { return isCancelled.withLock{$0} }
     package func cancel() {
         isCancelled.withLock{$0 = true}
@@ -543,12 +544,12 @@ package class InfoOperation {
         }
     }
 
-    private let tasks: LockedValue<[_Concurrency.Task<Void, Never>]> = .init([])
+    private let tasks: SWBMutex<[_Concurrency.Task<Void, Never>]> = .init([])
     package func addTask(_ task: _Concurrency.Task<Void, Never>) {
         tasks.withLock { $0.append(task) }
     }
 
-    private static let lastID: LockedValue<Int> = .init(0)
+    private static let lastID: SWBMutex<Int> = .init(0)
     package let id: Int
 
     package let diagnosticContext: DiagnosticContextData

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -31,6 +31,7 @@ package import struct SWBProtocol.TargetDependencyRelationship
 package import struct SWBProtocol.BuildOperationMetrics
 private import SWBLLBuild
 package import SWBMacro
+import Synchronization
 
 /// Delegate protocol used to communicate build operation results and status.
 package protocol BuildOperationDelegate {
@@ -1405,7 +1406,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
         return operation.userPreferences
     }
 
-    private let dynamicTasks: LockedValue<[TaskIdentifier: SWBTaskExecution.Task]> = .init([:])
+    private let dynamicTasks: SWBMutex<[TaskIdentifier: SWBTaskExecution.Task]> = .init([:])
 
     /// Serial queue used to order interactions with the operation delegate.
     fileprivate let queue: SWBQueue

--- a/Sources/SWBCAS/ToolchainCASPlugin.swift
+++ b/Sources/SWBCAS/ToolchainCASPlugin.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SWBCSupport
+import Synchronization
 public import SWBUtil
 
 public final class ToolchainCASPlugin: Sendable {
@@ -265,7 +266,7 @@ fileprivate final class ContextBox<T, E: Error> {
 }
 
 fileprivate final class CancellationHandler: Sendable {
-    private let state: LockedValue<UnsafeSendableBox<(cancelled: Bool, cancellationToken: llcas_cancellable_t?)>>
+    private let state: SWBMutex<UnsafeSendableBox<(cancelled: Bool, cancellationToken: llcas_cancellable_t?)>>
     private let api: plugin_api_t
 
     init(api: plugin_api_t) {

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -18,6 +18,7 @@ public import SWBCAS
 public import SWBServiceCore
 import SWBMacro
 import SWBProtocol
+import Synchronization
 
 /// Delegate protocol used to parameterize creation of a `Core` object and to report diagnostics.
 public protocol CoreDelegate: DiagnosticProducingDelegate, Sendable {
@@ -412,7 +413,7 @@ public final class Core: Sendable {
         }
     }
 
-    private let casPlugin: LockedValue<ToolchainCASPlugin?> = .init(nil)
+    private let casPlugin: SWBMutex<ToolchainCASPlugin?> = .init(nil)
     public func lookupCASPlugin() -> ToolchainCASPlugin? {
         return casPlugin.withLock { casPlugin in
             if casPlugin == nil {

--- a/Sources/SWBMacro/MacroNamespace.swift
+++ b/Sources/SWBMacro/MacroNamespace.swift
@@ -26,7 +26,7 @@ public final class MacroNamespace: CustomDebugStringConvertible, Encodable, Send
     let parentNamespace: MacroNamespace?
 
     /// Maps macro names to declarations.  Each declaration is of one of the concrete subclasses of MacroDeclaration, based on its type.
-    private let macroRegistry = LockedValue<Dictionary<String,MacroDeclaration>>([:])
+    private let macroRegistry = SWBMutex<Dictionary<String,MacroDeclaration>>([:])
 
     private enum CodingKeys: String, CodingKey {
         case parentNamespace
@@ -146,7 +146,7 @@ public final class MacroNamespace: CustomDebugStringConvertible, Encodable, Send
     }
 
     /// Maps condition parameter names to condition parameters.  Each declaration is an instance of MacroConditionParameter.
-    private let conditionParameters = LockedValue<Dictionary<String,MacroConditionParameter>>([:])
+    private let conditionParameters = SWBMutex<Dictionary<String,MacroConditionParameter>>([:])
 
     /// Looks up and returns the macro condition parameter that's associated with 'name', if any.  The name is not allowed to be the empty string.
     public func lookupConditionParameter(_ name: String) -> MacroConditionParameter? {

--- a/Sources/SWBServiceCore/ServiceHostConnection.swift
+++ b/Sources/SWBServiceCore/ServiceHostConnection.swift
@@ -13,6 +13,7 @@
 import SWBLibc
 import SWBUtil
 import Foundation
+import Synchronization
 
 #if canImport(System)
 import System
@@ -44,7 +45,7 @@ final class ServiceHostConnection: @unchecked Sendable {
     var handler: (UInt64, [UInt8]) async -> Void = { (_, _) in }
 
     /// Whether the queue is suspended.
-    private let isSuspended = LockedValue(true)
+    private let isSuspended = SWBMutex(true)
 
     /// The queue used to send outgoing messages.
     private let sendQueue: SWBQueue

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -719,7 +719,7 @@ package final class BuildDescriptionManager: Sendable {
 
 /// The delegate for planning BuildSystem compatible tasks.
 private final class BuildSystemTaskPlanningDelegate: TaskPlanningDelegate {
-    private let diagnosticsEngines = LockedValue<[ConfiguredTarget?: DiagnosticsEngine]>([:])
+    private let diagnosticsEngines = SWBMutex<[ConfiguredTarget?: DiagnosticsEngine]>([:])
 
     /// Queue for synchronizing access to shared state.
     let queue: SWBQueue

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 package import SWBCore
 package import SWBUtil
 
@@ -342,11 +343,11 @@ package final class ClangModuleDependencyGraph {
 
         let fileDeps: DependencyScanner.FileDependencies
         let scanningCommandLine = [compiler] + originalFileArgs
-        let modulesCallbackErrors = LockedValue<[any Error]>([])
-        let dependencyPaths = LockedValue<[Path]>([])
-        let includeTrees = LockedValue<[String]>([])
-        let cacheKeys = LockedValue<[String]>([])
-        let requiredTargetDependencies = LockedValue<Set<ScanResult.RequiredDependency>>([])
+        let modulesCallbackErrors = SWBMutex<[any Error]>([])
+        let dependencyPaths = SWBMutex<[Path]>([])
+        let includeTrees = SWBMutex<[String]>([])
+        let cacheKeys = SWBMutex<[String]>([])
+        let requiredTargetDependencies = SWBMutex<Set<ScanResult.RequiredDependency>>([])
         do {
             fileDeps = try clangWithScanner.scanner.scanDependencies(
                 commandLine: scanningCommandLine,

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingDataPruner.swift
@@ -15,6 +15,7 @@ import SWBProtocol
 package import SWBUtil
 package import SWBCAS
 import Foundation
+import Synchronization
 
 package struct ClangCachingPruneDataTaskKey: Hashable, Serializable, CustomDebugStringConvertible, Sendable {
     let path: Path
@@ -57,7 +58,7 @@ package final class CompilationCachingDataPruner: Sendable {
         var pendingActions: Int = 0
     }
 
-    private let state: LockedValue<State> = .init(State())
+    private let state: SWBMutex<State> = .init(State())
 
     deinit {
         precondition(state.withLock { $0.pendingActions } == 0)

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/CompilationCachingUploader.swift
@@ -14,6 +14,7 @@ package import SWBCore
 import SWBProtocol
 import SWBUtil
 import Foundation
+import Synchronization
 
 #if canImport(os)
 import os
@@ -32,21 +33,24 @@ import os
 package final class CompilationCachingUploader {
     private let group: SWBDispatchGroup = .init()
 
-    private let lock: Lock = .init()
-    private var uploadedKeys: Set<String> = []
-    private var pendingUploads: Int = 0
+    private struct State {
+        var uploadedKeys: Set<String> = []
+        var pendingUploads: Int = 0
+    }
+
+    private let lock = SWBMutex(State())
 
     deinit {
-        precondition(pendingUploads == 0)
+        precondition(lock.withLock { $0.pendingUploads } == 0)
     }
 
     private func startedUpload() {
         group.enter()
-        lock.withLock { pendingUploads += 1 }
+        lock.withLock { $0.pendingUploads += 1 }
     }
 
     private func finishedUpload() {
-        lock.withLock { pendingUploads -= 1 }
+        lock.withLock { $0.pendingUploads -= 1 }
         group.leave()
     }
 
@@ -61,7 +65,7 @@ package final class CompilationCachingUploader {
         enableStrictCASErrors: Bool,
         activityReporter: any ActivityReporter
     ) {
-        let inserted = lock.withLock { uploadedKeys.insert(cacheKey).inserted }
+        let inserted = lock.withLock { $0.uploadedKeys.insert(cacheKey).inserted }
         guard inserted else {
             return // already uploaded
         }
@@ -119,7 +123,7 @@ package final class CompilationCachingUploader {
         enableStrictCASErrors: Bool,
         activityReporter: any ActivityReporter
     ) {
-        let inserted = lock.withLock { uploadedKeys.insert(cacheKey).inserted }
+        let inserted = lock.withLock { $0.uploadedKeys.insert(cacheKey).inserted }
         guard inserted else {
             return // already uploaded
         }

--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -12,6 +12,7 @@
 
 import struct Foundation.Date
 import class Foundation.ProcessInfo
+import Synchronization
 
 package import Testing
 
@@ -1800,7 +1801,7 @@ private final class BuildOperationTesterDelegate: BuildOperationDelegate {
 
     private class TesterBuildOutputDelegate: BuildOutputDelegate {
         private let delegate: BuildOperationTesterDelegate
-        private var _diagnosticsEngines = LockedValue<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
+        private let _diagnosticsEngines = SWBMutex<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
 
         init(delegate: BuildOperationTesterDelegate) {
             self.delegate = delegate

--- a/Sources/SWBTestSupport/TargetBuildGraphTestSupport.swift
+++ b/Sources/SWBTestSupport/TargetBuildGraphTestSupport.swift
@@ -13,13 +13,14 @@
 package import SWBCore
 package import SWBUtil
 package import Testing
+import Synchronization
 
 /// An empty delegate implementation.
 package final class EmptyTargetDependencyResolverDelegate: TargetDependencyResolverDelegate, Sendable {
     package let diagnosticContext: DiagnosticContextData
 
     package let workspace: Workspace
-    private let diagnosticsEngines = LockedValue<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
+    private let diagnosticsEngines = SWBMutex<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
 
     package init(workspace: Workspace) {
         self.workspace = workspace

--- a/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
@@ -58,7 +58,7 @@ package final class MockTestBuildDescriptionConstructionDelegate: BuildDescripti
 
     package func buildDescriptionCreated(_ buildDescriptionID: BuildDescriptionID) {}
 
-    private let diagnosticsEngines = LockedValue<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
+    private let diagnosticsEngines = SWBMutex<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
 
     /// - parameter forPerf: Pass `true` if this delegate is for a performance test.  This will skip recording the manifest to the delegate, as that could take significant time.
     package init(forPerf: Bool = false) {

--- a/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskPlanningTestSupport.swift
@@ -236,7 +236,7 @@ open class MockTestTaskPlanningClientDelegate: TaskPlanningClientDelegate, @unch
 }
 
 package class TestTaskPlanningDelegate: TaskPlanningDelegate, @unchecked Sendable {
-    private let _diagnosticsEngines = LockedValue<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
+    private let _diagnosticsEngines = SWBMutex<[ConfiguredTarget?: DiagnosticsEngine]>(.init())
 
     private let queue = SWBQueue(label: "SWBTestSupport.TestTaskPlanningDelegate.queue", qos: UserDefaults.defaultRequestQoS)
 

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -12,6 +12,7 @@
 
 import class Foundation.Bundle
 import class Foundation.ProcessInfo
+import Synchronization
 
 package import SWBCore
 package import SWBProtocol
@@ -57,7 +58,7 @@ extension TestInternalItem {
     }
 }
 
-private let _nextGuidIdentifier = LockedValue(1)
+private let _nextGuidIdentifier = SWBMutex(1)
 private func nextGuidIdentifier() -> String {
     return _nextGuidIdentifier.withLock { value in
         defer { value += 1 }

--- a/Sources/SWBUtil/Dispatch+Async.swift
+++ b/Sources/SWBUtil/Dispatch+Async.swift
@@ -14,6 +14,7 @@
 // In the long term, these ideally all go away.
 
 import Foundation
+import Synchronization
 
 /// Runs an async function and synchronously waits for the response.
 /// - warning: This function is extremely dangerous because it blocks the calling thread and may lead to deadlock, and should only be used as a temporary transitional aid.
@@ -24,7 +25,7 @@ public func runAsyncAndBlock<T: Sendable, E>(_ block: @Sendable @escaping () asy
             assertionFailure("This function should not be invoked from the Swift Concurrency thread pool as it may lead to deadlock via thread starvation.")
         }
     }
-    let result: LockedValue<Result<T, E>?> = .init(nil)
+    let result: SWBMutex<Result<T, E>?> = .init(nil)
     let sema: SWBDispatchSemaphore? = Thread.isMainThread ? nil : SWBDispatchSemaphore(value: 0)
     Task<Void, Never> {
         let value = await Result.catching { () throws(E) -> T in try await block() }
@@ -38,7 +39,7 @@ public func runAsyncAndBlock<T: Sendable, E>(_ block: @Sendable @escaping () asy
             RunLoop.current.run(until: Date())
         }
     }
-    return try result.value!.get()
+    return try result.withLock { r throws(E) -> T in try r!.get() }
 }
 
 extension DispatchFD {

--- a/Sources/SWBUtil/HeavyCache.swift
+++ b/Sources/SWBUtil/HeavyCache.swift
@@ -22,8 +22,20 @@ private protocol _HeavyCacheBase: AnyObject {
     func removeAll()
 }
 
+private final class CopyableWrapper<T>: Sendable {
+    let value: SWBMutex<T>
+
+    init(_ value: consuming sending T) {
+        self.value = SWBMutex<T>(value)
+    }
+
+    public borrowing func withLock<Result: ~Copyable, E: Error>(_ body: (inout sending T) throws(E) -> sending Result) throws(E) -> sending Result {
+        try value.withLock(body)
+    }
+}
+
 /// All heavy-weight caches are available as a global, to support mass eviction.
-@TaskLocal private var allHeavyCaches = LockedValue<[WeakRef<any _HeavyCacheBase>]>([])
+@TaskLocal private var allHeavyCaches = CopyableWrapper<[WeakRef<any _HeavyCacheBase>]>([])
 
 // MARK: Global Operations
 
@@ -325,7 +337,7 @@ public final class HeavyCache<Key: Hashable & Sendable, Value: Sendable>: _Heavy
         }
     }
 
-    private let _preventExpirationLock = Lock()
+    private let _preventExpirationLock = SWBMutex<Void>(())
     private var _expirationWaiters: [CheckedContinuation<Void, Never>] = []
     private var _currentTimeTestingOverride: HeavyCacheClock.Instant?
 
@@ -353,7 +365,7 @@ extension HeavyCache {
     }
 
     /// Performs the given body while preventing TTL-based cache expiration.
-    @_spi(Testing) public func preventExpiration(_ body: @Sendable () throws -> Void) rethrows {
+    @_spi(Testing) public func preventExpiration(_ body: @Sendable () throws -> sending Void) rethrows {
         try _preventExpirationLock.withLock(body)
     }
 }

--- a/Sources/SWBUtil/LazyCache.swift
+++ b/Sources/SWBUtil/LazyCache.swift
@@ -67,7 +67,7 @@ public final class Lazy<T: Sendable>: Sendable {
 /// Wrapper for thread-safe lazily computed values.
 public final class LazyCache<Class, T: Sendable>: Sendable {
     private let body: @Sendable (Class) -> T
-    private let cachedValue = LockedValue<T?>(nil)
+    private let cachedValue = SWBMutex<T?>(nil)
 
     public init(body: @escaping @Sendable (Class) -> T) {
         self.body = body
@@ -89,7 +89,7 @@ public final class LazyCache<Class, T: Sendable>: Sendable {
 /// Wrapper for thread-safe lazily computed key-value pairs.
 public final class LazyKeyValueCache<Class, Key: Hashable & Sendable, Value: Sendable> {
     private let body: @Sendable (Class, Key) -> Value
-    private let cachedValues = LockedValue<[Key: Value]>([:])
+    private let cachedValues = SWBMutex<[Key: Value]>([:])
 
     public init(body: @escaping @Sendable (Class, Key) -> Value) {
         self.body = body

--- a/Sources/SWBUtil/Lock.swift
+++ b/Sources/SWBUtil/Lock.swift
@@ -10,81 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(os)
-public import os
-#elseif os(Windows)
-public import WinSDK
-#else
-public import SWBLibc
-#endif
+public import Synchronization
 
-// FIXME: Replace the contents of this file with the Swift standard library's Mutex type once it's available everywhere we deploy.
+#if canImport(Darwin)
+public import os
 
 /// A more efficient lock than a DispatchQueue (esp. under contention).
-#if canImport(os)
 public typealias Lock = OSAllocatedUnfairLock
-#else
-public final class Lock: @unchecked Sendable {
-    #if os(Windows)
-    @usableFromInline
-    let mutex: UnsafeMutablePointer<SRWLOCK> = UnsafeMutablePointer.allocate(capacity: 1)
-    #elseif os(FreeBSD) || os(OpenBSD)
-    @usableFromInline
-    let mutex: UnsafeMutablePointer<pthread_mutex_t?> = UnsafeMutablePointer.allocate(capacity: 1)
-    #else
-    @usableFromInline
-    let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
-    #endif
-
-    public init() {
-        #if os(Windows)
-        InitializeSRWLock(self.mutex)
-        #else
-        let err = pthread_mutex_init(self.mutex, nil)
-        precondition(err == 0)
-        #endif
-    }
-
-    deinit {
-        #if os(Windows)
-        // SRWLOCK does not need to be freed
-        #else
-        let err = pthread_mutex_destroy(self.mutex)
-        precondition(err == 0)
-        #endif
-        mutex.deallocate()
-    }
-
-    @usableFromInline
-    func lock() {
-        #if os(Windows)
-        AcquireSRWLockExclusive(self.mutex)
-        #else
-        let err = pthread_mutex_lock(self.mutex)
-        precondition(err == 0)
-        #endif
-    }
-
-    @usableFromInline
-    func unlock() {
-        #if os(Windows)
-        ReleaseSRWLockExclusive(self.mutex)
-        #else
-        let err = pthread_mutex_unlock(self.mutex)
-        precondition(err == 0)
-        #endif
-    }
-
-    @inlinable
-    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        self.lock()
-        defer {
-            self.unlock()
-        }
-        return try body()
-    }
-}
-#endif
 
 /// Small wrapper to provide only locked access to its value.
 /// Be aware that it's not possible to share this lock for multiple data
@@ -110,18 +42,6 @@ extension LockedValue where Value: ~Copyable {
 extension LockedValue: @unchecked Sendable where Value: ~Copyable {
 }
 
-extension LockedValue where Value: Sendable {
-    /// Sets the value of the wrapped value to `newValue` and returns the original value.
-    public func exchange(_ newValue: Value) -> Value {
-        withLock {
-            let old = $0
-            $0 = newValue
-            return old
-        }
-    }
-}
-
-#if canImport(Darwin)
 @available(macOS, deprecated: 15.0, renamed: "Synchronization.Mutex")
 @available(iOS, deprecated: 18.0, renamed: "Synchronization.Mutex")
 @available(tvOS, deprecated: 18.0, renamed: "Synchronization.Mutex")
@@ -129,12 +49,22 @@ extension LockedValue where Value: Sendable {
 @available(visionOS, deprecated: 2.0, renamed: "Synchronization.Mutex")
 public typealias SWBMutex = LockedValue
 #else
-public import Synchronization
 public typealias SWBMutex = Mutex
 #endif
 
 extension SWBMutex where Value: ~Copyable, Value == Void {
     public borrowing func withLock<Result: ~Copyable, E: Error>(_ body: () throws(E) -> sending Result) throws(E) -> sending Result {
         try withLock { _ throws(E) -> sending Result in return try body() }
+    }
+}
+
+extension SWBMutex where Value: Sendable {
+    /// Sets the value of the wrapped value to `newValue` and returns the original value.
+    public func exchange(_ newValue: Value) -> Value {
+        withLock {
+            let old = $0
+            $0 = newValue
+            return old
+        }
     }
 }

--- a/Sources/SWBUtil/NamedTemporaryDirectory.swift
+++ b/Sources/SWBUtil/NamedTemporaryDirectory.swift
@@ -12,6 +12,7 @@
 
 import SWBLibc
 import Foundation
+import Synchronization
 
 /// This type encapsulates an individual named temporary directory which can optionally be removed when no longer used.
 public final class NamedTemporaryDirectory: Sendable {
@@ -25,7 +26,7 @@ public final class NamedTemporaryDirectory: Sendable {
     private let rootPath: Path
 
     /// Whether the directory should be deleted when the struct goes out of scope.
-    private let delete: LockedValue<Bool>
+    private let delete: SWBMutex<Bool>
 
     /// Create a new named temporary directory.
     /// - remark: This is not a safe API to use if you cannot guarantee the lifetime of of the instance you are tracking. If possible, it is better to use the `withTemporaryDirectory()` function to ensure proper lifetime handling.

--- a/Sources/SWBUtil/Promise.swift
+++ b/Sources/SWBUtil/Promise.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Synchronization
+
 /// Represents a placeholder for a value which will be provided by synchronous code running in another execution context.
 public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
     private struct State {
@@ -17,11 +19,11 @@ public final class Promise<Success: Sendable, Failure: Swift.Error>: Sendable {
         var value: Result<Success, Failure>?
     }
 
-    private let state: LockedValue<State>
+    private let state: SWBMutex<State>
 
     /// Creates a new promise in the unfulfilled state.
     public init() {
-        state = LockedValue(State(value: nil))
+        state = SWBMutex(State(value: nil))
     }
 
     deinit {

--- a/Sources/SWBUtil/Statistics.swift
+++ b/Sources/SWBUtil/Statistics.swift
@@ -17,7 +17,7 @@ public final class StatisticsGroup: Sendable {
     /// The name for this group.
     public let name: String
 
-    private let _statistics = LockedValue<[any _StatisticBackend]>([])
+    private let _statistics = SWBMutex<[any _StatisticBackend]>([])
 
     /// The list of statistics in the group.
     public var statistics: [any _StatisticBackend] { return _statistics.withLock { $0 } }

--- a/Sources/SwiftBuild/SWBBuildOperation.swift
+++ b/Sources/SwiftBuild/SWBBuildOperation.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import Foundation
+import Synchronization
 
 import SWBProtocol
 import SWBUtil
@@ -51,7 +52,7 @@ public final class SWBBuildOperation: Sendable {
     /// The identifier of the build.
     private var buildID: Int? = nil
 
-    private let lockedState: LockedValue<SWBBuildOperationState>
+    private let lockedState: SWBMutex<SWBBuildOperationState>
 
     /// The state of the operation.
     public private(set) var state: SWBBuildOperationState {

--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -15,6 +15,7 @@ import SWBProtocol
 import SWBUtil
 
 public import Foundation
+import Synchronization
 
 #if canImport(System)
 import System
@@ -27,10 +28,10 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
 /// Represents and manages a connection to an Swift Build service subprocess.  Clients do not normally talk directly to the connection; instead, they almost always go through a SWBBuildService object, which provides higher-level operations.  The connection doesn’t know about the service-specific semantics, but instead provides general machinery for sending synchronous and asynchronous messages over one or more muxed communication “channels”, and for controlling the subprocess.
 @_spi(Testing) public final class SWBBuildServiceConnection: @unchecked Sendable {
     /// Whether the connection is suspended.
-    private let _isSuspended = LockedValue(true)
+    private let _isSuspended = SWBMutex(true)
 
     /// Whether the connection has been closed.
-    private let _isClosed = LockedValue(false)
+    private let _isClosed = SWBMutex(false)
 
     /// Our synchronization queue, on which dispatch I/O and other blocks are run.
     private let _queue = SWBQueue(label: "SWBBuildServiceConnection.queue", autoreleaseFrequency: .workItem)
@@ -59,7 +60,7 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
     }
 
     /// An "unfair lock" that protects the channels state.  Should be held only for very short periods of time.
-    private let channelState = LockedValue<ChannelState>(.init())
+    private let channelState = SWBMutex<ChannelState>(.init())
 
     /// Absolute path to the dyld-loaded dylib binary that contains this class.
     fileprivate class var swiftbuildDylibPath: Path {
@@ -668,7 +669,7 @@ fileprivate final class InProcessStaticConnection: ConnectionTransport {
     private let stdoutPipe: IOPipe
     private let serviceBundleURL: URL?
     private let done = WaitCondition()
-    private let _state: LockedValue<SWBBuildServiceConnection.State> = .init(.running)
+    private let _state: SWBMutex<SWBBuildServiceConnection.State> = .init(.running)
     private let startFunc: @Sendable (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void
 
     init(serviceBundleURL: URL?, stdinPipe: IOPipe, stdoutPipe: IOPipe, startFunc: @Sendable @escaping (Int32, Int32, URL?, @Sendable @escaping ((any Error)?) -> Void) -> Void) throws {
@@ -741,7 +742,7 @@ fileprivate final class InProcessConnection: ConnectionTransport {
     private let stdinPipe: IOPipe
     private let stdoutPipe: IOPipe
     private let done = WaitCondition()
-    private let _state: LockedValue<SWBBuildServiceConnection.State> = .init(.running)
+    private let _state: SWBMutex<SWBBuildServiceConnection.State> = .init(.running)
 
     init(variant: SWBBuildServiceVariant, serviceBundleURL: URL?, stdinPipe: IOPipe, stdoutPipe: IOPipe) throws {
         self.variant = variant

--- a/Sources/SwiftBuild/SWBBuildServiceConsole.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConsole.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 
 import SWBProtocol
 import SWBUtil
@@ -229,7 +230,7 @@ open class SWBBuildServiceConsole: @unchecked Sendable {
 }
 
 public final class SWBServiceConsoleCommandRegistry: Sendable {
-    private static let commandClasses = LockedValue<[String: any SWBServiceConsoleCommand.Type]>([:])
+    private static let commandClasses = SWBMutex<[String: any SWBServiceConsoleCommand.Type]>([:])
 
     public static func registerCommandClass(_ type: any SWBServiceConsoleCommand.Type) {
         commandClasses.withLock { commandClasses in

--- a/Sources/SwiftBuild/SWBBuildServiceSession.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceSession.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 
 import SWBProtocol
 import SWBUtil
@@ -117,7 +118,7 @@ public final class SWBBuildServiceSession: Sendable {
 
     private let sessionResourceTracker = SessionResourceTracker()
 
-    private let closed = LockedValue(false)
+    private let closed = SWBMutex(false)
 
     init(name: String, uid: String, service: SWBBuildService) {
         // Check parameters.

--- a/Sources/SwiftBuildTestSupport/TestBuildOperationDelegate.swift
+++ b/Sources/SwiftBuildTestSupport/TestBuildOperationDelegate.swift
@@ -13,10 +13,11 @@
 package import SWBUtil
 package import SwiftBuild
 import SWBTestSupport
+package import Synchronization
 
 package final class TestBuildOperationDelegate: SWBPlanningOperationDelegate, SWBDocumentationDelegate, SWBLocalizationDelegate, SWBIndexingDelegate, SWBPreviewDelegate {
     /// The number of provisioning task input requests.
-    package let numProvisioningTaskInputRequests = LockedValue(0)
+    package let numProvisioningTaskInputRequests = SWBMutex(0)
 
     package init() {
     }

--- a/Sources/SwiftBuildTestSupport/TestUtilities.swift
+++ b/Sources/SwiftBuildTestSupport/TestUtilities.swift
@@ -13,6 +13,7 @@
 package import class Foundation.Bundle
 package import struct Foundation.OperatingSystemVersion
 package import struct Foundation.URL
+import Synchronization
 
 import Testing
 
@@ -100,7 +101,7 @@ package actor TestSWBSession {
     /// - Returns: The signatures of all objects which were transferred.
     package func sendPIFIncrementally(_ testWorkspace: TestWorkspace, auditWorkspace: TestWorkspace? = nil, file: StaticString = #filePath, line: UInt = #line) async throws -> [String] {
         // Build a map of all the objects.
-        let objects = LockedValue<[String: PropertyListItem]>([:])
+        let objects = SWBMutex<[String: PropertyListItem]>([:])
         let pifObjects = try testWorkspace.toObjects()
         for object in pifObjects {
             guard let signature = object.dictValue?["signature"]?.stringValue else {
@@ -111,7 +112,7 @@ package actor TestSWBSession {
 
         let auditPifObjects = try auditWorkspace?.toObjects()
 
-        let transferredSignatures = LockedValue<[String]>([])
+        let transferredSignatures = SWBMutex<[String]>([])
         do {
             // Send the workspace context.
             try await session.sendPIF(workspaceSignature: testWorkspace.signature, auditPIF: (auditPifObjects?.propertyListItem).map { try .init($0) }) { (objectType, signature) async throws -> SWBPropertyListItem in

--- a/Tests/SWBUtilTests/StaticTests.swift
+++ b/Tests/SWBUtilTests/StaticTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 import Testing
 public import SWBUtil
 
@@ -21,7 +22,7 @@ extension Int: StaticStorable {
 @Suite fileprivate struct StaticTests {
     @Test
     func basic() {
-        let numConstructCalls = LockedValue(0)
+        let numConstructCalls = SWBMutex(0)
 
         func foo() -> Int {
             return Static {

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 import Testing
 
 @_spi(Testing) import SwiftBuild

--- a/Tests/SwiftBuildTests/PIFTests.swift
+++ b/Tests/SwiftBuildTests/PIFTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 import Testing
 import SwiftBuild
 import SwiftBuildTestSupport
@@ -33,7 +34,7 @@ fileprivate struct PIFTests {
                 }
 
                 // Send a bad PIF.
-                let lookups = LockedValue<[(SwiftBuildServicePIFObjectType, String)]>([])
+                let lookups = SWBMutex<[(SwiftBuildServicePIFObjectType, String)]>([])
                 @Sendable func lookup(_ type: SwiftBuildServicePIFObjectType, _ signature: String) async throws -> SWBPropertyListItem {
                     lookups.withLock { $0.append((type, signature)) }
                     return .plArray([])
@@ -288,7 +289,7 @@ fileprivate struct PIFTests {
         ]
 
         // Send the initial PIF.
-        let lookups = LockedValue<[String]>([])
+        let lookups = SWBMutex<[String]>([])
         let lookupObject: LookupObject = { @Sendable (type, signature) async throws in
             lookups.withLock {
                 $0.append(signature)
@@ -349,7 +350,7 @@ fileprivate struct PIFTests {
                     await service.close()
                 }
 
-                let lookups = LockedValue<[String]>([])
+                let lookups = SWBMutex<[String]>([])
                 let lookupObject: LookupObject = { (type, signature) async throws in
                     lookups.withLock { $0.append(signature) }
                     switch type {


### PR DESCRIPTION
On Darwin this is a no-op since they are typealiased. On other platforms this moves clients to sit on top of the stdlib implementation rather than Swift Build's polyfill. This preps the codebase for removing the polyfill and standardizing on Mutex on all platforms in the main branch targeting the next Swift release.