### PR TITLE
Fix some failing performance tests.

### DIFF
--- a/Tests/SwiftBuildPerfTests/BuildOperationPerfTests.swift
+++ b/Tests/SwiftBuildPerfTests/BuildOperationPerfTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -170,7 +170,7 @@ fileprivate struct BuildOperationPerfTests: PerfTests {
                         let events = try await testSession.runBuildOperation(request: request, delegate: TestBuildOperationDelegate())
 
                         try await tester.checkResults(events: events) { results in
-                            results.consumeTasksMatchingRuleTypes(["CreateBuildDescription", "ComputeTargetDependencyGraph", "GatherProvisioningInputs", "ClangStatCache"])
+                            results.consumeTasksMatchingRuleTypes(["CreateBuildDescription", "ComputeTargetDependencyGraph", "GatherProvisioningInputs", "ClangStatCache", "PruneExplicitPrecompiledModules"])
                             results.checkNoTask()
 
                             results.checkNote(.equal("Building targets in dependency order"))


### PR DESCRIPTION
These tests don't need to check for PruneExplicitPrecompiledModules tasks.

rdar://177574756