### PR TITLE
Add support for loading macros from a binary

### DIFF
--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -142,6 +142,7 @@ extension ProjectModel {
             case SUPPORTED_PLATFORMS
             case SWIFT_ACTIVE_COMPILATION_CONDITIONS
             case SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES
+            case SWIFT_LOAD_BINARY_MACROS
             case SWIFT_MODULE_ALIASES
             case SWIFT_SDK_TOOLSETS
             case SWIFT_WARNINGS_AS_WARNINGS_GROUPS


### PR DESCRIPTION
Adds support for loading macros from a binary, part of a coordinated change with SwiftPM. Ensures the build settings are carried forward during PIF encode and decode and not dropped if swift build doesn't know about the case

[SwiftPM change that's needed alongside this](https://github.com/swiftlang/swift-package-manager/pull/10210)

Forum pitch: https://forums.swift.org/t/pitch-distributing-swift-macros-as-prebuilt-binaries/87447