### PR TITLE
Infer api library level for public install paths under the Cryptex prefix

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2190,13 +2190,23 @@ private class SettingsBuilder: ProjectMatchLookup {
         if scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).isEmpty &&
            scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib" {
             let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
-            let publicInstallPaths = [
-                Path("/System/Library/Frameworks"),
-                Path("/System/Library/SubFrameworks"),
-                Path("/usr/lib"),
-                Path("/System/iOSSupport/System/Library/Frameworks"),
-                Path("/System/iOSSupport/System/Library/SubFrameworks"),
-                Path("/System/iOSSupport/usr/lib"),]
+            // Public frameworks and libraries can be installed directly at these base
+            // locations, or relocated under one of the known prefixes.
+            let publicInstallPathPrefixes = [
+                "",                       // No prefix.
+                "/System/Cryptexes/OS",
+            ]
+            let publicInstallPathBaseLocations = [
+                "/System/Library/Frameworks",
+                "/System/Library/SubFrameworks",
+                "/usr/lib",
+                "/System/iOSSupport/System/Library/Frameworks",
+                "/System/iOSSupport/System/Library/SubFrameworks",
+                "/System/iOSSupport/usr/lib",
+            ]
+            let publicInstallPaths = publicInstallPathPrefixes.flatMap { prefix in
+                publicInstallPathBaseLocations.map { Path(prefix + $0) }
+            }
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
             if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL)

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4033,6 +4033,32 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             task.checkCommandLineContains(["-library-level", "api"])
         }
 
+        // Infer "api" under the Cryptex prefix.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/System/Cryptexes/OS/System/Library/Frameworks/MyFramework"]) { task in
+            task.checkCommandLineContains(["-library-level", "api"])
+        }
+        // Infer "api" under the iOSSupport prefix.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/System/iOSSupport/System/Library/Frameworks/MyFramework"]) { task in
+            task.checkCommandLineContains(["-library-level", "api"])
+        }
+        // Infer "api" under the combined Cryptex + iOSSupport prefix.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/System/Cryptexes/OS/System/iOSSupport/System/Library/Frameworks/MyFramework"]) { task in
+            task.checkCommandLineContains(["-library-level", "api"])
+        }
+        // Infer "api" for /usr/lib under the combined prefix.
+        try await checkLibraryLevelForConfig(targetType: .dynamicLibrary,
+                                             buildSettings: ["INSTALL_PATH" : "/System/Cryptexes/OS/System/iOSSupport/usr/lib"]) { task in
+            task.checkCommandLineContains(["-library-level", "api"])
+        }
+        // Don't infer "api" for an unknown prefix.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/Foo/System/Library/Frameworks/MyFramework"]) { task in
+            task.checkCommandLineDoesNotContain("-library-level")
+        }
+
         // Don't infer library-level from an unknown install path.
         try await checkLibraryLevelForConfig(targetType: .framework,
                                              buildSettings: [:]) { task in


### PR DESCRIPTION
When SWIFT_LIBRARY_LEVEL is unset, it's inferred from INSTALL_PATH, but libraries under `/System/Cryptexes/OS/...` silently miss the api level, dropping public-module checks and marking their Swift symbols private in SDKDBs.

Restructure the hardcoded list into a cross product of known prefixes and public base locations, adding the Cryptex prefix.

rdar://178664280