### PR TITLE
Add support for "cohorts" of architectures which can be compiled and linked together.

### DIFF
--- a/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
+++ b/Sources/SWBApplePlatform/AppIntentsMetadataCompiler.swift
@@ -87,11 +87,11 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
         allInputs.append(delegate.createNode(binaryOutput))
 
         let effectivePlatformName = LocalizationBuildPortion.effectivePlatformName(scope: cbc.scope, sdkVariant: cbc.producer.sdkVariant)
-        let archs: [String] = cbc.scope.evaluate(BuiltinMacros.ARCHS)
+        let baseArchs: [String] = cbc.scope.evaluate(BuiltinMacros.ARCHS_BASE)
         let buildVariants = cbc.scope.evaluate(BuiltinMacros.BUILD_VARIANTS)
         var dependencyFiles = [String]()
         var stringDataFiles = [AppIntentsLocalizationPayload.StringsdataFile]()
-        var sourceFileListFiles = [String]()
+        var sourceFileListFiles = OrderedSet<String>()
         var swiftConstValuesFileListFiles = [String]()
         var metadataDependencyFileListFiles = [String]()
         var staticMetadataDependencyFileListFiles = [String]()
@@ -121,7 +121,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
         let isObject = cbc.scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_object"
         for variant in buildVariants {
             let scope = cbc.scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
-            for arch in archs {
+            for arch in baseArchs {
                 let scope = scope.subscopeBindingArchAndTriple(arch: arch)
                 let dependencyInfoFile = scope.evaluate(BuiltinMacros.LD_DEPENDENCY_INFO_FILE)
                 let libtoolDependencyInfo = scope.evaluate(BuiltinMacros.LIBTOOL_DEPENDENCY_INFO_FILE)
@@ -191,7 +191,7 @@ final public class AppIntentsMetadataCompilerSpec: GenericCommandLineToolSpec, S
                 }
                 return cbc.scope.table.namespace.parseLiteralString("NO")
             case BuiltinMacros.LM_SOURCE_FILE_LIST_PATH:
-                return cbc.scope.table.namespace.parseLiteralStringList(sourceFileListFiles)
+                return cbc.scope.table.namespace.parseLiteralStringList(sourceFileListFiles.elements)
             case BuiltinMacros.LM_SWIFT_CONST_VALS_LIST_PATH:
                 return cbc.scope.table.namespace.parseLiteralStringList(swiftConstValuesFileListFiles)
             case BuiltinMacros.LM_INTENTS_METADATA_FILES_LIST_PATH:

--- a/Sources/SWBCore/BuildRuleAction.swift
+++ b/Sources/SWBCore/BuildRuleAction.swift
@@ -41,6 +41,9 @@ public protocol BuildRuleAction: AnyObject, CustomStringConvertible, Sendable {
 
     /// The name of the build rule.
     var name: String { get }
+
+    /// Validate whether the rule should be used or skipped.
+    func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool
 }
 
 
@@ -86,6 +89,10 @@ public final class BuildRuleTaskAction: BuildRuleAction {
 
     public var description: String {
         return "<\(type(of: self)):\(toolSpec.identifier)>"
+    }
+
+    public func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        return toolSpec.validate(cbc: cbc, delegate: delegate)
     }
 }
 
@@ -155,5 +162,9 @@ public final class BuildRuleScriptAction: BuildRuleAction {
 
     public var description: String {
         return "<\(type(of: self)):\(interpreterPath):\(scriptSource)>"
+    }
+
+    public func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        return true
     }
 }

