### PR TITLE
[6.4 🍒] Default PCM pruning to the target's toolchain libclang

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1666,9 +1666,16 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
             if let value = TimeInterval(targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_MODULES_PRUNE_INTERVAL)) {
                 pruneInterval = value
             }
-            let path = targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_EXPLICIT_MODULES_LIBCLANG_PATH)
-            if !path.isEmpty {
-                libclangPath = Path(path)
+            let configuredLibclangPath = targetSettings.globalScope.evaluate(BuiltinMacros.CLANG_EXPLICIT_MODULES_LIBCLANG_PATH)
+            if !configuredLibclangPath.isEmpty {
+                libclangPath = Path(configuredLibclangPath)
+            } else if libclangPath == nil {
+                for toolchain in targetSettings.toolchains {
+                    if let path = toolchain.librarySearchPaths.findLibrary(operatingSystem: core.hostOperatingSystem, basename: "clang") {
+                        libclangPath = path
+                        break
+                    }
+                }
             }
         }
 

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -987,7 +987,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                     try await tester.checkResults(events: events) { results in
                         results.checkNote(.equal("Building targets in dependency order"))
                         results.checkNoDiagnostics()
-                        results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs"])
+                        results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs", "PruneExplicitPrecompiledModules"])
                         results.checkTasks(.matchRuleType("ClangStatCache")) { _ in }
                         results.checkNoTask()
 
@@ -1009,7 +1009,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                     let events = try await testSession.runBuildOperation(request: request, delegate: TestBuildOperationDelegate())
 
                     try await tester.checkResults(events: events) { results in
-                        results.consumeTasksMatchingRuleTypes(["WriteAuxiliaryFile", "MkDir", "SymLink", "CreateBuildDirectory", "ClangStatCache"])
+                        results.consumeTasksMatchingRuleTypes(["WriteAuxiliaryFile", "MkDir", "SymLink", "CreateBuildDirectory", "ClangStatCache", "PruneExplicitPrecompiledModules"])
                         results.checkTask(.matchRule(["ComputeTargetDependencyGraph"])) { task in
                             #expect(task.executionDescription == "Compute target dependency graph")
                         }
@@ -1033,7 +1033,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                     let events = try await testSession.runBuildOperation(request: request, delegate: TestBuildOperationDelegate())
 
                     try await tester.checkResults(events: events) { results in
-                        results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs", "WriteAuxiliaryFile", "ClangStatCache", "ProcessInfoPlistFile", "CodeSign"])
+                        results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs", "WriteAuxiliaryFile", "ClangStatCache", "ProcessInfoPlistFile", "CodeSign", "PruneExplicitPrecompiledModules"])
                         results.checkNoTask()
 
                         results.checkNote(.equal("Building targets in dependency order"))


### PR DESCRIPTION
Explanation: Previously PCM pruning would only run if CLANG_EXPLICIT_MODULES_LIBCLANG_PATH was explicitly set. Now use the toolchain's libclang as backup
Scope: Pruning of pcms older than 4 days will happen by default now.
Risk: Medium
Original PR: https://github.com/swiftlang/swift-build/pull/1414
Testing:  Tests that require the libclang API are run and not skipped
Reviewers: @owenv