### PR TITLE
Use access level on import in resource_bundle_accessor.swift

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -2021,8 +2021,18 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
     private func generatePackageTargetBundleAccessorForSwift(_ scope: MacroEvaluationScope, bundleName: String) async -> GeneratedSourceCodeResult {
         let filePath = scope.evaluate(BuiltinMacros.DERIVED_SOURCES_DIR).join("resource_bundle_accessor.swift")
 
+        // Emit an explicit access level on imports if access-level-on-import is part of the language mode (>= 6.0).
+        // Without this, targets that use access levels on imports will fail to compile.
+        let importPrefix: String = {
+            guard let swiftVersion = try? Version(scope.evaluate(BuiltinMacros.SWIFT_VERSION)),
+                  swiftVersion >= Version(6) else {
+                return ""
+            }
+            return "public "
+        }()
+
         let contents = bundleName.isEmpty ? """
-            import class Foundation.Bundle
+            \(importPrefix)import class Foundation.Bundle
 
             extension Foundation.Bundle {
                 static let module = {
@@ -2031,9 +2041,9 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }()
             }
             """ : """
-            import class Foundation.Bundle
-            import class Foundation.ProcessInfo
-            import struct Foundation.URL
+            \(importPrefix)import class Foundation.Bundle
+            \(importPrefix)import class Foundation.ProcessInfo
+            \(importPrefix)import struct Foundation.URL
 
             private class BundleFinder {}
 

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -1076,6 +1076,9 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in
                     XCTAssertMatch(contents.unsafeStringValue, .contains("static nonisolated let module: Bundle"))
                     XCTAssertMatch(contents.unsafeStringValue, .contains("let bundleName = \"tool_resources\""))
+                    // For SWIFT_VERSION < 6.0, access-level-on-import is not part of the language mode.
+                    // Imports in the generated file must not specify an access level in this case.
+                    XCTAssertMatch(contents.unsafeStringValue, (.regex(#/^import class Foundation\.Bundle/#)))
                 }
             }
 
@@ -1124,6 +1127,58 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                     XCTAssertMatch(contents.unsafeStringValue, .contains("static let module = {"))
                     XCTAssertMatch(contents.unsafeStringValue, .not(.contains("let bundleName = \"tool_resources\"")))
                     XCTAssertMatch(contents.unsafeStringValue, .not(.contains("let bundleName = \"tools_resources\"")))
+                }
+            }
+        }
+    }
+
+    /// For SWIFT_VERSION >= 6.0, access-level-on-import is part of the language mode.
+    /// If any source file in the target uses an access level on an import, then
+    /// every import in the module must specify an access level, including imports
+    /// in generated files.
+    @Test(.requireSDKs(.macOS))
+    func resourceBundleAccessorEmitsAccessLevelImportForSwift6() async throws {
+        let testProject = try await TestPackageProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("main.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "SWIFT_VERSION": "6",
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "GENERATE_RESOURCE_ACCESSORS": "YES",
+                    "USE_HEADERMAP": "NO",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "tool", type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "USE_HEADERMAP": "NO",
+                            "DEFINES_MODULE": "YES",
+                            "PACKAGE_RESOURCE_BUNDLE_NAME": "tool_resources",
+                            "CODE_SIGNING_ALLOWED": "NO",
+                        ]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["main.swift"]),
+                    ]
+                ),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        await tester.checkBuild(runDestination: .macOS) { results in
+            results.checkNoDiagnostics()
+            results.checkTarget("tool") { target in
+                results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in
+                    XCTAssertMatch(contents.unsafeStringValue, .contains("public import class Foundation.Bundle"))
                 }
             }
         }


### PR DESCRIPTION
When a Swift package specifies a resource as part of a build target, SwiftPM synthesizes a resource_bundle_accessor.swift to provide runtime hooks to access the resource. This generated file imports Foundation but does not specify an access level. With Swift 6.0, access-level-on-import is part of the language mode, meaning that if a target specified a resource and contained a non-public import of Foundation, the build would fail with:

```
error: ambiguous implicit access level for import of 'Foundation'
```

This patch updates the generation logic to include an explicit `public` access level modifier for the Foundation import in `bundle_resource_accessor.swift` if the Swift version is >= 6.0.

Fixes swiftlang/swift-package-manager#10163

## Additional testing

1. Create a package with `swift-tools-version: 6.0`.
2. Add a target with resources: [.copy("SomeFolder")] so SwiftPM synthesizes resource_bundle_accessor.swift.
3. In one of that target's source files, add `internal import Foundation`.
4. Run `swift build --build-system swiftbuild`.

Without this patch, the build fails with the above specified error. With this patch, the build succeeds.