--- a/Sources/SWBCore/Core.swift
+++ b/Sources/SWBCore/Core.swift
@@ -731,21 +731,27 @@ extension PlatformInfoLookup {
 }
 
 extension Core: PlatformInfoLookup {
-    public func lookupPlatformInfo(platform buildPlatform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+    /// Returns a set of platform names (suitable for use as a domain for looking up up specifications) for the given build platform.
+    public func lookupPlatformNames(platform buildPlatform: BuildVersion.Platform) -> Set<String> {
         func sdkMatchesBuildPlatform(_ sdk: SDK) -> Bool {
             sdk.isBaseSDK && !sdk.variants.isEmpty && sdk.variants.values.contains(where: { sdk.targetBuildVersionPlatform(sdkVariant: $0) == buildPlatform }) && sdk.cohortPlatforms.isEmpty
         }
 
         // Find the platform name of all SDKs containing a variant whose platform ID matches our platform.
-        let platformNames: Set<String> = {
-            var platformNames = Set<String>()
-            for platform in platformRegistry.platforms {
-                for sdk in platform.sdks where sdkMatchesBuildPlatform(sdk) {
-                    platformNames.insert(platform.name)
-                }
+        var platformNames = Set<String>()
+        for platform in platformRegistry.platforms {
+            for sdk in platform.sdks where sdkMatchesBuildPlatform(sdk) {
+                platformNames.insert(platform.name)
             }
-            return platformNames
-        }()
+        }
+        return platformNames
+    }
+
+    /// Returns a `PlatformInfoProvider`, if one can be found, for the given build platform, by finding the appropriate SDK and locating the variant in the SDK which matches the build platform.
+    /// - remark: The returned object will *not* contain information suitable for use as a domain for looking up specifications.
+    public func lookupPlatformInfo(platform buildPlatform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+        // Find the platform name of all SDKs containing a variant whose platform ID matches our platform.
+        let platformNames = lookupPlatformNames(platform: buildPlatform)
 
         // If we found a match, look up the SDK -- we'll deterministically get the latest version of that SDK,
         // and it should have only one variant whose platform ID matches our platform.

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -232,9 +232,13 @@ public final class BuiltinMacros {
 
     public static let ACTION = BuiltinMacros.declareStringMacro("ACTION")
     public static let ARCHS = BuiltinMacros.declareStringListMacro("ARCHS")
+    public static let ARCHS_BASE = BuiltinMacros.declareStringListMacro("ARCHS_BASE")
     public static let BUILD_COMPONENTS = BuiltinMacros.declareStringListMacro("BUILD_COMPONENTS")
+    public static let COHORT_ARCHS = BuiltinMacros.declareStringListMacro("COHORT_ARCHS")
+    public static let COHORT_BASE_ARCH = BuiltinMacros.declareStringMacro("COHORT_BASE_ARCH")
     public static let DEPLOYMENT_LOCATION = BuiltinMacros.declareBooleanMacro("DEPLOYMENT_LOCATION")
     public static let DEPLOYMENT_POSTPROCESSING = BuiltinMacros.declareBooleanMacro("DEPLOYMENT_POSTPROCESSING")
+    public static let ENABLE_COHORT_ARCHS = BuiltinMacros.declareBooleanMacro("ENABLE_COHORT_ARCHS")
     public static let ENABLE_TESTABILITY = BuiltinMacros.declareBooleanMacro("ENABLE_TESTABILITY")
     public static let ENABLE_TESTING_SEARCH_PATHS = BuiltinMacros.declareBooleanMacro("ENABLE_TESTING_SEARCH_PATHS")
     public static let ENABLE_CODESIZE_PROFILE = BuiltinMacros.declareBooleanMacro("ENABLE_CODESIZE_PROFILE")
@@ -845,6 +849,7 @@ public final class BuiltinMacros {
     public static let LD_EXPORT_GLOBAL_SYMBOLS = BuiltinMacros.declareBooleanMacro("LD_EXPORT_GLOBAL_SYMBOLS")
     public static let LD_LTO_OBJECT_FILE = BuiltinMacros.declarePathMacro("LD_LTO_OBJECT_FILE")
     public static let LD_NO_PIE = BuiltinMacros.declareBooleanMacro("LD_NO_PIE")
+    public static let PRELINK_TOOL = BuiltinMacros.declareStringMacro("PRELINK_TOOL")
     public static let LD_RUNPATH_SEARCH_PATHS = BuiltinMacros.declareStringListMacro("LD_RUNPATH_SEARCH_PATHS")
     public static let LD_SDK_IMPORTS_FILE = BuiltinMacros.declarePathMacro("LD_SDK_IMPORTS_FILE")
     public static let LD_WARN_UNUSED_DYLIBS = BuiltinMacros.declareBooleanMacro("LD_WARN_UNUSED_DYLIBS")
@@ -1498,6 +1503,7 @@ public final class BuiltinMacros {
         AR,
         ARCHIVER_SUPPORTS_SEARCH_PATHS,
         ARCHS,
+        ARCHS_BASE,
         ARCHS_STANDARD,
         ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1,
         ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1,
@@ -1614,6 +1620,8 @@ public final class BuiltinMacros {
         CODE_SIGN_RESOURCE_RULES_PATH,
         CODE_SIGN_RESTRICT,
         CODE_SIGN_STYLE,
+        COHORT_ARCHS,
+        COHORT_BASE_ARCH,
         COMBINE_HIDPI_IMAGES,
         COMPILER_WORKING_DIRECTORY,
         MERGEABLE_LIBRARY,
@@ -1775,6 +1783,7 @@ public final class BuiltinMacros {
         ENABLE_ADDITIONAL_CODESIGN_INPUT_TRACKING,
         ENABLE_ADDITIONAL_CODESIGN_INPUT_TRACKING_FOR_SCRIPT_OUTPUTS,
         ENABLE_APPLE_KEXT_CODE_GENERATION,
+        ENABLE_COHORT_ARCHS,
         ENABLE_DEFAULT_SEARCH_PATHS,
         ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS,
         ENABLE_DEFAULT_SEARCH_PATHS_IN_FRAMEWORK_SEARCH_PATHS,
@@ -2169,6 +2178,7 @@ public final class BuiltinMacros {
         __POPULATE_COMPATIBILITY_ARCH_MAP,
         PRELINK_DEPENDENCY_INFO_FILE,
         PRELINK_FLAGS,
+        PRELINK_TOOL,
         PRELINK_LIBS,
         PRIVATE_HEADERS_FOLDER_PATH,
         PROCESSED_INFOPLIST_PATH,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2583,11 +2583,28 @@ private class SettingsBuilder: ProjectMatchLookup {
         let archSpecs = specLookupContext.findSpecs(ArchitectureSpec.self).sorted(by: \.identifier)
         platformTable.push(BuiltinMacros.VALID_ARCHS, literal: archSpecs.compactMap { $0.isRealArch ? $0.canonicalName : nil })
 
-        // Add the build settings which are defined in architecture specs.
+        // Go through the arch specs to gather macros we want to push.
+        var cohorts = [String: Set<String>]()
         for spec in archSpecs {
-            guard let macro = spec.archSetting else { continue }
-            guard let realArchs = spec.realArchs else { continue }
-            platformTable.push(macro, realArchs)
+            // Add the build settings which are defined in architecture specs.
+            if let macro = spec.archSetting, let realArchs = spec.realArchs {
+                platformTable.push(macro, realArchs)
+            }
+
+            // Collect arch cohorts.
+            if let cohortArch = spec.cohortArch {
+                cohorts[cohortArch, default: Set<String>()].insert(spec.identifier)
+            }
+        }
+        // Add ARCH_COHORT_ settings, if there are any defined cohorts.
+        // Note that these are defined even when ENABLE_COHORT_ARCHS is not enabled, because this is exposing the relationship among these archs even if we're not building them together. People can use this in EXCLUDED_ARCHS to exclude all existing and potential future archs in a cohort.
+        for (cohortArch, archs) in cohorts {
+            let sortedArchs = Array(archs).sorted()
+            // Validate that the cohort name is the same as one of the archs in the cohort, as the cohort is misconfigured in the xcspec files if this is not the case.  This won't block users from building (and the issue is not something that the user can fix), but they might not work as expected.
+            assert(archs.contains(cohortArch), "architecture cohort '\(cohortArch)' for platform '\(specLookupContext.domain)' does not contain an arch of the same name, but only these: \(sortedArchs.joined(separator: " "))")
+            let settingName = "ARCH_COHORT_\(cohortArch)"
+            let macro = platformTable.namespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, settingName)
+            platformTable.push(macro, BuiltinMacros.namespace.parseStringList(Array(archs).sorted()))
         }
 
         // Push the table.
@@ -4344,10 +4361,108 @@ private class SettingsBuilder: ProjectMatchLookup {
 
         // Determine a preferred architecture for indexing, single-file actions, and the static analyzer.
         self.preferredArch = getPreferredArch(effectiveArchs)
+        effectiveArchs = effectiveArchs.removingDuplicates()
 
-        // Set `ARCHS` to the list of architectures we ended up with, and save the original value.
+        // Now that we know what architectures we're building for, determine whether any of them are in cohorts of more than one architecture, so we can efficiently compile them in groups.
+        // This is done by setting up arch-conditional build settings which the SourcesTaskProducer can use to make decisions as it goes.
+        // We also rebuild the list of effectiveArchs because we want to make sure the base archs of each cohort build before the others.
+        var orderedEffectiveArchs = [String]()
+        var archsBase = [String]()
+        // Cohort arch support is guarded by a build setting.
+        if scope.evaluate(BuiltinMacros.ENABLE_COHORT_ARCHS) {
+            // First collect all the archs which are part of cohorts, even if only one arch in a cohort is present.  Record other archs as standalone.
+            var cohortArchs = [String: Set<String>]()
+            var standaloneArchs = Set<String>()
+            for arch in effectiveArchs {
+                // If we don't have a spec for this arch, then it can't be part of a cohort.
+                guard let spec = specLookupContext.getSpec(arch) as? ArchitectureSpec else {
+                    standaloneArchs.insert(arch)
+                    continue
+                }
+
+                // If the spec has a defined cohort arch, then add this arch to the list under the cohort arch.  Otherwise record it as a standalone arch.
+                if let cohortArch = spec.cohortArch {
+                    // cohortArchs is indexed by the defined cohort arch, even if that arch is not itself in the list.
+                    cohortArchs[cohortArch, default: Set<String>()].insert(arch)
+                }
+                else {
+                    standaloneArchs.insert(arch)
+                }
+            }
+
+            // Next go through the cohort archs we collected to determine the base arch (the primary arch among those in the cohort present in effectiveArchs) and the non-base archs in the cohort.
+            var effectiveCohorts = [String: [String]]()
+            for (cohortArch, archs) in cohortArchs {
+                // If this cohort has only a single arch in effectiveArchs, then we can skip the rest of this block and treat it as a standalone arch.
+                if let arch = archs.only {
+                    standaloneArchs.insert(arch)
+                    continue
+                }
+
+                // Sort the archs for stability.
+                let sortedArchs = archs.sorted()
+
+                // Compute the base arch. The purpose of this is to always choose the same base arch from the same list of archs (if we don't have a preferredArch), and picking the first one from a sorted list is a simple way to do that.
+                guard let firstArch = sortedArchs.first else {
+                    // If there are no archs then we don't need to set up a cohort.
+                    continue
+                }
+                let preferredBaseArch = self.preferredArch ?? cohortArch
+                let baseArch = archs.contains(preferredBaseArch) ? preferredBaseArch : firstArch
+                let otherArchs = sortedArchs.filter({ $0 != baseArch })
+
+                // Set up the build settings for the cohort which CURRENT_ARCH is in.  (They will of course be empty if there is no cohort - we won't even have gotten here.)
+                // COHORT_BASE_ARCH is the base arch for the cohort being used for build tasks.
+                // COHORT_ARCHS are all archs in the cohort *other than* the base arch which are in effectiveArchs, being passed as variant archs to build tasks.
+                // Note that since we continued above if we only have a single arch in this cohort, we won't get here to set these up; we're treating it as a single standalone arch.
+                for arch in sortedArchs {
+                    table.push(BuiltinMacros.COHORT_BASE_ARCH, literal: baseArch, conditions: MacroConditionSet(conditions: [MacroCondition(parameter: BuiltinMacros.archCondition, valuePattern: arch)]))
+                    table.push(BuiltinMacros.COHORT_ARCHS, literal: otherArchs, conditions: MacroConditionSet(conditions: [MacroCondition(parameter: BuiltinMacros.archCondition, valuePattern: arch)]))
+                }
+
+                // Record the effective cohort.
+                effectiveCohorts[baseArch] = otherArchs
+            }
+
+            // Finally, compute orderedEffectiveArchs and archsBase.
+            if effectiveCohorts.isEmpty {
+                // If we didn't find any cohorts with more than one arch in them (i.e., all archs ended up being standalone), then we can just copy the original values.
+                orderedEffectiveArchs = effectiveArchs
+                archsBase = effectiveArchs
+            }
+            else {
+                // The goal here is to preserve the ordering of the original archs as far as the standalone and base archs are concerned, and (more importantly) to order the cohort archs in the list *after* their base arch.  We *could* strive to avoid reordering the list at all if it already meets that second criterion, but doing so would be more work for very little gain.
+                for arch in effectiveArchs {
+                    // If this is the base arch of a cohort, then copy it and add its cohort archs immediately after it.
+                    if let cohortArchs = effectiveCohorts[arch] {
+                        orderedEffectiveArchs.append(arch)
+                        orderedEffectiveArchs.append(contentsOf: cohortArchs)
+                        archsBase.append(arch)
+                    }
+                    // Otherwise if this a standalone arch then add it.
+                    else if standaloneArchs.contains(arch) {
+                        orderedEffectiveArchs.append(arch)
+                        archsBase.append(arch)
+                    }
+                }
+            }
+
+            // Consistency checks in debug builds.
+            assert(Set(effectiveArchs) == Set(orderedEffectiveArchs), "ARCHS after reordering to handle cohorts do not contain the same values")
+            assert(Set(orderedEffectiveArchs).isSuperset(of: Set(archsBase)), "not all base archs are contained in orderedEffectiveArchs")
+        }
+        else {
+            orderedEffectiveArchs = effectiveArchs
+            archsBase = effectiveArchs
+        }
+
+        // Set ARCHS to the list of architectures we ended up with, and save the original value.
         table.push(BuiltinMacros.__ARCHS__, literal: originalArchs)
-        table.push(BuiltinMacros.ARCHS, literal: effectiveArchs.removingDuplicates())
+        table.push(BuiltinMacros.ARCHS, literal: orderedEffectiveArchs)
+
+        // Set ARCHS_BASE to the list of architecture for which we're actually running compile & link tasks.
+        // This will omit cohort archs, code for which is generated by the task for the base arch of the cohort.
+        table.push(BuiltinMacros.ARCHS_BASE, literal: archsBase)
 
         // The set of Swift module-only architectures should be a set of valid architectures that's disjoint from the
         // set of effective architectures. We don't necessarily care about these architectures being deprecated as this
@@ -4360,7 +4475,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         let moduleOnlyArchs = (onlyActiveArchApplied || tripleOverridesApplied) ? [] : originalModuleOnlyArchs
             .filter { validArchs.contains($0) }
             .filter { !excludedArchs.contains($0) }
-            .filter { !effectiveArchs.contains($0) }
+            .filter { !orderedEffectiveArchs.contains($0) }
             .removingDuplicates()
 
         table.push(BuiltinMacros.__SWIFT_MODULE_ONLY_ARCHS__, literal: originalModuleOnlyArchs)
@@ -4736,22 +4851,41 @@ private class SettingsBuilder: ProjectMatchLookup {
         // Set up the variant/arch-specific SWIFT_RESPONSE_FILE_PATH_/LINK_FILE_LIST_... macros.
         //
         // FIXME: Eliminate this. It would also be nice to be able to avoid the user defined type here, but I don't believe it is safe to inject this into the internal namespace.
+        func defineArchVariantMacro(prefix: String, variant: String, definedArch: String, effectiveArch: String, fileExtension: String, exportType: ExportType = .none) {
+            let macro = userNamespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, "\(prefix)_\(variant)_\(definedArch)")
+            tableSet.push(exportType, macro, BuiltinMacros.namespace.parseStringList(["$(OBJECT_FILE_DIR)-\(variant)/\(effectiveArch)/$(PRODUCT_NAME).\(fileExtension)"]))
+            exportedMacroNames.insert(macro)
+        }
+
         let scope = createScope(sdkToUse: sdk)
         let combinedArchs = scope.evaluate(BuiltinMacros.ARCHS) + scope.evaluate(BuiltinMacros.SWIFT_MODULE_ONLY_ARCHS)
         for variant in scope.evaluate(BuiltinMacros.BUILD_VARIANTS) {
             for arch in combinedArchs {
-
-                func defineMacro(prefix: String, fileExtension: String, exportType: ExportType = .none) {
-                    let macro = userNamespace.lookupOrDeclareMacro(UserDefinedMacroDeclaration.self, "\(prefix)_\(variant)_\(arch)")
-                    tableSet.push(exportType, macro, BuiltinMacros.namespace.parseStringList(["$(OBJECT_FILE_DIR)-\(variant)/\(arch)/$(PRODUCT_NAME).\(fileExtension)"]))
-                    exportedMacroNames.insert(macro)
+                // If the arch is a cohort arch, then redirect to using the base arch for the cohort for some paths.
+                let subscope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                let cohortArchs = subscope.evaluate(BuiltinMacros.COHORT_ARCHS)
+                let effectiveArch: String
+                if cohortArchs.contains(arch) {
+                    let baseArch = subscope.evaluate(BuiltinMacros.COHORT_BASE_ARCH)
+                    if !baseArch.isEmpty {
+                        effectiveArch = baseArch
+                    }
+                    else {
+                        // If we don't have a base arch, then something has gone wrong.
+                        self.errors.append("internal error: No base arch found for cohort arch '\(arch)'")
+                        continue
+                    }
+                }
+                else {
+                    effectiveArch = arch
                 }
 
                 // We push the value here with an embedded literal, since this can be referenced in places when the arch and variant conditions may not be active (e.g., shell scripts).
                 // FIXME: Use object-file macro. Note that we must parse as a string list here given the expression type.
-                defineMacro(prefix: "LINK_FILE_LIST", fileExtension: "LinkFileList")
-                defineMacro(prefix: "SWIFT_RESPONSE_FILE_PATH", fileExtension: "SwiftFileList", exportType: .exported)
-                defineMacro(prefix: "LM_AUX_CONST_METADATA_LIST_PATH", fileExtension: "SwiftConstValuesFileList")
+                defineArchVariantMacro(prefix: "LINK_FILE_LIST", variant: variant, definedArch: arch, effectiveArch: arch, fileExtension: "LinkFileList")
+                // We don't create Swift tasks for cohort archs, so there is no response file for them.  Instead we use the response file for the base arch.
+                defineArchVariantMacro(prefix: "SWIFT_RESPONSE_FILE_PATH", variant: variant, definedArch: arch, effectiveArch: effectiveArch, fileExtension: "SwiftFileList", exportType: .exported)
+                defineArchVariantMacro(prefix: "LM_AUX_CONST_METADATA_LIST_PATH", variant: variant, definedArch: arch, effectiveArch: arch, fileExtension: "SwiftConstValuesFileList")
             }
         }
 
@@ -4780,7 +4914,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             ] {
                 let macroName = "\(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS.name)_IN_\(searchPathMacro.name)"
                 guard let macro = userNamespace.lookupMacroDeclaration(macroName) as? BooleanMacroDeclaration else {
-                    core.delegate.error("internal error: Build setting \(macroName) is not of boolean type")
+                    self.errors.append("internal error: Build setting \(macroName) is not of boolean type")
                     continue
                 }
                 // Note that this implies if the macro is unset or set to empty then it defaults to YES, which is the opposite of most macros, but probably fine for this very niche functionality.  If this becomes an issue then we should declare all of these macros in CoreBuildSystem.xcspec with default values of YES, or maybe $(ENABLE_DEFAULT_SEARCH_PATHS).

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -849,6 +849,11 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         return nil
     }
 
+    /// Validate whether this spec should be used for the given `CommandBuildContext`. Any issues related to why it shouldn't be can be reported via the `delegate`, though this is also useful for silently skipping creating a task because we're handling it in a special way (e.g., cohort archs).
+    public func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        return true
+    }
+
     /// Constructs the "rule info" and command line arguments for a task, and then instructs the task generation delegate to create the task with that information.
     open func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         await constructTasks(cbc, delegate, specialArgs: [])
@@ -1208,7 +1213,10 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         var executionDescription = cbc.scope.evaluate(execDescription, lookup: { return self.lookup($0, cbc, delegate, lookup) })
         if !self.isArchitectureNeutral, let currentArch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH).nilIfEmpty, currentArch != "undefined_arch" {
             // If we're in a context with a defined current architecture, then append it to the description so users can more easily disambiguate between tasks that are replicated across multiple architectures.
-            executionDescription = executionDescription + " (\(currentArch))"
+            // If we are also compiling for cohort archs in this task, then add a comma-separated list of these archs as well so this is clear in the IDE build log. We don't add cohort archs to the rule info string because the rule info is also used as the key for the task used by llbuild and having it change when the archs change could lead to problems like the one described in rdar://63196141.
+            let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
+            let cohortArchsSuffix = cohortArchs.isEmpty ? "" : (", " + cohortArchs.joined(separator: ", "))
+            executionDescription = executionDescription + " (\(currentArch)\(cohortArchsSuffix))"
         }
         return executionDescription
     }

--- a/Sources/SWBCore/SpecImplementations/Specs.swift
+++ b/Sources/SWBCore/SpecImplementations/Specs.swift
@@ -152,6 +152,13 @@ public final class ArchitectureSpec : Spec, SpecType, @unchecked Sendable {
     /// The list of compatible architectures.
     public let compatibilityArchs: [String]
 
+    /// The name of the cohort this architecture belongs to.
+    ///
+    /// A file will be compiled for all architectures in this cohort in a single command, and archs in the cohort may share other behavior as well.
+    ///
+    /// The architecture named here will be preferred as the base arch for the cohort, if it among those being built for. But a cohort may be named with an arch which is not presently (or is no longer) supported, as a maintenance convenience.
+    public let cohortArch: String?
+
     /// If set, this constrains when this architecture appears in `ARCHS_STANDARD`.
     public let deploymentTargetRange: Range<Version>?
 
@@ -213,6 +220,8 @@ public final class ArchitectureSpec : Spec, SpecType, @unchecked Sendable {
 
         // FIXME: Make the MacOSX Architectures INTERNAL version of this use an array, for consistency.
         compatibilityArchs = parser.parseCommandLineString("CompatibilityArchitectures", inherited: true) ?? []
+
+        cohortArch = parser.parseString("CohortArchitecture")
 
         deploymentTargetRange = { () -> Range<Version>? in
             let key = "DeploymentTargetRange"

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -31,6 +31,16 @@ class AbstractCCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatibleCom
         return compilerSpec
     }
 
+    public override func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        // Don't compute a compile task for cohort archs; those archs will be compiler in the task for the base arch.
+        let currentArch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)
+        let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
+        if cohortArchs.contains(currentArch) {
+            return false
+        }
+        return super.validate(cbc: cbc, delegate: delegate)
+    }
+
     override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // FIXME: Report an error if we are ever asked to produce tasks directly.
     }
@@ -704,8 +714,8 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             var previousArg: ByteString? = nil
             while let arg = iterator.next() {
                 let argAsByteString = ByteString(encodingAsUTF8: arg)
-                if arg == "-target" {
-                    // Exclude -target from the response file to make reading the build log easier.
+                if arg == "-target" || arg == "-target-arch-variant" {
+                    // Exclude -target and similar options from the response file to make reading the build log easier.
                     regularCommandLine.append(arg)
                     if let nextArg = iterator.next() {
                         regularCommandLine.append(nextArg)
@@ -1040,6 +1050,16 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
     private func compilerWorkingDirectory(_ cbc: CommandBuildContext) -> Path {
         cbc.scope.evaluate(BuiltinMacros.COMPILER_WORKING_DIRECTORY).nilIfEmpty.map { Path($0) } ?? cbc.producer.defaultWorkingDirectory
+    }
+
+    public override func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        // Don't compute a compile task for cohort archs; those archs will be compiler in the task for the base arch.
+        let currentArch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)
+        let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
+        if cohortArchs.contains(currentArch) {
+            return false
+        }
+        return super.validate(cbc: cbc, delegate: delegate)
     }
 
     override public func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
@@ -1743,7 +1763,8 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         }
 
         // Finally, create the task.
-        delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo, additionalSignatureData: additionalSignatureData, commandLine: byteStringCommandLine, additionalOutput: additionalOutput, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: inputPaths + extraInputs, outputs: outputPaths, action: action ?? delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences), execDescription: "Precompile \(headerPath.basename) (\(arch))", enableSandboxing: enableSandboxing, usesExecutionInputs: usesExecutionInputs, showEnvironment: true)
+        let execDescription = archSpecificExecutionDescription(cbc.scope.namespace.parseString("Precompile \(headerPath.basename)"), cbc, delegate)
+        delegate.createTask(type: self, dependencyData: dependencyData, payload: payload, ruleInfo: ruleInfo, additionalSignatureData: additionalSignatureData, commandLine: byteStringCommandLine, additionalOutput: additionalOutput, environment: environmentBindings, workingDirectory: compilerWorkingDirectory(cbc), inputs: inputPaths + extraInputs, outputs: outputPaths, action: action ?? delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences), execDescription: execDescription, enableSandboxing: enableSandboxing, usesExecutionInputs: usesExecutionInputs, showEnvironment: true)
 
         // If the object file verifier is enabled and we are building with explicit modules, also create a job to produce an adjacent PCH using implicit modules.
         if cbc.scope.evaluate(BuiltinMacros.CLANG_ENABLE_EXPLICIT_MODULES_OBJECT_FILE_VERIFIER) && action != nil {

--- a/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/PrelinkedObjectLink.swift
@@ -22,9 +22,17 @@ public final class PrelinkedObjectLinkSpec: CommandLineToolSpec, SpecImplementat
     }
 
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
-        guard let toolSpecInfo = await cbc.producer.ldLinkerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate) as? DiscoveredLdLinkerToolSpecInfo else {
-            delegate.error("Could not find path to ld binary")
-            return
+        let ldPath: Path
+        let PRELINK_TOOL = cbc.scope.evaluate(BuiltinMacros.PRELINK_TOOL)
+        if !PRELINK_TOOL.isEmpty {
+            ldPath = Path(PRELINK_TOOL)
+        }
+        else {
+            guard let toolSpecInfo = await cbc.producer.ldLinkerSpec.discoveredCommandLineToolSpecInfo(cbc.producer, cbc.scope, delegate) as? DiscoveredLdLinkerToolSpecInfo else {
+                delegate.error("Could not find path to ld binary to call for generating prelink object file")
+                return
+            }
+            ldPath = toolSpecInfo.toolPath
         }
 
         let outputPath = cbc.output
@@ -32,8 +40,13 @@ public final class PrelinkedObjectLinkSpec: CommandLineToolSpec, SpecImplementat
         let arch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)
         var extraInputs = [Path]()
 
-        var commandLine = [toolSpecInfo.toolPath.str]
+        var commandLine = [ldPath.str]
         commandLine += ["-r", "-arch", arch]
+
+        let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
+        if !cohortArchs.isEmpty {
+            commandLine += cohortArchs.flatMap { ["-arch-variant", $0] }
+        }
 
         if let sdk = cbc.producer.sdk, let sdkVersion = sdk.version {
             for buildPlatform in cbc.producer.targetBuildVersionPlatforms(in: cbc.scope)?.sorted() ?? [] {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -371,6 +371,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
     public let explicitModulesTempDirPath: Path
     public let variant: String
     public let architecture: String
+    public let cohortArchitectures: [String]
     public let eagerCompilationEnabled: Bool
     public let explicitModulesEnabled: Bool
     public let commandLine: [String]
@@ -385,7 +386,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
     public let scannerDiagnosticsOutputPath: Path?
     public let diagnosticAttachmentInfo: LibclangDiagnosticAttachmentInfo?
 
-    internal init(uniqueID: String, compilerLocation: LibSwiftDriver.CompilerLocation, moduleName: String, outputPrefix: String, tempDirPath: Path, explicitModulesTempDirPath: Path, variant: String, architecture: String, eagerCompilationEnabled: Bool, explicitModulesEnabled: Bool, commandLine: [String], ruleInfo: [String], isUsingWholeModuleOptimization: Bool, casOptions: CASOptions?, reportRequiredTargetDependencies: BooleanWarningLevel, linkerResponseFilePath: Path?, linkerResponseFileFormat: ResponseFileFormat, dependencyFilteringRootPath: Path?, verifyScannerDependencies: Bool, scannerDiagnosticsOutputPath: Path?, diagnosticAttachmentInfo: LibclangDiagnosticAttachmentInfo?) {
+    internal init(uniqueID: String, compilerLocation: LibSwiftDriver.CompilerLocation, moduleName: String, outputPrefix: String, tempDirPath: Path, explicitModulesTempDirPath: Path, variant: String, architecture: String, cohortArchitectures: [String], eagerCompilationEnabled: Bool, explicitModulesEnabled: Bool, commandLine: [String], ruleInfo: [String], isUsingWholeModuleOptimization: Bool, casOptions: CASOptions?, reportRequiredTargetDependencies: BooleanWarningLevel, linkerResponseFilePath: Path?, linkerResponseFileFormat: ResponseFileFormat, dependencyFilteringRootPath: Path?, verifyScannerDependencies: Bool, scannerDiagnosticsOutputPath: Path?, diagnosticAttachmentInfo: LibclangDiagnosticAttachmentInfo?) {
         self.uniqueID = uniqueID
         self.compilerLocation = compilerLocation
         self.moduleName = moduleName
@@ -394,6 +395,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
         self.explicitModulesTempDirPath = explicitModulesTempDirPath
         self.variant = variant
         self.architecture = architecture
+        self.cohortArchitectures = cohortArchitectures
         self.eagerCompilationEnabled = eagerCompilationEnabled
         self.explicitModulesEnabled = explicitModulesEnabled
         self.commandLine = commandLine
@@ -410,7 +412,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
     }
 
     public init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(21)
+        try deserializer.beginAggregate(22)
         self.uniqueID = try deserializer.deserialize()
         self.compilerLocation = try deserializer.deserialize()
         self.moduleName = try deserializer.deserialize()
@@ -419,6 +421,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
         self.explicitModulesTempDirPath = try deserializer.deserialize()
         self.variant = try deserializer.deserialize()
         self.architecture = try deserializer.deserialize()
+        self.cohortArchitectures = try deserializer.deserialize()
         self.eagerCompilationEnabled = try deserializer.deserialize()
         self.explicitModulesEnabled = try deserializer.deserialize()
         self.commandLine = try deserializer.deserialize()
@@ -435,7 +438,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
     }
 
     public func serialize<T>(to serializer: T) where T : Serializer {
-        serializer.serializeAggregate(21) {
+        serializer.serializeAggregate(22) {
             serializer.serialize(self.uniqueID)
             serializer.serialize(self.compilerLocation)
             serializer.serialize(self.moduleName)
@@ -444,6 +447,7 @@ public struct SwiftDriverPayload: Serializable, TaskPayload, Encodable {
             serializer.serialize(self.explicitModulesTempDirPath)
             serializer.serialize(self.variant)
             serializer.serialize(self.architecture)
+            serializer.serialize(self.cohortArchitectures)
             serializer.serialize(self.eagerCompilationEnabled)
             serializer.serialize(self.explicitModulesEnabled)
             serializer.serialize(self.commandLine)
@@ -1108,6 +1112,16 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         }
     }
 
+    public override func validate(cbc: CommandBuildContext, delegate: any TaskGenerationDelegate) -> Bool {
+        // Don't compute a compile task for cohort archs; those archs will be compiler in the task for the base arch.
+        let currentArch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)
+        let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
+        if cohortArchs.contains(currentArch) {
+            return false
+        }
+        return super.validate(cbc: cbc, delegate: delegate)
+    }
+
     public override func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         // Our command build context should not contain any outputs, since we construct the output path ourselves.
         precondition(cbc.outputs.isEmpty, "Unexpected output paths \(cbc.outputs.map { "'\($0.str)'" }) passed to \(type(of: self)).")
@@ -1115,6 +1129,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         // Compute general parameters about this Swift invocation.
         let targetName = cbc.scope.evaluate(BuiltinMacros.TARGET_NAME)
         let arch = cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)
+        let cohortArchs = cbc.scope.evaluate(BuiltinMacros.COHORT_ARCHS)
         let variant = cbc.scope.evaluate(BuiltinMacros.CURRENT_VARIANT)
         let isNormalVariant = variant == "normal"
         let objectFileDir = cbc.scope.evaluate(BuiltinMacros.PER_ARCH_OBJECT_FILE_DIR)
@@ -1942,7 +1957,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 previewPayload: previewPayload,
                 localizationPayload: localizationPayload,
                 numExpectedCompileSubtasks: isUsingWholeModuleOptimization ? 1 : cbc.inputs.count,
-                driverPayload: await driverPayload(uniqueID: String(args.hashValue), scope: cbc.scope, delegate: delegate, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, args: args, tempDirPath: objectFileDir, explicitModulesTempDirPath: cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH), variant: variant, arch: arch + compilationMode.moduleBaseNameSuffix, commandLine: ["builtin-SwiftDriver", "--"] + args, ruleInfo: ruleInfo(compilationMode.ruleNameIntegratedDriver, targetName), casOptions: casOptions, scannerDiagnosticsOutputPath: scannerDiagnosticsPath, linkerResponseFilePath: moduleLinkerArgsPath),
+                driverPayload: await driverPayload(uniqueID: String(args.hashValue), scope: cbc.scope, delegate: delegate, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, args: args, tempDirPath: objectFileDir, explicitModulesTempDirPath: cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH), variant: variant, arch: arch + compilationMode.moduleBaseNameSuffix, cohortArchs: cohortArchs, commandLine: ["builtin-SwiftDriver", "--"] + args, ruleInfo: ruleInfo(compilationMode.ruleNameIntegratedDriver, targetName), casOptions: casOptions, scannerDiagnosticsOutputPath: scannerDiagnosticsPath, linkerResponseFilePath: moduleLinkerArgsPath),
                 previewStyle: cbc.scope.previewStyle
             )
 
@@ -2151,7 +2166,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             }
         }
 
-        func driverPayload(uniqueID: String, scope: MacroEvaluationScope, delegate: any TaskGenerationDelegate, compilationMode: SwiftCompilationMode, isUsingWholeModuleOptimization: Bool, args: [String], tempDirPath: Path, explicitModulesTempDirPath: Path, variant: String, arch: String, commandLine: [String], ruleInfo: [String], casOptions: CASOptions?, scannerDiagnosticsOutputPath: Path?, linkerResponseFilePath: Path?) async -> SwiftDriverPayload? {
+        func driverPayload(uniqueID: String, scope: MacroEvaluationScope, delegate: any TaskGenerationDelegate, compilationMode: SwiftCompilationMode, isUsingWholeModuleOptimization: Bool, args: [String], tempDirPath: Path, explicitModulesTempDirPath: Path, variant: String, arch: String, cohortArchs: [String], commandLine: [String], ruleInfo: [String], casOptions: CASOptions?, scannerDiagnosticsOutputPath: Path?, linkerResponseFilePath: Path?) async -> SwiftDriverPayload? {
             guard integratedDriverEnabled(scope: scope) else {
                 return nil
             }
@@ -2171,7 +2186,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             let verifyScannerDependencies = explicitModuleBuildEnabled && cbc.scope.evaluate(BuiltinMacros.SWIFT_DEPENDENCY_REGISTRATION_MODE) == .verifySwiftDependencyScanner
             let diagnosticAttachmentInfo = LibclangDiagnosticAttachmentInfo.attachmentInfo(scope: scope)
 
-            return SwiftDriverPayload(uniqueID: uniqueID, compilerLocation: compilerLocation, moduleName: scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME), outputPrefix: scope.evaluate(BuiltinMacros.TARGET_NAME) + compilationMode.moduleBaseNameSuffix, tempDirPath: tempDirPath, explicitModulesTempDirPath: explicitModulesTempDirPath, variant: variant, architecture: arch, eagerCompilationEnabled: eagerCompilationEnabled(args: args, scope: scope, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization), explicitModulesEnabled: explicitModuleBuildEnabled, commandLine: commandLine, ruleInfo: ruleInfo, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, casOptions: casOptions, reportRequiredTargetDependencies: scope.evaluate(BuiltinMacros.DIAGNOSE_MISSING_TARGET_DEPENDENCIES), linkerResponseFilePath: linkerResponseFilePath, linkerResponseFileFormat: cbc.scope.evaluate(BuiltinMacros.LINKER_RESPONSE_FILE_FORMAT), dependencyFilteringRootPath: cbc.producer.sdk?.path, verifyScannerDependencies: verifyScannerDependencies, scannerDiagnosticsOutputPath: scannerDiagnosticsOutputPath, diagnosticAttachmentInfo: diagnosticAttachmentInfo)
+            return SwiftDriverPayload(uniqueID: uniqueID, compilerLocation: compilerLocation, moduleName: scope.evaluate(BuiltinMacros.SWIFT_MODULE_NAME), outputPrefix: scope.evaluate(BuiltinMacros.TARGET_NAME) + compilationMode.moduleBaseNameSuffix, tempDirPath: tempDirPath, explicitModulesTempDirPath: explicitModulesTempDirPath, variant: variant, architecture: arch, cohortArchitectures: cohortArchs, eagerCompilationEnabled: eagerCompilationEnabled(args: args, scope: scope, compilationMode: compilationMode, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization), explicitModulesEnabled: explicitModuleBuildEnabled, commandLine: commandLine, ruleInfo: ruleInfo, isUsingWholeModuleOptimization: isUsingWholeModuleOptimization, casOptions: casOptions, reportRequiredTargetDependencies: scope.evaluate(BuiltinMacros.DIAGNOSE_MISSING_TARGET_DEPENDENCIES), linkerResponseFilePath: linkerResponseFilePath, linkerResponseFileFormat: cbc.scope.evaluate(BuiltinMacros.LINKER_RESPONSE_FILE_FORMAT), dependencyFilteringRootPath: cbc.producer.sdk?.path, verifyScannerDependencies: verifyScannerDependencies, scannerDiagnosticsOutputPath: scannerDiagnosticsOutputPath, diagnosticAttachmentInfo: diagnosticAttachmentInfo)
         }
 
         func constructSwiftResponseFileTask(path: Path) {

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -988,6 +988,11 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleIdenti
                 AvoidEmptyValue = YES;
             },
             {
+                Name = "ARCHS_BASE";
+                Type = StringList;
+                DefaultValue = "$(ARCHS)";
+            },
+            {
                 Name = "ONLY_ACTIVE_ARCH";
                 Type = Boolean;
                 DefaultValue = NO;
@@ -1017,6 +1022,21 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleIdenti
                 ConditionFlavors = (
                     sdk,
                 );
+            },
+            {
+                Name = "ENABLE_COHORT_ARCHS";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
+            {
+                Name = "COHORT_BASE_ARCH";
+                Type = String;
+                DefaultValue = "";
+            },
+            {
+                Name = "COHORT_ARCHS";
+                Type = StringList;
+                DefaultValue = "";
             },
             {
                 Name = "ARCHS_STANDARD_32_64_BIT";

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -982,7 +982,7 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
     /// Validates whether the spec is actually valid for this build rule action.
     /// Returning `true` will allow to continue to task construction, returning `false` will prevent it.
     func validateSpecForRule(_ spec: Spec, _ rule: any BuildRuleAction, _ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> Bool {
-        return true
+        return rule.validate(cbc: cbc, delegate: delegate)
     }
 
     func defaultOutputsForSpec(_ spec: CommandLineToolSpec, _ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) -> [Path] {

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -882,6 +882,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         tasks.append(copyHeadersCompletionTask)
 
         let archs: [String] = scope.evaluate(BuiltinMacros.ARCHS)
+        let baseArchs: [String] = scope.evaluate(BuiltinMacros.ARCHS_BASE)
         let moduleOnlyArchs: [String] = scope.evaluate(BuiltinMacros.SWIFT_MODULE_ONLY_ARCHS)
         let targetBuildDir = scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR)
 
@@ -917,14 +918,17 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
             let preferredArch = context.settings.preferredArch
 
-            var singleArchBinaries: [Path] = []
-            var singleArchPreviewDylibBinaries: [Path] = []
-            var singleArchInjectionDylibBinaries: [Path] = []
+            // Record the individual binaries we create.  These may be thin (single-arch), or they might be fat (produced using the cohort arch support).
+            var perArchBinaries = [Path]()
+            var perArchPreviewDylibBinaries = [Path]()
+            var perArchInjectionDylibBinaries = [Path]()
 
             // Tracks whether a TBD used for eager linking must be processed by lipo or copied to the build products so downstream targets can link against it.
             var shouldPrepareEagerLinkingTBD = false
 
-            for arch in archs {
+            // We only iterate over the "base" architectures (solo archs and the archs which are the base ones in a cohort), not the other archs in the cohorts.
+            // It's not clear that any tool can usefully run on a per-arch basis for a cohort arch if its output can't be compiled or otherwise used, since we don't create any compile or link tasks for those archs.
+            for arch in baseArchs {
                 // Enter the per-arch scope.
                 let scope = scope.subscopeBindingArchAndTriple(arch: arch)
                 let currentArchSpec = context.getSpec(arch) as! ArchitectureSpec?
@@ -1071,7 +1075,9 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     let commandOrderingOutputsPreviewDylib: [any PlannedNode]
                     let commandOrderingOutputsBlankInjectionDylib: [any PlannedNode]
 
-                    if archs.count == 1 {
+                    // If we're only linking once (because there's only one arch, or all archs are part of the same cohort), then we link directly into the TARGET_BUILD_DIR.
+                    // If we're performing multiple links, then we will link into the OBJROOT and later merge the binaries into the final universal file in the TARGET_BUILD_DIR.
+                    if (baseArchs.count == 1) {
                         output = binaryOutput
                         commandOrderingOutputs = [linkedBinaryNode]
 
@@ -1093,7 +1099,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     shouldPrepareEagerLinkingTBD = shouldPrepareEagerLinkingTBD || canBeEagerlyLinkedAgainstUsingTBD
 
                     var linkerOpts: TaskOrderingOptions = [.unsignedProductRequirement, .linking]
-                    // The link task is a requirement for linking downstream tasks unless this target can be linked against using a TBD.
+                    // The link task is a requirement for linking downstream tasks unless this target can be linked against using a TBD file.
                     if !canBeEagerlyLinkedAgainstUsingTBD {
                         linkerOpts.insert(.linkingRequirement)
                     }
@@ -1106,11 +1112,11 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                     }
 
                     if let outputPreviewDylib, let outputPreviewBlankInjectionDylib {
-                        singleArchPreviewDylibBinaries.append(outputPreviewDylib)
-                        singleArchInjectionDylibBinaries.append(outputPreviewBlankInjectionDylib)
+                        perArchPreviewDylibBinaries.append(outputPreviewDylib)
+                        perArchInjectionDylibBinaries.append(outputPreviewBlankInjectionDylib)
                     }
                     else {
-                        singleArchBinaries.append(output)
+                        perArchBinaries.append(output)
                     }
 
                     // Link the preview shim.
@@ -1276,13 +1282,13 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             )
                         }
 
-                        singleArchBinaries.append(output)
+                        perArchBinaries.append(output)
                     }
                 }
 
                 // Add all the collected per-arch tasks.
                 tasks.append(contentsOf: perArchTasks)
-            }
+            }  // for arch in baseArchs
 
             // Generate tasks for the module-only architectures.
             for arch in moduleOnlyArchs {
@@ -1314,10 +1320,10 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
 
                 // Add all the collected per-arch tasks.
                 tasks.append(contentsOf: perArchTasks)
-            }
+            }  // for arch in moduleOnlyArchs
 
             // If nothing was built, we are done with this variant.
