### PR TITLE
[6.4] Fix unbalanced parens in settings contruction macro refs

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -742,7 +742,7 @@ public final class Settings: PlatformBuildContext, Sendable {
             supportsMacCatalystMacros.formUnion(sdkVariantInfoExtension.supportsMacCatalystMacroNames)
         }
 
-        return supportsMacCatalystMacros.contains { scope.evaluate(scope.namespace.parseString("$(\($0)")).boolValue } ||
+        return supportsMacCatalystMacros.contains { scope.evaluate(scope.namespace.parseString("$(\($0))")).boolValue } ||
             // For index build ensure zippered frameworks can be configured separately for both macOS and macCatalyst.
             (scope.evaluate(BuiltinMacros.IS_ZIPPERED) && scope.evaluate(BuiltinMacros.INDEX_ENABLE_BUILD_ARENA))
     }
@@ -2929,7 +2929,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         for sdkVariantInfoExtension in core.pluginManager.extensions(of: SDKVariantInfoExtensionPoint.self) {
             macCatalystDeriveBundleIDMacros.formUnion(sdkVariantInfoExtension.macCatalystDeriveBundleIDMacroNames)
         }
-        let wantsDerivedMacCatalystBundleId = macCatalystDeriveBundleIDMacros.contains { scope.evaluate(scope.namespace.parseString("$(\($0)")).boolValue }
+        let wantsDerivedMacCatalystBundleId = macCatalystDeriveBundleIDMacros.contains { scope.evaluate(scope.namespace.parseString("$(\($0))")).boolValue }
         if let sdkVariant, sdkVariant.isMacCatalyst {
             if wantsDerivedMacCatalystBundleId {
                 pushTable(.exported) { table in
@@ -3078,7 +3078,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             }
 
             for macro in disallowedMacCatalystMacros {
-                if scope.evaluate(scope.namespace.parseString("$(\(macro)")).boolValue {
+                if scope.evaluate(scope.namespace.parseString("$(\(macro))")).boolValue {
                     let message = "`\(macro)` is not supported. Remove the build setting and conditionalize `PRODUCT_BUNDLE_IDENTIFIER` instead."
                     if scope.evaluate(BuiltinMacros.__DIAGNOSE_DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER_ERROR) {
                         self.errors.append(message)

--- a/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
@@ -38,7 +38,7 @@ public final class PrelinkedObjectLinkSpec: CommandLineToolSpec, SpecImplementat
         if let sdk = cbc.producer.sdk, let sdkVersion = sdk.version {
             for buildPlatform in cbc.producer.targetBuildVersionPlatforms(in: cbc.scope)?.sorted() ?? [] {
                 let deploymentTargetSettingName = buildPlatform.deploymentTargetSettingName(infoLookup: cbc.producer)
-                if let minDeploymentTarget = cbc.scope.evaluate(cbc.scope.namespace.parseString("$(\(deploymentTargetSettingName)")).nilIfEmpty {
+                if let minDeploymentTarget = cbc.scope.evaluate(cbc.scope.namespace.parseString("$(\(deploymentTargetSettingName))")).nilIfEmpty {
                     let version: Version
                     if cbc.scope.evaluate(BuiltinMacros.IS_ZIPPERED) && buildPlatform == .macCatalyst {
                         guard let correspondingVersion = sdk.versionMap["macOS_iOSMac"]?[sdkVersion] else {


### PR DESCRIPTION
These happened to have the right behavior when parsed, but we really shouldn't rely on the parser to fix them up