### PR TITLE
[ssaf] Integrate SSAF entity linker tool with swift-build

### DIFF
--- a/Sources/SWBApplePlatform/EntityLinkerTool.swift
+++ b/Sources/SWBApplePlatform/EntityLinkerTool.swift
@@ -23,7 +23,7 @@ public final class EntityLinkerToolSpec: GenericCommandLineToolSpec, SpecIdentif
     }
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
-        let toolPath = self.resolveExecutablePath(producer, Path("entity-linker"))
+        let toolPath = self.resolveExecutablePath(producer, Path("clang-ssaf-linker"))
 
         do {
             return try await DiscoveredEntityLinkerToolSpecInfo.parseProjectNameAndSourceVersionStyleVersionInfo(producer, delegate, commandLine: [toolPath.str, "version"]) { versionInfo in

--- a/Sources/SWBApplePlatform/EntityLinkerTool.swift
+++ b/Sources/SWBApplePlatform/EntityLinkerTool.swift
@@ -1,0 +1,37 @@
+//
+//  EntityLinkerTool.swift
+//  xcbuild
+//
+//  Copyright © 2026 Apple Inc. All rights reserved.
+//
+
+import Foundation
+public import SWBUtil
+public import SWBCore
+public import SWBMacro
+
+
+public final class EntityLinkerToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
+    public static let identifier = "com.apple.build-tools.entity-linker"
+    required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
+        super.init(parser, basedOnSpec)
+    }
+
+    public struct DiscoveredEntityLinkerToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
+        public let toolPath: Path
+        public var toolVersion: Version?
+    }
+
+    override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
+        let toolPath = self.resolveExecutablePath(producer, Path("entity-linker"))
+
+        do {
+            return try await DiscoveredEntityLinkerToolSpecInfo.parseProjectNameAndSourceVersionStyleVersionInfo(producer, delegate, commandLine: [toolPath.str, "version"]) { versionInfo in
+                DiscoveredEntityLinkerToolSpecInfo(toolPath: toolPath, toolVersion: versionInfo.version)
+            }
+        } catch {
+            delegate.error(error)
+            return nil
+        }
+    }
+}

--- a/Sources/SWBApplePlatform/EntityLinkerTool.swift
+++ b/Sources/SWBApplePlatform/EntityLinkerTool.swift
@@ -17,7 +17,7 @@ public import SWBMacro
 
 
 public final class EntityLinkerToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
-    public static let identifier = "com.apple.build-tools.entity-linker"
+    public static let identifier = "com.apple.build-tools.clang-ssaf-linker"
     required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         super.init(parser, basedOnSpec)
     }

--- a/Sources/SWBApplePlatform/EntityLinkerTool.swift
+++ b/Sources/SWBApplePlatform/EntityLinkerTool.swift
@@ -1,9 +1,14 @@
+//===----------------------------------------------------------------------===//
 //
-//  EntityLinkerTool.swift
-//  xcbuild
+// This source file is part of the Swift open source project
 //
-//  Copyright © 2026 Apple Inc. All rights reserved.
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 import Foundation
 public import SWBUtil

