### PR TITLE
[6.4.x] Fix a missing deserialization case for PathOrderedSet macro declarations

### DIFF
--- a/Sources/SWBMacro/MacroValueAssignmentTable.swift
+++ b/Sources/SWBMacro/MacroValueAssignmentTable.swift
@@ -342,6 +342,7 @@ public struct MacroValueAssignmentTable: Serializable, Sendable {
                 case 3: decl = delegate.namespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, name)
                 case 4: decl = delegate.namespace.lookupOrDeclareMacro(PathMacroDeclaration.self, name)
                 case 5: decl = delegate.namespace.lookupOrDeclareMacro(PathListMacroDeclaration.self, name)
+                case 6: decl = delegate.namespace.lookupOrDeclareMacro(PathOrderedSetMacroDeclaration.self, name)
                 default: throw DeserializerError.deserializationFailed("Unrecognized code for MacroType for MacroDeclaration \(name): \(typeCode)")
                 }
             }


### PR DESCRIPTION
This is only used for pre-existing declarations today, but avoid future deserialization issues by handling this case properly.