### PR TITLE
Argument Parser 1.8.0 now does parsing async

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -503,7 +503,7 @@ if useLocalDependencies {
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.5.0")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", branch: relatedDependenciesBranch),
     ]
     if !useLLBuildFramework {

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -568,7 +568,7 @@ public func pbxcp(_ argv: [String], cwd: Path) async -> (success: Bool, output: 
     do {
         var argv = argv
         argv.removeFirst()
-        options = try CopyOptions.parse(argv)
+        options = try await CopyOptions.parse(argv)
     } catch {
         return (false, CopyOptions.message(for: error))
     }


### PR DESCRIPTION
I've had to patch this locally for the last couple months of using the main branch of Argument Parser, which we'll need merged now that the toolchain is being updated to use Argument Parser 1.8.0, swiftlang/swift#89404, with this change most likely tied to apple/swift-argument-parser#855.