### PR TITLE
Fix dependency diagnostics for dynamic target variants

### DIFF
--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -13,7 +13,7 @@
 package import SWBUtil
 package import SWBCore
 import SWBMacro
-import SWBProtocol
+package import SWBProtocol
 import Foundation
 
 /// The `GlobalProductPlanDelegate` is a subset of the more ubiquitous `TaskPlanningDelegate` which provides functionality only needed by a `GlobalProductPlan`, even if it exists outside the context of a build.
@@ -107,6 +107,25 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
     /// Get the dependencies of a target in the graph.
     package func dependencies(of target: ConfiguredTarget) -> [ConfiguredTarget] {
         resolvedDependencies(of: target).map { $0.target }
+    }
+
+    package var targetDependenciesByGuid: [TargetDependencyRelationship] {
+        allTargets.map { target in
+            .init(
+                .init(
+                    name: target.target.name,
+                    guid: target.guid.stringValue
+                ),
+                dependencies: resolvedDependencies(of: target).map {
+                    .init(
+                        name: $0.target.target.name,
+                        guid: $0.target.guid.stringValue
+                    )
+                }
+                .sorted(by: \.guid)
+            )
+        }
+        .sorted(by: \.target.guid)
     }
 
     package func resolvedDependencies(of target: ConfiguredTarget) -> [ResolvedTargetDependency] {

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -248,7 +248,7 @@ package final class BuildDescriptionManager: Sendable {
 
         let definingTargetsByModuleName = {
             var definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>] = [:]
-            for target in buildGraph.allTargets {
+            for target in plan.globalProductPlan.allTargets {
                 let settings = plan.globalProductPlan.getTargetSettings(target)
                 let moduleInfo = plan.globalProductPlan.getModuleInfo(target)
                 let specLookupContext = SpecLookupCtxt(specRegistry: planRequest.workspaceContext.core.specRegistry, platform: settings.platform)
@@ -265,7 +265,36 @@ package final class BuildDescriptionManager: Sendable {
         }()
 
         // Create the build description.
-        return try await BuildDescription.construct(workspace: planRequest.workspaceContext.workspace, tasks: plan.tasks, path: path, signature: signature, buildCommand: planRequest.buildRequest.buildCommand, diagnostics: planningDiagnostics, indexingInfo: [], fs: fs, bypassActualTasks: bypassActualTasks, targetsBuildInParallel: buildGraph.targetsBuildInParallel, emitFrontendCommandLines: plan.emitFrontendCommandLines, moduleSessionFilePath: planRequest.workspaceContext.getModuleSessionFilePath(planRequest.buildRequest.parameters), invalidationPaths: plan.invalidationPaths, recursiveSearchPathResults: plan.recursiveSearchPathResults, copiedPathMap: plan.copiedPathMap, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos.values, staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget, settingsPerTarget: settingsPerTarget, delegate: delegate, targetDependencies: buildGraph.targetDependenciesByGuid, definingTargetsByModuleName: definingTargetsByModuleName, userPreferences: planRequest.workspaceContext.userPreferences)
+        return try await BuildDescription.construct(
+            workspace: planRequest.workspaceContext.workspace,
+            tasks: plan.tasks,
+            path: path,
+            signature: signature,
+            buildCommand: planRequest.buildRequest.buildCommand,
+            diagnostics: planningDiagnostics,
+            indexingInfo: [],
+            fs: fs,
+            bypassActualTasks: bypassActualTasks,
+            targetsBuildInParallel: buildGraph.targetsBuildInParallel,
+            emitFrontendCommandLines: plan.emitFrontendCommandLines,
+            moduleSessionFilePath: planRequest.workspaceContext
+                .getModuleSessionFilePath(
+                    planRequest.buildRequest.parameters
+                ),
+            invalidationPaths: plan.invalidationPaths,
+            recursiveSearchPathResults: plan.recursiveSearchPathResults,
+            copiedPathMap: plan.copiedPathMap,
+            rootPathsPerTarget: rootPathsPerTarget,
+            moduleCachePathsPerTarget: moduleCachePathsPerTarget,
+            artifactInfoPerTarget: artifactInfoPerTarget,
+            casValidationInfos: casValidationInfos.values,
+            staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget,
+            settingsPerTarget: settingsPerTarget,
+            delegate: delegate,
+            targetDependencies: plan.globalProductPlan.targetDependenciesByGuid,
+            definingTargetsByModuleName: definingTargetsByModuleName,
+            userPreferences: planRequest.workspaceContext.userPreferences
+        )
     }
 
     /// Encapsulates the two ways `getNewOrCachedBuildDescription` can be called, whether we want to retrieve or create a build description based on a plan or whether we have an explicit build description ID that we want to retrieve and we don't need to create a new one.

--- a/Tests/SWBBuildSystemTests/DiscoveredDependenciesBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/DiscoveredDependenciesBuildOperationTests.swift
@@ -279,6 +279,167 @@ fileprivate struct DiscoveredDependenciesBuildOperationTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS))
+    func doesNotDiagnoseMissingTargetDependenciesForDynamicTargetVariants() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let swiftVersionValue = try await swiftVersion
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "AppProject",
+                        groupTree: TestGroup("Sources"),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "CODE_SIGNING_ALLOWED": "NO",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SDKROOT": "macosx",
+                                    "SWIFT_VERSION": swiftVersionValue,
+                                ]
+                            ),
+                        ],
+                        targets: [
+                            TestStandardTarget(
+                                "App",
+                                type: .framework,
+                                buildPhases: [
+                                    TestFrameworksBuildPhase([
+                                        TestBuildFile(.target("macOSFwk")),
+                                        TestBuildFile(.target("PackageLibProduct2")),
+                                    ]),
+                                ],
+                                dependencies: [
+                                    "macOSFwk",
+                                    "PackageLibProduct2",
+                                ]
+                            ),
+                            TestStandardTarget(
+                                "macOSFwk",
+                                type: .framework,
+                                buildPhases: [
+                                    TestFrameworksBuildPhase([
+                                        TestBuildFile(.target("PackageLibProduct")),
+                                    ]),
+                                ],
+                                dependencies: ["PackageLibProduct"]
+                            ),
+                        ]
+                    ),
+                    TestPackageProject(
+                        "Modules",
+                        groupTree: TestGroup(
+                            "Sources", path: "Sources", children: [
+                                TestFile("Common.swift"),
+                                TestFile("Core.swift"),
+                            ]),
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "ALWAYS_SEARCH_USER_PATHS": "NO",
+                                    "DIAGNOSE_MISSING_TARGET_DEPENDENCIES": "YES",
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SDKROOT": "auto",
+                                    "SDK_VARIANT": "auto",
+                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                    "SWIFT_VERSION": swiftVersionValue,
+                                ]
+                            ),
+                        ],
+                        targets: [
+                            TestPackageProductTarget(
+                                "PackageLibProduct",
+                                frameworksBuildPhase: TestFrameworksBuildPhase([
+                                    TestBuildFile(.target("Common")),
+                                ]),
+                                dependencies: ["Common"]
+                            ),
+                            TestPackageProductTarget(
+                                "PackageLibProduct2",
+                                frameworksBuildPhase: TestFrameworksBuildPhase([
+                                    TestBuildFile(.target("Common")),
+                                ]),
+                                dependencies: ["Common"]
+                            ),
+                            TestStandardTarget(
+                                "Common",
+                                type: .objectFile,
+                                buildPhases: [TestSourcesBuildPhase(["Common.swift"])],
+                                dependencies: ["Core"],
+                                dynamicTargetVariantName: "Common-dynamic"
+                            ),
+                            TestStandardTarget(
+                                "Common-dynamic",
+                                type: .framework,
+                                buildConfigurations: [
+                                    TestBuildConfiguration(
+                                        "Debug",
+                                        buildSettings: [
+                                            "PRODUCT_NAME": "Common",
+                                            "SDKROOT": "auto",
+                                            "SDK_VARIANT": "auto",
+                                            "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                            "SWIFT_MODULE_NAME": "Common",
+                                            "SWIFT_VERSION": swiftVersionValue,
+                                        ]
+                                    ),
+                                ],
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["Common.swift"]),
+                                    TestFrameworksBuildPhase([
+                                        TestBuildFile(.target("Core")),
+                                    ]),
+                                ],
+                                dependencies: ["Core"]
+                            ),
+                            TestStandardTarget(
+                                "Core",
+                                type: .objectFile,
+                                buildPhases: [TestSourcesBuildPhase(["Core.swift"])],
+                                dynamicTargetVariantName: "Core-dynamic"
+                            ),
+                            TestStandardTarget(
+                                "Core-dynamic",
+                                type: .framework,
+                                buildConfigurations: [
+                                    TestBuildConfiguration(
+                                        "Debug",
+                                        buildSettings: [
+                                            "PRODUCT_NAME": "Core",
+                                            "SDKROOT": "auto",
+                                            "SDK_VARIANT": "auto",
+                                            "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                            "SWIFT_MODULE_NAME": "Core",
+                                            "SWIFT_VERSION": swiftVersionValue,
+                                        ]
+                                    ),
+                                ],
+                                buildPhases: [TestSourcesBuildPhase(["Core.swift"])]
+                            ),
+                        ]
+                    ),
+                ]
+            )
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+            let packageSourceRoot = testWorkspace.sourceRoot.join("Modules/Sources")
+
+            try await tester.fs.writeFileContents(packageSourceRoot.join("Common.swift")) { contents in
+                contents <<< "import Core\n"
+                contents <<< "public func commonValue() -> String { coreValue() }\n"
+            }
+            try await tester.fs.writeFileContents(packageSourceRoot.join("Core.swift")) { contents in
+                contents <<< "public func coreValue() -> String { \"core\" }\n"
+            }
+
+            try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug"), runDestination: .macOS) { results in
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
     // This tests checks for a very particular sequence of actions that lead to a cyclical dependency error. The gist of
     // it is that <rdar://59011589> clang incorrectly adds the module it is building for as a dependency through an
     // LC_LINKER_OPTION. This leads to the linker linking a binary against itself, which is propagated to llbuild


