### PR TITLE
[6.4] macOS 27.0 architecture updates

### DIFF
--- a/Sources/SWBApplePlatform/Specs/DriverKit.xcspec
+++ b/Sources/SWBApplePlatform/Specs/DriverKit.xcspec
@@ -82,6 +82,7 @@
         Name = "Intel 64-bit";
         Description = "64-bit Intel";
         PerArchBuildSettingName = "Intel 64-bit";
+        DeploymentTargetRange = ( "0", "27" );
     },
     {
         _Domain = driverkit;

--- a/Sources/SWBApplePlatform/Specs/macOSArchitectures.xcspec
+++ b/Sources/SWBApplePlatform/Specs/macOSArchitectures.xcspec
@@ -79,6 +79,7 @@
 		PerArchBuildSettingName = "Intel 64-bit";
 		ListInEnum = NO;
 		SortNumber = 106;
+        DeploymentTargetRange = ( "10.4.4", "27" );
 	},
     {
         _Domain = macosx;

--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -28,12 +28,12 @@ package protocol _RunDestinationInfo {
 extension _RunDestinationInfo {
     /// A generic run destination targeting macOS, using the public SDK.
     package static var anyMac: Self {
-        return generic(sdk: "macosx", sdkVariant: "macos", supportedArchitectures: ["arm64", "arm64e", "x86_64", "x86_64h"])
+        return generic(sdk: "macosx", sdkVariant: "macos", supportedArchitectures: ["arm64", "arm64e"])
     }
 
     /// A generic run destination targeting Mac Catalyst, using the public SDK.
     package static var anyMacCatalyst: Self {
-        return generic(sdk: "macosx", sdkVariant: MacCatalystInfo.sdkVariantName, supportedArchitectures: ["arm64", "arm64e", "x86_64", "x86_64h"])
+        return generic(sdk: "macosx", sdkVariant: MacCatalystInfo.sdkVariantName, supportedArchitectures: ["arm64", "arm64e"])
     }
 
     /// A generic run destination targeting iOS, using the public SDK.
@@ -86,7 +86,14 @@ extension _RunDestinationInfo {
     static func destination(operatingSystem: OperatingSystem) -> Self {
         switch operatingSystem {
         case .macOS:
-            macOS
+            switch Architecture.host.stringValue {
+            case "arm64":
+                macOSAppleSilicon
+            case "x86_64":
+                macOSIntel
+            default:
+                preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
+            }
         case .iOS(let simulator):
             simulator ? iOSSimulator : iOS
         case .tvOS(let simulator):
@@ -119,18 +126,8 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting macOS, using the public SDK.
     package static var macOS: Self {
-        #if os(macOS)
-        switch Architecture.host.stringValue {
-        case "arm64":
-            return macOSAppleSilicon
-        case "x86_64":
-            return macOSIntel
-        default:
-            preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
-        }
-        #else
-        return macOSIntel
-        #endif
+        // Default to Apple Silicon now that x86 is no longer supported in new versions of macOS
+        return .macOSAppleSilicon
     }
 
     /// A run destination targeting macOS running on Intel, using the public SDK.
@@ -150,19 +147,8 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting macOS (Mac Catalyst), using the public SDK.
     package static var macCatalyst: Self {
-        #if os(macOS)
-        switch Architecture.host.stringValue {
-        case "arm64":
-            // FIXME: <rdar://78361860> Use results.runDestinationTargetArchitecture in our tests where appropriate so that this works
-            fallthrough // return macCatalystAppleSilicon
-        case "x86_64":
-            return macCatalystIntel
-        default:
-            preconditionFailure("Unknown architecture \(Architecture.host.stringValue ?? "<nil>")")
-        }
-        #else
-        return macCatalystIntel
-        #endif
+        // Default to Apple Silicon now that x86 is no longer supported in new versions of macOS
+        return .macCatalystAppleSilicon
     }
 
     /// A run destination targeting macOS (Mac Catalyst) running on Intel, using the public SDK.

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -329,6 +329,10 @@ extension Trait where Self == Testing.ConditionTrait {
         requireMinimumXcodeBuildVersion("17A1", sourceLocation: sourceLocation)
     }
 
+    package static func requireXcode27(sourceLocation: SourceLocation = #_sourceLocation) -> Self {
+        requireMinimumXcodeBuildVersion("27A1", sourceLocation: sourceLocation)
+    }
+
     package static func requireXcode26dot4(sourceLocation: SourceLocation = #_sourceLocation) -> Self {
         requireMinimumXcodeBuildVersion("17E1", sourceLocation: sourceLocation)
     }

--- a/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
@@ -263,7 +263,7 @@ fileprivate struct BuildBacktraceTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func backtracesForDeletedOutputs() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = TestWorkspace(

--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -287,9 +287,9 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
     }
 
     /// Check assembling of a single file.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func assembleSingleFile() async throws {
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel, overrides: ["MACOSX_DEPLOYMENT_TARGET": "26.0"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -301,7 +301,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         // Ensure that RUN_CLANG_STATIC_ANALYZER=YES doesn't interfere with the assemble build command
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel, overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES", "MACOSX_DEPLOYMENT_TARGET": "26.0"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m") { results, excludedTypes, inputs, outputs in
             results.consumeTasksMatchingRuleTypes(excludedTypes)
             try results.checkTask(.matchRuleType("Assemble"), .matchRuleItemBasename("File.m"), .matchRuleItem("normal"), .matchRuleItem(results.runDestinationTargetArchitecture)) { task in
                 task.checkCommandLineContainsUninterrupted(["-x", "objective-c"])
@@ -313,7 +313,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
 
         // Include the single file to assemble in multiple targets
-        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m", multipleTargets: true) { results, excludedTypes, inputs, outputs in
+        try await runSingleFileTask(BuildParameters(configuration: "Debug", activeRunDestination: .macOSIntel, overrides: ["MACOSX_DEPLOYMENT_TARGET": "26.0"]), buildCommand: .generateAssemblyCode(buildOnlyTheseFiles: [Path("")]), fileName: "File.m", multipleTargets: true) { results, excludedTypes, inputs, outputs in
             let firstOutput = try #require(outputs.sorted()[safe: 0])
             let secondOutput = try #require(outputs.sorted()[safe: 1])
             results.consumeTasksMatchingRuleTypes(excludedTypes)

--- a/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
@@ -854,6 +854,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
 
     @Test(.requireSDKs(.macOS))
     func packageDiamondProblemDiagnosticWithBundleLoader() async throws {
+        let core = try await getCore()
         try await withTemporaryDirectory { tmpDir in
             let workspace = try await TestWorkspace("Workspace",
                                                     sourceRoot: tmpDir,
@@ -874,8 +875,8 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                                                 "USE_HEADERMAP": "NO",
                                                                 "SKIP_INSTALL": "YES",
-                                                                "MACOSX_DEPLOYMENT_TARGET": "10.15",
-                                                                "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
+                                                                "MACOSX_DEPLOYMENT_TARGET": core.loadSDK(.macOS).defaultDeploymentTarget,
+                                                                "IPHONEOS_DEPLOYMENT_TARGET": core.loadSDK(.iOS).defaultDeploymentTarget,
                                                                 "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                                                                 "SUPPORTS_MACCATALYST": "YES",
                                                             ]),

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -3097,7 +3097,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Check the actual behavior of mutable tasks in an [incremental] build.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func actualMutableBehaviors() async throws {
         func checkScenario(_ name: String, expectedTasks: [String], generic: Bool = false, settings: [String: String] = [:], enableSigning: Bool = false, targetType: TestStandardTarget.TargetType = .commandLineTool) async throws {
             let targetName = targetType == .framework ? "Fwk" : "Tool"
@@ -3239,6 +3239,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
         try await checkScenario("Universal Tool Mutation", expectedTasks: ["ScanDependencies", "ScanDependencies", "CompileC", "CompileC", "CreateUniversalBinary", "Ld", "Ld", "Strip"], generic: true, settings: [
             "STRIP_INSTALLED_PRODUCT": "YES",
             "ARCHS": "x86_64 x86_64h",
+            "MACOSX_DEPLOYMENT_TARGET": "26.0",
             "VALID_ARCHS[sdk=macosx*]": "$(inherited) x86_64h"])
 
         // Check the behavior of signing a framework.
@@ -3481,7 +3482,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
     }
 
     /// Tests that content such as headers is removed from frameworks when they are processed by a copy files build phase.
-    @Test(.requireSDKs(.macOS, .iOS), arguments: [.anyMac, .anyiOSDevice, .anyMacCatalyst] as [RunDestinationInfo])
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode27(), arguments: [.anyMac, .anyiOSDevice, .anyMacCatalyst] as [RunDestinationInfo])
     func copiedFrameworkContentPruning(runDestination: RunDestinationInfo) async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let testWorkspace = TestWorkspace(
@@ -3551,7 +3552,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             let signableTargets: Set<String> = ["App", "App2"]
 
             let sourceDynamicFrameworkPath = tmpDirPath.join("ADynamicFwk.framework")
-            try await tester.fs.writeFramework(sourceDynamicFrameworkPath, archs: runDestination.platform == "macosx" ? ["arm64", "x86_64"] : ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: false) { _, _, headersDir, resourcesDir in
+            try await tester.fs.writeFramework(sourceDynamicFrameworkPath, archs: ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: false) { _, _, headersDir, resourcesDir in
                 try await tester.fs.writeFileContents(headersDir.join("ADynamicFwk.h")) { $0 <<< "" }
                 try await tester.fs.writePlist(resourcesDir.join("ADynamicResource.plist"), .plDict([:]))
                 try await tester.fs.writePlist(resourcesDir.join("Info.plist"), .plDict([
@@ -3589,7 +3590,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             let bundleSupportedPlatforms = try #require(platform?.additionalInfoPlistEntries["CFBundleSupportedPlatforms"])
 
             let sourceStaticFrameworkPath = tmpDirPath.join("AStaticFwk.framework")
-            try await tester.fs.writeFramework(sourceStaticFrameworkPath, archs: runDestination.platform == "macosx" ? ["arm64", "x86_64"] : ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: true) { _, _, headersDir, resourcesDir in
+            try await tester.fs.writeFramework(sourceStaticFrameworkPath, archs: ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: true) { _, _, headersDir, resourcesDir in
                 try await tester.fs.writeFileContents(headersDir.join("AStaticFwk.h")) { $0 <<< "" }
                 try await tester.fs.writePlist(resourcesDir.join("AStaticResource.plist"), .plDict([:]))
                 try await tester.fs.writePlist(resourcesDir.join("Info.plist"), .plDict([
@@ -3669,7 +3670,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                             } else {
                                 let minos = try #require(vtoolOutput.components(separatedBy: "\n").first(where: { $0.contains("minos") })?.trimmingPrefix(while: { $0.isWhitespace }))
                                 #expect(minos == (runDestination.buildVersionPlatform(core) == .macCatalyst ? "minos 14.2" : "minos 11.0"))
-                                #expect(try Set(MachO(reader: BinaryReader(data: tester.fs.read(Path(frameworkPath)))).slices().map { $0.arch }) == ["arm64", "x86_64"])
+                                #expect(try Set(MachO(reader: BinaryReader(data: tester.fs.read(Path(frameworkPath)))).slices().map { $0.arch }) == ["arm64"])
                             }
                         }
 
@@ -7253,7 +7254,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
         try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["arm64e"])
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func pointerAuthenticationBuildSetting_macOS() async throws {
         func test(buildSettings: [String: String], expectedArchs: [String], line: UInt = #line) async throws {
 
@@ -7314,14 +7315,14 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             }
         }
 
-        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["x86_64", "arm64", "arm64e"])
-        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["x86_64", "arm64"])
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "YES", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_POINTER_AUTHENTICATION": "NO", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64"])
 
         // ENABLE_ENHANCED_SECURITY enables pointer authentication unless ENABLE_POINTER_AUTHENTICATION is explicitly disabled.
-        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES"], expectedArchs: ["x86_64", "arm64", "arm64e"])
-        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO"], expectedArchs: ["x86_64", "arm64"])
-        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES", "ENABLE_POINTER_AUTHENTICATION": "NO"], expectedArchs: ["x86_64", "arm64"])
-        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "ENABLE_POINTER_AUTHENTICATION": "YES"], expectedArchs: ["x86_64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64", "arm64e"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "YES", "ENABLE_POINTER_AUTHENTICATION": "NO", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64"])
+        try await test(buildSettings: ["ENABLE_ENHANCED_SECURITY": "NO", "ENABLE_POINTER_AUTHENTICATION": "YES", "MACOSX_DEPLOYMENT_TARGET": "26.0"], expectedArchs: ["x86_64", "arm64e"])
     }
 
     @Test(.requireSDKs(.macOS))

--- a/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/HostBuildToolBuildOperationTests.swift
@@ -23,7 +23,7 @@ import SWBUtil
 
 @Suite
 fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func buildingHostTools() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testProject = try await TestProject(
@@ -178,6 +178,9 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "CODE_SIGNING_ALLOWED": "NO",
                         "SDKROOT": "auto",
                         "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -228,6 +231,8 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "CODE_SIGNING_ALLOWED": "NO",
                         "SDKROOT": "auto",
                         "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -314,7 +319,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice])
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26(), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice])
     func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparation(destination: RunDestinationInfo) async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -329,6 +334,9 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGNING_ALLOWED": "NO",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -421,7 +429,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice], [true, false])
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26(), arguments: [RunDestinationInfo.anyMac, .anyMacCatalyst, .anyiOSDevice], [true, false])
     func testHostToolsAndDependenciesAreBuiltDuringIndexingPreparationForPackage(
         destination: RunDestinationInfo, targetBuild: Bool
     ) async throws {
@@ -440,6 +448,8 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                         "CODE_SIGNING_ALLOWED": "NO",
                         "SDKROOT": "auto",
                         "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -606,7 +616,7 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func hostToolsAreNotFullyBuiltWhenNotPreparingDependents() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testProject = try await TestProject(
@@ -622,6 +632,8 @@ fileprivate struct HostBuildToolBuildOperationTests: CoreBasedTests {
                             "GENERATE_INFOPLIST_FILE": "YES",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CODE_SIGNING_ALLOWED": "NO",
+                            // Workaround for CI which have Intel hosts.
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                 ],
                 targets: [

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -260,7 +260,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .skipDeveloperDirectoryWithEqualSign) // mig will fail on CAS mounts due to rdar://137363780 (env can't handle commands with = signs in the filename)
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .skipDeveloperDirectoryWithEqualSign) // mig will fail on CAS mounts due to rdar://137363780 (env can't handle commands with = signs in the filename)
     func preparingForIndexingOnlyTheseTargets() async throws {
         try await withTemporaryDirectory { tmpDirPath in
             let appTarget = TestStandardTarget(
@@ -322,6 +322,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "CLANG_ENABLE_MODULES": "YES",
                                     "DEFINES_MODULE": "YES",
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ])],
                         targets: [
                             appTarget,
@@ -611,7 +612,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func preparingForIndexingPackages() async throws {
 
         try await withTemporaryDirectory { tmpDirPath in
@@ -622,6 +623,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                     "SDK_VARIANT": "auto",
                     "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                     "SWIFT_VERSION": swiftVersion,
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0"
                 ])
             ], buildPhases: [TestSourcesBuildPhase(["test.swift"])])
 
@@ -636,6 +638,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                             "SDK_VARIANT": "auto",
                             "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                             "SWIFT_VERSION": swiftVersion,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0"
                         ]),
                     ],
                     dependencies: ["PackageLib"]
@@ -699,6 +702,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                                 buildSettings: [
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "SWIFT_VERSION": swiftVersion,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0"
                                 ])],
                         targets: [
                             macAppTarget,
@@ -738,7 +742,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                 try await tester.checkIndexBuild(prepareTargets: prepareTargets, runDestination: runDestination, body: body)
             }
 
-            try await checkBuild(prepareTargets: [packageLib.guid], runDestination: .macOS) { results in
+            try await checkBuild(prepareTargets: [packageLib.guid], runDestination: .macOSIntel) { results in
                 let intermediatesRoot = try #require(results.arena).buildIntermediatesPath.str
                 let osxTargetRuleInfos = getTargetRuleInfosForBuildDir(intermediatesRoot: intermediatesRoot, configurationName: "Debug")
                 results.consumeTasksMatchingRuleTypes(Self.excludedStartTaskTypes)

--- a/Tests/SWBBuildSystemTests/InfoPlistBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/InfoPlistBuildOperationTests.swift
@@ -19,7 +19,7 @@ import SWBTaskExecution
 
 @Suite
 fileprivate struct InfoPlistBuildOperationTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func infoPlistPreprocessingMerging() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testProject = TestProject(
@@ -44,6 +44,7 @@ fileprivate struct InfoPlistBuildOperationTests: CoreBasedTests {
                         // Disable the SetOwnerAndGroup action by setting them to empty values.
                         "INSTALL_GROUP": "",
                         "INSTALL_OWNER": "",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
                     TestBuildConfiguration("Release", buildSettings: [
                         "PRODUCT_NAME": "$(TARGET_NAME)",
@@ -56,6 +57,7 @@ fileprivate struct InfoPlistBuildOperationTests: CoreBasedTests {
                         // Disable the SetOwnerAndGroup action by setting them to empty values.
                         "INSTALL_GROUP": "",
                         "INSTALL_OWNER": "",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
                 ],
                 targets: [
@@ -118,14 +120,14 @@ fileprivate struct InfoPlistBuildOperationTests: CoreBasedTests {
                 for arch in ["arm64", "x86_64"] {
                     // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
                     results.checkTask(.matchTargetName("Tool"), .matchRule(["Preprocess", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist", "\(SRCROOT)/Tool.plist"])) { task in
-                        task.checkCommandLine(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-o", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist"])
+                        task.checkCommandLine(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos26.0", "-isysroot", core.loadSDK(.macOS).path.str, "-o", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist"])
                     }
                 }
 
                 for arch in ["arm64", "x86_64"] {
                     // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
                     results.checkTask(.matchTargetName("App"), .matchRule(["Preprocess", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist", "\(SRCROOT)/Tool.plist"])) { task in
-                        task.checkCommandLine(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist"])
+                        task.checkCommandLine(["\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos26.0", "-isysroot", core.loadSDK(.macOS).path.str, "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist"])
                     }
                 }
 

--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -20,7 +20,7 @@ import SWBTaskExecution
 
 @Suite
 fileprivate struct LinkerTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func linkerDriverDiagnosticsParsing() async throws {
 
         try await withTemporaryDirectory { tmpDir in
@@ -44,7 +44,8 @@ fileprivate struct LinkerTests: CoreBasedTests {
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "SWIFT_VERSION": swiftVersion,
                                     "OTHER_LDFLAGS": "-not-a-real-flag",
-                                    "ARCHS" : "x86_64 aarch64"
+                                    "ARCHS" : "x86_64 aarch64",
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ])
                         ],
                         buildPhases: [

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -191,7 +191,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func multipleArchs() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             let testWorkspace = try await TestWorkspace(
@@ -219,7 +219,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                                     "BUILD_VARIANTS": "normal",
                                     "ARCHS": "$(VALID_ARCHS)",
                                     "VALID_ARCHS": "arm64e x86_64",
-
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                     "SWIFT_USE_INTEGRATED_DRIVER": "YES",
                                 ])
                         ],
@@ -2714,7 +2714,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftDriverJobExecutionEnvironment() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
 
@@ -2738,7 +2738,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
                                     "SWIFT_VERSION": swiftVersion,
                                     "BUILD_VARIANTS": "normal",
                                     "ARCHS": "arm64e x86_64",
-
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                     "SWIFT_USE_INTEGRATED_DRIVER": "YES",
                                     "SUPPORTS_TEXT_BASED_API": "YES",
                                 ])

--- a/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
@@ -28,34 +28,34 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
     }
 
     /// Check the handling of processing dynamically linked XCFrameworks.
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessing() async throws {
         try await testXCFrameworkProcessing(fileType: .macho(.dylib))
     }
 
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessingSkipDynamicAutoEmbed() async throws {
         try await testXCFrameworkProcessing(fileType: .macho(.dylib), skipDynamicAutoEmbed: true)
     }
 
     /// Check the handling of processing statically linked XCFrameworks.
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessingStatic() async throws {
         try await testXCFrameworkProcessing(fileType: .static)
     }
 
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessingStaticSkipAutoEmbed() async throws {
         try await testXCFrameworkProcessing(fileType: .static, skipStaticAutoEmbed: true)
     }
 
     /// Check the handling of processing XCFrameworks containing object files.
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessingObject() async throws {
         try await testXCFrameworkProcessing(fileType: .macho(.object))
     }
 
-    @Test(.requireSDKs(.macOS, .iOS, .watchOS))
+    @Test(.requireSDKs(.macOS, .iOS, .watchOS), .requireXcode26())
     func xCFrameworkProcessingObjectSkipAutoEmbed() async throws {
         try await testXCFrameworkProcessing(fileType: .macho(.object), skipStaticAutoEmbed: true)
     }
@@ -124,6 +124,7 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
                                 "COPY_PHASE_STRIP": "NO",
                                 "PACKAGE_SKIP_AUTO_EMBEDDING_DYNAMIC_BINARY_FRAMEWORKS": skipDynamicAutoEmbed ? "YES" : "NO",
                                 "PACKAGE_SKIP_AUTO_EMBEDDING_STATIC_BINARY_FRAMEWORKS": skipStaticAutoEmbed ? "YES" : "NO",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         )],
                         targets: [
@@ -667,7 +668,7 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func mismatchingSignatureDoesNotProduceDiagnostics() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testProject = TestProject(
@@ -684,7 +685,8 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
                     TestBuildConfiguration("Debug", buildSettings: [
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "-",
-                        "GENERATE_INFOPLIST_FILE": "YES"
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
                 ],
                 targets: [
@@ -732,7 +734,7 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
     }
 
     // Regression test for rdar://110396889 (Xcode 15 fails to build project with Crashlytics run script build phase)
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func xCFrameworksAreCopiedIndependentlyOfUserBuildPhases() async throws {
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in
             // Create an XCFramework
@@ -770,6 +772,7 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
                                 "GENERATE_INFOPLIST_FILE": "YES",
                                 "SWIFT_VERSION": swiftVersion,
                                 "SKIP_EMBEDDED_FRAMEWORKS_VALIDATION": "YES",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         )],
                         targets: [

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -24,7 +24,7 @@ import SWBTestSupport
 @_spi(Testing) import SWBCore
 
 @Suite fileprivate struct SettingsTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func projectBasics() async throws {
         let core = try await getCore()
 
@@ -49,7 +49,8 @@ import SWBTestSupport
                                                                     "USER_PROJECT_SETTING": "USER_PROJECT_VALUE",
                                                                     "OTHER_CFLAGS[arch=*]": "-Wall",
                                                                     "OTHER_CFLAGS": "this value should be shadowed",
-                                                                    "HEADER_SEARCH_PATHS": "$(inherited) $(SRCROOT)/include $(XCCONFIG_HEADER_SEARCH_PATHS)"
+                                                                    "HEADER_SEARCH_PATHS": "$(inherited) $(SRCROOT)/include $(XCCONFIG_HEADER_SEARCH_PATHS)",
+                                                                    "MACOSX_DEPLOYMENT_TARGET": "26.0"
                                                                 ])
                                                             ],
                                                             appPreferencesBuildSettings: [
@@ -228,7 +229,7 @@ import SWBTestSupport
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func standardTargetBasics() async throws {
         let core = try await getCore()
         try await withTemporaryDirectory { (sdksDirPath: Path) in
@@ -253,6 +254,7 @@ import SWBTestSupport
                                                                                 "ARCHS": "x86_64 x86_64h",
                                                                                 "RC_ARCHS": "x86_64 x86_64h",
                                                                                 "VALID_ARCHS": "$(inherited) x86_64h",
+                                                                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                                                             ])],
                                                                          targets: [
                                                                             TestStandardTarget("Target1",
@@ -3345,7 +3347,7 @@ import SWBTestSupport
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func impartedProperties() async throws {
         let testWorkspace = try await TestWorkspace("Workspace",
                                                     projects: [TestPackageProject("aProject",
@@ -3356,12 +3358,14 @@ import SWBTestSupport
                                                                                         "HEADER_SEARCH_PATHS": "$(inherited) $(SRCROOT)/include /usr/include .",
                                                                                         "FRAMEWORK_SEARCH_PATHS": "$(inherited) /System/Library/Frameworks /Applications/Xcode.app /usr",
                                                                                         "OTHER_LDFLAGS": "-current_version 2.0",
+                                                                                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                                                                     ])],
                                                                                   targets: [
                                                                                     TestStandardTarget("Target1",
                                                                                                        type: .application,
                                                                                                        buildConfigurations: [
                                                                                                         TestBuildConfiguration("Config1", buildSettings: [
+                                                                                                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                                                                                             "BUILD_VARIANTS": "normal other",
                                                                                                             "ENABLE_TESTABILITY": "YES",
                                                                                                             "INSTALL_PATH": "",
@@ -4893,13 +4897,14 @@ import SWBTestSupport
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func activeRunDestination_ONLY_ACTIVE_ARCH_interaction() async throws {
         // Prefer the run destination's targetArchitecture
         try await testActiveRunDestination(
             extraBuildSettings: [
                 "SDKROOT": "macosx",
                 "ARCHS": "arm64 foo x86_64 baz x86_64h qux arm64e",
+                "MACOSX_DEPLOYMENT_TARGET": "26.0",
             ],
             runDestination: .macOSIntel,
             activeArchitecture: "x86_64h",
@@ -4918,6 +4923,7 @@ import SWBTestSupport
                 "SDKROOT": "macosx",
                 "VALID_ARCHS": "foo x86_64h x86_64 qux",
                 "ARCHS": "$(VALID_ARCHS)",
+                "MACOSX_DEPLOYMENT_TARGET": "26.0"
             ],
             runDestination: .macOSAppleSilicon,
             activeArchitecture: "x86_64h",
@@ -4935,6 +4941,7 @@ import SWBTestSupport
             extraBuildSettings: [
                 "SDKROOT": "macosx",
                 "ARCHS": "$(ARCHS_STANDARD)",
+                "MACOSX_DEPLOYMENT_TARGET": "26.0"
             ],
             runDestination: .anyMac,
             activeArchitecture: nil,
@@ -4951,6 +4958,7 @@ import SWBTestSupport
                 "SDKROOT": "macosx",
                 "VALID_ARCHS": "foo i386 bar x86_64 baz x86_64h qux",
                 "ARCHS": "$(VALID_ARCHS)",
+                "MACOSX_DEPLOYMENT_TARGET": "26.0"
             ],
             runDestination: nil,
             activeArchitecture: "x86_64",

--- a/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ArtifactBundleTaskConstructionTests.swift
@@ -21,7 +21,7 @@ import SWBTaskConstruction
 
 @Suite
 fileprivate struct ArtifactBundleTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildSettingsTripleCondition() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testProject = try await TestProject(
@@ -43,6 +43,7 @@ fileprivate struct ArtifactBundleTaskConstructionTests: CoreBasedTests {
                             "SWIFT_EXEC": swiftCompilerPath.str,
                             "LIBTOOL": libtoolPath.str,
                             "SWIFT_ACTIVE_COMPILATION_CONDITIONS[__normalized_unversioned_triple=arm64-apple-macos]": "CONDITION_ACTIVE",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                 ],
                 targets: [

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -1971,7 +1971,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
     }
 
     /// Check the OpenCL compilation commands.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func openCL() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -1990,6 +1990,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                         "SWIFT_VERSION": swiftVersion,
                                         "USE_HEADERMAP": "NO",
                                         "LIBTOOL": libtoolPath.str,
+                                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                        ])
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/ClangStaticAnalyzerTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangStaticAnalyzerTests.swift
@@ -21,7 +21,7 @@ import SWBTaskConstruction
 @Suite
 fileprivate struct ClangStaticAnalyzerTests: CoreBasedTests {
     /// Check that Build & Analyze works.
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireXcode26())
     func buildAndAnalyze() async throws {
         let testProject = TestProject(
             "aProject",
@@ -98,7 +98,8 @@ fileprivate struct ClangStaticAnalyzerTests: CoreBasedTests {
                 "ONLY_ACTIVE_ARCH": "NO",
                 "RUN_CLANG_STATIC_ANALYZER": "YES",
                 "CLANG_STATIC_ANALYZER_MODE": "deep",
-                "VALID_ARCHS": architectures.joined(separator: " ")
+                "VALID_ARCHS": architectures.joined(separator: " "),
+                "MACOSX_DEPLOYMENT_TARGET": "26.0",
             ]
             await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides), runDestination: .host) { results in
                 results.checkTarget("Lib") { target in

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -147,7 +147,8 @@ fileprivate struct ClangTests: CoreBasedTests {
         .skipHostOS(.windows, "clang-cache is not available on Windows"),
         .skipHostOS(.linux, "test is incompatible with fallback system toolchain mechanism"),
         .skipHostOS(.freebsd, "test is incompatible with fallback system toolchain mechanism"),
-        .skipHostOS(.openbsd, "test is incompatible with fallback system toolchain mechanism")
+        .skipHostOS(.openbsd, "test is incompatible with fallback system toolchain mechanism"),
+        .requireXcode27()
     )
     func clangCacheEnableLauncher() async throws {
         let runDestination: RunDestinationInfo = .host

--- a/Tests/SWBTaskConstructionTests/DocumentationTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/DocumentationTaskConstructionTests.swift
@@ -36,7 +36,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         .init(withSwift: true,  withObjectiveCLevel: .public),
     ]
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func regularBuildDoesNotBuildDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -53,7 +53,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildWithAllFilesExcludedDoesNotBuildDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -70,7 +70,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildActionsWithoutBuildComponentDoesNotBuildDocumentationWhenBuildSettingIsSet() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let buildActionsWithoutBuildComponents = BuildAction.allCases.filter{ !$0.buildComponents.contains("build") }
@@ -97,7 +97,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func documentationBuildDoesNotBuildDocumentationWhenSkipBuildingDocumentationIsSet() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
 
@@ -119,7 +119,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildWithSymbolExtractWithoutDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let sourceLanguages = SourceLanguageConfiguration(withSwift: true, withObjectiveCLevel: .public)
@@ -142,7 +142,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildActionsWithoutBuildComponentDoesNotBuildRunSymbolExtractWhenBuildSettingIsSet() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let buildActionsWithoutBuildComponents = BuildAction.allCases.filter{ !$0.buildComponents.contains("build") }
@@ -169,7 +169,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func documentationBuildBuildsDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -186,7 +186,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func runDocumentationCompilerInRegularBuild() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -203,7 +203,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func runDocumentationCompilerInRegularBuildWithoutDocsCatalogInput() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -220,7 +220,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func runDocumentationCompilerWithZipperedProduct() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -237,7 +237,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func runDocumentationCompilerWithReverseZipperedProduct() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -254,7 +254,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func documentationIdentifierFallbackValues() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -271,7 +271,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func documentationTemplateBuildSetting() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -288,7 +288,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithoutExtensionSymbolsSupport() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -305,7 +305,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithOtherDocCFlags() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -322,7 +322,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithHostingBasePath() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -339,7 +339,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithoutTransformingForStaticHosting() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -356,7 +356,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithSPIObjectiveCDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -376,7 +376,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithSwiftDeclarationsForObjectiveCSymbols() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withSwift == true {
@@ -396,7 +396,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithoutInstalledCompatibilityHeader() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withSwift == true {
@@ -416,7 +416,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithContradictingObjectiveCRelatedBuildSettings() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withSwift == true {
@@ -441,7 +441,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithObjectiveCDeclarationsForSwiftSymbols() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -461,7 +461,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func objectiveCDeclarationsForSwiftSymbolsWithoutModule() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -484,7 +484,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithoutModuleSupport() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withObjectiveC {
@@ -504,7 +504,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithoutARC() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withObjectiveC {
@@ -524,7 +524,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildDocumentationWithOldSwiftVersion() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withObjectiveC && !sourceLanguages.withSwift {
@@ -544,7 +544,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildWithAllSwiftFilesExcludedViaDirectoryGlobBuildsDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let sourceLanguages = SourceLanguageConfiguration(withSwift: true, withObjectiveCLevel: .public)
@@ -564,7 +564,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
     }
 
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildAppDocumentationWithoutHeaderBuildPhase() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest where sourceLanguages.withObjectiveC {
@@ -586,7 +586,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func privateHeadersDoesNotCauseDocumentationBuild() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let sourceLanguages = SourceLanguageConfiguration(withSwift: false, withObjectiveCLevel: .private)
@@ -602,7 +602,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func multipleDocumentationCatalogsError() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let sourceLanguages = SourceLanguageConfiguration(withSwift: true, withObjectiveCLevel: .private)
@@ -618,7 +618,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func additionalBuildVariantsDoNotCauseDuplicateBuilds() async throws {
         let sourceLanguages = SourceLanguageConfiguration(withSwift: true, withObjectiveCLevel: nil)
         let (tester, fs, SRCROOT) = try await setUpTesterForTestProject(
@@ -751,7 +751,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func expandedTargetTypesSupportBuildingDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             for sourceLanguages in Self.sourceLanguageConfigurationsToTest {
@@ -909,6 +909,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
                                 "DEFINES_MODULE": (sourceLanguages.withObjectiveCLevel == .public) ? "YES" : "NO",
                                 "EAGER_LINKING": "NO",
                                 "DOCC_EXEC": doccToolPath.str,
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ].merging(extraBuildSettings, uniquingKeysWith: { _, new in new }).compactMapValues({ $0 })
                         )
                     ],
@@ -929,6 +930,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
                                 "TAPI_EXEC": tapiToolPath.str,
                                 "INFOPLIST_FILE":"SomeFiles/Info.plist",
                                 "MODULEMAP_PATH": "platform_specific_dependency_module_map_path",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         )
                     ]
@@ -944,6 +946,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
                                 "TAPI_EXEC": tapiToolPath.str,
                                 "INFOPLIST_FILE":"SomeFiles/Info.plist",
                                 "MODULEMAP_PATH": "expected_dependency_module_map_path",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         )
                     ]
@@ -1709,7 +1712,7 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
             // The tapi target triple includes the deployment target
             targetTriple = targetTriplePlatform == "-ios-macabi"
             ? targetTriple.replacingOccurrences(of: "-ios-macabi", with: "-ios\(core.macCatalystSDKVariant.defaultDeploymentTarget)-macabi")
-            : targetTriple + core.loadSDK(.macOS).defaultDeploymentTarget
+            : targetTriple + "26.0"
         }
 
         let symbolGraphSubDir = forObjectiveC ? "clang" : "swift"

--- a/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/DriverKitTaskConstructionTests.swift
@@ -93,7 +93,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
 
         let iigPath = try await self.iigPath
 
-        await tester.checkBuild(runDestination: hasDriverKitPlatform ? .driverKit : .macOS, fs: fs) { results in
+        await tester.checkBuild(runDestination: hasDriverKitPlatform ? .driverKitAppleSilicon : .macOS, fs: fs) { results in
             results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "CodeSign", "Gate", "Ld", "GenerateTAPI", "MkDir", "RegisterExecutionPolicyException", "ProcessInfoPlistFile", "ProcessProductPackaging", "ProcessProductPackagingDER", "SymLink", "Touch", "WriteAuxiliaryFile"])
 
             results.checkTarget("DextTarget") { target in
@@ -295,7 +295,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.driverKit))
+    @Test(.requireSDKs(.driverKit), .requireXcode27())
     func driverKitAnalyze() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testProject = TestProject(
@@ -337,7 +337,6 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
             // Analyze for a generic destination should analyze arm64 + x86_64
             await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .anyDriverKit, fs: fs) { results in
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "arm64"])) { _ in }
-                results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "x86_64"])) { _ in }
                 results.checkNoTask(.matchRuleItem("AnalyzeShallow"))
                 results.checkNoDiagnostics()
             }
@@ -349,7 +348,7 @@ fileprivate struct DriverKitTaskConstructionTests: CoreBasedTests {
                 results.checkNoDiagnostics()
             }
 
-            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES"]), runDestination: .driverKitIntel, fs: fs) { results in
+            await tester.checkBuild(BuildParameters(action: .analyze, configuration: "Debug", overrides: ["RUN_CLANG_STATIC_ANALYZER": "YES", "DRIVERKIT_DEPLOYMENT_TARGET": "25.0"]), runDestination: .driverKitIntel, fs: fs) { results in
                 results.checkTask(.matchRule(["AnalyzeShallow", "\(tmpDir.str)/Sources/main.c", "normal", "x86_64"])) { _ in }
                 results.checkNoTask(.matchRuleItem("AnalyzeShallow"))
                 results.checkNoDiagnostics()

--- a/Tests/SWBTaskConstructionTests/EagerLinkingTests.swift
+++ b/Tests/SWBTaskConstructionTests/EagerLinkingTests.swift
@@ -37,6 +37,7 @@ fileprivate struct EagerLinkingTests: CoreBasedTests {
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "EAGER_LINKING": "YES",
                     "EAGER_LINKING_REQUIRE": "YES",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ]
             )],
             targets: [
@@ -113,7 +114,7 @@ fileprivate struct EagerLinkingTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func objCTaskDependenciesEagerLinkingEnabled() async throws {
         let tester = try await TaskConstructionTester(getCore(), objcTestProject)
         try await tester.checkBuild(runDestination: .macOS) { results in
@@ -161,7 +162,7 @@ fileprivate struct EagerLinkingTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func objCLinkerInputsReadyDependsOnLipo() async throws {
         let tester = try await TaskConstructionTester(getCore(), objcTestProject)
         try await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ARCHS": "arm64 x86_64"]), runDestination: .anyMac) { results in
@@ -274,7 +275,7 @@ fileprivate struct EagerLinkingTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func eagerLinkingEnablementCriteria() async throws {
         let tester = try await TaskConstructionTester(getCore(), objcTestProject)
         await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["EAGER_LINKING": "NO"]), runDestination: .macOS) { results in

--- a/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
@@ -21,7 +21,7 @@ import SWBTaskConstruction
 
 @Suite
 fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func basics() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -36,6 +36,8 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "SWIFT_VERSION": swiftVersion,
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -79,7 +81,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func hostToolBuildsForHostPlatform() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -96,6 +98,9 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "Apple Development",
+
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         "OTHER_SWIFT_FLAGS[__host_platform=YES]": "$(inherited) -DHOST_YES",
                         "OTHER_SWIFT_FLAGS[__host_platform=NO]": "$(inherited) -DHOST_NO",
                         "OTHER_SWIFT_FLAGS[__destination_platform=YES]": "$(inherited) -DDEST_YES",
@@ -222,7 +227,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func hostToolBuildsForHostPlatformWithSwiftSDK() async throws {
         try await withTemporaryDirectory { tmpDir in
             let swiftCompilerPath = try await self.swiftCompilerPath
@@ -242,6 +247,10 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                             "GENERATE_INFOPLIST_FILE": "YES",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CODE_SIGN_IDENTITY": "Apple Development",
+
+                            // Workaround for CI which have Intel hosts.
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
+
                             "OTHER_SWIFT_FLAGS[__host_platform=YES]": "$(inherited) -DHOST_YES",
                             "OTHER_SWIFT_FLAGS[__host_platform=NO]": "$(inherited) -DHOST_NO",
                             "OTHER_SWIFT_FLAGS[__destination_platform=YES]": "$(inherited) -DDEST_YES",
@@ -369,7 +378,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func swiftMacroPluginLoadingFlags() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -388,6 +397,8 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "Apple Development",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -486,7 +497,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func swiftMacroBinaryPluginLoadingFlags() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -503,6 +514,8 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "Apple Development",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -672,7 +685,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftMacroSwiftSyntaxSearchPaths() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -685,7 +698,9 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                         "SWIFT_VERSION": swiftVersion,
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
-                        "SWIFT_EXEC": swiftCompilerPath.str
+                        "SWIFT_EXEC": swiftCompilerPath.str,
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -20,7 +20,7 @@ import SWBUtil
 
 @Suite
 fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func multiPlatformTargets() async throws {
         let macApp = TestStandardTarget(
             "macApp",
@@ -89,6 +89,8 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                         "GENERATE_INFOPLIST_FILE": "YES",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "ALWAYS_SEARCH_USER_PATHS": "NO",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ])],
             targets: [
                 macApp,
@@ -482,7 +484,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftWithIndexBuildArena() async throws {
         let swiftFeatures = try await self.swiftFeatures
         let buildSettings: [String: String] = try await [
@@ -499,6 +501,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             "SWIFT_EXEC": swiftCompilerPath.str,
             "SWIFT_VERSION": swiftVersion,
             "SWIFT_INCLUDE_PATHS": "/tmp/some-dir",
+            "MACOSX_DEPLOYMENT_TARGET": "26.0",
         ]
         let testProject = TestProject(
             "aProject",
@@ -647,7 +650,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func noIndexStorePathForGenerateSwiftModule() async throws {
         let buildSettings: [String: String] = try await [
             "GENERATE_INFOPLIST_FILE": "YES",
@@ -674,7 +677,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
             "SWIFT_MODULE_ONLY_ARCHS": "i386",
 
             "SWIFT_MODULE_ONLY_MACOSX_DEPLOYMENT_TARGET": "11.0",
-
+            "MACOSX_DEPLOYMENT_TARGET": "26.0",
         ]
         let testProject = TestProject(
             "aProject",
@@ -715,7 +718,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func customEffectivePlatformName() async throws {
         // rdar://128421634 - Check that a target with an
         // EFFECTIVE_PLATFORM_NAME gets its own separate product directory.
@@ -753,6 +756,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     "SUPPORTED_PLATFORMS": "macosx",
                     "SWIFT_EXEC": swiftCompilerPath.str,
                     "SWIFT_VERSION": swiftVersion,
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ])
             ],
             targets: [target1, target2]
@@ -1222,7 +1226,7 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func macCatalystAppWithZipperedFramework() async throws {
         let catalystAppTarget = TestStandardTarget(
             "catalystApp",
@@ -1270,6 +1274,8 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
                     "SWIFT_VERSION": swiftVersion,
                     // Ensure that the index build forces distinct build directories for macOS vs macCatalyst, even if the project overrides and sets the same EFFECTIVE_PLATFORM_NAME.
                     "EFFECTIVE_PLATFORM_NAME[sdk=macos*]": "-mac",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                    "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                 ])],
             targets: [
                 catalystAppTarget,

--- a/Tests/SWBTaskConstructionTests/InfoPlistTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InfoPlistTaskConstructionTests.swift
@@ -21,7 +21,7 @@ import SWBProtocol
 
 @Suite
 fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func infoPlistPreprocessing() async throws {
         let testProject = TestProject(
             "aProject",
@@ -61,6 +61,7 @@ fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
                     "INFOPLIST_PREPROCESSOR_DEFINITIONS": "FOO=INFOPLIST_PREPROCESSOR_DEFINITIONS BAR=INFOPLIST_PREPROCESSOR_DEFINITIONS",
                     "INFOPLIST_OTHER_PREPROCESSOR_FLAGS": "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS1 -INFOPLIST_OTHER_PREPROCESSOR_FLAGS2",
                     "INFOPLIST_PREFIX_HEADER": "$(PROJECT_DIR)/infoplist-prefix.h",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ]),
             ],
             targets: [
@@ -121,7 +122,7 @@ fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
                 for arch in ["arm64", "x86_64"] {
                     // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
                     results.checkTask(.matchTarget(target), .matchRule(["Preprocess", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist", "\(SRCROOT)/Tool.plist"])) { task in
-                        task.checkCommandLine(["cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-DFOO=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-DBAR=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-include", "\(SRCROOT)/infoplist-prefix.h", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS1", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS2", "-o", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist"])
+                        task.checkCommandLine(["cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos26.0", "-isysroot", core.loadSDK(.macOS).path.str, "-DFOO=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-DBAR=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-include", "\(SRCROOT)/infoplist-prefix.h", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS1", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS2", "-o", "\(SRCROOT)/build/aProject.build/Release/Tool.build/normal/\(arch)/Preprocessed-Info.plist"])
                         task.checkInputs([
                             .path("\(SRCROOT)/Tool.plist"),
                             .path("\(SRCROOT)/infoplist-prefix.h"),
@@ -139,7 +140,7 @@ fileprivate struct InfoPlistTaskConstructionTests: CoreBasedTests {
                 for arch in ["arm64", "x86_64"] {
                     // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
                     results.checkTask(.matchTarget(target), .matchRule(["Preprocess", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist", "\(SRCROOT)/Tool.plist"])) { task in
-                        task.checkCommandLine(["cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-DFOO=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-DBAR=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-include", "\(SRCROOT)/infoplist-prefix.h", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS1", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS2", "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist"])
+                        task.checkCommandLine(["cc", "-E", "-P", "-x", "c", "-Wno-trigraphs", "\(SRCROOT)/Tool.plist", "-F\(SRCROOT)/build/Release", "-target", "\(arch)-apple-macos26.0", "-isysroot", core.loadSDK(.macOS).path.str, "-DFOO=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-DBAR=INFOPLIST_PREPROCESSOR_DEFINITIONS", "-include", "\(SRCROOT)/infoplist-prefix.h", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS1", "-INFOPLIST_OTHER_PREPROCESSOR_FLAGS2", "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/normal/\(arch)/Preprocessed-Info.plist"])
                         task.checkInputs([
                             .path("\(SRCROOT)/Tool.plist"),
                             .path("\(SRCROOT)/infoplist-prefix.h"),

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -1487,7 +1487,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
     /// This test makes sure RuleScriptExecution tasks are scheduled if
     /// `APPLY_RULES_IN_INSTALLAPI` is set, and also that they
     /// are not scheduled when it's not set.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftInstallAPIBuildRuleScripts() async throws {
         let sdkRoot = "macosx"
         let testProject = try await TestProject(
@@ -1510,7 +1510,8 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
                             "SWIFT_VERSION": swiftVersion,
                             "TAPI_EXEC": tapiToolPath.str,
                             "SUPPORTS_TEXT_BASED_API": "YES",
-                            "SDKROOT": sdkRoot
+                            "SDKROOT": sdkRoot,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -1546,7 +1547,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftInstallAPIDylibTarget() async throws {
         let sdkRoot = "macosx"
         let tapiToolPath = try await self.tapiToolPath
@@ -1573,7 +1574,8 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
                             "TAPI_VERIFY_MODE": "ErrorsOnly",
                             "TAPI_USE_SRCROOT": "NO",
                             "SUPPORTS_TEXT_BASED_API": "YES",
-                            "SDKROOT": sdkRoot
+                            "SDKROOT": sdkRoot,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -2055,7 +2057,7 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftInstallAPIPackageProducts() async throws {
         let tapiToolPath = try await self.tapiToolPath
         let sdkRoot = "macosx"
@@ -2114,7 +2116,8 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
                             "SUPPORTS_TEXT_BASED_API": "YES",
                             "TAPI_DYLIB_INSTALL_NAME": "ProductName",
                             // This will need to be passed by the user to make InstallAPI for packages opt-in.
-                            "INSTALLAPI_IGNORE_SKIP_INSTALL": "YES"
+                            "INSTALLAPI_IGNORE_SKIP_INSTALL": "YES",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -2154,6 +2154,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
     /// Test an App that has an embedded bundle from a Swift package project
     @Test(.requireSDKs(.macOS))
     func packageResourceBundleEmbedding() async throws {
+        let core = try await getCore()
         let testProject = try await TestProject(
             "aProject",
             groupTree: TestGroup(
@@ -2172,8 +2173,8 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "USE_HEADERMAP": "NO",
                     "SKIP_INSTALL": "YES",
-                    "MACOSX_DEPLOYMENT_TARGET": "10.15",
-                    "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
+                    "MACOSX_DEPLOYMENT_TARGET": core.loadSDK(.macOS).defaultDeploymentTarget,
+                    "IPHONEOS_DEPLOYMENT_TARGET": core.loadSDK(.iOS).defaultDeploymentTarget,
                     "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                     "SUPPORTS_MACCATALYST": "YES",
                 ]),
@@ -2222,7 +2223,7 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                     "FOO", type: .bundle
                 ),
             ])
-        let tester = try await TaskConstructionTester(getCore(), testProject)
+        let tester = try TaskConstructionTester(core, testProject)
 
         await tester.checkBuild(BuildParameters(action: .installLoc, configuration: "Debug", overrides: ["INSTALLLOC_LANGUAGE": "ja"]), runDestination: .macOS) { results in
             results.checkNoDiagnostics()

--- a/Tests/SWBTaskConstructionTests/KernelExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/KernelExtensionTaskConstructionTests.swift
@@ -20,7 +20,7 @@ import SWBProtocol
 @Suite
 fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
     /// Tests that macOS kernel extensions build for arm64e rather than arm64, when using `ARCHS_STANDARD`.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func kernelExtensionStandardArchitectures() async throws {
         let testProject = TestProject(
             "aProject",
@@ -43,6 +43,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
                             "MODULE_START": "KextTest_start",
                             "MODULE_STOP": "KextTest_stop",
                             "MODULE_VERSION": "1.0.0d1",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -63,7 +64,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func kernelExtensionModuleInfo() async throws {
         let testProject = TestProject(
             "aProject",
@@ -87,6 +88,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
                             "MODULE_START": "KextTest_start",
                             "MODULE_STOP": "KextTest_stop",
                             "MODULE_VERSION": "1.0.0d1",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -122,7 +124,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
     }
 
     /// We shouldn't generate module info if there are no other items in the sources phase
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func kernelExtensionModuleInfoEmpty() async throws {
         let testProject = TestProject(
             "aProject",
@@ -145,6 +147,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
                             "MODULE_START": "KextTest_start",
                             "MODULE_STOP": "KextTest_stop",
                             "MODULE_VERSION": "1.0.0d1",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -221,7 +224,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
     }
 
     /// Test a build rule which overrides the _info.c file compilation.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func overrideKernelExtensionModuleInfoBuildRule() async throws {
         let testProject = TestProject(
             "aProject",
@@ -239,6 +242,7 @@ fileprivate struct KernelExtensionTaskConstructionTests: CoreBasedTests {
                                         "MODULE_NAME": "foo",
                                         "MODULE_START": "foo_start",
                                         "MODULE_STOP": "foo_stop",
+                                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                        ])
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ModuleVerifierTaskConstructionTests.swift
@@ -23,7 +23,7 @@ import Testing
 @Suite
 fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
     /// Test the core functionality of the modules verifier.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func builtinModuleVerifierTargetSetDiagnostics() async throws {
         let archs = ["arm64", "arm64", "x86_64"]
         let targetName = "Orange"
@@ -59,6 +59,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CC": clangCompilerPath.str,
                             "CLANG_USE_RESPONSE_FILE": "NO",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -82,7 +83,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule))
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .requireClangFeatures(.wSystemHeadersInModule))
     func builtinModuleVerifier() async throws {
         let clangCompilerPath = try await self.clangCompilerPath
         let archs = ["arm64", "x86_64"]
@@ -125,6 +126,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                             "OTHER_CFLAGS": "$(inherited) -DTARGET_FLAG",
                             "FRAMEWORK_SEARCH_PATHS": "$(inherited) /TARGET_PATH",
                             "CLANG_USE_RESPONSE_FILE": "NO",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -162,7 +164,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                         guard task.ruleInfo.count > 5 else { continue }
                         let language = task.ruleInfo[5]
                         task.checkCommandLineContainsUninterrupted(["-x", language])
-                        task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)"])
+                        task.checkCommandLineContainsUninterrupted(["-target", "\(arch)-apple-macos26.0"])
                         task.checkCommandLineContains([
                             "-F\(SRCROOT)/build/aProject.build/Debug/Orange.build/VerifyModule/Orange/\(language)",
                             "-F\(SRCROOT)/build/Debug",
@@ -307,7 +309,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule))
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .requireClangFeatures(.wSystemHeadersInModule))
     func builtinModuleVerifierSDK() async throws {
         let clangCompilerPath = try await self.clangCompilerPath
         try await withTemporaryDirectory { tmpDir in
@@ -354,6 +356,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                                 "SDKROOT": sdkPath.str,
                                 "CC": clangCompilerPath.str,
                                 "CLANG_USE_RESPONSE_FILE": "NO",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]),
                         ],
                         buildPhases: [
@@ -385,7 +388,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
     }
 
     /// Tests iosmac variant applied for verifying a macos target due to `MODULE_VERIFIER_TARGET_TRIPLE_VARIANTS`.
-    @Test(.requireSDKs(.macOS), .requireClangFeatures(.wSystemHeadersInModule))
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .requireClangFeatures(.wSystemHeadersInModule))
     func builtinModuleVerifierSDKVariantFromMacOS() async throws {
         let settings: [String: PropertyListItem] = [
             "CanonicalName": "com.apple.my_sdk.1.0",
@@ -452,6 +455,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                                 "SDKROOT": sdkPath.str,
                                 "CC": clangCompilerPath.str,
                                 "CLANG_USE_RESPONSE_FILE": "NO",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]),
                         ],
                         buildPhases: [
@@ -748,7 +752,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func externalModuleVerifier() async throws {
         let archs = ["arm64", "x86_64"]
         let targetName = "Orange"
@@ -780,6 +784,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                             "MODULES_VERIFIER_EXEC": "/alternate/modules-verifier",
                             "OTHER_MODULE_VERIFIER_FLAGS": "-- -I$(BUILT_PRODUCTS_DIR)/usr/include",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -812,7 +817,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                         "--diagnostic-filename-map", "\(SRCROOT)/build/aProject.build/Debug/Orange.build/Orange-diagnostic-filename-map.json",
                         "--sdk", core.loadSDK(.macOS).path.str,
                         "--intermediates-directory", "\(SRCROOT)/build/aProject.build/Debug/Orange.build/VerifyModule",
-                        "--target", "\(arch)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)",
+                        "--target", "\(arch)-apple-macos26.0",
                         "--language", "objective-c", "--language", "objective-c++",
                         "--standard", "gnu11", "--standard", "gnu17", "--standard", "gnu++20",
                         "--verbose",
@@ -864,7 +869,7 @@ fileprivate struct ModuleVerifierTaskConstructionTests: CoreBasedTests {
                         "--sdk", core.loadSDK(.macOS).path.str,
                         "--intermediates-directory", "\(SRCROOT)/build/aProject.build/Debug/Orange.build/VerifyModule"
                     ]
-                    + archs.flatMap { ["--target", "\($0)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)"] } + [
+                    + archs.flatMap { ["--target", "\($0)-apple-macos26.0"] } + [
                         "--language", "objective-c", "--language", "objective-c++",
                         "--standard", "gnu11", "--standard", "gnu17", "--standard", "gnu++20",
                         "--verbose",

--- a/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
+++ b/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
@@ -21,7 +21,7 @@ import SWBProtocol
 
 @Suite
 fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func skipsDocumentationWhenTargetHasPlusPlusHeader() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             try await checkBuildWithPlusPlusHeader(targetType: .framework, withHeaderBuildPhase: true, plusPlusHeaderVisibility: .public, shouldSkip: true) // Public headers are processed for all target types
@@ -97,6 +97,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "TOOLCHAIN_DIR": toolchainPath.str,
                                     "CLANG_CXX_LANGUAGE_STANDARD": "c++23",
                                     "OTHER_CPLUSPLUSFLAGS": "-fchar8_t",
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ].merging(extraBuildSettings, uniquingKeysWith: { _, new in new }).compactMapValues({ $0 })
                             )
                         ],
@@ -153,8 +154,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                         // Check the extract-api related tasks are generated:
 
                         for arch in ["x86_64", "arm64"] {
-                            let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Framework.sdkdb"
-                            let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Framework.symbols.json"
+                            let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos26.0/Framework.sdkdb"
+                            let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos26.0/Framework.symbols.json"
 
                             results.checkTask(
                                 .matchTarget(target),
@@ -185,7 +186,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func documentationWithoutHeaderMembership() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             // Apps and other executables include all headers that are siblings to their source files in their documentation builds
@@ -243,6 +244,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                 "PRODUCT_BUNDLE_IDENTIFIER": "test.bundle.identifier",
                                 "CURRENT_PROJECT_VERSION": "0.0.1",
                                 "TOOLCHAIN_DIR": core.developerPath.path.join("Toolchains/XcodeDefault.xctoolchain").str,
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ].merging(extraBuildSettings, uniquingKeysWith: { _, new in new }).compactMapValues({ $0 })
                         )
                     ],
@@ -279,8 +281,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                     results.checkNoTask(.matchTarget(target), .matchRuleItem("CompileDocumentation"))
                 } else {
                     for arch in ["x86_64", "arm64"] {
-                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Framework.sdkdb"
-                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Framework.symbols.json"
+                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos26.0/Framework.sdkdb"
+                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos26.0/Framework.symbols.json"
 
                         results.checkTaskExists(
                             .matchTarget(target),
@@ -301,7 +303,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.iOS, .macOS))
+    @Test(.requireSDKs(.iOS, .macOS), .requireXcode26())
     func objectiveCAppDocumentationHeaderHeuristic() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
             let core = try await getCore()
@@ -376,6 +378,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "PRODUCT_BUNDLE_IDENTIFIER": "test.bundle.identifier",
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "TOOLCHAIN_DIR": core.developerPath.path.join("Toolchains/XcodeDefault.xctoolchain").str,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -408,6 +411,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "PRODUCT_BUNDLE_IDENTIFIER": "test.bundle.identifier",
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "TOOLCHAIN_DIR": core.developerPath.path.join("Toolchains/XcodeDefault.xctoolchain").str,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -510,8 +514,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
 
                 results.checkTarget("macOS App") { target in
                     for arch in ["x86_64", "arm64"] {
-                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/macOS App.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/macOS App.sdkdb"
-                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/macOS App.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/macOS_App.symbols.json"
+                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/macOS App.build/symbol-graph/clang/\(arch)-apple-macos26.0/macOS App.sdkdb"
+                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/macOS App.build/symbol-graph/clang/\(arch)-apple-macos26.0/macOS_App.symbols.json"
                         results.checkTask(
                             .matchTarget(target),
                             .matchRule([
@@ -580,7 +584,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func dependencyModuleMapsArePassedToExtractAPI() async throws {
         let clangFeatures = try await self.clangFeatures
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
@@ -623,6 +627,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "PRODUCT_BUNDLE_IDENTIFIER": "test.bundle.sub-dependency",
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "TOOLCHAIN_DIR": core.developerPath.path.join("Toolchains/XcodeDefault.xctoolchain").str,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -653,6 +658,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "PRODUCT_BUNDLE_IDENTIFIER": "test.bundle.dependency",
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "TOOLCHAIN_DIR": core.developerPath.path.join("Toolchains/XcodeDefault.xctoolchain").str,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -686,6 +692,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "SWIFT_EXEC": swiftCompilerPath.str,
                                     // Set the real clang tool path so that we can check it's features.json file
                                     "CC": clangCompilerPath.str,
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -738,8 +745,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
 
                 results.checkTarget("Objective-C App") { target in
                     for arch in ["x86_64", "arm64"] {
-                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Objective-C App.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Objective-C App.sdkdb"
-                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Objective-C App.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Objective_C_App.symbols.json"
+                        let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug/Objective-C App.build/symbol-graph/clang/\(arch)-apple-macos26.0/Objective-C App.sdkdb"
+                        let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug/Objective-C App.build/symbol-graph/clang/\(arch)-apple-macos26.0/Objective_C_App.symbols.json"
 
                         results.checkTask(
                             .matchTarget(target),
@@ -771,7 +778,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .enabled(if: SWBFeatureFlag.enableClangExtractAPI.value))
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .enabled(if: SWBFeatureFlag.enableClangExtractAPI.value))
     func cXXFilesAreIgnoredWhenCXXSupportIsDisabled() async throws {
         // This test only applies to clang base symbol graph generation
         try await withTemporaryDirectory { sourceRoot in
@@ -810,7 +817,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "CLANG_CXX_LANGUAGE_STANDARD": "c++23",
                                     "OTHER_CPLUSPLUSFLAGS": "-fchar8_t",
-                                    "DOCC_ENABLE_CXX_SUPPORT": "NO" // Disable C++ symbol graph generation
+                                    "DOCC_ENABLE_CXX_SUPPORT": "NO", // Disable C++ symbol graph generation
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -844,7 +852,8 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                     "CURRENT_PROJECT_VERSION": "0.0.1",
                                     "CLANG_CXX_LANGUAGE_STANDARD": "c++23",
                                     "OTHER_CPLUSPLUSFLAGS": "-fchar8_t",
-                                    "DOCC_ENABLE_CXX_SUPPORT": "NO" // Disable C++ symbol graph generation
+                                    "DOCC_ENABLE_CXX_SUPPORT": "NO", // Disable C++ symbol graph generation
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ]
                             )
                         ],
@@ -878,7 +887,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                     // Check the extract-api related tasks are generated:
                     for arch in ["x86_64", "arm64"] {
                         let symbolGraphFile = projectFolder.join(
-                            "build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos\(core.loadSDK(.macOS).version)/Framework.symbols.json"
+                            "build/aProject.build/Debug/Framework.build/symbol-graph/clang/\(arch)-apple-macos26.0/Framework.symbols.json"
                         )
 
                         results.checkTask(

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -164,7 +164,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func canLinkUsingObjectOnlyFrameworkBuildPhase() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -181,6 +181,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "USE_HEADERMAP": "NO",
                     "SKIP_INSTALL": "YES",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ]),
             ],
             targets: [
@@ -231,6 +232,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "USE_HEADERMAP": "NO",
                     "SKIP_INSTALL": "YES",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ]),
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -648,9 +648,10 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
     // MARK: macCatalyst
 
     /// Basic test of building an macCatalyst app.
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func macCatalystBasics() async throws {
-        let IPHONEOS_DEPLOYMENT_TARGET = "13.1"
+        // Since we're building a universal binary including Intel, we set a deployment target which supports that arch.
+        let IPHONEOS_DEPLOYMENT_TARGET = "26.0"
         let archs = ["arm64", "x86_64"]
         let swiftCompilerPath = try await self.swiftCompilerPath
 
@@ -892,7 +893,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                 // There should be a clang task for the ObjC file.
                 results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
                     let expectedClangOptions = ["clang",
-                                                "-target", "x86_64-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
+                                                "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
                                                 "-isysroot", core.loadSDK(.macOS).path.str,
                                                 "-isystem", "/usr/local/include",
                                                 "-isystem", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/include",
@@ -909,7 +910,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                     let expectedSwiftOptions = [swiftCompilerPath.str,
                                                 "-module-name", "AppTarget",
                                                 "-sdk", core.loadSDK(.macOS).path.str,
-                                                "-target", "x86_64-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
+                                                "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
                                                 "-F", "/Library/Frameworks",
                                                 "-Fsystem", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks",
                                                 "-c",
@@ -922,7 +923,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
                 // Check the link task.
                 results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                     let expectedLinkerOptions = ["clang",
-                                                 "-target", "x86_64-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
+                                                 "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-macabi",
                                                  "-isysroot", core.loadSDK(.macOS).path.str,
                                                  "-L/usr/local/lib",
                                                  "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib",

--- a/Tests/SWBTaskConstructionTests/PrelinkedObjectFileTests.swift
+++ b/Tests/SWBTaskConstructionTests/PrelinkedObjectFileTests.swift
@@ -152,7 +152,7 @@ fileprivate struct PrelinkedObjectFileTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func prelinkedObjectFileGenerationVariant_macCatalyst() async throws {
         let core = try await getCore()
         // Test that a prelinked object file gets generated even if the target contains no sources or libraries in its build phases.
@@ -167,8 +167,9 @@ fileprivate struct PrelinkedObjectFileTests: CoreBasedTests {
                     "Debug",
                     buildSettings: [
                         "PRODUCT_NAME": "$(TARGET_NAME)",
-                        "IPHONEOS_DEPLOYMENT_TARGET": core.loadSDK(.iOS).defaultDeploymentTarget,
                         "SDKROOT": "iphoneos",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -203,7 +204,7 @@ fileprivate struct PrelinkedObjectFileTests: CoreBasedTests {
             results.checkTarget("AllLibraries") { target in
                 // There should be tasks to create the prelinked object file and then the static library.
                 results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", .equal(results.runDestinationTargetArchitecture), "-platform_version", "6", .any, .any, "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", .equal(results.runDestinationTargetArchitecture), "-platform_version", "6", .any, .any, "-syslibroot", .equal(core.loadSDK(.macOS).path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/libAllLibraries.a-\(results.runDestinationTargetArchitecture)-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", .equal(results.runDestinationTargetArchitecture), "-D", "-syslibroot", .equal(core.loadSDK(.macOS).path.str), .equal("-L\(SRCROOT)/build/Debug-maccatalyst"), "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug-maccatalyst/AllLibraries.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug-maccatalyst/libAllLibraries.a")])
@@ -483,7 +484,7 @@ fileprivate struct PrelinkedObjectFileTests: CoreBasedTests {
             results.checkTarget("AllLibraries") { target in
                 // There should be tasks to create the prelinked object file and then the static library.
                 results.checkTask(.matchTarget(target), .matchRuleType("PrelinkedObjectLink")) { task in
-                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", .equal(results.runDestinationTargetArchitecture), "-platform_version", "7", .any, .any, "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/libAllLibraries.a-x86_64-prelink.o")])
+                    task.checkCommandLineMatches([.suffix("ld"), "-r", "-arch", .equal(results.runDestinationTargetArchitecture), "-platform_version", "7", .any, .any, "-syslibroot", .equal(results.runDestinationSDK.path.str), "-o", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/libAllLibraries.a-\(results.runDestinationTargetArchitecture)-prelink.o")])
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("Libtool")) { task in
                     task.checkCommandLineMatches([.suffix("libtool"), "-static", "-arch_only", .equal(results.runDestinationTargetArchitecture), "-D", "-syslibroot", .equal(results.runDestinationSDK.path.str), .equal("-L\(SRCROOT)/build/Debug-iphonesimulator"), "-filelist", .equal("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AllLibraries.LinkFileList"), "-dependency_info", "\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AllLibraries.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AllLibraries_libtool_dependency_info.dat", "-o", .equal("\(SRCROOT)/build/Debug-iphonesimulator/libAllLibraries.a")])

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -23,7 +23,7 @@ import SWBTaskConstruction
 
 @Suite(.requireXcode16())
 fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func app() async throws {
         let core = try await getCore()
 
@@ -51,6 +51,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                             "VALID_ARCHS": "$(inherited) x86_64h",
                             "ENABLE_PREVIEWS": "YES",
                             "INFOPLIST_FILE": "Sources/Info.plist",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -88,7 +89,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func previewsDylibMode() async throws {
         let core = try await getCore()
         let archs = ["x86_64", "x86_64h"]
@@ -128,6 +129,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                             "GCC_GENERATE_DEBUGGING_SYMBOLS": "YES",
                             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                             "LD_RUNPATH_SEARCH_PATHS": "@executable_path/../Frameworks2",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -360,7 +362,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func unitTestHostGetsPreviewsDylibLinkedAsLibraryWhenPresent() async throws {
         let core = try await getCore()
         let archs = ["x86_64", "x86_64h"]
@@ -396,6 +398,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "BUNDLE_LOADER": "$(TEST_HOST)",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -429,6 +432,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "INFOPLIST_FILE": "Sources/Info.plist",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -465,7 +469,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func unitTestHostWithoutBundleLoaderDoesNotGetPreviewsDylibLinkedAsLibrary() async throws {
         let core = try await getCore()
         let archs = ["x86_64", "x86_64h"]
@@ -501,6 +505,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "BUNDLE_LOADER": "",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -534,6 +539,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "INFOPLIST_FILE": "Sources/Info.plist",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -565,7 +571,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func ldClientNameBuildSettingWithNoDebugDylib() async throws {
         let core = try await getCore()
         let archs = ["x86_64", "x86_64h"]
@@ -606,6 +612,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "INFOPLIST_FILE": "Sources/Info.plist",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -636,7 +643,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func xOJITLdClientNamePropagatedAsInstallNameToPreviewsDylib() async throws {
         let core = try await getCore()
         let archs = ["x86_64", "x86_64h"]
@@ -677,6 +684,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                                 "INFOPLIST_FILE": "Sources/Info.plist",
                                 "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                                 "CODE_SIGN_IDENTITY": "-",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ]
                         ),
                     ],
@@ -1304,7 +1312,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
     /// rdar://171933514 — Same ordering invariant as above, but for multi-arch builds where
     /// per-arch link tasks go through lipo. The per-arch stub executor link must be ordered
     /// after the lipo'd debug.dylib.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func previewsDylibStubExecutorDependsOnDebugDylibMultiArch() async throws {
         let core = try await getCore()
         let archs = ["arm64", "x86_64"]
@@ -1338,6 +1346,8 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                             "INFOPLIST_FILE": "Sources/Info.plist",
                             "CODE_SIGN_ENTITLEMENTS": "Sources/Entitlements.plist",
                             "CODE_SIGN_IDENTITY": "-",
+                            // Set a deployment target of 26.0 so we don't get warnings when building for Intel.
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -230,8 +230,9 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
 
         let actoolPath = try await self.actoolPath
+        let sdkVersion = try await InstalledXcode.currentlySelected().productBuildVersion(sdkCanonicalName: "macosx")
 
-        await tester.checkBuild(runDestination: .macOS) { results in
+        try await tester.checkBuild(runDestination: .macOS) { results in
             // Ignore all the auxiliary file tasks.
             results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
             // Ignore all the mkdir and touch tasks.

--- a/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ShellScriptTaskConstructionTests.swift
@@ -109,6 +109,7 @@ fileprivate struct ShellScriptTaskConstructionTests: CoreBasedTests {
 
 extension CoreBasedTests {
     func testShellScriptDeploymentTargetPruning(sdkroot: String, sdkVariant: String? = nil, expectedDeploymentTargetPrefix: String) async throws {
+        let core = try await getCore()
         let testProject = try await TestProject(
             "MyProject",
             sourceRoot: Path("/MyProject"),
@@ -124,11 +125,11 @@ extension CoreBasedTests {
                         "SDK_VARIANT": sdkVariant ?? "",
                         "SUPPORTED_PLATFORMS": "appletvos appletvsimulator driverkit iphoneos iphonesimulator linux macosx watchos watchsimulator",
 
-                        "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
-                        "MACOSX_DEPLOYMENT_TARGET": "10.15",
-                        "TVOS_DEPLOYMENT_TARGET": "13.0",
-                        "WATCHOS_DEPLOYMENT_TARGET": "6.0",
-                        "DRIVERKIT_DEPLOYMENT_TARGET": "19.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": core.loadSDK(.iOS).defaultDeploymentTarget,
+                        "MACOSX_DEPLOYMENT_TARGET": core.loadSDK(.macOS).defaultDeploymentTarget,
+                        "TVOS_DEPLOYMENT_TARGET": core.loadSDK(.tvOS).defaultDeploymentTarget,
+                        "WATCHOS_DEPLOYMENT_TARGET": core.loadSDK(.watchOS).defaultDeploymentTarget,
+                        "DRIVERKIT_DEPLOYMENT_TARGET": core.loadSDK(.driverKit).defaultDeploymentTarget,
                     ])],
             targets: [
                 TestStandardTarget(

--- a/Tests/SWBTaskConstructionTests/SignatureCollectionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SignatureCollectionTaskConstructionTests.swift
@@ -20,7 +20,7 @@ import SWBTestSupport
 
 @Suite
 fileprivate struct SignatureCollectionTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode26())
     func basicSignatureCollection() async throws {
 
         let testProject = try await TestProject(
@@ -42,6 +42,8 @@ fileprivate struct SignatureCollectionTaskConstructionTests: CoreBasedTests {
                     "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator macosx",
                     "SUPPORTS_MACCATALYST": "YES",
                     "LIBTOOL": libtoolPath.str,
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                    "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                 ]),
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -2330,7 +2330,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func autolinkingFlags() async throws {
         let testProject = try await TestProject(
             "ProjectName",
@@ -2351,6 +2351,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             "SWIFT_VERSION": swiftVersion,
                             "SDKROOT": "macosx",
                             "SWIFT_EXEC": swiftCompilerPath.str,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -2403,7 +2404,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func installAPISetting() async throws {
         let sdkRoot = "macosx"
         let testProject = try await TestProject(
@@ -2426,7 +2427,8 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             "SWIFT_VERSION": swiftVersion,
                             "TAPI_EXEC": tapiToolPath.str,
                             "SUPPORTS_TEXT_BASED_API": "YES",
-                            "SDKROOT": sdkRoot
+                            "SDKROOT": sdkRoot,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -2481,6 +2483,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                             "SWIFT_EXEC": swiftCompilerPath.str,
                             "SWIFT_VERSION": swiftVersion,
                             "TAPI_EXEC": tapiToolPath.str,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -2493,7 +2496,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         return try await TaskConstructionTester(getCore(), testProject)
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func emptySwiftVersion() async throws {
         let tester = try await createTester(swiftVersion: "")
         await tester.checkBuild(runDestination: .macOS) { results in
@@ -2501,7 +2504,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func unsupportedSwiftVersion() async throws {
         let tester = try await createTester(swiftVersion: "1.1")
         await tester.checkBuild(runDestination: .macOS) { results in
@@ -2509,7 +2512,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func unparseableSwiftVersion() async throws {
         let tester = try await createTester(swiftVersion: "test")
         await tester.checkBuild(runDestination: .macOS) { results in
@@ -2517,7 +2520,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func minorSwiftVersions() async throws {
         let tester = try await createTester(swiftVersion: "4.1")
         await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["GENERATE_INFOPLIST_FILE": "YES"]), runDestination: .macOS) { results in
@@ -3161,7 +3164,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func swiftLinkerSearchPaths() async throws {
         let swiftFeatures = try await self.swiftFeatures
         let testProject = try await TestProject(
@@ -3184,6 +3187,8 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                         "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
                         "SWIFT_EXEC": swiftCompilerPath.str,
                         "SWIFT_VERSION": swiftVersion,
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
                     ]
                 )
             ],
@@ -3212,9 +3217,9 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Ld")) { task in
                 if swiftFeatures.has(.debugInfoExplicitDependency) {
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos26.0", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
                 } else {
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos26.0", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
                 }
             }
             results.checkNoDiagnostics()
@@ -3228,7 +3233,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             results.checkTask(.matchRuleType("Ld")) { task in
                 let containsSubFrameworksPath = task.commandLineAsStrings.contains("\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks")
                 let expectedCommandLine: [String] = [
-                    ["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(catalystVersion.description)-macabi", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-L\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-F\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
+                    ["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-ios26.0-macabi", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-L\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-F\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
                     ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
@@ -3242,9 +3247,9 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["IS_ZIPPERED": "YES"]), runDestination: .macOS) { results in
             results.checkTask(.matchRuleType("Ld")) { task in
                 if swiftFeatures.has(.debugInfoExplicitDependency) {
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos26.0", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
                 } else {
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-macos26.0", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget.swiftmodule", "@\(SRCROOT)/build/aProject.build/Debug/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/AppTarget-linker-args.resp", "-o", "\(SRCROOT)/build/Debug/AppTarget.app/Contents/MacOS/AppTarget"])
                 }
             }
             results.checkNoDiagnostics()
@@ -3254,7 +3259,7 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             results.checkTask(.matchRuleType("Ld")) { task in
                 let containsSubFrameworksPath = task.commandLineAsStrings.contains("\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks")
                 let expectedCommandLine: [String] = [
-                    ["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(catalystVersion.description)-macabi", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-L\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-F\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
+                    ["clang", "-Xlinker", "-reproducible", "-target", "\(results.runDestinationTargetArchitecture)-apple-ios26.0-macabi", "-isysroot", "\(core.loadSDK(.macOS).path.str)", "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-L\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-L\(core.loadSDK(.macOS).path.str)/System/iOSSupport/usr/lib", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/maccatalyst", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-maccatalyst", "-F\(SRCROOT)/build/Debug\(MacCatalystInfo.publicSDKBuiltProductsDirSuffix)", "-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),
                     ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/Frameworks"],
                     (containsSubFrameworksPath ? ["-iframework", "\(core.loadSDK(.macOS).path.str)/System/iOSSupport/System/Library/SubFrameworks"] : []),

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -1598,7 +1598,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireXcode26())
     func toolBasics() async throws {
         // Test the basics of task construction for a command line tool which uses a static library.
         let runDestination: RunDestinationInfo = .host
@@ -1622,7 +1622,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     "LIBTOOL": libtoolPath.str,
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "GCC_PREFIX_HEADER": "Prefix.pch",
-                    "CLANG_USE_RESPONSE_FILE": "NO",]),
+                    "CLANG_USE_RESPONSE_FILE": "NO",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",]),
                 TestBuildConfiguration("Release", buildSettings: [
                     "LIBTOOL": libtoolPath.str,
                     "PRODUCT_NAME": "$(TARGET_NAME)",
@@ -1631,6 +1632,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     "INFOPLIST_FILE": "Tool.plist",
                     "INFOPLIST_PREPROCESS": "YES",
                     "CLANG_USE_RESPONSE_FILE": "NO",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ]),
             ],
             targets: [
@@ -1665,7 +1667,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-        let MACOSX_DEPLOYMENT_TARGET = runDestination == .macOS ? core.loadSDK(.macOS).defaultDeploymentTarget : ""
+        let MACOSX_DEPLOYMENT_TARGET = "26.0"
 
         // MacOS is the only platform where we can create universal binaries
         let architectures = runDestination == .macOS ?  ["arm64", "x86_64"] : [runDestination.targetArchitecture]
@@ -3106,7 +3108,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Check that using CURRENT_* macros along with include paths that require prefixing is supported. rdar://problem/46039547 for more details.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func remappedHeaderSearchPathsWithCurrentMacros() async throws {
         let archs = ["arm64", "x86_64"]
         let buildVariants = ["normal", "debug"]
@@ -3133,6 +3135,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                                 "SDKROOT": "macosx",
                                                 "SWIFT_VERSION": swiftVersion,
                                                 "CLANG_USE_RESPONSE_FILE": "NO",
+                                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                                ]),
                     ],
                     buildPhases: [
@@ -3697,7 +3700,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func assemblyCompile() async throws {
         let testProject = TestProject(
             "ProjectName",
@@ -3715,6 +3718,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             "GENERATE_INFOPLIST_FILE": "YES",
                             "PRODUCT_NAME": "ProductName",
                             "ARCHS": "x86_64",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -3732,7 +3736,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func indexingWhileBuilding() async throws {
         let clangFeatures = try await self.clangFeatures
         let swiftFeatures = try await self.swiftFeatures
@@ -3760,6 +3764,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             "GCC_OPTIMIZATION_LEVEL": "0",
                             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                             "CC": clangCompilerPath.str,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -3805,7 +3810,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func indexingWhileBuildingDisabledInRelease() async throws {
         let swiftFeatures = try await self.swiftFeatures
         let testProject = try await TestProject(
@@ -3832,6 +3837,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             "GCC_OPTIMIZATION_LEVEL": "s",
                             "SWIFT_OPTIMIZATION_LEVEL": "-Os",
                             "CC": clangCompilerPath.str,
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -4067,6 +4073,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
     @Test(
         .requireSDKs(.macOS),
+        .requireXcode26(),
         arguments: Self.sanitizersTestData,
     )
     func sanitizers(
@@ -4438,7 +4445,12 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
 
             // Check that memory-tagging address sanitizer shows an error on unsupported architectures.
             let x86_64RunDestination = RunDestinationInfo(platform: "macosx", sdk: "macosx", sdkVariant: "macosx", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
-            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER": "YES", "ONLY_ACTIVE_ARCH": "YES"]), runDestination: x86_64RunDestination, fs: fs) { results in
+            let x86_64Overrides = [
+                "ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER": "YES",
+                "ONLY_ACTIVE_ARCH": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "26.0",                 // x86_64 is no longer in ARCHS_STANDARD when targeting macOS 27.0
+            ]
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: x86_64Overrides), runDestination: x86_64RunDestination, fs: fs) { results in
                 // Should get an error for x86_64 architecture not being supported
                 results.checkError(.contains("Memory-Tagging Address Sanitizer is enabled (ENABLE_MEMORY_TAGGING_ADDRESS_SANITIZER = YES), but is not supported for architecture(s): x86_64"))
             }
@@ -4834,7 +4846,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Exercise some unusual behaviors in shell script build phases.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func scriptPhaseBehaviors() async throws {
         let testProject = TestProject(
             "aProject",
@@ -4851,6 +4863,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         "CODE_SIGN_IDENTITY": "",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "ARCHS": "x86_64",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
                 TestBuildConfiguration(
                     "Release",
@@ -4860,6 +4873,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         "ARCHS": "x86_64 x86_64h",
                         "VALID_ARCHS": "$(inherited) x86_64h",
                         "BUILD_VARIANTS": "normal debug profile",
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [
@@ -6867,7 +6881,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// This tests an edge case in which a product is configured with multiple `ARCHS`, but `EXCLUDED_SOURCE_FILE_NAMES` is set to exclude compiling all files for one architecture. So we copy the single-arch binary into the place where we would lipo the multi-arch binary if there were multiple architectures.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func multiArchConfigurationYieldsSingleArchBinary() async throws {
         let SDKROOT = "macosx"
         let builtArch = "arm64"
@@ -6897,6 +6911,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             "ARCHS": "\(builtArch) \(skippedArch)",
                             "INFOPLIST_FILE": "Sources/Info.plist",
                             "EXCLUDED_SOURCE_FILE_NAMES[arch=\(skippedArch)]": "*",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
                         ]),
                     ],
                     buildPhases: [
@@ -7477,7 +7492,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Tests that the CopyStringsFile task is arch-neutral and doesn't emit duplicate task errors for multi-arch and/or multi-variant builds.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func copyStringsArchNeutral() async throws {
         let testProject = TestProject(
             "aProject",
@@ -7498,7 +7513,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     "ARCHS": "x86_64 x86_64h",
                     "BUILD_VARIANTS": "normal debug profile",
                     "GENERATE_INFOPLIST_FILE": "YES",
-                    "PRODUCT_NAME": "$(TARGET_NAME)"])],
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",])],
             targets: [
                 TestStandardTarget(
                     "Foo",
@@ -7528,7 +7544,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Ensure that the intents headers are still generated for `installhdrs` and `installapi`  builds.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func intentsCodegenForInstallHeadersAndApi() async throws {
         let testProject = try await TestProject(
             "aProject",
@@ -7555,6 +7571,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     "SUPPORTS_TEXT_BASED_API": "YES",
                     "SWIFT_VERSION": "5.2",
                     "TAPI_EXEC": tapiToolPath.str,
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                 ])],
             targets: [
                 TestStandardTarget(
@@ -7637,7 +7654,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Test that multiple occurrences of the same architecture in ARCHS doesn't produce duplicate tasks.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func duplicateArchFiltering() async throws {
         let testProject = TestProject(
             "aProject",
@@ -7652,7 +7669,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 buildSettings: [
                     "ARCHS": "x86_64 x86_64",
                     "GENERATE_INFOPLIST_FILE": "YES",
-                    "PRODUCT_NAME": "$(TARGET_NAME)"])],
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",])],
             targets: [
                 TestStandardTarget(
                     "Foo",
@@ -7749,8 +7767,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             buildSettings: [
                                 // avoid multi-arch builds to make the checkTask formats identical across platforms
                                 "ARCHS": "arm64",
-                                "ARCHS[sdk=macosx*]": "x86_64",
-                                "ARCHS[sdk=driverkit*]": "x86_64",
+                                "ARCHS[sdk=macosx*]": "arm64",
+                                "ARCHS[sdk=driverkit*]": "arm64",
                                 "ARCHS[sdk=watchos*]": "arm64_32",
 
                                 "CODE_SIGNING_ALLOWED": "NO",
@@ -9961,7 +9979,6 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                                 "TARGET_BUILD_DIR": "/tmp/SomeFiles.dst",
                                 "GENERATE_INFOPLIST_FILE": "YES",
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
-                                "ARCHS": "x86_64 arm64",
                                 "EMIT_SARIF_DIAGNOSTICS_FILE": "YES"
                             ])
                         ],
@@ -9980,7 +9997,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                 results.checkTarget("AppTarget") { target -> Void in
                     let command = "-fdiagnostics-add-output=sarif:file="
                     let buildPath = tmpDir.join("build/aProject.build/Debug/AppTarget.build/Objects-normal/")
-                    for arch in ["x86_64", "arm64"] {
+                    for arch in ["arm64"] {
                         let metadataPath = buildPath.join(arch)
                         let inputs = sources.map{metadataPath.join(Path($0).basenameWithoutSuffix + ".o.compiled.sarif").str}
 

--- a/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
@@ -36,7 +36,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     "GCC_WARN_64_TO_32_BIT_CONVERSION": "YES",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "CLANG_USE_RESPONSE_FILE": "NO",
                 ]),
@@ -67,7 +67,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -98,7 +98,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-x", "c", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fasm-blocks", "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.o"])
+                    task.checkCommandLine(["clang", "-x", "c", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.o"])
                 }
 
                 // Validate that we are getting the "-framework Support" flag added an no unexpected parameters.
@@ -106,7 +106,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
                 }
             }
         }
@@ -128,7 +128,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     "GCC_WARN_64_TO_32_BIT_CONVERSION": "YES",
                     "DEAD_CODE_STRIPPING": "YES",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "CLANG_USE_RESPONSE_FILE": "NO",
                 ]),
@@ -175,8 +175,8 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.writeSimulatedProvisioningProfile(uuid: "8db0e92c-592c-4f06-bfed-9d945841b78d")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", supportedPlatform: "driverkit", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", supportedPlatform: "driverkit", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
         try fs.createDirectory(supportXCFrameworkPath, recursive: true)
@@ -207,7 +207,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-x", "c", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fasm-blocks", "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.o"])
+                    task.checkCommandLine(["clang", "-x", "c", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.o"])
                 }
 
                 // Validate that we are getting the "-framework Support" flag added an no unexpected parameters.
@@ -215,7 +215,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.LinkFileList", "-Xlinker", "-dead_strip", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.LinkFileList", "-Xlinker", "-dead_strip", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
                 }
             }
 
@@ -242,9 +242,9 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-x", "c", "-target", "x86_64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.driverKit).path.str, "-fasm-blocks", "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-project-headers.hmap",
+                    task.checkCommandLine(["clang", "-x", "c", "-target", "arm64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.driverKit).path.str, "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Driver-project-headers.hmap",
                                            "-I\(SRCROOT)/build/Debug-driverkit/include",
-                                           "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources-normal/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources", "-F\(SRCROOT)/build/Debug-driverkit", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/file.o"])
+                                           "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources-normal/arm64", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources/arm64", "-I\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/DerivedSources", "-F\(SRCROOT)/build/Debug-driverkit", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/file.o"])
                 }
 
                 // Validate that we are getting the "-framework Support" flag added an no unexpected parameters.
@@ -252,7 +252,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.driverKit).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-driverkit", "-L\(SRCROOT)/build/Debug-driverkit", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-driverkit", "-F\(SRCROOT)/build/Debug-driverkit", "-filelist", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/Driver.LinkFileList", "-Xlinker", "-dead_strip", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/Driver_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/x86_64/Driver_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug-driverkit/Driver.dext/Driver"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-driverkit\(core.loadSDK(.driverKit).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.driverKit).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug-driverkit", "-L\(SRCROOT)/build/Debug-driverkit", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug-driverkit", "-F\(SRCROOT)/build/Debug-driverkit", "-filelist", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/Driver.LinkFileList", "-Xlinker", "-dead_strip", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/Driver_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug-driverkit/Driver.build/Objects-normal/arm64/Driver_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug-driverkit/Driver.dext/Driver"])
                 }
             }
 
@@ -276,7 +276,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     "GCC_WARN_64_TO_32_BIT_CONVERSION": "YES",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "CLANG_USE_RESPONSE_FILE": "NO",
                 ]),
@@ -307,7 +307,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -339,7 +339,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-x", "c", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fasm-blocks", "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Release/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Release/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Release/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Release/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Release/include", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources-normal/x86_64", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources/x86_64", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources", "-F\(SRCROOT)/build/Release", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/x86_64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/x86_64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/x86_64/file.o"])
+                    task.checkCommandLine(["clang", "-x", "c", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Release/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Release/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Release/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Release/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Release/include", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources-normal/arm64", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources/arm64", "-I\(SRCROOT)/build/aProject.build/Release/App.build/DerivedSources", "-F\(SRCROOT)/build/Release", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/arm64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/arm64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Release/App.build/Objects-normal/arm64/file.o"])
                 }
 
                 // Validate that we are getting the "-framework Support" flag added an no unexpected parameters.
@@ -347,7 +347,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L/tmp/Test/aProject/build/EagerLinkingTBDs/Release", "-L/tmp/Test/aProject/build/Release", "-F/tmp/Test/aProject/build/EagerLinkingTBDs/Release", "-F/tmp/Test/aProject/build/Release", "-filelist", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/x86_64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/x86_64/App_lto.o", "-Xlinker", "-final_output", "-Xlinker", "/Applications/App.app/Contents/MacOS/App", "-Xlinker", "-dependency_info", "-Xlinker", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/x86_64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "/tmp/aProject.dst/Applications/App.app/Contents/MacOS/App"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L/tmp/Test/aProject/build/EagerLinkingTBDs/Release", "-L/tmp/Test/aProject/build/Release", "-F/tmp/Test/aProject/build/EagerLinkingTBDs/Release", "-F/tmp/Test/aProject/build/Release", "-filelist", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/arm64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/arm64/App_lto.o", "-Xlinker", "-final_output", "-Xlinker", "/Applications/App.app/Contents/MacOS/App", "-Xlinker", "-dependency_info", "-Xlinker", "/tmp/Test/aProject/build/aProject.build/Release/App.build/Objects-normal/arm64/App_dependency_info.dat", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "/tmp/aProject.dst/Applications/App.app/Contents/MacOS/App"])
                 }
             }
         }
@@ -370,7 +370,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
                     "_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES": "NO",
@@ -402,7 +402,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("main.swift"), contents: "func f() -> Int { return 0 }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -434,7 +434,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
                     // Validate that we are looking into the build location with -F.
-                    task.checkCommandLineContains([swiftCompilerPath.str, "-module-name", "App", "-O", "@\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.SwiftFileList", "-sdk", core.loadSDK(.macOS).path.str, "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-g", "-Xfrontend", "-serialize-debugging-options", "-swift-version", "5", "-I", "\(SRCROOT)/build/Debug", "-F", "\(SRCROOT)/build/Debug", "-c", "-j\(compilerParallelismLevel)", "-enable-batch-mode", "-incremental", "-output-file-map", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App-OutputFileMap.json", "-emit-dependencies", "-emit-module", "-emit-module-path", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.swiftmodule", "-serialize-diagnostics", "-Xcc", "-iquote", "-Xcc", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-Xcc", "-iquote", "-Xcc", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-Xcc", "-I\(SRCROOT)/build/Debug/include", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/x86_64", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/x86_64", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-emit-objc-header", "-emit-objc-header-path", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App-Swift.h", "-working-directory", "\(SRCROOT)"])
+                    task.checkCommandLineContains([swiftCompilerPath.str, "-module-name", "App", "-O", "@\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.SwiftFileList", "-sdk", core.loadSDK(.macOS).path.str, "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-g", "-Xfrontend", "-serialize-debugging-options", "-swift-version", "5", "-I", "\(SRCROOT)/build/Debug", "-F", "\(SRCROOT)/build/Debug", "-c", "-j\(compilerParallelismLevel)", "-enable-batch-mode", "-incremental", "-output-file-map", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App-OutputFileMap.json", "-emit-dependencies", "-emit-module", "-emit-module-path", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.swiftmodule", "-serialize-diagnostics", "-Xcc", "-iquote", "-Xcc", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-Xcc", "-iquote", "-Xcc", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-Xcc", "-I\(SRCROOT)/build/Debug/include", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/arm64", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/arm64", "-Xcc", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-emit-objc-header", "-emit-objc-header-path", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App-Swift.h", "-working-directory", "\(SRCROOT)"])
                 }
 
                 try results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements")) { task in
@@ -442,7 +442,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
                 }
 
-                results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.SwiftFileList"])) { _, contents in
+                results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRule(["WriteAuxiliaryFile", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.SwiftFileList"])) { _, contents in
                     let lines = contents.asString.components(separatedBy: .newlines)
                     #expect(lines == ["\(SRCROOT)/main.swift", ""])
                 }
@@ -452,7 +452,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.swiftmodule", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_dependency_info.dat", "-fobjc-link-runtime", "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx", "-L/usr/lib/swift", "-Xlinker", "-add_ast_path", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.swiftmodule", "-framework", "Support", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
                 }
             }
         }
@@ -476,7 +476,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     "DEAD_CODE_STRIPPING": "YES",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                 ]),
             ],
@@ -541,10 +541,10 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let xctrunnerPath = core.developerPath.path.join("Platforms/MacOSX.platform/Developer/Library/Xcode/Agents/XCTRunner.app")
-        try await fs.writeXCTRunnerApp(xctrunnerPath, archs: ["arm64", "arm64e", "x86_64"], platform: .macOS, infoLookup: core)
+        try await fs.writeXCTRunnerApp(xctrunnerPath, archs: ["arm64", "arm64e"], platform: .macOS, infoLookup: core)
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
         try fs.createDirectory(supportXCFrameworkPath, recursive: true)
@@ -585,7 +585,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                 ]),
             ],
@@ -614,7 +614,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -645,7 +645,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-strip-unsigned-binaries", "-strip-deterministic", "-strip-tool", "strip", "-resolve-src-symlinks", "-remove-static-executable", "\(SRCROOT)/Support.xcframework/x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)/Support.framework", "\(SRCROOT)/build/Debug/MyFrameworks/more/subpaths"])
+                    task.checkCommandLine(["builtin-copy", "-exclude", ".DS_Store", "-exclude", "CVS", "-exclude", ".svn", "-exclude", ".git", "-exclude", ".hg", "-strip-unsigned-binaries", "-strip-deterministic", "-strip-tool", "strip", "-resolve-src-symlinks", "-remove-static-executable", "\(SRCROOT)/Support.xcframework/arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)/Support.framework", "\(SRCROOT)/build/Debug/MyFrameworks/more/subpaths"])
                 }
             }
         }
@@ -667,7 +667,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     "GCC_WARN_64_TO_32_BIT_CONVERSION": "YES",
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "HEADER_SEARCH_PATHS": "hp1 hp2",
                     "CLANG_USE_RESPONSE_FILE": "NO",
@@ -698,7 +698,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("libsupport.a"), binaryPath: Path("libsupport.a"), headersPath: Path("Headers")),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("libsupport.a"), binaryPath: Path("libsupport.a"), headersPath: Path("Headers")),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("libsupport.a"), binaryPath: Path("libsupport.a"), headersPath: Path("Headers")),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -749,14 +749,14 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-x", "c", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fasm-blocks", "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-Ihp1", "-Ihp2", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/x86_64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/file.o"])
+                    task.checkCommandLine(["clang", "-x", "c", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-fmessage-length=0", "-fdiagnostics-show-note-include-stack", "-fmacro-backtrace-limit=0", "-fno-color-diagnostics", "-Wno-trigraphs", "-fpascal-strings", "-Os", "-Wno-missing-field-initializers", "-Wno-missing-prototypes", "-Wno-return-type", "-Wno-missing-braces", "-Wparentheses", "-Wswitch", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter", "-Wno-unused-variable", "-Wunused-value", "-Wno-empty-body", "-Wno-uninitialized", "-Wno-unknown-pragmas", "-Wno-shadow", "-Wno-four-char-constants", "-Wno-conversion", "-Wno-constant-conversion", "-Wno-int-conversion", "-Wno-bool-conversion", "-Wno-enum-conversion", "-Wno-float-conversion", "-Wno-non-literal-null-conversion", "-Wno-objc-literal-conversion", "-Wshorten-64-to-32", "-Wpointer-sign", "-Wno-newline-eof", "-Wno-implicit-fallthrough", "-isysroot", core.loadSDK(.macOS).path.str, "-fstrict-aliasing", "-Wdeprecated-declarations", "-g", "-fvisibility=hidden", "-Wno-sign-conversion", "-Wno-infinite-recursion", "-Wno-comma", "-Wno-block-capture-autoreleasing", "-Wno-strict-prototypes", "-Wno-semicolon-before-method-body", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-generated-files.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-own-target-headers.hmap", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/App-all-target-headers.hmap", "-iquote", "\(SRCROOT)/build/aProject.build/Debug/App.build/App-project-headers.hmap", "-I\(SRCROOT)/build/Debug/include", "-Ihp1", "-Ihp2", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources-normal/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources/arm64", "-I\(SRCROOT)/build/aProject.build/Debug/App.build/DerivedSources", "-F\(SRCROOT)/build/Debug", "-MMD", "-MT", "dependencies", "-MF", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.d", "--serialize-diagnostics", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.dia", "-c", "\(SRCROOT)/file.c", "-o", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/file.o"])
                 }
 
                 try results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                     // There needs to be a strong dependency on the XCFramework processing.
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/x86_64/App_dependency_info.dat", "-lsupport", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App.build/Objects-normal/arm64/App_dependency_info.dat", "-lsupport", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App.app/Contents/MacOS/App"])
                 }
             }
         }
@@ -778,7 +778,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                     "HEADER_SEARCH_PATHS": "hp1 hp2",
                     "SWIFT_EXEC": swiftCompilerPath.str,
@@ -810,7 +810,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("support.framework"), binaryPath: Path("support.framework/Versions/A/support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("support.framework"), binaryPath: Path("support.framework/Versions/A/support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("support.framework"), binaryPath: Path("support.framework/support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -819,7 +819,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         let otherXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("other.dylib"), binaryPath: Path("other.dylib"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("other.dylib"), binaryPath: Path("other.dylib"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("other.dylib"), binaryPath: Path("other.dylib"), headersPath: nil),
         ])
         let otherXCFrameworkPath = Path(SRCROOT).join("Other.xcframework")
@@ -940,7 +940,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -949,7 +949,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         let extrasXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Versions/A/Extras"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Versions/A/Extras"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Extras"), headersPath: nil),
         ])
         let extrasXCFrameworkPath = Path(SRCROOT).join("Extras.xcframework")
@@ -1073,8 +1073,8 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     type: .application,
                     buildConfigurations: [
                         TestBuildConfiguration("Debug", buildSettings: [
-                            "ARCHS": "x86_64h",
-                            "VALID_ARCHS": "$(inherited) x86_64h",
+                            "ARCHS": "arm64e",
+                            "VALID_ARCHS": "$(inherited) arm64e",
                         ]),
                     ],
                     buildPhases: [
@@ -1095,7 +1095,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("lib1.c"), contents: "int l() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
         let supportXCFrameworkPath = Path(SRCROOT).join("Support.xcframework")
@@ -1104,7 +1104,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         let extrasXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Versions/A/Extras"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Versions/A/Extras"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Extras.framework"), binaryPath: Path("Extras.framework/Extras"), headersPath: nil),
         ])
         let extrasXCFrameworkPath = Path(SRCROOT).join("Extras.xcframework")
@@ -1211,11 +1211,11 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                     results.checkTaskFollows(task, antecedent: try #require(processSupportXCFrameworkTask))
                     results.checkTaskFollows(task, antecedent: try #require(processExtrasXCFrameworkTask))
 
-                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "x86_64h-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/x86_64h/App2.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/x86_64h/App2_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/x86_64h/App2_dependency_info.dat", "-framework", "Support", "-framework", "Extras", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App2.app/Contents/MacOS/App2"])
+                    task.checkCommandLine(["clang", "-Xlinker", "-reproducible", "-target", "arm64e-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "-isysroot", core.loadSDK(.macOS).path.str, "-Os", "-Xlinker", "-no_warn_duplicate_libraries", "-L\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-L\(SRCROOT)/build/Debug", "-F\(SRCROOT)/build/EagerLinkingTBDs/Debug", "-F\(SRCROOT)/build/Debug", "-filelist", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/arm64e/App2.LinkFileList", "-Xlinker", "-object_path_lto", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/arm64e/App2_lto.o", "-Xlinker", "-dependency_info", "-Xlinker", "\(SRCROOT)/build/aProject.build/Debug/App2.build/Objects-normal/arm64e/App2_dependency_info.dat", "-framework", "Support", "-framework", "Extras", "-Xlinker", "-no_adhoc_codesign", "-o", "\(SRCROOT)/build/Debug/App2.app/Contents/MacOS/App2"])
                 }
 
-                results.checkNote(.equal("'\(SRCROOT)/Extras.xcframework' is missing architecture(s) required by this target (x86_64h), but may still be link-compatible. (in target 'App2' from project 'aProject')"))
-                results.checkNote(.equal("'\(SRCROOT)/Support.xcframework' is missing architecture(s) required by this target (x86_64h), but may still be link-compatible. (in target 'App2' from project 'aProject')"))
+                results.checkNote(.equal("'\(SRCROOT)/Extras.xcframework' is missing architecture(s) required by this target (arm64e), but may still be link-compatible. (in target 'App2' from project 'aProject')"))
+                results.checkNote(.equal("'\(SRCROOT)/Support.xcframework' is missing architecture(s) required by this target (arm64e), but may still be link-compatible. (in target 'App2' from project 'aProject')"))
             }
 
             results.checkNoDiagnostics()
@@ -1237,7 +1237,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
                 TestBuildConfiguration("Debug", buildSettings: [
                     "PRODUCT_NAME": "$(TARGET_NAME)",
                     "CODE_SIGN_IDENTITY": "-",
-                    "ARCHS": "x86_64",
+                    "ARCHS": "arm64",
                     "INFOPLIST_FILE": "Info.plist",
                 ]),
             ],
@@ -1267,7 +1267,7 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try fs.write(Path(SRCROOT).join("file.c"), contents: "int f() { return 0; }")
 
         let supportXCFramework = try XCFramework(version: Version(1, 0), libraries: [
-            XCFramework.Library(libraryIdentifier: "x86_64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["x86_64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+            XCFramework.Library(libraryIdentifier: "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
             XCFramework.Library(libraryIdentifier: "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)", supportedPlatform: "ios", supportedArchitectures: ["arm64", "arm64e"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
         ])
 

--- a/Tests/SwiftBuildPerfTests/XCFrameworkPerfTests.swift
+++ b/Tests/SwiftBuildPerfTests/XCFrameworkPerfTests.swift
@@ -34,9 +34,9 @@ fileprivate struct XCFrameworkCreationPerfTests: CoreBasedTests, PerfTests {
     @Test(.requireSDKs(.macOS, .iOS), arguments: [true, false])
     func XCFrameworkCreationWithFrameworksPerf(useSwift: Bool) async throws {
         try await withTemporaryDirectory { tmpDir in
-            let path1 = try await xcode.compileFramework(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["x86_64"], useSwift: useSwift)
+            let path1 = try await xcode.compileFramework(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["arm64"], useSwift: useSwift)
             let path2 = try await xcode.compileFramework(path: tmpDir.join("iphoneos"), platform: .iOS, infoLookup: infoLookup, archs: ["arm64", "arm64e"], useSwift: useSwift)
-            let path3 = try await xcode.compileFramework(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["x86_64"], useSwift: useSwift)
+            let path3 = try await xcode.compileFramework(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["arm64"], useSwift: useSwift)
 
             let commandLine = ["createXCFramework", "-framework", path1.str, "-framework", path2.str, "-framework", path3.str, "-output"]
 
@@ -53,9 +53,9 @@ fileprivate struct XCFrameworkCreationPerfTests: CoreBasedTests, PerfTests {
     @Test(.requireSDKs(.macOS, .iOS), arguments: [true, false])
     func XCFrameworkCreationWithDynamicLibrariesPerf(useSwift: Bool) async throws {
         try await withTemporaryDirectory { tmpDir in
-            let path1 = try await xcode.compileDynamicLibrary(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["x86_64"], useSwift: useSwift)
+            let path1 = try await xcode.compileDynamicLibrary(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["arm64"], useSwift: useSwift)
             let path2 = try await xcode.compileDynamicLibrary(path: tmpDir.join("iphoneos"), platform: .iOS, infoLookup: infoLookup, archs: ["arm64", "arm64e"], useSwift: useSwift)
-            let path3 = try await xcode.compileDynamicLibrary(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["x86_64"], useSwift: useSwift)
+            let path3 = try await xcode.compileDynamicLibrary(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["arm64"], useSwift: useSwift)
 
             let commandLine = ["createXCFramework", "-library", path1.str, "-headers", path1.dirname.join("include").str, "-library", path2.str, "-headers", path2.dirname.join("include").str, "-library", path3.str, "-headers", path3.dirname.join("include").str, "-output"]
 
@@ -82,9 +82,9 @@ fileprivate struct XCFrameworkCreationPerfTests: CoreBasedTests, PerfTests {
                     }
                 }
 
-                let path1 = try await xcode.compileFramework(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["x86_64"], useSwift: true)
+                let path1 = try await xcode.compileFramework(path: tmpDir.join("macos"), platform: .macOS, infoLookup: infoLookup, archs: ["arm64"], useSwift: true)
                 let path2 = try await xcode.compileFramework(path: tmpDir.join("iphoneos"), platform: .iOS, infoLookup: infoLookup, archs: ["arm64", "arm64e"], useSwift: true)
-                let path3 = try await xcode.compileFramework(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["x86_64"], useSwift: true)
+                let path3 = try await xcode.compileFramework(path: tmpDir.join("iphonesimulator"), platform: .iOSSimulator, infoLookup: infoLookup, archs: ["arm64"], useSwift: true)
 
                 let outputPath = tmpDir.join("sample.xcframework")
                 let commandLine = ["createXCFramework", "-framework", path1.str, "-framework", path2.str, "-framework", path3.str, "-output", outputPath.str]
@@ -121,7 +121,7 @@ fileprivate struct XCFrameworkCreationPerfTests: CoreBasedTests, PerfTests {
                             "GENERATE_INFOPLIST_FILE": "YES",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "CODE_SIGN_IDENTITY": "-",
-                            "ARCHS": "x86_64",
+                            "ARCHS": "arm64",
                             "SWIFT_VERSION": "5",
                         ]),
                     ],

--- a/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
@@ -20,7 +20,7 @@ import SWBUtil
 // These tests use the new model of enabling `enableIndexBuildArena` in the build request, along with passing a build description ID.
 @Suite
 struct ArenaIndexingInfoTests: CoreBasedTests {
-    @Test(.requireSDKs(.macOS, .iOS))
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode27())
     func indexInfoForMultiPlatformTargets() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -87,6 +87,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                                 buildSettings: [
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "ALWAYS_SEARCH_USER_PATHS": "NO",
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ])],
                         targets: [
                             macApp,
@@ -127,7 +128,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                 do {
                     let info = try await IndexingInfoResults(infoProducer.generateIndexingInfo(fwkTarget_ios, .macOS))
                     await info.checkIndexingInfo { info in
-                        info.clang.checkCommandLineMatches(["-target", .prefix("x86_64-apple-ios")])
+                        info.clang.checkCommandLineMatches(["-target", .prefix("arm64-apple-ios")])
                     }
                     info.checkNoIndexingInfo()
                 }
@@ -413,7 +414,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func indexOutputUnitPathModifiesOutputInfo() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -454,6 +455,7 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                                 buildSettings: [
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "COMPILER_INDEX_STORE_ENABLE": "YES",
+                                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                 ])],
                         targets: [
                             appTarget,

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -138,7 +138,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
+    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS), .requireXcode27())
     func multiFileAssembleBuild() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -184,11 +184,9 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         return nil
                     }
                 }).only)
-                #expect(pathMap.count == 4)
-                for arch in ["arm64", "x86_64"] {
-                    for target in ["aFramework", "bFramework"] {
-                        #expect(try pathMap[AbsolutePath(validating: "\(srcroot.str)/aProject/build/aProject.build/Debug/\(target).build/Objects-normal/\(arch)/Test.s")] == AbsolutePath(validating: "\(srcroot.str)/Test.c"))
-                    }
+                #expect(pathMap.count == 2)
+                for target in ["aFramework", "bFramework"] {
+                    #expect(try pathMap[AbsolutePath(validating: "\(srcroot.str)/aProject/build/aProject.build/Debug/\(target).build/Objects-normal/arm64/Test.s")] == AbsolutePath(validating: "\(srcroot.str)/Test.c"))
                 }
 
                 XCTAssertLastBuildEvent(events)
@@ -2232,7 +2230,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS))
+    @Test(.requireSDKs(.macOS), .requireHostOS(.macOS), .requireXcode26())
     func swiftPerFileBatchedTaskSignaturesAreStable() async throws {
         try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
             try await withAsyncDeferrable { deferrable in
@@ -2257,7 +2255,8 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                                 "GENERATE_INFOPLIST_FILE": "YES",
                                 "USE_HEADERMAP": "NO",
                                 "ALWAYS_SEARCH_USER_PATHS": "NO",
-                                "SWIFT_ENABLE_EXPLICIT_MODULES": "NO"
+                                "SWIFT_ENABLE_EXPLICIT_MODULES": "NO",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ])],
                     buildPhases: [
                         TestSourcesBuildPhase([

--- a/Tests/SwiftBuildTests/IndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/IndexingInfoTests.swift
@@ -575,7 +575,7 @@ fileprivate struct IndexingInfoTests: CoreBasedTests {
 
     /// Test that we compute right indexing argument when there is
     /// a PCH file.
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func indexingPCH() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -610,7 +610,8 @@ fileprivate struct IndexingInfoTests: CoreBasedTests {
                                             buildSettings: [
                                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                                 "USE_HEADERMAP": "NO",
-                                                "GCC_PREFIX_HEADER": "Foo/PrefixHeader.pch"
+                                                "GCC_PREFIX_HEADER": "Foo/PrefixHeader.pch",
+                                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                                             ])],
                                     buildPhases: [
                                         TestSourcesBuildPhase([TestBuildFile("foo.c")]),

--- a/Tests/SwiftBuildTests/LocalizationInfoTests.swift
+++ b/Tests/SwiftBuildTests/LocalizationInfoTests.swift
@@ -20,7 +20,7 @@ import SwiftBuild
 
 @Suite(.requireHostOS(.macOS), .requireLocalizedStringExtraction)
 fileprivate struct LocalizationInfoTests {
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func singleTargetMacOSAllArchs() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -72,6 +72,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ])
                         ],
                         targets: [
@@ -121,7 +122,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func compilerExtractionOff() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -173,6 +174,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ])
                         ],
                         targets: [
@@ -216,7 +218,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func XCStringsNotNeedingBuilt() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -268,6 +270,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0"
                             ])
                         ],
                         targets: [
@@ -310,7 +313,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func XCStringsInCopyFiles() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -362,6 +365,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0"
                             ])
                         ],
                         targets: [
@@ -400,7 +404,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func XCStringsNotNeedingBuiltInCopyFiles() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -452,6 +456,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0"
                             ])
                         ],
                         targets: [
@@ -994,7 +999,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func withSanitizer() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -1047,6 +1052,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ])
                         ],
                         targets: [
@@ -1366,7 +1372,7 @@ fileprivate struct LocalizationInfoTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS))
+    @Test(.requireSDKs(.macOS), .requireXcode26())
     func XCStringsInVariantGroup() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -1419,6 +1425,7 @@ fileprivate struct LocalizationInfoTests {
                         buildConfigurations: [
                             TestBuildConfiguration("Debug", buildSettings: [
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "MACOSX_DEPLOYMENT_TARGET": "26.0",
                             ])
                         ],
                         targets: [

--- a/Tests/SwiftBuildTests/ServiceTests.swift
+++ b/Tests/SwiftBuildTests/ServiceTests.swift
@@ -303,7 +303,7 @@ fileprivate struct ServiceTests {
     }
 
     /// Tests an obscure edge case where a project configured in a specific way can trigger a condition such that the build operation's "target preparation" can be requested multiple times. If the target fails scanning due to a missing input, but also emits diagnostics early in its build process such that they'll be handled by the deferred diagnostics mechanism, we may call the `targetPreparationStarted` callback multiple times. Ensure that we check if we've done do to avoid triggering the assertion in debug mode, and inserting a duplicate ID mapping for the configured target.
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireXcode26())
     func deferredTargetDiagnosticsWithDuplicateTargetPreparation() async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
@@ -338,6 +338,7 @@ fileprivate struct ServiceTests {
                         TestBuildConfiguration("Debug", buildSettings: [
                             "ALWAYS_SEARCH_USER_PATHS": "NO",
                             "PRODUCT_NAME": "$(TARGET_NAME)",
+                            "MACOSX_DEPLOYMENT_TARGET": "26.0",
 
                             // We need a setting that'll cause a diagnostic to get emitted quite early,
                             // but not one that's an error and stops the build


### PR DESCRIPTION
macOS 27.0 no longer supports x86_64. Mark the architecture deprecated so we only build an x86 slice by default when using a deployment target macOS 26 or earlier. This PR also updates a number of tests to account for this change.