--- a/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
@@ -3,10 +3,10 @@
     {
         Type = Compiler;
         Identifier = com.apple.build-tools.entity-linker;
-        ExecPath = "entity-linker";
+        ExecPath = "clang-ssaf-linker";
         Name = "Entity Linking Tool";
         Description = "Links entity files emitted from compiler";
-        CommandLine = "/Users/admin/clang-internal-extract-summaries/build-xcode/bin/clang-ssaf-linker [inputs] -o $(OutputPath)";
+        CommandLine = "clang-ssaf-linker [inputs] -o $(OutputPath)";
         RuleName = "LinkEntity $(OutputPath)";
         ExecDescription = "Concatenating Summary files";
         ProgressDescription = "Linking $(OutputPath)";

--- a/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
@@ -1,0 +1,19 @@
+// Copyright © 2026 Apple Inc.  All rights reserved.  CONFIDENTIAL AND PROPRIETARY.
+(
+    {
+        Type = Compiler;
+        Identifier = com.apple.build-tools.entity-linker;
+        ExecPath = "entity-linker";
+        Name = "Entity Linking Tool";
+        Description = "Links entity files emitted from compiler";
+        CommandLine = "/Users/admin/clang-internal-extract-summaries/build-xcode/bin/clang-ssaf-linker [inputs] -o $(OutputPath)";
+        RuleName = "LinkEntity $(OutputPath)";
+        ExecDescription = "Concatenating Summary files";
+        ProgressDescription = "Linking $(OutputPath)";
+        InputFileTypes = ();
+        CommandOutputParser = XCGenericCommandOutputParser;
+        InputFileGroupings = ();
+        SynthesizeBuildRule = YES;
+        IsArchitectureNeutral = NO;
+    }
+)

--- a/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
@@ -13,7 +13,7 @@
 (
     {
         Type = Compiler;
-        Identifier = com.apple.build-tools.entity-linker;
+        Identifier = com.apple.build-tools.clang-ssaf-linker;
         ExecPath = "clang-ssaf-linker";
         Name = "Entity Linking Tool";
         Description = "Links entity files emitted from compiler";

--- a/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/EntityLinker.xcspec
@@ -1,4 +1,15 @@
-// Copyright © 2026 Apple Inc.  All rights reserved.  CONFIDENTIAL AND PROPRIETARY.
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 (
     {
         Type = Compiler;

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1355,7 +1355,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
         if cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true {
             let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
-            let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".json")
+            let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".ssaf-tu.json")
             commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-tu-summary-file=\(jsonPath.str)"]
             extraOutputs.append(delegate.createNode(jsonPath))
         }

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -149,6 +149,8 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     /// The Clang static analyzer tool spec to use.
     var clangStaticAnalyzerSpec: ClangCompilerSpec { get }
 
+    var entityLinkerToolSpec: CommandLineToolSpec { get }
+
     /// The Clang modules verifier tool spec to use.
     var clangModuleVerifierSpec: ClangCompilerSpec { get }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -992,13 +992,13 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }
 
                 if scope.evaluate(BuiltinMacros.INVOKE_SSAF) {
+                    // Collect only the JSON sidecars that clang actually planned as task outputs.
+                    let ssafInputs = perArchTasks.flatMap { $0.outputs }
+                        .filter { $0.path.fileExtension == "json" }
+                        .map { FileToBuild(context: context, absolutePath: $0.path) }
                     await appendGeneratedTasks(&perArchTasks) { delegate in
                         let output = Path(binaryOutput.str + ".linked-summaries.json")
-                        let inputs = linkerInputNodes.map { node -> FileToBuild in
-                            let jsonPath = node.path.dirname.join(node.path.basenameWithoutSuffix + ".json")
-                            return FileToBuild(context: context, absolutePath: jsonPath)
-                        }
-                        await context.entityLinkerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: inputs, output: output), delegate)
+                        await context.entityLinkerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: ssafInputs, output: output), delegate)
                     }
                 }
 

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -991,6 +991,17 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     }
                 }
 