### PR DESCRIPTION
# Problem

A missing target dependency warning or error can be emitted during dependency scanning even when the target dependency is configured correctly.

Example warning:

```text
warning: 'FirebaseCore' is missing a dependency on 'FirebaseCoreInternal' because dependency scan of 'FIRHeartbeatLogger.m' discovered a dependency on 'FirebaseCoreInternal'
```

In this case, FirebaseCore does have a dependency on FirebaseCoreInternal, but the warning can still be emitted.
This issue can be reproduced with a small test case.

The problem happens when the dependent target is replaced with a dynamic variant. swift-build has logic that changes targets to be dynamically linked, and dependency validation needs to use the result of that transformation.

## Cause

`BuildOperation.transitiveDependencyExists(target:antecedent:)` checks whether target can reach `antecedent` using the dependency graph built from `BuildDescription.targetDependencies.`

However, `BuildDescription.targetDependencies` was populated with `buildGraph.targetDependenciesByGuid`, which represents the pre-dynamic-linkage target graph.

As a result, even when the actual task was executed for a post-dynamic-linkage target, the dependency graph used for reachability checks was still based on the pre-dynamic-linkage target.

This caused the reachability check from the post-dynamic-linkage target to its dependency target to fail, and swift-build could emit a missing target dependency warning/error even though the target dependency was configured correctly.