-            if singleArchBinaries.isEmpty {
+            if perArchBinaries.isEmpty {
                 continue
             }
 
@@ -1326,34 +1332,34 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
             }
 
             // Lipo the linked binaries if there's more than one of them.
-            if singleArchBinaries.count > 1 {
+            if perArchBinaries.count > 1 {
                 await appendGeneratedTasks(&tasks, options: [.linking, .linkingRequirement, .unsignedProductRequirement]) { delegate in
-                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: singleArchBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryOutput, commandOrderingOutputs: [linkedBinaryNode]), delegate)
+                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: perArchBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryOutput, commandOrderingOutputs: [linkedBinaryNode]), delegate)
                 }
             }
-            else if singleArchBinaries.count == 1, archs.count > 1, let singleArchBinaryPath = singleArchBinaries.first {
+            else if perArchBinaries.count == 1, archs.count > 1, let perArchBinaryPath = perArchBinaries.first {
                 // If there's only one binary but multiple architectures defined for the target, then for some reason we didn't produce a binary for any of the others - probably due to a strange target configuration.  If so, then we should create a copy task to copy the single-arch binary to the final location.
                 let productBinaryPath = scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.EXECUTABLE_PATH))
-                if singleArchBinaryPath != productBinaryPath {
+                if perArchBinaryPath != productBinaryPath {
                     await appendGeneratedTasks(&tasks, options: [.linking, .linkingRequirement, .unsignedProductRequirement]) { delegate in
-                        await context.copySpec.constructCopyTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: singleArchBinaryPath)], output: productBinaryPath, commandOrderingOutputs: [linkedBinaryNode]), delegate, executionDescription: "Copy binary to product", stripUnsignedBinaries: false)
+                        await context.copySpec.constructCopyTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: perArchBinaryPath)], output: productBinaryPath, commandOrderingOutputs: [linkedBinaryNode]), delegate, executionDescription: "Copy binary to product", stripUnsignedBinaries: false)
                     }
                 }
             }
 
