### PR TITLE
Avoid assertion for legitimate case where reply received for handler that was closed

### DIFF
--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -57,13 +57,6 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
 
         /// Track whether the channels have been cleared because the service has crashed.
         var channelsHaveBeenCleared = false
-
-        /// Returns true if the channel ID is unknown (has never been assigned), false otherwise
-        /// A nil handler for a known channel is expected, service crash or client closed the channel before the reply arrived.
-        /// A nil handler for an unknown channel is unexpected.
-        func isChannelUnknown(_ channel: UInt64) -> Bool {
-            return channel > nextChannelID
-        }
     }
 
     /// An "unfair lock" that protects the channels state.  Should be held only for very short periods of time.
@@ -310,14 +303,6 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
                         let channel = headerFrame.channel
                         let msgSize = Int(headerFrame.messageSize)
 
-                        // Look up the channel by its number.
-                        let (handler, isChannelUnknown) = self.channelState.withLock { state in
-                            return (state.channels[channel], state.isChannelUnknown(channel))
-                        }
-                        if handler == nil && isChannelUnknown {
-                            assertionFailure("Received reply for unknown channel: \(channel)")
-                        }
-
                         // If we don’t have all the data yet, we can go no further.
                         if offset + msgSize > data.count {
                             // Move the offset back to just before the header, so we’ll see it again next time around.
@@ -327,7 +312,11 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
                         }
 
                         // Otherwise, look up the channel by its number.
-                        handler?(channel, data.subdata(in: offset..<(offset + msgSize)))
+                        if let handler = self.channelState.withLock({ $0.channels[channel] }) {
+                              handler(channel, data.subdata(in: offset..<(offset + msgSize)))
+                        } else {
+                            // A nil handler is expected. The caller cancelled before the server's async reply was received.
+                        }
 
                         // Move on to the next message.
                         offset += msgSize

--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -57,6 +57,12 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
 
         /// Track whether the channels have been cleared because the service has crashed.
         var channelsHaveBeenCleared = false
+
+        /// A nil handler for a known channel is expected, service crash or client closed the channel before the reply arrived.
+        /// A nil handler for an unknown channel is unexpected.
+        func isChannelKnown(_ channel: UInt64) -> Bool {
+            return channel <= nextChannelID
+        }
     }
 
     /// An "unfair lock" that protects the channels state.  Should be held only for very short periods of time.
@@ -312,10 +318,14 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
                         }
 
                         // Otherwise, look up the channel by its number.
-                        if let handler = self.channelState.withLock({ $0.channels[channel] }) {
-                              handler(channel, data.subdata(in: offset..<(offset + msgSize)))
+                        let (handler, isChannelKnown) = self.channelState.withLock {
+                            return ($0.channels[channel], $0.isChannelKnown(channel))
+                        }
+
+                        if let handler {
+                            handler(channel, data.subdata(in: offset..<(offset + msgSize)))
                         } else {
-                            // A nil handler is expected. The caller cancelled before the server's async reply was received.
+                            assert(isChannelKnown, "Received reply for unknown channel: \(channel)")
                         }
 
                         // Move on to the next message.

--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -59,6 +59,8 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
         var channelsHaveBeenCleared = false
 
         /// Returns true if the channel ID is unknown (has never been assigned), false otherwise
+        /// A nil handler for a known channel is expected, service crash or client closed the channel before the reply arrived.
+        /// A nil handler for an unknown channel is unexpected.
         func isChannelUnknown(_ channel: UInt64) -> Bool {
             return channel > nextChannelID
         }
@@ -312,10 +314,6 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
                         let (handler, isChannelUnknown) = self.channelState.withLock { state in
                             return (state.channels[channel], state.isChannelUnknown(channel))
                         }
-                        // Guard against the service sending a reply for a channel the client never opened.
-                        // A nil handler for a known channel is expected (service crash or client closed the
-                        // channel before the reply arrived)
-                        // A nil handler for an unknown channel is unexpected.
                         if handler == nil && isChannelUnknown {
                             assertionFailure("Received reply for unknown channel: \(channel)")
                         }

--- a/Sources/SwiftBuild/SWBBuildServiceConnection.swift
+++ b/Sources/SwiftBuild/SWBBuildServiceConnection.swift
@@ -57,6 +57,11 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
 
         /// Track whether the channels have been cleared because the service has crashed.
         var channelsHaveBeenCleared = false
+
+        /// Returns true if the channel ID is unknown (has never been assigned), false otherwise
+        func isChannelUnknown(_ channel: UInt64) -> Bool {
+            return channel > nextChannelID
+        }
     }
 
     /// An "unfair lock" that protects the channels state.  Should be held only for very short periods of time.
@@ -304,11 +309,15 @@ typealias swb_build_service_connection_message_handler_t = @Sendable (UInt64, SW
                         let msgSize = Int(headerFrame.messageSize)
 
                         // Look up the channel by its number.
-                        let handler = self.channelState.withLock({ $0.channels[channel] })
-                        if handler == nil {
-                            // It’s an error if we didn’t find a channel here.
-                            // FIXME: We need to handle this error in a better way.
-                            assertionFailure("no handler for channel: \(channel)")
+                        let (handler, isChannelUnknown) = self.channelState.withLock { state in
+                            return (state.channels[channel], state.isChannelUnknown(channel))
+                        }
+                        // Guard against the service sending a reply for a channel the client never opened.
+                        // A nil handler for a known channel is expected (service crash or client closed the
+                        // channel before the reply arrived)
+                        // A nil handler for an unknown channel is unexpected.
+                        if handler == nil && isChannelUnknown {
+                            assertionFailure("Received reply for unknown channel: \(channel)")
                         }
 
                         // If we don’t have all the data yet, we can go no further.


### PR DESCRIPTION
Avoid assertion for legitimate case where reply received for handler that was closed