### PR TITLE
Pass IPI Clang module names to the Swift compiler

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -616,6 +616,7 @@ public struct DiscoveredSwiftCompilerToolSpecInfo: DiscoveredCommandLineToolSpec
         case emitLocalizedStrings = "emit-localized-strings"
         case libraryLevel = "library-level"
         case packageName = "package-name-if-supported"
+        case ipiClangModule = "ipi-clang-module"
         case vfsDirectoryRemap = "vfs-directory-remap"
         case indexUnitOutputPath = "index-unit-output-path"
         case indexUnitOutputPathWithoutWarning = "no-warn-superfluous-index-unit-path"
@@ -1621,6 +1622,22 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             if toolSpecInfo.toolFeatures.has(.libraryLevel),
                let libraryLevel = cbc.scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).nilIfEmpty {
                 args += ["-library-level", libraryLevel]
+            }
+
+            let ipiNames = cbc.producer.ipiClangModuleNames
+            if !ipiNames.isEmpty && cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL) {
+                if LibSwiftDriver.supportsDriverFlag(spelled: "-ipi-clang-module") {
+                    // Driver knows the option; let it forward to the frontend.
+                    for name in ipiNames {
+                        args += ["-ipi-clang-module", name]
+                    }
+                } else if toolSpecInfo.toolFeatures.has(.ipiClangModule) {
+                    // Older driver that doesn't recognise the option, but the
+                    // frontend supports it. Pass it through directly.
+                    for name in ipiNames {
+                        args += ["-Xfrontend", "-ipi-clang-module", "-Xfrontend", name]
+                    }
+                }
             }
 
             if toolSpecInfo.toolFeatures.has(.packageName),

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -210,6 +210,11 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     /// The module info for the target, if available.
     var moduleInfo: ModuleInfo? { get }
 
+    /// The names of Clang modules in this target's transitive dependency closure that should
+    /// be treated as IPI (project-internal), and thus passed to the Swift compiler via
+    /// `-ipi-clang-module`.
+    var ipiClangModuleNames: [String] { get }
+
     /// Whether or not the build is using a VFS.
     var needsVFS: Bool { get }
 
@@ -284,6 +289,11 @@ extension CommandProducer {
     /// Whether the current context is targeting an Apple platform, based on the target triple's vendor being "apple".
     public var isApplePlatform: Bool {
         sdkVariant?.llvmTargetTripleVendor == "apple"
+    }
+
+    /// By default, no Clang modules are treated as IPI.
+    public var ipiClangModuleNames: [String] {
+        []
     }
 
     package func discoveredCommandLineToolSpecInfo<T: DiscoveredCommandLineToolSpecInfo>(_ delegate: any CoreClientTargetDiagnosticProducingDelegate, _ toolName: String, _ path: Path, _ process: @Sendable (_ contents: Data) async throws -> any DiscoveredCommandLineToolSpecInfo) async throws -> T {

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -100,6 +100,11 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
     /// Maps each target to its artifactbundles (direct and transitive).
     package private(set) var artifactBundlesByTarget: [ConfiguredTarget: [ArtifactBundleInfo]]
 
+    /// For each consumer target, the names of Clang modules in its transitive deps that should
+    /// be treated as IPI — a dep with `SKIP_INSTALL=YES` and a `MODULEMAP_FILE` resolving to a
+    /// path under any `SRCROOT` in the closure.
+    package private(set) var ipiClangModuleNamesByTarget: [ConfiguredTarget: [String]]
+
     /// All targets in the product plan.
     /// - remark: This property is preferred over the `TargetBuildGraph` in the `BuildPlanRequest` as it performs additional computations for Swift packages.
     package private(set) var allTargets: [ConfiguredTarget] = []
@@ -241,6 +246,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
         // Perform post-processing analysis of the build graph
         self.clientsOfBundlesByTarget = Self.computeBundleClients(buildGraph: planRequest.buildGraph, buildRequestContext: planRequest.buildRequestContext)
         self.artifactBundlesByTarget = await Self.computeArtifactBundleInfo(buildGraph: planRequest.buildGraph, provisioningInputs: planRequest.provisioningInputs, buildRequest: planRequest.buildRequest, buildRequestContext: planRequest.buildRequestContext, workspaceContext: planRequest.workspaceContext, getLinkageGraph: getLinkageGraph, metadataCache: self.artifactBundleMetadataCache, delegate: delegate)
+        self.ipiClangModuleNamesByTarget = Self.computeIPIClangInfo(buildGraph: planRequest.buildGraph, buildRequestContext: planRequest.buildRequestContext, workspaceContext: planRequest.workspaceContext)
         let directlyLinkedDependenciesByTarget: [ConfiguredTarget: OrderedSet<LinkedDependency>]
         (self.impartedBuildPropertiesByTarget, directlyLinkedDependenciesByTarget) = await Self.computeImpartedBuildProperties(planRequest: planRequest, getLinkageGraph: getLinkageGraph, delegate: delegate)
         self.mergeableTargetsToMergingTargets = Self.computeMergeableLibraries(buildGraph: planRequest.buildGraph, provisioningInputs: planRequest.provisioningInputs, buildRequestContext: planRequest.buildRequestContext)
@@ -604,6 +610,128 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
             }
         }
         return (impartedBuildPropertiesByTarget, directlyLinkedDependenciesByTarget)