-            if singleArchPreviewDylibBinaries.count > 1,
+            if perArchPreviewDylibBinaries.count > 1,
                 let binaryPreviewDylibOutput,
                 let linkedBinaryPreviewDylibNode {
                 await appendGeneratedTasks(&tasks, options: [.linking, .linkingRequirement, .unsignedProductRequirement]) { delegate in
-                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: singleArchPreviewDylibBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryPreviewDylibOutput, commandOrderingOutputs: [linkedBinaryPreviewDylibNode]), delegate)
+                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: perArchPreviewDylibBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryPreviewDylibOutput, commandOrderingOutputs: [linkedBinaryPreviewDylibNode]), delegate)
                 }
             }
 
-            if singleArchInjectionDylibBinaries.count > 1,
+            if perArchInjectionDylibBinaries.count > 1,
                 binaryPreviewDylibOutput != nil,
                 let linkedBinaryPreviewBlankInjectionDylibNode {
                 await appendGeneratedTasks(&tasks, options: [.linking, .unsignedProductRequirement]) { delegate in
-                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: singleArchInjectionDylibBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryPreviewBlankInjectionDylibOutput, commandOrderingOutputs: [linkedBinaryPreviewBlankInjectionDylibNode]), delegate)
+                    await context.lipoSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: perArchInjectionDylibBinaries.map { FileToBuild(context: context, absolutePath: $0) }, output: binaryPreviewBlankInjectionDylibOutput, commandOrderingOutputs: [linkedBinaryPreviewBlankInjectionDylibNode]), delegate)
                 }
             }
 
@@ -1448,7 +1454,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 dsymutilOutputs.append(output)
                 context.addProducedDSYM(path: output, forVariant: variant)
             }
