### PR TITLE
[6.4] Fix architectures of test Windows run destination

### DIFF
--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -251,7 +251,7 @@ extension _RunDestinationInfo {
         guard let arch = Architecture.hostStringValue  else {
             preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
         }
-        return .init(platform: "windows", sdk: "windows", sdkVariant: "windows", targetArchitecture: arch, supportedArchitectures: ["x86_64, aarch64"], disableOnlyActiveArch: false)
+        return .init(platform: "windows", sdk: "windows", sdkVariant: "windows", targetArchitecture: arch, supportedArchitectures: ["x86_64", "aarch64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting Linux generic device, using the public SDK.


### PR DESCRIPTION
Fix a typo in the supported architectures list for the test Windows run destination. I'm actually a bit surprised this wasn't causing much test breakage in practice