# Changes

## Add GlobalProductPlan.targetDependenciesByGuid

This PR adds targetDependenciesByGuid to GlobalProductPlan.

This property builds target dependency relationships from GlobalProductPlan.allTargets and 
`GlobalProductPlan.resolvedDependencies(of:)`, so the relationships are based on the post-dynamic-linkage target graph.

`BuildDescription` construction now passes `GlobalProductPlan.targetDependenciesByGuid` instead of `TargetBuildGraph.targetDependenciesByGuid`.

This makes dependency validation use the same post-dynamic-linkage target graph when the dependent target has been replaced with a dynamic variant.

## Build `definingTargetsByModuleName` from `GlobalProductPlan`

The dependency target can also be a post-dynamic-linkage target.

For that reason, `definingTargetsByModuleName`, which is used to resolve a dependency target from a module name, is now built from `plan.globalProductPlan.allTargets` instead of buildGraph.allTargets.

## Test case

The regression test sets up a dynamically linked embedded framework named `macOSFwk`.

```text
App
├── macOSFwk
│   └── PackageLibProduct
│        └── Common
│            └── Core
└── PackageLibProduct2
      └── Common
          └── Core
```

In this configuration, both `Common` and `Core` have diamond linkage, so swift-build replaces them with dynamic variants.

```text
App
├── macOSFwk
│   └── PackageLibProduct
│        └── Common-dynamic
│            └── Core-dynamic
└── PackageLibProduct2
      └── Common-dynamic
          └── Core-dynamic
```

`Common` contains `import Core`, so dependency scanning detects a module dependency from `Common` to `Core`.

Before this PR, the actual task was executed as `Common-dynamic`, but the dependency graph used for the reachability check was built from the pre-dynamic-linkage `buildGraph.targetDependenciesByGuid`. Therefore, dependency validation could not look up dependency relationships starting from `Common-dynamic`.

Also, `definingTargetsByModuleName`, which is used to resolve the dependency target from the module name, was not built from `GlobalProductPlan`. Therefore, it treated the dependency target as the pre-dynamic-linkage `Core` instead of the post-dynamic-linkage `Core-dynamic`.

As a result, a warning or error could be emitted even though the target dependency was configured correctly.

## Not addressed in this PR

After this change, `BuildDescription` construction no longer uses `TargetBuildGraph.targetDependenciesByGuid`. This PR keeps it in place because it is a public API. If reviewers think it should be removed, please let me know.