### PR TITLE
Add build setting to record the codegen name of a symbol in the index

### DIFF
--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -3546,6 +3546,13 @@ For more information on mergeable libraries, see [Configuring your project to us
                 Description = "Compress the index store, reducing its size on disk.";
             },
             {
+                Name = "INDEX_STORE_CODEGEN_NAME";
+                Type = Boolean;
+                DefaultValue = NO;
+                DisplayName = "Record Codegen names in index";
+                Description = "Record the names by which symbols can be referenced by linkers inside the Index Store, in addition to their USR.";
+            },
+            {
                 Name = "INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE";
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3260,6 +3260,18 @@
                 };
             },
             {
+                Name = "CLANG_INDEX_STORE_CODEGEN_NAME";
+                Type = Boolean;
+                DefaultValue = "$(INDEX_STORE_CODEGEN_NAME)";
+                Condition = "$(CLANG_INDEX_STORE_ENABLE)  &&  ( $(COMPILER_INDEX_STORE_ENABLE)  ||  ( $(COMPILER_INDEX_STORE_ENABLE) == Default  &&  $(GCC_OPTIMIZATION_LEVEL) == 0 ) )";
+                CommandLineArgs = {
+                    YES = (
+                        "-index-record-codegen-name",
+                    );
+                    NO = ();
+                };
+            },
+            {
                 Name = "CLANG_INDEX_STORE_IGNORE_MACROS";
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -362,6 +362,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                                     "INDEX_STORE_COMPRESS": "YES",
                                     "INDEX_STORE_ONLY_PROJECT_FILES": "YES",
                                     "CLANG_INDEX_STORE_IGNORE_MACROS": "YES",
+                                    "INDEX_STORE_CODEGEN_NAME": "YES",
                                 ]
                             ),
                         ],
@@ -380,6 +381,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                     compileTask.checkCommandLineContains(["-index-ignore-system-symbols"])
                     compileTask.checkCommandLineContains(["-index-ignore-pcms"])
                     compileTask.checkCommandLineContains(["-index-ignore-macros"])
+                    compileTask.checkCommandLineContains(["-index-record-codegen-name"])
                 }
             }
             // Check that we don't emit any index-related options when INDEX_ENABLE_DATA_STORE is not enabled
@@ -390,6 +392,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                     compileTask.checkCommandLineDoesNotContain("-index-ignore-system-symbols")
                     compileTask.checkCommandLineDoesNotContain("-index-ignore-pcms")
                     compileTask.checkCommandLineDoesNotContain("-index-ignore-macros")
+                    compileTask.checkCommandLineDoesNotContain("-index-record-codegen-name")
                 }
             }
         }


### PR DESCRIPTION
Add a builds setting to effectively control `-index-record-codegen-name` in clang. Eventually, I want to also add the equivalent of `-index-record-codegen-name` to swiftc, in which case `INDEX_STORE_CODEGEN_NAME` will also control the equivalent setting in Swift.

rdar://177361637
