### PR TITLE
[6.4 🍒] Fix IPI library-level derivation

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2199,11 +2199,10 @@ private class SettingsBuilder: ProjectMatchLookup {
                 Path("/System/iOSSupport/usr/lib"),]
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
-            if scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
+            if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL)
+                && scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
                 // Build-time / IPI module.
-                if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL) {
-                    table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "ipi")
-                }
+                table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "ipi")
             } else if privateInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
                 // SPI module.
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "spi")

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4062,6 +4062,16 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             task.checkCommandLineDoesNotContain("-library-level")
         }
 
+        // Don't infer "ipi" when IPI library level is disabled and if SKIP_INSTALL=NO.
+        // This is the corner case from rdar://176209013
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/System/Library/PrivateFrameworks/MyFramework",
+                                                             "SKIP_INSTALL"  : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "NO",
+                                                             "__KNOWN_SPI_INSTALL_PATHS" : "/System/Library/PrivateFrameworks"]) { task in
+            task.checkCommandLineContains(["-library-level", "spi"])
+        }
+
         // Explicit SWIFT_LIBRARY_LEVEL takes precedence over SKIP_INSTALL.
         try await checkLibraryLevelForConfig(targetType: .framework,
                                              buildSettings: ["SKIP_INSTALL" : "YES",


### PR DESCRIPTION
Explanation: In corner cases, when module is IPI (due to SKIP_INSTALL setting), but is still treated as SPI (while IPI library-level is not enabled), swift-build in the current state detects (correctly) the IPI module and just does not emit any flag. Instead, for backward-compatibility, it should skip IPI detection completely and proceed to SPI/API check
Scope: Fixes typechecking errors when module is IPI due to SKIP_INSTALL setting but is still treated as SPI
Risk: Low
Original PR: https://github.com/swiftlang/swift-build/pull/1393
Testing: Added test to test suite and validated
Reviewers: @owenv 