+                if scope.evaluate(BuiltinMacros.INVOKE_SSAF) {
+                    await appendGeneratedTasks(&perArchTasks) { delegate in
+                        let output = Path(binaryOutput.str + ".linked-summaries.json")
+                        let inputs = linkerInputNodes.map { node -> FileToBuild in
+                            let jsonPath = node.path.dirname.join(node.path.basenameWithoutSuffix + ".json")
+                            return FileToBuild(context: context, absolutePath: jsonPath)
+                        }
+                        await context.entityLinkerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: inputs, output: output), delegate)
+                    }
+                }
+
                 // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.
                 // FIXME: The implicitly means that if GENERATE_PRELINK_OBJECT_FILE is enabled then we will always try to link.  That's arguably not correct.
                 if !isForAPI && scope.evaluate(BuiltinMacros.GENERATE_PRELINK_OBJECT_FILE) {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -992,9 +992,9 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }
 
                 if scope.evaluate(BuiltinMacros.INVOKE_SSAF) {
-                    // Collect only the JSON sidecars that clang actually planned as task outputs.
+                    // Collect only the .ssaf-tu.json sidecars that clang actually planned as task outputs.
                     let ssafInputs = perArchTasks.flatMap { $0.outputs }
-                        .filter { $0.path.fileExtension == "json" }
+                        .filter { $0.path.str.hasSuffix(".ssaf-tu.json") }
                         .map { FileToBuild(context: context, absolutePath: $0.path) }
                     await appendGeneratedTasks(&perArchTasks) { delegate in
                         let output = Path(binaryOutput.str + ".linked-summaries.json")

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -233,6 +233,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     public let clangAssemblerSpec: ClangCompilerSpec
     public let clangPreprocessorSpec: ClangCompilerSpec
     public let clangStaticAnalyzerSpec: ClangCompilerSpec
+    public let entityLinkerToolSpec: CommandLineToolSpec
     public let clangModuleVerifierSpec: ClangCompilerSpec
     private let _clangStatCacheSpec: Result<ClangStatCacheSpec, any Error>
     var clangStatCacheSpec: ClangStatCacheSpec? { return specForResult(_clangStatCacheSpec) }
@@ -356,6 +357,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.clangAssemblerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangAssemblerSpec.self)
         self.clangPreprocessorSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
+        self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.entity-linker", domain: domain, ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
         self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }
         self.codesignSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain, ofType: CodesignToolSpec.self)

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -357,7 +357,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.clangAssemblerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangAssemblerSpec.self)
         self.clangPreprocessorSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
-        self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.entity-linker", domain: domain, ofType: CommandLineToolSpec.self)
+        self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-linker", domain: domain, ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
         self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }
         self.codesignSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain, ofType: CodesignToolSpec.self)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -91,6 +91,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.clangAssemblerSpec = try getSpec(ofType: ClangAssemblerSpec.self)
         self.clangPreprocessorSpec = try getSpec(ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
+        self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.entity-linker", ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
         self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
         self.stripSpec = try getSpec("com.apple.build-tools.strip", ofType: StripToolSpec.self)
@@ -127,6 +128,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package let clangAssemblerSpec: ClangCompilerSpec
     package let clangPreprocessorSpec: ClangCompilerSpec
     package let clangStaticAnalyzerSpec: ClangCompilerSpec
+    package let entityLinkerToolSpec: CommandLineToolSpec
     package let clangModuleVerifierSpec: ClangCompilerSpec
     package let diffSpec: CommandLineToolSpec
     package let stripSpec: StripToolSpec

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -91,7 +91,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.clangAssemblerSpec = try getSpec(ofType: ClangAssemblerSpec.self)
         self.clangPreprocessorSpec = try getSpec(ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
-        self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.entity-linker", ofType: CommandLineToolSpec.self)
+        self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-linker", ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
         self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
         self.stripSpec = try getSpec("com.apple.build-tools.strip", ofType: StripToolSpec.self)

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -444,16 +444,16 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
             try await tester.checkBuild(runDestination: .host) { results in
                 try results.checkTask(.matchRuleType("CompileC")) { task throws in
                     let objectPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".o") })
-                    let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".json").str
+                    let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
                     task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
 
                     let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
                     #expect(!jsonBytes.isEmpty)
                 }
-                // The entity linker should receive File1.json as input and produce a .linked-summaries.json file.
+                // The entity linker should receive File1.ssaf-tu.json as input and produce a .linked-summaries.json file.
                 try results.checkTask(.matchRuleType("LinkEntity")) { task throws in
-                    #expect(task.inputPaths.contains(where: { $0.str.hasSuffix("File1.json") }))
+                    #expect(task.inputPaths.contains(where: { $0.str.hasSuffix("File1.ssaf-tu.json") }))
                     let linkedSummaryPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".linked-summaries.json") })
                     #expect(tester.fs.exists(linkedSummaryPath))
                     let linkedSummaryBytes = try tester.fs.read(linkedSummaryPath)

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -451,6 +451,14 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
                     #expect(!jsonBytes.isEmpty)
                 }
