### PR TITLE
fix: add missing `await`

### DIFF
--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -568,7 +568,7 @@ public func pbxcp(_ argv: [String], cwd: Path) async -> (success: Bool, output: 
     do {
         var argv = argv
         argv.removeFirst()
-        options = try CopyOptions.parse(argv)
+        options = try await CopyOptions.parse(argv)
     } catch {
         return (false, CopyOptions.message(for: error))
     }


### PR DESCRIPTION
Fixes:
```
SwiftCompile normal arm64 /Users/brettbest/Developer/swift-build/Sources/SWBUtil/PbxCp.swift (in target 'SWBUtil' from project 'SwiftBuild')
    cd /Users/brettbest/Developer/swift-build/.swiftpm/xcode
    

/Users/brettbest/Developer/swift-build/Sources/SWBUtil/PbxCp.swift:571:19: error: expression is 'async' but is not marked with 'await'
        options = try CopyOptions.parse(argv)
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                      await 
/Users/brettbest/Developer/swift-build/Sources/SWBUtil/PbxCp.swift:571:23: note: call is 'async'
        options = try CopyOptions.parse(argv)
```

I believe this was caused by https://github.com/apple/swift-argument-parser/commit/d6f4e7a371cbd322a89305ae831d36a47d0e3357 and the dependency constraint for it is `from: "1.0.3"` meaning `1.8.0` satisfies this - hence it breaking.

If a lower version is checked out now a warning of: `No 'async' operations occur within 'await' expression` is generated.

I thought the below might work:
```swift
        #if canImport(ArgumentParser, _version: 1.8.0)
        options = try await CopyOptions.parse(argv)
        #else
        options = try CopyOptions.parse(argv)
        #endif
```
But I get: https://docs.swift.org/compiler/documentation/diagnostics/module-version-missing/

I thought I saw SwiftPM would set this but perhaps that hasn't shipped yet or I imagined it :D