### PR TITLE
Ensure linux platform filters match linux-musl triples

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -287,6 +287,7 @@ public extension ProjectModel.BuildSettings.Platform {
 
         case .linux:
             result.append(.init(platform: "linux", environment: "gnu"))
+            result.append(.init(platform: "linux", environment: "musl"))
 
         case .android:
             result.append(.init(platform: "linux", environment: "android"))


### PR DESCRIPTION
This ensures the right platform conditions are active when building with the static linux SDK