### PR TITLE
Don't use preferredArch when computing the base arch to use in a cohort.

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -4402,13 +4402,14 @@ private class SettingsBuilder: ProjectMatchLookup {
                 // Sort the archs for stability.
                 let sortedArchs = archs.sorted()
 
-                // Compute the base arch. The purpose of this is to always choose the same base arch from the same list of archs (if we don't have a preferredArch), and picking the first one from a sorted list is a simple way to do that.
+                // Compute the base arch. The purpose of this is to always choose the same base arch from the same list of archs in a stable manner.
+                // If the name of the arch cohort is in the list, then we prefer that one. Otherwise we pick the first one from the sorted list, which is a simple way to ensure stability.
+                // We don't want to use self.preferredArch here, because that can vary depending on context (for example different run destinations may provide different preferredArchs).
                 guard let firstArch = sortedArchs.first else {
                     // If there are no archs then we don't need to set up a cohort.
                     continue
                 }
-                let preferredBaseArch = self.preferredArch ?? cohortArch
-                let baseArch = archs.contains(preferredBaseArch) ? preferredBaseArch : firstArch
+                let baseArch = archs.contains(cohortArch) ? cohortArch : firstArch
                 let otherArchs = sortedArchs.filter({ $0 != baseArch })
 
                 // Set up the build settings for the cohort which CURRENT_ARCH is in.  (They will of course be empty if there is no cohort - we won't even have gotten here.)

--- a/Tests/SWBTaskConstructionTests/CohortArchTests.swift
+++ b/Tests/SWBTaskConstructionTests/CohortArchTests.swift
@@ -744,6 +744,86 @@ fileprivate struct CohortArchTests: CoreBasedTests {
         }
     }
 
+    /// Test that we always select the same base arch for the cohort even when passing run destinations with different target architectures.
+    ///
+    /// In all cases, `arch.base` should be the primary arch and `arch.cohort` the variant arch.
+    @Test(.requireSDKs(.iOS))
+    func testCohortBaseArchStability() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+
+            let testWorkspace = try await makeTestWorkspace()
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+            let IPHONEOS_DEPLOYMENT_TARGET = core.loadSDK(.iOS).defaultDeploymentTarget
+
+            let fs = PseudoFS()
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(baseArch)-ios.json"), .plDict([:]))
+            try await fs.writeJSON(abiBaselinesDir.join("ABI/\(soloArch)-ios.json"), .plDict([:]))
+
+            let archs = [baseArch, cohortArch]
+            let parameters = BuildParameters(configuration: CONFIGURATION, overrides: [
+                "ARCHS": archs.joined(separator: " "),
+                "ENABLE_COHORT_ARCHS": "YES",
+            ])
+            guard let target = tester.workspace.projects[0].targets.first.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }) else {
+                Issue.record("Could not find top level target for project")
+                return
+            }
+            let request = BuildRequest(parameters: parameters, buildTargets: [target], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+
+            // Test with a run destination where the base arch is the target.
+            let baseRunDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: baseRunDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // Check the clang and swift tasks to make sure we're seeing them with the correct options.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CFile.o"])
+                        #expect(task.execDescription == "Compile CFile.c (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"))
+
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch,])
+                        #expect(task.execDescription == "Compile \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+                }
+            }
+
+            // Test with a run destination where the cohort arch is the target.
+            let cohortRunDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: cohortArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+            await tester.checkBuild(runDestination: cohortRunDestination, buildRequest: request, fs: fs) { results in
+                results.consumeTasksMatchingRuleTypes(["AppIntentsSSUTraining", "CodeSign", "CreateBuildDirectory", "Gate", "GenerateDSYMFile", "GenerateTAPI", "IntentDefinitionCompile", "MkDir", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "RegisterExecutionPolicyException", "SymLink", "Touch", "Validate"])
+
+                results.checkNoDiagnostics()
+
+                results.checkTarget(fwkTargetName) { target in
+                    // Check the clang and swift tasks to make sure we're seeing them with the correct options.
+                    results.checkTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch])
+                        task.checkCommandLineContainsUninterrupted(["-o", "\(SRCROOT)/build/aProject.build/\(CONFIGURATION)-iphoneos/\(target.target.name).build/Objects-normal/\(baseArch)/CFile.o"])
+                        #expect(task.execDescription == "Compile CFile.c (\(archs.joined(separator: ", ")))")
+                    }
+                    results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileC"), .matchRuleItemBasename("CFile.o"))
+
+                    results.checkTask(.matchTarget(target), .matchRuleItem("SwiftDriver Compilation"), .matchRuleItem(baseArch)) { task in
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(baseArch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)"])
+                        task.checkCommandLineContainsUninterrupted(["-target-arch-variant", cohortArch,])
+                        #expect(task.execDescription == "Compile \(target.target.name) (\(archs.joined(separator: ", ")))")
+                    }
+                }
+            }
+        }
+    }
+
     /// Test that cohort arch support is disabled for archs which declare they are part of a cohort when `ENABLE_COHORT_ARCHS` is `NO`.
     ///
     /// This is to make sure we can disable cohort arch support successfully if we have to.


### PR DESCRIPTION
This can vary based on certain inputs from Xcode, resulting in unstable build descriptions.

rdar://178193701