+    }
+
+    /// Compute, per consumer target, the Clang module names to treat as IPI.
+    /// A target-produced Clang module qualifies when the target has `SKIP_INSTALL=YES` and a
+    /// `MODULEMAP_FILE` whose resolved path lies under some `SRCROOT` in the consumer's
+    /// transitive dependency closure (including the consumer's own `SRCROOT`).
+    private static func computeIPIClangInfo(buildGraph: TargetBuildGraph, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext) -> [ConfiguredTarget: [String]] {
+        // Target-local info, computed once per target. None of these depend on which
+        // consumer pulls the target into its closure, no need to be recomputed per consumer
+        struct TargetIPIInfo {
+            let resolvedSrcroot: Path?       // realpath-resolved SRCROOT, for building consumer srcroot sets
+            let producesClangModule: Bool
+            let skipInstall: Bool
+            let resolvedModulemapDir: Path?  // realpath-resolved dir of MODULEMAP_FILE, nil if none
+            let moduleNames: [String]        // populated only for targets that could qualify
+        }
+        // Precomputing the expensive per-target info (computeModuleInfo, realpath, macro evaluations)
+        var ipiInfoByTarget: [ConfiguredTarget: TargetIPIInfo] = [:]
+        for target in buildGraph.allTargets {
+            let settings = buildRequestContext.getCachedSettings(target.parameters, target: target.target)
+            let scope = settings.globalScope
+            let srcroot = scope.evaluate(BuiltinMacros.SRCROOT)
+            let resolvedSrcroot: Path? = srcroot.isEmpty ? nil : ((try? localFS.realpath(srcroot)) ?? srcroot)
+            // Must produce a Clang module
+            let definesModule = scope.evaluate(BuiltinMacros.DEFINES_MODULE)
+            let modulemapFile = scope.evaluate(BuiltinMacros.MODULEMAP_FILE)
+            let modulemapContents = scope.evaluate(BuiltinMacros.MODULEMAP_FILE_CONTENTS)
+            let producesClangModule = definesModule || !modulemapFile.isEmpty || !modulemapContents.isEmpty
+            let skipInstall = scope.evaluate(BuiltinMacros.SKIP_INSTALL)
+            let resolvedModulemapDir: Path? = {
+                guard !modulemapFile.isEmpty else { return nil }
+                let modulemapPath = Path(modulemapFile).isAbsolute
+                    ? Path(modulemapFile)
+                    : srcroot.join(modulemapFile)
+                // Resolve symlinks via the parent directory — the modulemap file itself may not
+                // exist yet during planning, but its parent directory should.
+                return (try? localFS.realpath(modulemapPath.dirname)) ?? modulemapPath.dirname
+            }()
+            // Pre-filtering, run name computation for targets that could qualify as IPI.
+            var moduleNames: [String] = []
+            if producesClangModule && (skipInstall || resolvedModulemapDir != nil) {
+                // Prefer the centralized Clang module name(s) from `ModuleInfo`, which is the single
+                // source of truth and will inherit any future modulemap parsing.
+                let moduleInfo = computeModuleInfo(workspaceContext: workspaceContext, target: target.target, settings: settings, diagnosticHandler: { _, _, _, _ in })
+                let knownNames = moduleInfo?.knownClangModuleNames ?? []
+                if !knownNames.isEmpty {
+                    moduleNames = knownNames
+                } else {
+                    // Fall back to $(PRODUCT_MODULE_NAME) when the module name isn't known.
+                    // The case for hand-authored modulemaps, which `computeModuleInfo` doesn't yet parse.
+                    // NOTE: this can be wrong — a hand-authored MODULEMAP_FILE / MODULEMAP_FILE_CONTENTS
+                    // may declare a differently-named module (or several), so the emitted name might
+                    // not match the actual module.
+                    // Once `computeModuleInfo` parses modulemaps this fallback (and the inaccuracy) goes away.
+                    let name = scope.evaluate(BuiltinMacros.PRODUCT_MODULE_NAME)
+                    if !name.isEmpty {
+                        moduleNames = [name]
+                    }
+                }
+            }
+            ipiInfoByTarget[target] = TargetIPIInfo(
+                resolvedSrcroot: resolvedSrcroot,
+                producesClangModule: producesClangModule,
+                skipInstall: skipInstall,
+                resolvedModulemapDir: resolvedModulemapDir,
+                moduleNames: moduleNames)
+        }
+        // Aggregate each target's closure by folding over `buildGraph.allTargets`, which the
+        // resolver provides in dependency-first topological order: by the time we reach a target,
+        // each of its dependencies already holds its full aggregate, so we just union those in.
+        var srcrootsByTarget: [ConfiguredTarget: Set<Path>] = [:]
+        var skipNamesByTarget: [ConfiguredTarget: Set<String>] = [:]
+        var candidatesByTarget: [ConfiguredTarget: [Path: Set<String>]] = [:]
+        for target in buildGraph.allTargets {
+            guard let info = ipiInfoByTarget[target] else { continue }
+            // The target's own contribution.
+            var srcroots: Set<Path> = []
+            if let root = info.resolvedSrcroot {
+                srcroots.insert(root)
+            }
+            var skipNames: Set<String> = []
+            var candidates: [Path: Set<String>] = [:]
+            if info.producesClangModule {
+                if info.skipInstall {
+                    skipNames.formUnion(info.moduleNames)
+                }
+                if let dir = info.resolvedModulemapDir {
+                    candidates[dir, default: []].formUnion(info.moduleNames)
+                }
+            }
+            // Fold in each dependency's already-computed aggregate.
+            for dependency in buildGraph.dependencies(of: target) {
+                if let depSrcroots = srcrootsByTarget[dependency] {
+                    srcroots.formUnion(depSrcroots)
+                }
+                if let depSkipNames = skipNamesByTarget[dependency] {
+                    skipNames.formUnion(depSkipNames)
+                }
+                if let depCandidates = candidatesByTarget[dependency] {
+                    for (dir, names) in depCandidates {
+                        candidates[dir, default: []].formUnion(names)
+                    }
+                }
+            }
+            srcrootsByTarget[target] = srcroots
+            skipNamesByTarget[target] = skipNames
+            candidatesByTarget[target] = candidates
+        }
+
+        // Apply the consumer-specific modulemap qualification against each consumer's folded srcroots.
+        var namesByTarget: [ConfiguredTarget: [String]] = [:]
+        for configuredTarget in buildGraph.allTargets {
+            let srcroots = srcrootsByTarget[configuredTarget] ?? []
+            var names = skipNamesByTarget[configuredTarget] ?? []
+            for (dir, candidateNames) in candidatesByTarget[configuredTarget] ?? [:] {
+                if srcroots.contains(where: { $0.isAncestorOrEqual(of: dir) }) {
+                    names.formUnion(candidateNames)
+                }
+            }
+            namesByTarget[configuredTarget] = names.sorted()
+        }
+        return namesByTarget
     }
 
     /// Determine which target produced each product in the build.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -1263,6 +1263,11 @@ extension TaskProducerContext: CommandProducer {
         return globalProductPlan.getModuleInfo(configuredTarget!)
     }
 
