### PR TITLE
Add SWIFT_TREAT_WARNINGS_AS_ERRORS to the project model BuildSettings and PIF model so SwiftPM can toggle it for local and remote package

### DIFF
--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -1024,6 +1024,7 @@ public enum PIF {
         public var SUPPORTS_MACCATALYST: String?
         public var SUPPORTS_TEXT_BASED_API: String?
         public var SUPPRESS_WARNINGS: String?
+        public var SWIFT_TREAT_WARNINGS_AS_ERRORS: String?
         public var SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]?
         public var SWIFT_ADD_TOOLCHAIN_SWIFTSYNTAX_SEARCH_PATHS: String?
         public var SWIFT_FORCE_STATIC_LINK_STDLIB: String?

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -104,6 +104,7 @@ extension ProjectModel {
             case STRIP_INSTALLED_PRODUCT
             case SUPPORTS_TEXT_BASED_API
             case SUPPRESS_WARNINGS
+            case SWIFT_TREAT_WARNINGS_AS_ERRORS
             case SWIFT_COMPILE_FOR_STATIC_LINKING
             case SWIFT_DISABLE_PARSE_AS_LIBRARY
             case SWIFT_ENABLE_BARE_SLASH_REGEX


### PR DESCRIPTION
Add SWIFT_TREAT_WARNINGS_AS_ERRORS to the project model BuildSettings and PIF model so SwiftPM can toggle it for local and remote package.

SwiftBuild part to address: https://github.com/swiftlang/swift-package-manager/issues/10192