+                // The entity linker should receive File1.json as input and produce a .linked-summaries.json file.
+                try results.checkTask(.matchRuleType("LinkEntity")) { task throws in
+                    #expect(task.inputPaths.contains(where: { $0.str.hasSuffix("File1.json") }))
+                    let linkedSummaryPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".linked-summaries.json") })
+                    #expect(tester.fs.exists(linkedSummaryPath))
+                    let linkedSummaryBytes = try tester.fs.read(linkedSummaryPath)
+                    #expect(!linkedSummaryBytes.isEmpty)
+                }
                 results.checkNoDiagnostics()
             }
         }
@@ -477,6 +485,7 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     task.checkCommandLineNoMatch([.prefix("--ssaf-extract-summaries=")])
                     task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
                 }
+                results.checkNoTask(.matchRuleType("LinkEntity"))
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -491,11 +491,22 @@ fileprivate struct ClangTests: CoreBasedTests {
                         Issue.record("No .o output found in CompileC task outputs")
                     }
                 }
+                // The entity linker task should receive the .json summary matching File1.c as input
+                // and produce a .linked-summaries.json output.
+                results.checkTask(.matchRuleType("LinkEntity")) { task in
+                    let jsonInputs = task.inputs.filter { $0.path.fileExtension == "json" }
+                    if let jsonInput = jsonInputs.first {
+                        #expect(jsonInput.path.basenameWithoutSuffix == "File1")
+                    } else {
+                        Issue.record("Expected File1.json as input to the LinkEntity task")
+                    }
+                    #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".linked-summaries.json") }))
+                }
                 results.checkNoDiagnostics()
             }
         }
 
-        // When INVOKE_SSAF is NO, neither ssaf flag is present.
+        // When INVOKE_SSAF is NO, neither ssaf flag is present and no entity linker task is created.
         do {
             let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "NO"))
             await tester.checkBuild(runDestination: .host) { results in
@@ -503,6 +514,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                     task.checkCommandLineNoMatch([.prefix("--ssaf-extract-summaries=")])
                     task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
                 }
+                results.checkNoTask(.matchRuleType("LinkEntity"))
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -477,28 +477,28 @@ fileprivate struct ClangTests: CoreBasedTests {
 
         let core = try await getCore()
 
-        // When INVOKE_SSAF is YES, the extract-summaries value and a .json summary file path are added.
-        // The summary file is co-located with the object file: same directory, same basename, .json extension.
+        // When INVOKE_SSAF is YES, the extract-summaries value and a .ssaf-tu.json summary file path are added.
+        // The summary file is co-located with the object file: same directory, same basename, .ssaf-tu.json extension.
         do {
             let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph"))
             await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC")) { task in
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
                     if let objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") }) {
-                        let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".json").str
+                        let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
                         task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
                     } else {
                         Issue.record("No .o output found in CompileC task outputs")
                     }
                 }
-                // The entity linker task should receive the .json summary matching File1.c as input
+                // The entity linker task should receive the .ssaf-tu.json summary matching File1.c as input
                 // and produce a .linked-summaries.json output.
                 results.checkTask(.matchRuleType("LinkEntity")) { task in
                     let jsonInputs = task.inputs.filter { $0.path.fileExtension == "json" }
                     if let jsonInput = jsonInputs.first {
-                        #expect(jsonInput.path.basenameWithoutSuffix == "File1")
+                        #expect(jsonInput.path.basenameWithoutSuffix == "File1.ssaf-tu")
                     } else {
-                        Issue.record("Expected File1.json as input to the LinkEntity task")
+                        Issue.record("Expected File1.ssaf-tu.json as input to the LinkEntity task")
                     }
                     #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".linked-summaries.json") }))
                 }


### PR DESCRIPTION
Add EntityLinkerToolSpec and EntityLinker.xcspec, wire entityLinkerToolSpec into the CommandProducer protocol and TaskProducerContext, and invoke it from SourcesTaskProducer when INVOKE_SSAF is enabled to link JSON summary files produced by the compiler into a single .linked-summaries.json output.
    
rdar://176927559