-        }
+        }  // for variant in buildVariants
 
         if let preparedForIndexNode = targetContext.preparedForIndexPreCompilationNode, let configuredTarget = context.configuredTarget {
             // The pre-compilation marker should update if any of its dependencies updates the module content marker.

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SwiftFrameworkABICheckerTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/SwiftFrameworkABICheckerTaskProducer.swift
@@ -63,6 +63,7 @@ final class SwiftFrameworkABICheckerTaskProducer: PhasedTaskProducer, TaskProduc
     func generateTasks() async -> [any PlannedTask]
     {
         var tasks = [any PlannedTask]()
+        let specLookupContext = SpecLookupCtxt(specRegistry: context.workspaceContext.core.specRegistry, platform: context.settings.platform)
         let scope = context.settings.globalScope
         // If running this tool is disabled via build setting, then we can abort this task provider.
         guard scope.evaluate(BuiltinMacros.RUN_SWIFT_ABI_CHECKER_TOOL) else { return [] }
@@ -78,6 +79,14 @@ final class SwiftFrameworkABICheckerTaskProducer: PhasedTaskProducer, TaskProduc
             // Enter the per-variant scope.
             let scope = scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
             for arch in archs {
+                // If this is an arch which is part of a cohort, but it's not the 'named' arch in the cohort, then we don't run this tool for it (even when not building cohorts together).
+                // This effectively says that archs in a cohort all share the same ABI of the cohort's named arch.
+                if let archSpec = specLookupContext.getSpec(arch) as? ArchitectureSpec, let cohortArch = archSpec.cohortArch {
+                    if cohortArch != arch {
+                        continue
+                    }
+                }
+
                 // Enter the per-arch scope.
                 let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
                 let moduleDirPath = SwiftCompilerSpec.getSwiftModuleFilePath(scope)
@@ -126,6 +135,7 @@ class SwiftABIBaselineGenerationTaskProducer: PhasedTaskProducer, TaskProducer {
     }
     func generateTasks() async -> [any PlannedTask] {
         var tasks = [any PlannedTask]()
+        let specLookupContext = SpecLookupCtxt(specRegistry: context.workspaceContext.core.specRegistry, platform: context.settings.platform)
         let scope = context.settings.globalScope
         // If running this tool is disabled via build setting, then we can abort this task provider.
         guard scope.evaluate(BuiltinMacros.RUN_SWIFT_ABI_GENERATION_TOOL) else { return [] }
@@ -140,6 +150,14 @@ class SwiftABIBaselineGenerationTaskProducer: PhasedTaskProducer, TaskProducer {
             // Enter the per-variant scope.
             let scope = scope.subscope(binding: BuiltinMacros.variantCondition, to: variant)
             for arch in archs {
+                // If this is an arch which is part of a cohort, but it's not the 'named' arch in the cohort, then we don't run this tool for it (even when not building cohorts together).
+                // This effectively says that archs in a cohort all share the same ABI of the cohort's named arch.
+                if let archSpec = specLookupContext.getSpec(arch) as? ArchitectureSpec, let cohortArch = archSpec.cohortArch {
+                    if cohortArch != arch {
+                        continue
+                    }
+                }
+
                 // Enter the per-arch scope.
                 let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
 

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -812,11 +812,11 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
 
     public func availableMatchingArchitecturesInStubBinary(at stubBinary: Path, requestedArchs: [String]) async -> [String] {
         let stubArchs: Set<String>
-        let stubPlatforms: [any PlatformInfoProvider]
+        let stubPlatformNames: [String]
         do {
             let stubInfo = try globalProductPlan.planRequest.buildRequestContext.getCachedMachOInfo(at: stubBinary)
             stubArchs = stubInfo.architectures
-            stubPlatforms = stubInfo.platforms.compactMap { lookupPlatformInfo(platform: $0) }
+            stubPlatformNames = stubInfo.platforms.compactMap { lookupPlatformNames(platform: $0).only }
         } catch {
             delegate.error("unable to create tasks to copy stub binary: can't determine architectures of binary: \(stubBinary.str): \(error)")
             return []
@@ -826,8 +826,8 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
             if stubArchs.contains(arch) {
                 archsToExtract.insert(arch)
             } else {
-                let compatibilityArchs: [String] = stubPlatforms.flatMap { platform in
-                    (workspaceContext.core.specRegistry.getSpec(arch, domain: platform.name) as? ArchitectureSpec)?.compatibilityArchs ?? []
+                let compatibilityArchs: [String] = stubPlatformNames.flatMap { platformName in
+                    (workspaceContext.core.specRegistry.getSpec(arch, domain: platformName) as? ArchitectureSpec)?.compatibilityArchs ?? []
                 }
                 if let compatibleArch = compatibilityArchs.first(where: { stubArchs.contains($0) }) {
                     archsToExtract.insert(compatibleArch)
@@ -1216,6 +1216,13 @@ extension TaskProducerContext: Hashable {
 }
 
 extension TaskProducerContext: CommandProducer {
+    /// Returns a set of platform names (suitable for use as a domain for looking up up specifications) for the given build platform.
+    public func lookupPlatformNames(platform: BuildVersion.Platform) -> Set<String> {
+        workspaceContext.core.lookupPlatformNames(platform: platform)
+    }
+
+    /// Returns a `PlatformInfoProvider`, if one can be found, for the given build platform, by finding the appropriate SDK and locating the variant in the SDK which matches the build platform.
+    /// - remark: The returned object will *not* contain information suitable for use as a domain for looking up specifications.
     public func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
         workspaceContext.core.lookupPlatformInfo(platform: platform)
     }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverPlanningDynamicTaskSpec.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/SwiftDriverPlanningDynamicTaskSpec.swift
@@ -50,6 +50,8 @@ final class SwiftDriverPlanningDynamicTaskSpec: DynamicTaskSpec {
             fatalError("Attempted to request a driver planning operation with no driver payload")
         }
 
+        let cohortArchsSuffix = driverPayload.cohortArchitectures.isEmpty ? "" : ", " + driverPayload.cohortArchitectures.joined(separator: ", ")
+        let execDescription = "Planning Swift module \(driverPayload.moduleName) (\(driverPayload.architecture)\(cohortArchsSuffix))"
         return Task(type: self,
                     payload: key.swiftPayload,
                     forTarget: dynamicTask.target,
@@ -58,7 +60,7 @@ final class SwiftDriverPlanningDynamicTaskSpec: DynamicTaskSpec {
                     environment: dynamicTask.environment,
                     workingDirectory: dynamicTask.workingDirectory,
                     showEnvironment: dynamicTask.showEnvironment,
-                    execDescription: "Planning Swift module \(driverPayload.moduleName) (\(driverPayload.architecture))",
+                    execDescription: execDescription,
                     preparesForIndexing: true,
                     priority: .unblocksDownstreamTasks,
                     isDynamic: true

--- a/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/SwiftDriverTaskAction.swift
@@ -113,7 +113,8 @@ final public class SwiftDriverTaskAction: TaskAction, BuildValueValidatingTaskAc
                     $0.map({ "\t\t\($0.debugDescription)" }).joined(separator: "\n")
                 }
 
-                var message = "Swift Driver planned jobs for target \(task.forTarget?.target.name ?? "<unknown>") (\(driverPayload.architecture)-\(driverPayload.variant)):"
+                let cohortArchsSuffix = driverPayload.cohortArchitectures.isEmpty ? "" : ", " + driverPayload.cohortArchitectures.joined(separator: ", ")
+                var message = "Swift Driver planned jobs for target \(task.forTarget?.target.name ?? "<unknown>") (\(driverPayload.architecture)-\(driverPayload.variant)\(cohortArchsSuffix)):"
                 if driverPayload.explicitModulesEnabled {
                     message += "\n\tExplicit Modules:\n" + jobsDebugDescription(plannedBuild.explicitModulesPlannedDriverJobs()[...])
                 }

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -242,7 +242,10 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package func lookupLibclang(path: SWBUtil.Path) -> (libclang: SWBCore.Libclang?, version: Version?) {
         (nil, nil)
     }
-    package func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+    package func lookupPlatformNames(platform: SWBUtil.BuildVersion.Platform) -> Set<String> {
+        core.lookupPlatformNames(platform: platform)
+    }
+    package func lookupPlatformInfo(platform: SWBUtil.BuildVersion.Platform) -> (any PlatformInfoProvider)? {
         core.lookupPlatformInfo(platform: platform)
     }
 

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -83,6 +83,12 @@
                 ConditionFlavors = ( arch );
             },
             {
+                Name = "CLANG_COHORT_ARCHS";
+                Type = StringList;
+                DefaultValue = "$(COHORT_ARCHS)";
+                CommandLineFlag = "-target-arch-variant";
+            },
+            {
                                 // Custom compiler flags for a toolchain's
                                 // ToolchainInfo.plist.  Should be before
                                 // OTHER_C*_FLAGS to allow flags to be

--- a/Sources/SWBUniversalPlatform/Specs/ClangVerifier.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/ClangVerifier.xcspec
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -55,7 +55,7 @@
             {
                 Name = "MODULE_VERIFIER_TARGET_TRIPLE_ARCHS";
                 Type = StringList;
-                DefaultValue = "$(ARCHS)";
+                DefaultValue = "$(ARCHS_BASE)";
                 CommandLineArgs = (
                     "--target",
                     "$(value)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(LLVM_TARGET_TRIPLE_OS_VERSION)$(LLVM_TARGET_TRIPLE_SUFFIX)",

--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -74,6 +74,12 @@
                 ConditionFlavors = ( arch );
             },
             {
+                Name = "LD_COHORT_ARCHS";
+                Type = StringList;
+                DefaultValue = "$(COHORT_ARCHS)";
+                CommandLineFlag = "-target-arch-variant";
+            },
+            {
                 Name = "LD_ADDITIONAL_DEPLOYMENT_TARGET_FLAGS";
                 Type = StringList;
                 CommandLineArgs = "$(value)";

--- a/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Libtool.xcspec
@@ -17,7 +17,7 @@
         Description = "Create a static library using Apple Mach-O Librarian (libtool)";
         IsAbstract = Yes;       // This is an internal tool, so we keep it out of the user interface
         BinaryFormats = (mach-o);
-        CommandLine = "$(LIBTOOL) -static -arch_only $(arch) [options] [special-args] -o $(OutputPath)";      // 'special-args' includes the input files
+        CommandLine = "$(LIBTOOL) -static [options] [special-args] -o $(OutputPath)";      // 'special-args' includes the input files
         RuleName = "Libtool $(OutputPath) $(variant) $(arch)";
         CommandIdentifier = "create:$(OutputPath)";
         ExecDescription = "Create static library $(OutputFile:file)";
@@ -36,6 +36,18 @@
             {   Name = LIBTOOL;
                 Type = Path;
                 DefaultValue = "libtool";
+            },
+
+            // Architectures
+            {   Name = LIBTOOL_ARCH;
+                Type = String;
+                DefaultValue = "$(CURRENT_ARCH)";
+                CommandLineFlag = "-arch_only";
+            },
+            {   Name = LIBTOOL_COHORT_ARCHS;
+                Type = StringList;
+                DefaultValue = "$(COHORT_ARCHS)";
+                CommandLineFlag = "-arch_variant";
             },
 
             {   Name = LIBTOOL_DETERMINISTIC_MODE;

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -973,6 +973,12 @@
                 ConditionFlavors = ( arch );
             },
             {
+                Name = "SWIFT_COHORT_ARCHS";
+                Type = StringList;
+                DefaultValue = "$(COHORT_ARCHS)";
+                CommandLineFlag = "-target-arch-variant";
+            },
+            {
                 Name = "SWIFT_VERSION";
                 Type = String;
                 Category = "Language";

--- a/Sources/SWBUtil/MachO.swift
+++ b/Sources/SWBUtil/MachO.swift
@@ -44,10 +44,15 @@ public enum SwiftABIVersion: Equatable, Hashable, Sendable {
 // MARK: - LC_COMMANDS
 
 public protocol PlatformInfoLookup {
+    /// Returns a set of platform names (suitable for use as a domain for looking up up specifications) for the given build platform.
+    func lookupPlatformNames(platform: BuildVersion.Platform) -> Set<String>
+
+    /// Returns a `PlatformInfoProvider`, if one can be found, for the given build platform, by finding the appropriate SDK and locating the variant in the SDK which matches the build platform.
+    /// - remark: The returned object will *not* contain information suitable for use as a domain for looking up specifications.
     func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)?
 }
 
-/// A mechanism to get MachO info needed to construct a BuildVersion.Platform with a SupportedTargets entry from SDKSettings.
+/// A mechanism to get MachO info needed to construct a `BuildVersion.Platform` with a `SupportedTargets` entry from an SDK's settings.
 public protocol PlatformInfoProvider {
     /// Platform name
     var name: String { get }

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1587,6 +1587,8 @@ import SWBMacro
         let librarianSpec: LinkerSpec = try core.specRegistry.getSpec(ofType: LibtoolLinkerSpec.self)
 
         // Create the mock table.
+        // Since we're not pushing any of the settings from the xcspec here, the resulting task won't have any of those.
+        // The spec is inconsistent in its use of $(arch) vs. $(CURRENT_ARCH) (and also variant), so if we decide to test the spec here, we should unify those, probably on CURRENT_*** as that's the more modern form.
         var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
         table.push(try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("LIBTOOL") as? PathMacroDeclaration), literal: "libtool")
         table.push(BuiltinMacros.LIBTOOL_USE_RESPONSE_FILE, literal: true)
@@ -1631,7 +1633,7 @@ import SWBMacro
         #expect(task.execDescription == "Create static library output")
         // FIXME: This still has a lot of issues.
         task.checkCommandLine([
-            "libtool", "-static", "-arch_only", "x86_64",
+            "libtool", "-static",
             // libtool doesn't support weak linkage, so libraries and frameworks marked as weak are passed normally
             "-lfoo1", "-lfoo2", Path.root.join("usr/lib/libfoo3.a").str, Path.root.join("usr/lib/libfoo4.a").str,
             // dylibs are not passed

--- a/Tests/SWBCoreTests/SDKRegistryTests.swift
+++ b/Tests/SWBCoreTests/SDKRegistryTests.swift
@@ -484,7 +484,11 @@ import SWBMacro
                         self.toastosVariant = toastosVariant
                     }
 
-                    func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+                    func lookupPlatformNames(platform: SWBUtil.BuildVersion.Platform) -> Set<String> {
+                        return Set(["toastos"])
+                    }
+
+                    func lookupPlatformInfo(platform: SWBUtil.BuildVersion.Platform) -> (any PlatformInfoProvider)? {
                         platform.rawValue == 99 ? toastosVariant : nil
                     }
                 }

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -1433,6 +1433,188 @@ import SWBTestSupport
         #expect(settings.globalScope.evaluate(BuiltinMacros.ARCHS).sorted() == ["arm64", "arm64e"])
     }
 
+    /// Validate that the logic to compute `ARCHS` handles defining cohort archs properly.
+    ///
+    /// This test does this by writing several synthetic arch specs with cohort arch definitions and loading them.
+    @Test(.requireSDKs(.iOS))
+    func testCohortArchs() async throws {
+        let fs = localFS
+        try await withTemporaryDirectory(fs: fs) { (tmpDir: NamedTemporaryDirectory) in
+            // Write the synthetic spec file.
+            try await fs.writePlist(tmpDir.path.join("TestArchs.xcspec"), .plArray([
+                .plDict([
+                    "Identifier": .plString("arch.solo"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort1"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort1"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort1.variant1"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort1"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort2"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort2"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort2.variant1"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort2"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort2.variant2"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort2"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort.excluded"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort.excluded"),
+                ]),
+                .plDict([
+                    "Identifier": .plString("arch.cohort.excluded.variant1"),
+                    "Type": .plString("Architecture"),
+                    "_Domain": .plString("embedded"),
+                    "CohortArchitecture": .plString("arch.cohort.excluded"),
+                ]),
+            ]))
+
+            let core = try await Self.makeCore(simulatedInferiorProductsPath: tmpDir.path)
+
+            let includedArchs = ["arch.cohort1", "arch.cohort2", "arch.cohort1.variant1", "arch.cohort2.variant1", "arch.cohort2.variant2", "arch.solo"]
+            let excludedArchs = ["arch.cohort.excluded", "arch.cohort.excluded.variant1"]
+            let archs = includedArchs + excludedArchs
+            let workspace = try TestWorkspace("Workspace",
+                projects: [TestProject("aProject",
+                    groupTree: TestGroup("SomeFiles", children: [
+                        TestFile("Source.c"),
+                    ]),
+                    targets: [
+                        TestStandardTarget("Target1",
+                            type: .application,
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug", buildSettings: [
+                                    "ARCHS": archs.joined(separator: " "),
+                                    "SDKROOT": "iphoneos",
+                                    "PRODUCT_NAME": "Target1",
+                                    "ENABLE_COHORT_ARCHS": "YES",
+                                    "EXCLUDED_ARCHS": "$(ARCH_COHORT_arch.cohort.excluded)",
+                                ])
+                            ],
+                            buildPhases: [
+                                TestSourcesBuildPhase(["Source.c"]),
+                            ]
+                        ),
+                    ]
+                )]
+            ).load(core)
+            let context = try await contextForTestData(workspace, core: core, fs: fs)
+            let buildRequestContext = BuildRequestContext(workspaceContext: context)
+            guard let project = context.workspace.projects.first else {
+                Issue.record("Workspace has no projects.")
+                return
+            }
+            guard let target = project.targets.first else {
+                Issue.record("Workspace's project has no targets.")
+                return
+            }
+
+            let parameters = BuildParameters(action: .build, configuration: "Debug")
+            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: project, target: target)
+            guard settings.errors.isEmpty else {
+                Issue.record("Errors creating settings: \(settings.errors)")
+                return
+            }
+
+            let SRCROOT = project.sourceRoot.str
+
+            let scope = settings.globalScope
+
+            #expect(Set(scope.evaluate(BuiltinMacros.ARCHS)) == Set(includedArchs))
+            #expect(Set(scope.evaluate(BuiltinMacros.__ARCHS__)) == Set(archs))
+
+            // In the global scope, the cohort build settings should be empty.
+            #expect(scope.evaluate(BuiltinMacros.COHORT_BASE_ARCH).isEmpty)
+            #expect(scope.evaluate(BuiltinMacros.COHORT_ARCHS).isEmpty)
+
+            // For the non-cohort arch, the cohort build settings should be empty.
+            do {
+                let arch = "arch.solo"
+                let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                #expect(scope.evaluate(BuiltinMacros.COHORT_BASE_ARCH).isEmpty)
+                #expect(scope.evaluate(BuiltinMacros.COHORT_ARCHS).isEmpty)
+            }
+
+            // For each cohort arch, check that we have the expected base arch, and the expected list of archs in the cohort.
+            do {
+                let cohortArchs = ["arch.cohort1", "arch.cohort1.variant1"]
+                for arch in cohortArchs {
+                    let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                    #expect(scope.evaluate(BuiltinMacros.COHORT_BASE_ARCH) == "arch.cohort1")
+                    #expect(Set(scope.evaluate(BuiltinMacros.COHORT_ARCHS)) == Set(cohortArchs.filter({ $0 != "arch.cohort1" })))
+                }
+            }
+            do {
+                let cohortArchs = ["arch.cohort2", "arch.cohort2.variant1", "arch.cohort2.variant2"]
+                for arch in cohortArchs {
+                    let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                    #expect(scope.evaluate(BuiltinMacros.COHORT_BASE_ARCH) == "arch.cohort2")
+                    #expect(Set(scope.evaluate(BuiltinMacros.COHORT_ARCHS)) == Set(cohortArchs.filter({ $0 != "arch.cohort2" })))
+                }
+            }
+
+            // Check the values of some per-arch build settings.
+            for arch in includedArchs {
+                let scope = scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
+                let baseArch = scope.evaluate(BuiltinMacros.COHORT_BASE_ARCH)
+                if baseArch.isEmpty || arch == baseArch {
+                    // If this arch is not part of a cohort, or is the base arch of a cohort, then it should use itself in its paths.
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration(arch))) == "YES")
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration("SWIFT_RESPONSE_FILE_PATH_normal_\(arch)"))) == "\(SRCROOT)/build/aProject.build/Debug-iphoneos/Target1.build/Objects-normal/\(arch)/Target1.SwiftFileList")
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration("LINK_FILE_LIST_normal_\(arch)"))) == "\(SRCROOT)/build/aProject.build/Debug-iphoneos/Target1.build/Objects-normal/\(arch)/Target1.LinkFileList")
+                }
+                else {
+                    // If this arch is in a cohort but is not the base arch, then its values might be different in some cases.
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration(arch))) == "YES")
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration("SWIFT_RESPONSE_FILE_PATH_normal_\(arch)"))) == "\(SRCROOT)/build/aProject.build/Debug-iphoneos/Target1.build/Objects-normal/\(baseArch)/Target1.SwiftFileList")
+                    #expect(scope.evaluateAsString(try #require(scope.namespace.lookupMacroDeclaration("LINK_FILE_LIST_normal_\(arch)"))) == "\(SRCROOT)/build/aProject.build/Debug-iphoneos/Target1.build/Objects-normal/\(arch)/Target1.LinkFileList")
+                }
+            }
+
+            // Check that we have settings for the cohorts.
+            if let macro = scope.table.namespace.lookupMacroDeclaration("ARCH_COHORT_arch.cohort1") {
+                #expect(scope.evaluateAsString(macro) == "arch.cohort1 arch.cohort1.variant1")
+            }
+            else {
+                Issue.record("Could not lookup macro 'ARCH_COHORT_arch.cohort1'")
+            }
+            if let macro = scope.table.namespace.lookupMacroDeclaration("ARCH_COHORT_arch.cohort2") {
+                #expect(scope.evaluateAsString(macro) == "arch.cohort2 arch.cohort2.variant1 arch.cohort2.variant2")
+            }
+            else {
+                Issue.record("Could not lookup macro 'ARCH_COHORT_arch.cohort2'")
+            }
+            if let macro = scope.table.namespace.lookupMacroDeclaration("ARCH_COHORT_arch.cohort.excluded") {
+                #expect(scope.evaluateAsString(macro) == "arch.cohort.excluded arch.cohort.excluded.variant1")
+            }
+            else {
+                Issue.record("Could not lookup macro 'ARCH_COHORT_arch.cohort.excluded'")
+            }
+        }
+    }
+
     func testArchPointerAuthentication(platform: String) async throws {
         func test(buildSettings: [String: String], expectedARCHS_STANDARD: [String], expectedErrors: [String] = [], sourceLocation: SourceLocation = #_sourceLocation) async throws {
             let workspace = try await TestWorkspace("Workspace",

--- a/Tests/SWBTaskConstructionTests/CohortArchTests.swift
+++ b/Tests/SWBTaskConstructionTests/CohortArchTests.swift
@@ -1,0 +1,904 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBUtil
+import SWBProtocol
+@_spi(Testing) import SWBCore
+import SWBTaskConstruction
+import SWBTestSupport
+
+@Suite
+fileprivate struct CohortArchTests: CoreBasedTests {
+
+    // MARK: Initialization
+
+
+    private var LIBTOOL: String!
+    private var LD: String!
+
+    init() async throws {
+        LIBTOOL = try await libtoolPath.str
+        LD = try await {
+            let core = try await getCore()
+            let defaultToolchain = try #require(core.toolchainRegistry.defaultToolchain, "couldn't find the default toolchain")
+            let executableSearchPaths = core.createExecutableSearchPaths(userInfo: nil, platform: nil, toolchains: [defaultToolchain], fs: localFS)
+
+            let ld = executableSearchPaths.findExecutable(operatingSystem: core.hostOperatingSystem, basename: "ld")
+
+            return try #require(ld, "couldn't find ld in default toolchain").str
+        }()
+    }
+
+
+    // MARK: Utility variables and methods
+
+
+    private let baseArch = "arch.base"
+    private let cohortArch = "arch.cohort"
+    private let soloArch = "arch.solo"
+
+    /// Create and return a Core object with the synthetic architecture xcspecs these tests use.
+    private func makeCore(_ tmpDir: NamedTemporaryDirectory) async throws -> Core {
+        // Write the synthetic spec file.
+        try await localFS.writePlist(tmpDir.path.join("TestArchs.xcspec"), .plArray([
+            .plDict([
+                "_Domain": .plString("embedded"),
+                "Identifier": .plString(baseArch),
+                "Type": .plString("Architecture"),
+                "CohortArchitecture": .plString(baseArch),
+            ]),
+            .plDict([
+                "_Domain": .plString("embedded"),
+                "Identifier": .plString(cohortArch),
+                "Type": .plString("Architecture"),
+                "CohortArchitecture": .plString(baseArch),
+            ]),
+            .plDict([
+                "_Domain": .plString("embedded"),
+                "Identifier": .plString(soloArch),
+                "Type": .plString("Architecture"),
+                // No CohortArchitecture property
+            ]),
+        ]))
+
+        let core = try await Self.makeCore(simulatedInferiorProductsPath: tmpDir.path)
+
+        return core
+    }
+
+    private let appTargetName = "ApplicationTarget"
+    private let fwkTargetName = "FrameworkTarget"
+    private let libTargetName = "LibraryTarget"
+
+    private let abiBaselinesDir = Path.root.join("tmp/abi_baselines")
+    private let abiOutputDir = Path.root.join("tmp/abi_output")
+
+    private let CONFIGURATION = "Config"
+
+    /// Create and return a `TestWorkspace` common to many of the tests in this suite.
+    private func makeTestWorkspace() async throws -> TestWorkspace {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                path: "Sources",
+                children: [
+                    // Application target files.
+                    TestFile("AppFile.m"),
+
+                    // Framework target files.
+                    TestFile("CFile.c"),
+                    TestFile("CPPFile.cpp"),
+                    TestFile("SwiftFile.swift"),
+                    TestFile("Framework-Prefix.pch"),
+
+                    // Static library target files.
+                    TestFile("LibraryFileOne.m"),
+                    TestFile("LibraryFileTwo.m"),
+                ]
+            ),
+            buildConfigurations: [TestBuildConfiguration(
+                CONFIGURATION,
+                buildSettings: [
+                    "AD_HOC_CODE_SIGNING_ALLOWED": "YES",
+                    "ARCHS": "",        // Will be filled in by the build request
+                    "CLANG_USE_RESPONSE_FILE": "NO",
+                    "CODE_SIGN_IDENTITY": "-",
+                    "PRELINK_TOOL": LD,
+                    "LIBTOOL": LIBTOOL,
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "SDKROOT": "iphoneos",
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "SWIFT_VERSION": swiftVersion,
+                ]
+            )],
+            targets: [
+                // An application target, also the top-level target.
+                TestStandardTarget(
+                    appTargetName,
+                    type: .application,
+                    buildConfigurations: [TestBuildConfiguration(CONFIGURATION)],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "AppFile.m",
+                        ]),
+                        TestFrameworksBuildPhase([
+                            TestBuildFile("\(fwkTargetName).framework"),
+                            TestBuildFile(("lib\(libTargetName).a")),
+                        ]),
+                    ],
+                    dependencies: [
+                        TestTargetDependency(fwkTargetName),
+                        TestTargetDependency(libTargetName),
+                    ]
+                ),
+                // A framework target using a C file and a Swift file.
+                TestStandardTarget(
+                    fwkTargetName,
+                    type: .framework,
+                    buildConfigurations: [TestBuildConfiguration(CONFIGURATION, buildSettings: [
+                        "CLANG_ENABLE_MODULES": "YES",
+                        "CLANG_ENABLE_EXPLICIT_MODULES": "YES",
+                        "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                        "GCC_PREFIX_HEADER": "Sources/Framework-Prefix.pch",
+                        "GCC_PRECOMPILE_PREFIX_HEADER": "YES",
+
+                        // Swift ABI checker settings.
+                        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES",
+                        "RUN_SWIFT_ABI_CHECKER_TOOL": "YES",
+                        "SWIFT_ABI_CHECKER_BASELINE_DIR": abiBaselinesDir.str,
+                        "RUN_SWIFT_ABI_GENERATION_TOOL": "YES",
+                        "SWIFT_ABI_GENERATION_TOOL_OUTPUT_DIR": abiOutputDir.str,
+
+                        // Moduler verifier settings.
+                        "DEFINES_MODULE": "YES",
+                        "ENABLE_MODULE_VERIFIER": "YES",
+                        "MODULE_VERIFIER_KIND": "external",     // external gives us fewer tasks to match; can switch to builtin in the future if necessary
+                    ])],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "CFile.c",
+                            "CPPFile.cpp",
+                            "SwiftFile.swift",
+                        ]),
+                    ]
+                ),
+                // A static library target which prelinks its objects.
+                TestStandardTarget(
+                    libTargetName,
+                    type: .staticLibrary,
+                    buildConfigurations: [TestBuildConfiguration(CONFIGURATION,
+                        buildSettings: [
+                            "GENERATE_PRELINK_OBJECT_FILE": "YES",
+                        ]
+                    )],
+                    buildPhases: [
+                        TestSourcesBuildPhase([
+                            "LibraryFileOne.m",
+                            "LibraryFileTwo.m",
+                        ]),
+                    ]
+                ),
+            ]
+        )
+        let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+        return testWorkspace
+    }
+
+
+    // MARK: Tests
+
+
+    /// General test for cohort arch support.
+    ///
+    /// The general principle is that different targets are exercising different pieces of functionality which are behave differently when building with cohort archs, so not everything is clustered under a single target.
+    @Test(.requireSDKs(.iOS))
+    func testCohortArchSupport() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+
+            let testWorkspace = try await makeTestWorkspace()
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+            let IPHONEOS_DEPLOYMENT_TARGET = core.loadSDK(.iOS).defaultDeploymentTarget
+
+            let fs = PseudoFS()
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(baseArch)-ios.json"), .plDict([:]))
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(soloArch)-ios.json"), .plDict([:]))
+
+            let archs = [baseArch, cohortArch]
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
+                "ARCHS": archs.joined(separator: " "),
+                "ENABLE_COHORT_ARCHS": "YES",
+            ])
+            guard let target = tester.workspace.projects[0].targets.first.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }) else {
+                Issue.record("Could not find top level target for project")
+                return
+            }
+            let request = BuildRequest(parameters: parameters, buildTargets: [target], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+            let runDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: runDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "ClangStatCache", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // ExtractAppIntentsMetadata uses and generated some files based on the arch, but only for the base arch, not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ExtractAppIntentsMetadata")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--binary-file", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"])
+                        // Inputs and outputs that are present for the base arch and not the cohort arch.
+                        task.checkCommandLineContainsUninterrupted(["--dependency-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name)_dependency_info.dat"])
+                        task.checkCommandLineContainsUninterrupted(["--stringsdata-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/ExtractedAppShortcutsMetadata.stringsdata"])
+                        task.checkCommandLineContainsUninterrupted(["--source-file-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).SwiftFileList"])
+                        task.checkCommandLineContainsUninterrupted(["--swift-const-vals-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).SwiftConstValuesFileList"])
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name)_dependency_info.dat")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/ExtractedAppShortcutsMetadata.stringsdata")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftFileList")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftConstValuesFileList")
+                    }
+
+                    // Check the ScanDependencies tasks which exist for clang explicit modules.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ScanDependencies"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CFile.o"])
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ScanDependencies"), .matchRuleItemBasename("Framework-Prefix.pch"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineMatches(["-o", StringPattern.suffix("Framework-Prefix.pch.gch")])
+                    }
+
+                    // There doesn't seem to be an equivalent way to check for Swift explicit modules in a task construction test.
+
+                    // Check the precompiled header tasks.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ProcessPCH"), .matchRuleItemBasename("Framework-Prefix.pch"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineMatches(["-o", StringPattern.suffix("Framework-Prefix.pch.gch")])
+                        #expect(task.execDescription == "Precompile Framework-Prefix.pch (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ProcessPCH++"), .matchRuleItemBasename("Framework-Prefix.pch"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineMatches(["-o", StringPattern.suffix("Framework-Prefix.pch.gch")])
+                        #expect(task.execDescription == "Precompile Framework-Prefix.pch (\(archs.joined(separator: ", ")))")
+                    }
+
+                    // Check the compilation tasks.  We expect there to be tasks for the base arch, but not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CFile.o"])
+                        #expect(task.execDescription == "Compile CFile.c (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"))
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CPPFile.o"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CPPFile.o"])
+                        #expect(task.execDescription == "Compile CPPFile.cpp (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CPPFile.o"))
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation Requirements"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch,])
+                        #expect(task.execDescription == "Unblock downstream dependents of \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch,])
+                        #expect(task.execDescription == "Compile \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+
+                    // Check that we copy the content to the .swiftmodule for only the base arch.
+                    // We will implicitly catch any unexpected copies below when we check that we've matched all tasks.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(baseArch)-apple-ios.swiftmodule")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.swiftmodule"))) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/Project/\(baseArch)-apple-ios.swiftsourceinfo")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.swiftsourceinfo"))) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(baseArch)-apple-ios.abi.json")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.abi.json"))) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(baseArch)-apple-ios.swiftdoc")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.swiftdoc"))) { _ in }
+
+                    // Check that we are only generating the .swiftinterface file for the base arch (we're generating them because BUILD_LIBRARY_FOR_DISTRIBUTION is enabled),
+                    // and that we're only running the ABI checker and generating ABI baselines for the base arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(baseArch)-apple-ios.swiftinterface")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.swiftinterface"))) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(baseArch)-apple-ios.private.swiftinterface")), .matchRuleItemPattern(.suffix("\(baseArch)/FrameworkTarget.private.swiftinterface"))) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CheckSwiftABI"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-baseline-path", "\(abiBaselinesDir.str)/ABI/\(baseArch)-ios.json"])
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("GenerateSwiftABIBaseline"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(abiOutputDir.str)/\(baseArch)-ios.json"])
+                    }
+
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Interface Verification"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        #expect(task.execDescription == "Verify module interface of \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+
+                    // Check the linker tasks and the contents of the link-file-lists.
+                    results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemPattern(.suffix("\(target.target.name).LinkFileList"))) { task, contents in
+                        task.checkRuleInfo(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).LinkFileList"])
+                        let contentsLines = contents.asString.dropLast().components(separatedBy: .newlines)
+                        #expect(contentsLines == [
+                            "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CFile.o",
+                            "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CPPFile.o",
+                            "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/SwiftFile.o",
+                      ])
+                        #expect(task.execDescription == "Write \((target.target.name)).LinkFileList (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name)) { task in
+                        task.checkCommandLineContains([
+                            ["clang++"],
+                            ["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)", "-target-arch-variant", cohortArch],
+                            ["-o", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"]
+                        ].reduce([], +))
+                        #expect(task.execDescription == "Link \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+
+                    // There's only one of these.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftMergeGeneratedHeaders")) { task in
+                        task.checkCommandLineContainsUninterrupted(["-arch", baseArch])
+                        // We don't generate headers for the cohort archs.
+                        task.checkCommandLineDoesNotContain(cohortArch)
+                    }
+
+                    // Check that the module verifier only runs on the base arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemBasename("module.modulemap")) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("VerifyModule")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineDoesNotContain("\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)")
+                    }
+
+                    results.checkTasks(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile")) { _ in }
+                    results.checkNoTask(.matchTarget(target))
+                }
+
+                results.checkTarget(libTargetName) { target in
+                    // Check the compilation tasks.  We expect there to be tasks for the base arch, but not the cohort arch.
+                    for filename in ["LibraryFileOne", "LibraryFileTwo"] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("\(filename).o")) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(filename).o"])
+                        }
+                        results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("\(filename).o"))
+                    }
+
+                    // Check that we're prelinking the object files into a single object file.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("PrelinkedObjectLink"), .matchRuleItemBasename("lib\(target.target.name).a-\(baseArch)-prelink.o")) { task in
+                        task.checkCommandLineContains([
+                            [LD, "-r"],
+                            ["-arch", baseArch, "-arch-variant", cohortArch],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/LibraryFileOne.o",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/LibraryFileTwo.o"],
+                            ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/lib\(target.target.name).a-\(baseArch)-prelink.o"]
+                        ].reduce([], +))
+                        #expect(task.execDescription == "Link lib\(target.target.name).a-\(baseArch)-prelink.o")
+                    }
+
+                    // Check the libtool tasks are only linking the single object file from the prelink.
+                    results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemPattern(.suffix("\(target.target.name).LinkFileList"))) { task, contents in
+                        task.checkRuleInfo(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).LinkFileList"])
+                        let contentsLines = contents.asString.dropLast().components(separatedBy: .newlines)
+                        #expect(contentsLines == [
+                            "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/lib\(target.target.name).a-\(baseArch)-prelink.o",
+                      ])
+                        #expect(task.execDescription == "Write \((target.target.name)).LinkFileList (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Libtool"), .matchRuleItemBasename("lib\(target.target.name).a")) { task in
+                        task.checkCommandLineContains([
+                            [LIBTOOL, "-static"],
+                            ["-arch_only", baseArch, "-arch_variant", cohortArch],
+                            ["-o", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/lib\(target.target.name).a"]
+                        ].reduce([], +))
+                        #expect(task.execDescription == "Create static library lib\(target.target.name).a (\(archs.joined(separator: ", ")))")
+                    }
+
+                    results.checkTasks(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile")) { _ in }
+                    results.checkNoTask(.matchTarget(target))
+                }
+
+                results.checkTarget(appTargetName) { target in
+                    // Check the compilation tasks.  We expect there to be tasks for the base arch, but not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("AppFile.m"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/AppFile.o"])
+                    }
+
+                    // Check the linker task and the contents of the link-file-list.
+                    results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemPattern(.suffix("\(target.target.name).LinkFileList"))) { task, contents in
+                        task.checkRuleInfo(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).LinkFileList"])
+                        let contentsLines = contents.asString.dropLast().components(separatedBy: .newlines)
+                        #expect(contentsLines == [
+                            "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/AppFile.o",
+                      ])
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContains([
+                            ["clang"],
+                            ["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)", "-target-arch-variant", cohortArch],
+                            ["-o", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).app/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+
+                    results.checkTasks(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile")) { _ in }
+                    results.checkNoTask(.matchTarget(target))
+                }
+
+                results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
+                results.checkNoTask()
+            }
+        }
+    }
+
+    /// Test building the cohort archs along with the solo arch,
+    @Test(.requireSDKs(.iOS))
+    func testCohortArchsWithSoloArch() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+
+            let testWorkspace = try await makeTestWorkspace()
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+            let IPHONEOS_DEPLOYMENT_TARGET = core.loadSDK(.iOS).defaultDeploymentTarget
+
+            let fs = PseudoFS()
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(baseArch)-ios.json"), .plDict([:]))
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(soloArch)-ios.json"), .plDict([:]))
+
+            let archs = [soloArch, baseArch, cohortArch]
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
+                "ARCHS": archs.joined(separator: " "),
+                "ENABLE_COHORT_ARCHS": "YES",
+            ])
+            guard let target = tester.workspace.projects[0].targets.first.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }) else {
+                Issue.record("Could not find top level target for project")
+                return
+            }
+            let request = BuildRequest(parameters: parameters, buildTargets: [target], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+            let runDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: runDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // ExtractAppIntentsMetadata uses and generated some files based on the arch, but only for the base arch and the solo arch, not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ExtractAppIntentsMetadata")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(soloArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--binary-file", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"])
+                        // Inputs and outputs that are present for the base archand the solo arch, and not the cohort arch.
+                        for arch in [soloArch, baseArch] {
+                            task.checkCommandLineContainsUninterrupted(["--dependency-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name)_dependency_info.dat"])
+                            task.checkCommandLineContainsUninterrupted(["--stringsdata-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/ExtractedAppShortcutsMetadata.stringsdata"])
+                            task.checkCommandLineContainsUninterrupted(["--source-file-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name).SwiftFileList"])
+                            task.checkCommandLineContainsUninterrupted(["--swift-const-vals-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name).SwiftConstValuesFileList"])
+                        }
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name)_dependency_info.dat")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/ExtractedAppShortcutsMetadata.stringsdata")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftFileList")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftConstValuesFileList")
+                    }
+
+                    // Check that we are only generating the .swiftinterface file for the base and solo archs (we're generating them because BUILD_LIBRARY_FOR_DISTRIBUTION is enabled),
+                    // and that we're only running the ABI checker and generating ABI baselines for the base arch.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftinterface"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.private.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.private.swiftinterface"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("CheckSwiftABI"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineContainsUninterrupted(["-baseline-path", "\(abiBaselinesDir.str)/ABI/\(arch)-ios.json"])
+                        }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("GenerateSwiftABIBaseline"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(abiOutputDir.str)/\(arch)-ios.json"])
+                        }
+                    }
+
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                ["clang++"],
+                                ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"],
+                                arch == baseArch ? ["-target-arch-variant", cohortArch] : [],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/\(target.target.name)"]
+                            ].reduce([], +))
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/\(target.target.name)",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/\(target.target.name)"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+
+                    // Check that the module verifier runs on the base arch and the solo arch, but not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("VerifyModule")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target", "\(soloArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineDoesNotContain("\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)")
+                    }
+
+                }
+
+                results.checkTarget(libTargetName) { target in
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Libtool"), .matchRuleItemBasename("lib\(target.target.name).a"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                [LIBTOOL, "-static"],
+                                ["-arch_only", arch],
+                                arch == baseArch ? ["-arch_variant", cohortArch] : [],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/lib\(target.target.name).a"]
+                            ].reduce([], +))
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Libtool"), .matchRuleItemBasename("lib\(target.target.name).a"), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/lib\(target.target.name).a",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/lib\(target.target.name).a"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/lib\(target.target.name).a"]
+                        ].reduce([], +))
+                    }
+                }
+
+                results.checkTarget(appTargetName) { target in
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                ["clang"],
+                                ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"],
+                                arch == baseArch ? ["-target-arch-variant", cohortArch] : [],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/\(target.target.name)"]
+                            ].reduce([], +))
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/\(target.target.name)",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/\(target.target.name)"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).app/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Test enabling `ENABLE_COHORT_ARCHS` when the only arch in the cohort we're building for is the base arch.
+    ///
+    /// The original version of the cohort arch logic contained a bug where the base arch would be elided from the set of archs to build in this scenario.
+    @Test(.requireSDKs(.iOS))
+    func testCohortArchEnabledWithOnlyOneArch() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+
+            let testWorkspace = try await makeTestWorkspace()
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+            let IPHONEOS_DEPLOYMENT_TARGET = core.loadSDK(.iOS).defaultDeploymentTarget
+
+            let fs = PseudoFS()
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(baseArch)-ios.json"), .plDict([:]))
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(soloArch)-ios.json"), .plDict([:]))
+
+            let archs = [soloArch, baseArch]
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
+                "ARCHS": archs.joined(separator: " "),
+                "ENABLE_COHORT_ARCHS": "YES",
+            ])
+            guard let target = tester.workspace.projects[0].targets.first.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }) else {
+                Issue.record("Could not find top level target for project")
+                return
+            }
+            let request = BuildRequest(parameters: parameters, buildTargets: [target], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+            let runDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: runDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // ExtractAppIntentsMetadata uses and generated some files based on the arch, but only for the base arch and the solo arch, not the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ExtractAppIntentsMetadata")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(soloArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineDoesNotContain("\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)")
+                        task.checkCommandLineContainsUninterrupted(["--binary-file", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"])
+                        // Inputs and outputs that are present for the base archand the solo arch, and not the cohort arch.
+                        for arch in [soloArch, baseArch] {
+                            task.checkCommandLineContainsUninterrupted(["--dependency-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name)_dependency_info.dat"])
+                            task.checkCommandLineContainsUninterrupted(["--stringsdata-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/ExtractedAppShortcutsMetadata.stringsdata"])
+                            task.checkCommandLineContainsUninterrupted(["--source-file-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name).SwiftFileList"])
+                            task.checkCommandLineContainsUninterrupted(["--swift-const-vals-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name).SwiftConstValuesFileList"])
+                        }
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name)_dependency_info.dat")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/ExtractedAppShortcutsMetadata.stringsdata")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftFileList")
+                        task.checkCommandLineDoesNotContain("\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftConstValuesFileList")
+                    }
+
+                    // Check that we are only generating the .swiftinterface file for the base and solo archs (we're generating them because BUILD_LIBRARY_FOR_DISTRIBUTION is enabled),
+                    // and that we're only running the ABI checker and generating ABI baselines for the base arch.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftinterface"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.private.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.private.swiftinterface"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("CheckSwiftABI"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineContainsUninterrupted(["-baseline-path", "\(abiBaselinesDir.str)/ABI/\(arch)-ios.json"])
+                        }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("GenerateSwiftABIBaseline"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(abiOutputDir.str)/\(arch)-ios.json"])
+                        }
+                    }
+
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                ["clang++"],
+                                ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/\(target.target.name)"]
+                            ].reduce([], +))
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/\(target.target.name)",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/\(target.target.name)"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+                }
+
+                results.checkTarget(libTargetName) { target in
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Libtool"), .matchRuleItemBasename("lib\(target.target.name).a"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                [LIBTOOL, "-static"],
+                                ["-arch_only", arch],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/lib\(target.target.name).a"]
+                            ].reduce([], +))
+                            task.checkCommandLineDoesNotContain("-arch_variant")
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Libtool"), .matchRuleItemBasename("lib\(target.target.name).a"), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/lib\(target.target.name).a",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/lib\(target.target.name).a"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/lib\(target.target.name).a"]
+                        ].reduce([], +))
+                    }
+                }
+
+                results.checkTarget(appTargetName) { target in
+                    // Check that we have link tasks.
+                    for arch in [soloArch, baseArch] {
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                ["clang"],
+                                ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/\(target.target.name)"]
+                            ].reduce([], +))
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                        }
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(cohortArch))
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(soloArch)/Binary/\(target.target.name)",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/\(target.target.name)"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).app/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Test that cohort arch support is disabled for archs which declare they are part of a cohort when `ENABLE_COHORT_ARCHS` is `NO`.
+    ///
+    /// This is to make sure we can disable cohort arch support successfully if we have to.
+    @Test(.requireSDKs(.iOS))
+    func testDisabledCohortArchSupport() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+
+            let testWorkspace = try await makeTestWorkspace()
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+            let IPHONEOS_DEPLOYMENT_TARGET = core.loadSDK(.iOS).defaultDeploymentTarget
+
+            let fs = PseudoFS()
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(baseArch)-ios.json"), .plDict([:]))
+
+            let archs = [baseArch, cohortArch]
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
+                "ARCHS": archs.joined(separator: " "),
+                "ENABLE_COHORT_ARCHS": "NO",
+                "GCC_PRECOMPILE_PREFIX_HEADER": "NO",       // We're not testing PCH generation here
+            ])
+            guard let fwkTarget = tester.workspace.projects[0].targets[safe: 1].map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }) else {
+                Issue.record("Could not find framework target for project")
+                return
+            }
+            let request = BuildRequest(parameters: parameters, buildTargets: [fwkTarget], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+            let runDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: runDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "ClangStatCache", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // ExtractAppIntentsMetadata uses the SwiftFileList, so check that it only uses the arm64e one, since we won't generate one for the cohort arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("ExtractAppIntentsMetadata")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target-triple", "\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--source-file-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/\(target.target.name).SwiftFileList"])
+                        task.checkCommandLineContainsUninterrupted(["--source-file-list", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/\(target.target.name).SwiftFileList"])
+                        // These are the outputs of the task
+                        task.checkCommandLineContainsUninterrupted(["--stringsdata-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/ExtractedAppShortcutsMetadata.stringsdata"])
+                        task.checkCommandLineContainsUninterrupted(["--stringsdata-file", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/ExtractedAppShortcutsMetadata.stringsdata"])
+                    }
+
+                    // Check that we have separate tasks for each arch.
+                    for arch in archs {
+                        // Check the ScanDependencies tasks which exist for clang explicit modules.
+                        results.checkTask(.matchTarget(target), .matchRuleItem("ScanDependencies"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/CFile.o"])
+                        }
+
+                        // There doesn't seem to be an equivalent way to check for Swift explicit modules in a task construction test.
+
+                        // Check the compilation tasks.
+                        results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/CFile.o"])
+                        }
+                        results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(arch))
+                        results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CPPFile.o"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                            task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/CPPFile.o"])
+                        }
+                        results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CPPFile.o"), .matchRuleItem(arch))
+                        results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation Requirements"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-macho-arch-variant-\(baseArch)")
+                            task.checkCommandLineDoesNotContain("-macho-arch-variant-\(cohortArch)")
+                        }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-macho-arch-variant-\(baseArch)")
+                            task.checkCommandLineDoesNotContain("-macho-arch-variant-\(cohortArch)")
+                        }
+
+                        // Check that we copy the content to the .swiftmodule for each arch.
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.swiftmodule")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftmodule"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/Project/\(arch)-apple-ios.swiftsourceinfo")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftsourceinfo"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.abi.json")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.abi.json"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.swiftdoc")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftdoc"))) { _ in }
+
+                        // Check that we are generating the .swiftinterface file for each arch (we're generating them because BUILD_LIBRARY_FOR_DISTRIBUTION is enabled).
+                        // We *probably* should not be generating this for the cohort arch, even when not using the efficient workflow, but that is part of a larger chunk of work in the future. <rdar://163808075>
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.swiftinterface"))) { _ in }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemPattern(.suffix("FrameworkTarget.swiftmodule/\(arch)-apple-ios.private.swiftinterface")), .matchRuleItemPattern(.suffix("\(arch)/FrameworkTarget.private.swiftinterface"))) { _ in }
+
+                        results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Interface Verification"), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                            task.checkCommandLineDoesNotContain("-target-arch-variant")
+                        }
+
+                        // Check the linker tasks and the contents of the link-file-lists.
+                        results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemPattern(.suffix("\(arch)/\(target.target.name).LinkFileList"))) { task, contents in
+                            task.checkRuleInfo(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/\(target.target.name).LinkFileList"])
+                            let contentsLines = contents.asString.dropLast().components(separatedBy: .newlines)
+                            #expect(contentsLines == [
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/CFile.o",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/CPPFile.o",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/SwiftFile.o",
+                          ])
+                        }
+                        results.checkTask(.matchTarget(target), .matchRuleItem("Ld"), .matchRuleItemBasename(target.target.name), .matchRuleItem(arch)) { task in
+                            task.checkCommandLineContains([
+                                ["clang++"],
+                                ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"],
+                                ["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(arch)/Binary/\(target.target.name)"]
+                            ].reduce([], +))
+                        }
+                    }
+
+                    // Check tasks which are only generated for one arch.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftMergeGeneratedHeaders")) { task in
+                        task.checkCommandLineContainsUninterrupted(["-arch", baseArch])
+                        task.checkCommandLineContainsUninterrupted(["-arch", cohortArch])
+                    }
+
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CheckSwiftABI"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-baseline-path", "\(abiBaselinesDir.str)/ABI/\(baseArch)-ios.json"])
+                    }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("GenerateSwiftABIBaseline"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(abiOutputDir.str)/\(baseArch)-ios.json"])
+                    }
+
+                    // Check that there's a lipo task.
+                    results.checkTask(.matchTarget(target), .matchRuleType("CreateUniversalBinary")) { task in
+                        task.checkCommandLineContains([
+                            ["lipo", "-create"],
+                            ["\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/Binary/\(target.target.name)",
+                                "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(cohortArch)/Binary/\(target.target.name)"],
+                            ["-output", "\(SRCROOT)/build/\(CONFIGURATION)-iphoneos/\(target.target.name).framework/\(target.target.name)"]
+                        ].reduce([], +))
+                    }
+
+                    // Check that the module verifier runs on both archs.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("Copy"), .matchRuleItemBasename("module.modulemap")) { _ in }
+                    results.checkTask(.matchTarget(target), .matchRuleItem("VerifyModule")) { task in
+                        task.checkCommandLineContainsUninterrupted(["--target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["--target", "\(cohortArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                    }
+
+                    results.checkTasks(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile")) { _ in }
+                    results.checkNoTask(.matchTarget(target))
+                }
+
+                results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { _ in }
+                results.checkNoTask()
+            }
+        }
+    }
+
+}

