### PR TITLE
Ensure that the UILaunchScreen plist entry is an empty dictionary

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
@@ -843,7 +843,7 @@ public final class InfoPlistProcessorTaskAction: TaskAction
 
         if let launchScreenGenerationValue = valueForInfoPlistKeyMacro("UILaunchScreen_Generation") {
             if launchScreenGenerationValue == .plBool(true) {
-                content["UILaunchScreen"] = .plDict(["UILaunchScreen": .plDict([:])])
+                content["UILaunchScreen"] = .plDict([:])
             }
         }
 

--- a/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/InfoPlistProcessorTaskTests.swift
@@ -938,6 +938,19 @@ fileprivate struct InfoPlistProcessorTaskTests: CoreBasedTests {
         }
     }
 
+    /// `INFOPLIST_KEY_UILaunchScreen_Generation = YES` must synthesize a flat, empty
+    /// `UILaunchScreen` dictionary, not a nested one.
+    @Test(.requireSDKs(.iOS))
+    func processingInfoPlistWithLaunchScreenGeneration_iOS() async throws {
+        let scope = try createMockScope { namespace, table in
+            table.push(try #require(namespace.lookupMacroDeclaration("GENERATE_INFOPLIST_FILE") as? BooleanMacroDeclaration), literal: true)
+            table.push(try #require(namespace.lookupMacroDeclaration("INFOPLIST_KEY_UILaunchScreen_Generation") as? BooleanMacroDeclaration), literal: true)
+        }
+        try await createAndRunTaskAction(inputPlistData: [:], scope: scope, platformName: "iphoneos") { _, dict, _ in
+            #expect(dict["UILaunchScreen"]?.dictValue == [:])
+        }
+    }
+
     /// When processing an Info.plist configured to build for tvOS.
     @Test(.requireSDKs(.tvOS))
     func processingInfoPlistConfiguredForPlatform_tvOS() async throws {


### PR DESCRIPTION
Previously there was a nested dictionary for `UILaunchScreen` which seems to be incorrect. Ensure we only create a flat, empty dictionary and add a test for this.

After this change, instead of having a nested Info plist like:

```
    UILaunchScreen =     {
        UILaunchScreen =         {
        };
    };
```

It will be a flat list like:

```
UILaunchScreen = {};
```

Related: rdar://173729182

