### PR TITLE
Add Swift build setting for "DerivedSources" search paths

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1098,6 +1098,7 @@ public final class BuiltinMacros {
     public static let SWIFT_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALL_OBJC_HEADER")
     public static let SWIFT_INSTALLAPI_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALLAPI_LAZY_TYPECHECK")
     public static let SWIFT_DISABLE_HEADERMAPS = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_HEADERMAPS")
+    public static let SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS")
     public static let SWIFT_DISABLE_PARSE_AS_LIBRARY = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_PARSE_AS_LIBRARY")
     public static let SWIFT_LIBRARIES_ONLY = BuiltinMacros.declareBooleanMacro("SWIFT_LIBRARIES_ONLY")
     public static let SWIFT_LIBRARY_LEVEL = BuiltinMacros.declareStringMacro("SWIFT_LIBRARY_LEVEL")
@@ -2337,6 +2338,7 @@ public final class BuiltinMacros {
         _SWIFT_EXPLICIT_MODULES_ALLOW_BEFORE_SWIFT_5,
         _EXPERIMENTAL_SWIFT_EXPLICIT_MODULES,
         SWIFT_DISABLE_HEADERMAPS,
+        SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS,
         SWIFT_DISABLE_PARSE_AS_LIBRARY,
         SWIFT_ENABLE_BARE_SLASH_REGEX,
         SWIFT_ENABLE_EMIT_CONST_VALUES,

--- a/Sources/SWBCore/SpecImplementations/Tools/GCCCompatibleCompilerSupport.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/GCCCompatibleCompilerSupport.swift
@@ -304,7 +304,15 @@ package struct GCCCompatibleCompilerSpecSupport
         // Add paths to the derived file folders.  Since we don't know a priori whether there will be any generated files, we have to play it safe and add paths to anywhere Xcode might generate them.
         let derivedFileDir = scope.evaluate(BuiltinMacros.DERIVED_FILE_DIR)
 
-        if scope.evaluate(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS), (scope.evaluateAsString(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS).isEmpty || scope.evaluate(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS)) {
+        let swiftEnableDefaultSearchPathsInHeaderSearchPaths = scope.evaluateAsString(BuiltinMacros.SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS)
+        let enableDefaultSearchPathsInHeaderSearchPaths: Bool
+        if forSwift && !swiftEnableDefaultSearchPathsInHeaderSearchPaths.isEmpty {
+            enableDefaultSearchPathsInHeaderSearchPaths = scope.evaluate(BuiltinMacros.SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS)
+        } else {
+            enableDefaultSearchPathsInHeaderSearchPaths = scope.evaluateAsString(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS).isEmpty || scope.evaluate(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS)
+        }
+
+        if scope.evaluate(BuiltinMacros.ENABLE_DEFAULT_SEARCH_PATHS), enableDefaultSearchPathsInHeaderSearchPaths {
             // Note that we include the current-variant-and-architecture-specific directory because Xcode directs MiG (and possibly other tools) to generate separate derived files per architecture and variant.
             let currentArch = scope.evaluate(BuiltinMacros.CURRENT_ARCH)
             let variantPath = Path("\(derivedFileDir.str)-\(scope.evaluate(BuiltinMacros.CURRENT_VARIANT))")

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -2771,6 +2771,59 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func swiftEnableDefaultSearchPathsInHeaderSearchPaths() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("bar.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "CODE_SIGN_IDENTITY": "",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_EXEC": swiftCompilerPath.str,
+                        "SWIFT_VERSION": swiftVersion,
+                        // Disable Swift's default header search paths while leaving the Clang-facing setting at its default. SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS only takes effect for Swift compile tasks.
+                        "SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS": "NO",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "FwkTarget",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "DEFINES_MODULE": "YES",
+                            ]
+                        ),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["bar.swift"]),
+                    ]),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        let fs = PseudoFS()
+
+        await tester.checkBuild(runDestination: .macOS, fs: fs) { results in
+            results.checkTarget("FwkTarget") { target in
+                results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                    // The default DerivedSources header search paths added by ENABLE_DEFAULT_SEARCH_PATHS must not be present in the Swift compiler invocation.
+                    task.checkCommandLineNoMatch([.contains("/DerivedSources")])
+                }
+            }
+
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func swiftDisabledHeadermaps() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
One major reason Swift command lines differ between targets is the DerivedSources search paths passed through `-Xcc` to Clang. Removing this source of differences between targets means Clang's dependency scanner and explicit compiles need to create fewer module variants, speeding up builds. This PR adds a new build setting called `SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS` (sibling to the existing `ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS`) that controls these search paths for Swift specifically. This enables more fine-grained experimentation and adoption.