### PR TITLE
Skip swiftAstPathForStaticLibrariesMultiPlatform if using EBM-based debug info

### DIFF
--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -2583,7 +2583,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     // Checks that we pass `-add_ast_path` for each Swift module we link when linking statically.
-    @Test(.requireSDKs(.iOS, .watchOS))
+    @Test(.requireSDKs(.iOS, .watchOS), .skipIfHasSwiftFeature(.debugInfoExplicitDependency))
     func swiftAstPathForStaticLibrariesMultiPlatform() async throws {
         let testProject = try await TestProject(
             "Test",


### PR DESCRIPTION
Skip this test if the relevant feature is enabled because we don't expect to be using -add_ast_path in that case