### PR TITLE
Add INFOPLIST_KEY_NSViewGestureRecognizerIsExclusive build setting

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1353,6 +1353,7 @@ public final class BuiltinMacros {
     public static let INFOPLIST_KEY_LSUIElement = BuiltinMacros.declareBooleanMacro("INFOPLIST_KEY_LSUIElement")
     public static let INFOPLIST_KEY_NSMainNibFile = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NSMainNibFile")
     public static let INFOPLIST_KEY_NSMainStoryboardFile = BuiltinMacros.declareStringMacro("INFOPLIST_KEY_NSMainStoryboardFile")
+    public static let INFOPLIST_KEY_NSViewGestureRecognizerIsExclusive = BuiltinMacros.declareBooleanMacro("INFOPLIST_KEY_NSViewGestureRecognizerIsExclusive")
 
     // Info.plist Keys - iOS and Derived Platforms
     public static let INFOPLIST_KEY_UILaunchScreen_Generation = BuiltinMacros.declareBooleanMacro("INFOPLIST_KEY_UILaunchScreen_Generation")
@@ -2677,6 +2678,7 @@ public final class BuiltinMacros {
         INFOPLIST_KEY_LSUIElement,
         INFOPLIST_KEY_NSMainNibFile,
         INFOPLIST_KEY_NSMainStoryboardFile,
+        INFOPLIST_KEY_NSViewGestureRecognizerIsExclusive,
 
         // Info.plist Keys - iOS and Derived Platforms
         INFOPLIST_KEY_UILaunchScreen_Generation,

--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -4432,6 +4432,16 @@ When this setting is enabled:
                 DisplayName = "AppKit Main Storyboard File Base Name";
                 Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [NSMainStoryboardFile](https://developer.apple.com/documentation/bundleresources/information-property-list/nsmainstoryboardfile) key in the `Info.plist` file to the value of this build setting.";
             },
+            {
+                Name = INFOPLIST_KEY_NSViewGestureRecognizerIsExclusive;
+                Type = Boolean;
+                Category = "Info.plist Values";
+                ConditionFlavors = (
+                    sdk,
+                );
+                DisplayName = "View Gesture Recognizer Is Exclusive";
+                Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [NSViewGestureRecognizerIsExclusive](https://developer.apple.com/documentation/bundleresources/information-property-list/nsviewgesturerecognizerisexclusive) key in the `Info.plist` file to the value of this build setting.";
+            },
 
             // Info.plist Keys - iOS and Derived Platforms
             {

--- a/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/InfoPlistProcessorTaskAction.swift
@@ -755,6 +755,7 @@ public final class InfoPlistProcessorTaskAction: TaskAction
             "LSUIElement",
             "NSMainNibFile",
             "NSMainStoryboardFile",
+            "NSViewGestureRecognizerIsExclusive",
 
             // iOS and Derived
 

--- a/Tests/SWBCoreTests/SpecRegistryTests.swift
+++ b/Tests/SWBCoreTests/SpecRegistryTests.swift
@@ -313,7 +313,7 @@ import SWBUtil
         let unreachableURLs: [(String, String)]
 #if canImport(Darwin)
         if checkInfoPlistKeyURLReachability {
-            unreachableURLs = try await withThrowingTaskGroup(of: (String, String).self) { group in
+            unreachableURLs = try await withThrowingTaskGroup(of: (String, String)?.self) { group in
                 for keyName in Set(infoPlistKeyOptions.map({ $0.name.hasPrefix("INFOPLIST_KEY_") ? String($0.name.dropFirst("INFOPLIST_KEY_".count)) : (legacyKeyMappings[$0.name] ?? $0.name) })).sorted() {
                     switch keyName {
                     case "UISupportedInterfaceOrientations_iPhone", "UISupportedInterfaceOrientations_iPad":
@@ -337,14 +337,14 @@ import SWBUtil
                     group.addTask {
                         let (_, response) = try await URLSession.shared.data(from: #require(URL(string: url)))
                         guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
-                            throw StubError.error("Network failure")
+                            return (String(keyName), url)
                         }
 
-                        return (String(keyName), url)
+                        return nil
                     }
                 }
 
-                return try await group.collect()
+                return try await group.collect().compactMap { $0 }
             }
         } else {
             unreachableURLs = []

--- a/Tests/SWBCoreTests/SpecRegistryTests.swift
+++ b/Tests/SWBCoreTests/SpecRegistryTests.swift
@@ -322,8 +322,11 @@ import SWBUtil
                     case "UIApplicationSceneManifest_Generation", "UILaunchScreen_Generation":
                         // These map to UIApplicationSceneManifest and UILaunchScreen, which are dictionaries.
                         continue
-                    case "MetalCaptureEnabled", "NSBluetoothWhileInUseUsageDescription", "NSFileProviderPresenceUsageDescription", "NSFocusStatusUsageDescription", "NSSystemExtensionUsageDescription", "NSVoIPUsageDescription", "OSBundleUsageDescription":
+                    case "MetalCaptureEnabled", "NSBluetoothWhileInUseUsageDescription", "NSFileProviderPresenceUsageDescription":
                         // rdar://91269820 (Missing documentation for some Info.plist keys which are directly supported by Xcode)
+                        continue
+                    case "WKSupportsLiveActivityLaunchAttributeTypes":
+                        // rdar://179234654 (Missing documentation for WKSupportsLiveActivityLaunchAttributeTypes Info.plist key)
                         continue
                     default:
                         break


### PR DESCRIPTION
Exposes the `NSViewGestureRecognizerIsExclusive` Info.plist key as an `INFOPLIST_KEY_*` build setting alongside the other macOS Info.plist keys. The build setting's description links to the key's official documentation using the standard Info.plist documentation URL format.

Updates the documentation exception list in `SpecRegistryTests`. I removed several keys that are now documented and added the still-undocumented `WKSupportsLiveActivityLaunchAttributeTypes`.

This PR also fixes the URL reachability check (`CHECK_INFOPLIST_KEY_URL_REACHABILITY`), which recorded reachable URLs as unreachable and aborted on the first failure; it now reports only URLs that fail to return a 200 status code as originally intended. The `infoPlistKeyConfigurations()` is now passing and green with my changes.

<img width="457" height="153" alt="Screenshot 2026-06-10 at 11 17 58 AM" src="https://github.com/user-attachments/assets/5d78a89e-7790-4718-862e-a0efd111f5bc" />