+    public var ipiClangModuleNames: [String] {
+        guard let configuredTarget else { return [] }
+        return globalProductPlan.ipiClangModuleNamesByTarget[configuredTarget] ?? []
+    }
+
     public var userPreferences: UserPreferences {
         workspaceContext.userPreferences
     }

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4166,6 +4166,627 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    // Test -ipi-clang-module emission for a Clang IPI (SKIP_INSTALL=YES + MODULEMAP_FILE under SRCROOT).
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleBasic() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                        TestFile("InternalHelpers.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("MainLib.swift"),
+                            ]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "InternalHelpers.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "InternalHelpers"])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module is NOT emitted when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is unset (default NO),
+    // even when a dep matches the IPI heuristic (SKIP_INSTALL=YES + MODULEMAP_FILE under SRCROOT).
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleDisabledByDefault() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                        TestFile("InternalHelpers.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("MainLib.swift"),
+                            ]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "InternalHelpers.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineDoesNotContain("-ipi-clang-module")
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module emission follows transitive deps: A → B → C where C is the Clang IPI module.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleTransitive() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("A.swift"),
+                        TestFile("B.swift"),
+                        TestFile("C.h"),
+                        TestFile("C.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "A",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("A.swift")]),
+                        ],
+                        dependencies: ["B"]),
+                    TestStandardTarget(
+                        "B",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("B.swift")]),
+                        ],
+                        dependencies: ["C"]),
+                    TestStandardTarget(
+                        "C",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "C.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("C.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("A") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "C"])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module emits multiple names in alphabetical order regardless of dep declaration order.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleAlphabeticalOrder() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("Foo.h"),
+                        TestFile("Foo.modulemap"),
+                        TestFile("Bar.h"),
+                        TestFile("Bar.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["Foo", "Bar"]),
+                    TestStandardTarget(
+                        "Foo",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "Foo.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("Foo.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                    TestStandardTarget(
+                        "Bar",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "Bar.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("Bar.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        // Bar before Foo, regardless of declaration order.
+                        task.checkCommandLineContains([
+                            "-ipi-clang-module", "Bar", "-ipi-clang-module", "Foo",
+                        ])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module emission works across projects: consumer in project A, IPI dep in project B.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleCrossProject() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let project1 = try await TestProject(
+                "ProjectOne",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                ])
+
+            let project2 = TestProject(
+                "ProjectTwo",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("InternalHelpers.h"),
+                        TestFile("InternalHelpers.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "InternalHelpers.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let testWorkspace = TestWorkspace("Test", sourceRoot: tmpDir, projects: [project1, project2])
+            let tester = try await TaskConstructionTester(getCore(), testWorkspace)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "InternalHelpers"])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module IS emitted when a dep's MODULEMAP_FILE is under SRCROOT even without
+    // SKIP_INSTALL=YES. A modulemap committed to the project source tree is project-internal.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleSrcRootCondition() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                        TestFile("InternalHelpers.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "NO",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "InternalHelpers.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "InternalHelpers"])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module IS emitted for a dep with SKIP_INSTALL=YES and an auto-generated modulemap
+    // (DEFINES_MODULE=YES but no MODULEMAP_FILE). The SKIP_INSTALL condition covers this case regardless
+    // of where the modulemap lives.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleAutoGenerated() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                                // No MODULEMAP_FILE — modulemap is auto-generated into DERIVED_FILE_DIR.
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "InternalHelpers"])
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module is NOT emitted when SKIP_INSTALL is NO and the modulemap is outside SRCROOT —
+    // neither IPI condition is satisfied.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleNeitherCondition() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            // Modulemap path lives outside the project's SRCROOT (under tmpDir but NOT under srcRoot).
+            let externalModulemap = tmpDir.join("external").join("InternalHelpers.modulemap")
+
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "NO",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": externalModulemap.str,
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineDoesNotContain("-ipi-clang-module")
+                    }
+                }
+            }
+        }
+    }
+
+    // Test -ipi-clang-module emission works when MODULEMAP_FILE is an absolute path through a symlink
+    // to SRCROOT. The canonical location is under SRCROOT, but the path string goes through a symlink.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleSymlink() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            // Create tmpDir/srcroot-symlink → tmpDir/srcroot.
+            // SRCROOT is the real path; MODULEMAP_FILE references the same location via the symlink.
+            let srcRootSymlink = tmpDir.join("srcroot-symlink")
+            try localFS.createDirectory(srcRoot, recursive: true)
+            try localFS.symlink(srcRootSymlink, target: srcRoot)
+
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("InternalHelpers.h"),
+                        TestFile("InternalHelpers.modulemap"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["InternalHelpers"]),
+                    TestStandardTarget(
+                        "InternalHelpers",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "NO",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": srcRootSymlink.join("InternalHelpers.modulemap").str,
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("InternalHelpers.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkTarget("MainLib") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-ipi-clang-module", "InternalHelpers"])
+                    }
+                }
+            }
+        }
+    }
+
     @Test(.skipHostOS(.macOS), .skipHostOS(.windows), .requireSDKs(.host))
     func autolinkExtract() async throws {
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
When a Swift target is compiled, swift-build now computes which Clang modules in its transitive dependency closure should be treated as IPI (project-internal) and passes their names via frontend flags.

The SKIP_INSTALL condition covers target-produced modules including auto-generated modulemaps. The SRCROOT condition covers explicit modulemaps committed to a project's source tree regardless of SKIP_INSTALL.

rdar://177010683
