### PR TITLE
Test: Add conditional trait on scudoSanitizer

### DIFF
--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -4445,6 +4445,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     @Test(
+        .requireSDKs(.host),
         arguments: Self.sanitizersTestData,
     )
     func scudoSanitizer(


### PR DESCRIPTION
The scudoSanitizer test requires a host SDK to run.  Add an appropriate trait to the test to ensure the environment is able to execute the test.

Issue: rdar://175556280
