### PR TITLE
Add Metal 4.1 Language Version

### DIFF
--- a/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalCompiler.xcspec
@@ -268,6 +268,7 @@
                     Metal31,
                     Metal32,
                     Metal40,
+                    Metal41,
                 );
                 Category = BuildOptions;
             },
@@ -289,6 +290,7 @@
                     Metal31,
                     Metal32,
                     Metal40,
+                    Metal41,
                 );
                 CommandLineArgs = {
                     UseDeploymentTarget = (  );
@@ -304,6 +306,7 @@
                     Metal31 = ( "-std=metal3.1", );
                     Metal32 = ( "-std=metal3.2", );
                     Metal40 = ( "-std=metal4.0", );
+                    Metal41 = ( "-std=metal4.1", );
                 };
             },
             {

--- a/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MetalLinker.xcspec
@@ -85,6 +85,7 @@
                     Metal31 = ( "-std=metal3.1", );
                     Metal32 = ( "-std=metal3.2", );
                     Metal40 = ( "-std=metal4.0", );
+                    Metal41 = ( "-std=metal4.1", );
                 };
             },
             {

--- a/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.metal.strings
+++ b/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.metal.strings
@@ -92,6 +92,8 @@
 "[MTL_LANGUAGE_REVISION]-description-[Metal32]" = "Metal 3.2";
 "[MTL_LANGUAGE_REVISION]-value-[Metal40]" = "Metal 4.0";
 "[MTL_LANGUAGE_REVISION]-description-[Metal40]" = "Metal 4.0";
+"[MTL_LANGUAGE_REVISION]-value-[Metal41]" = "Metal 4.1";
+"[MTL_LANGUAGE_REVISION]-description-[Metal41]" = "Metal 4.1";
 
 "[MTL_ENABLE_DEBUG_INFO]-name" = "Produce Debugging Information";
 "[MTL_ENABLE_DEBUG_INFO]-description" = "Debugging information is required for shader debugging and profiling.";

--- a/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/BuildToolTaskConstructionTests.swift
@@ -1570,6 +1570,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["macosx", "Metal31"] : "-std=metal3.1",
                                   ["macosx", "Metal32"] : "-std=metal3.2",
                                   ["macosx", "Metal40"] : "-std=metal4.0",
+                                  ["macosx", "Metal41"] : "-std=metal4.1",
 
                                   ["iphoneos", "UseDeploymentTarget"] : "",
                                   ["iphoneos", "iOSMetal10"] : "-std=ios-metal1.0",
@@ -1584,6 +1585,7 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["iphoneos", "Metal31"] : "-std=metal3.1",
                                   ["iphoneos", "Metal32"] : "-std=metal3.2",
                                   ["iphoneos", "Metal40"] : "-std=metal4.0",
+                                  ["iphoneos", "Metal41"] : "-std=metal4.1",
 
                                   ["appletvos", "UseDeploymentTarget"] : "",
                                   ["appletvos", "Metal11"] : "-std=ios-metal1.1",
@@ -1597,11 +1599,13 @@ fileprivate struct BuildToolTaskConstructionTests: CoreBasedTests {
                                   ["appletvos", "Metal31"] : "-std=metal3.1",
                                   ["appletvos", "Metal32"] : "-std=metal3.2",
                                   ["appletvos", "Metal40"] : "-std=metal4.0",
+                                  ["appletvos", "Metal41"] : "-std=metal4.1",
 
                                   ["xros", "UseDeploymentTarget"] : "",
                                   ["xros", "Metal31"] : "-std=metal3.1",
                                   ["xros", "Metal32"] : "-std=metal3.2",
                                   ["xros", "Metal40"] : "-std=metal4.0",
+                                  ["xros", "Metal41"] : "-std=metal4.1",
         ]
 
         for (language, expectedOption) in optionForLanguage {


### PR DESCRIPTION
This change publicly exposes Metal 4.1 after its WWDC release.
