### PR TITLE
Update Xcode version to 26.4 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,7 +65,7 @@ jobs:
       linux_swift_versions: '["nightly-main"]'
       linux_host_archs: '["x86_64", "aarch64"]'
       enable_macos_checks: true
-      macos_xcode_versions: '["26.0"]'
+      macos_xcode_versions: '["26.4"]'
       macos_pre_build_command: SKIP_ANDROID=1 INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
       macos_build_command: 'export PATH=$PATH:$RUNNER_TOOL_CACHE && swift package cmake-smoke-test --disable-sandbox --cmake-path `which cmake` --ninja-path `which ninja` --extra-cmake-arg -DCMAKE_C_COMPILER=`which clang` --extra-cmake-arg -DCMAKE_CXX_COMPILER=`which clang++` --extra-cmake-arg -DCMAKE_Swift_COMPILER=`which swiftc`'
       windows_build_timeout: 180
@@ -108,7 +108,7 @@ jobs:
       linux_pre_build_command: ./.github/scripts/prebuild.sh && ./.github/scripts/clone-swiftpm-deps.sh "${{ github.base_ref }}"
       linux_build_command: 'SWIFTCI_USE_LOCAL_DEPS=1 swift test --package-path ../swiftpm'
       enable_macos_checks: true
-      macos_xcode_versions: '["26.0"]'
+      macos_xcode_versions: '["26.4"]'
       macos_pre_build_command: ./.github/scripts/prebuild.sh && ./.github/scripts/clone-swiftpm-deps.sh "${{ github.base_ref }}"
       macos_build_command: 'SWIFTCI_USE_LOCAL_DEPS=1 swift test --package-path ../swiftpm --skip testSDKTracking'
       enable_windows_checks: false


### PR DESCRIPTION
Runners no longer have 26.0 installed, so this should fix a handful of the failures seen in CI