--- a/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
+++ b/Tests/SWBTaskExecutionTests/InProcessTaskTestSupport.swift
@@ -25,6 +25,9 @@ import Synchronization
 
 struct MockExecutionDelegate: TaskExecutionDelegate {
     struct Lookup: PlatformInfoLookup {
+        func lookupPlatformNames(platform: SWBUtil.BuildVersion.Platform) -> Set<String> {
+            return Set()
+        }
         func lookupPlatformInfo(platform: SWBUtil.BuildVersion.Platform) -> (any SWBUtil.PlatformInfoProvider)? {
             nil
         }

--- a/Tests/SWBUtilTests/MachOTests.swift
+++ b/Tests/SWBUtilTests/MachOTests.swift
@@ -53,7 +53,10 @@ fileprivate struct MachOTests {
     func testMachO(archs: [String], platform: BuildVersion.Platform = .macOS, hideARM64: Bool = false) async throws {
         try await withTemporaryDirectory { (tmpDir: Path) in
             struct Lookup: PlatformInfoLookup {
-                func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+                func lookupPlatformNames(platform: SWBUtil.BuildVersion.Platform) -> Set<String> {
+                    return Set()
+                }
+                func lookupPlatformInfo(platform: SWBUtil.BuildVersion.Platform) -> (any PlatformInfoProvider)? {
                     nil
                 }
             }
@@ -415,6 +418,9 @@ fileprivate struct MachOTests {
     @Test
     func swiftABIVersion() async throws {
         struct Lookup: PlatformInfoLookup {
+            func lookupPlatformNames(platform: BuildVersion.Platform) -> Set<String> {
+                return Set()
+            }
             func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
                 nil
             }

--- a/Tests/SWBUtilTests/MiscTests.swift
+++ b/Tests/SWBUtilTests/MiscTests.swift
@@ -54,7 +54,10 @@ import SWBUtil
     func linkerSignedBinaryDetection() async throws {
         try await withTemporaryDirectory { tmpDir -> Void in
             struct Lookup: PlatformInfoLookup {
-                func lookupPlatformInfo(platform: BuildVersion.Platform) -> (any PlatformInfoProvider)? {
+                func lookupPlatformNames(platform: SWBUtil.BuildVersion.Platform) -> Set<String> {
+                    return Set()
+                }
+                func lookupPlatformInfo(platform: SWBUtil.BuildVersion.Platform) -> (any PlatformInfoProvider)? {
                     nil
                 }
             }


### PR DESCRIPTION
This supports an experimental compiler feature to improve build times of multiple architectures.

Cohorts are declared in a new property on an Architecture xcspec. As part of computing the effective value of `ARCHS` in `Settings.getProductSpecificTargetTaskOverrides()`, individual cohorts will be detected from the `ARCHS` via this property, and new settings to group the cohorts will be defined.

The architecture  loop in `SourcesTaskProducer` will iterate over only the base archs of a cohort and the archs which are not part of any cohort. For the cohort base archs, build tools (compilers, linkers) will be passed additional options for the other archs in the cohort. These will generate universal outputs (e.g., the compilers will generate universal object files) which will be used by downstream tools. Archs in a cohort other than the base arch will be skipped in the architecture loop.

Support is guarded by `ENABLE_COHORT_ARCHS` which can be turned off in scenarios where the archs must be built separately.

rdar://162157469
