### PR TITLE
[6.4] Tag tests which require specific platforms to be loaded when cross-compiling

### DIFF
--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -127,6 +127,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Skips a test case that requires one or more platforms to be loaded and available.
+    package static func requirePlatform(_ platform: String, comment: Comment? = nil) -> Self {
+        enabled(comment != nil ? "required platform is not available: \(comment?.description ?? "")" : "required platform is not available") { core in
+            return core.platformRegistry.lookup(name: platform) != nil
+        }
+    }
+
     /// Skips a test case that requires a Swift SDK whose artifact bundle identifier suffix matches the given pattern.
     ///
     /// Swift SDK artifact bundle identifiers follow the pattern `<compilerTag>_<suffix>`. This trait finds all installed

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -22,7 +22,7 @@ import SWBMacro
 
 @Suite
 fileprivate struct AndroidTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.host), .enabled("No Android NDK is installed at any of the standard locations", { try await AndroidPlugin().effectiveInstallation(host: ProcessInfo.processInfo.hostOperatingSystem())?.ndk != nil }), arguments: ["aarch64", "x86_64"])
+    @Test(.requireSDKs(.host), .requirePlatform("android"), .enabled("No Android NDK is installed at any of the standard locations", { try await AndroidPlugin().effectiveInstallation(host: ProcessInfo.processInfo.hostOperatingSystem())?.ndk != nil }), arguments: ["aarch64", "x86_64"])
     func androidSwiftSDKRunDestination(architecture: String) async throws {
         // FIXME: Switch to Test.cancel once we are on Swift 6.3.
         let ndk = try #require(try await AndroidPlugin().effectiveInstallation(host: ProcessInfo.processInfo.hostOperatingSystem())?.ndk)

--- a/Tests/SWBGenericUnixPlatformTests/SwiftSDKTaskConstructionTests.swift
+++ b/Tests/SWBGenericUnixPlatformTests/SwiftSDKTaskConstructionTests.swift
@@ -22,7 +22,7 @@ import Foundation
 
 @Suite
 fileprivate struct GenericUnixSwiftSDKTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.host), arguments: ["aarch64", "x86_64"])
+    @Test(.requireSDKs(.host), .requirePlatform("linux"), arguments: ["aarch64", "x86_64"])
     func staticLinuxSwiftSDKRunDestination(architecture: String) async throws {
         try await withTemporaryDirectory { tmpDir in
             let clangCompilerPath = try await self.clangCompilerPath
@@ -139,7 +139,7 @@ fileprivate struct GenericUnixSwiftSDKTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requirePlatform("linux"))
     func inMemoryStaticLinuxSwiftSDKRunDestination() async throws {
         try await withTemporaryDirectory { tmpDir in
             let clangCompilerPath = try await self.clangCompilerPath

--- a/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
@@ -227,7 +227,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireXcode26())
+    @Test(.requireSDKs(.macOS), .requireXcode26(), .requirePlatform("linux"))
     func hostToolBuildsForHostPlatformWithSwiftSDK() async throws {
         try await withTemporaryDirectory { tmpDir in
             let swiftCompilerPath = try await self.swiftCompilerPath

--- a/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
@@ -21,7 +21,7 @@ import SWBTestSupport
 
 @Suite
 fileprivate struct ToolsetTaskConstructionTests: CoreBasedTests {
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requirePlatform("linux"))
     func staticResourceDirectorySelection_toolsetImposesStaticStdlib() async throws {
         try await withTemporaryDirectory { tmpDir in
             let sdkManifestDir = tmpDir.join("TestSDK.artifactbundle")
@@ -143,7 +143,7 @@ fileprivate struct ToolsetTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requirePlatform("linux"))
     func staticResourceDirectorySelection_requestImposesStaticStdlib() async throws {
         try await withTemporaryDirectory { tmpDir in
             let sdkManifestDir = tmpDir.join("TestSDK.artifactbundle")
@@ -265,7 +265,7 @@ fileprivate struct ToolsetTaskConstructionTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requirePlatform("linux"))
     func dynamicResourceDirectorySelection() async throws {
         try await withTemporaryDirectory { tmpDir in
             let sdkManifestDir = tmpDir.join("TestSDK.artifactbundle")

--- a/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
+++ b/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
@@ -19,7 +19,7 @@ import SWBUtil
 
 @Suite
 fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requirePlatform("webassembly"))
     func wasmSwiftSDKRunDestination() async throws {
         try await withTemporaryDirectory { tmpDir in
             let clangCompilerPath = try await self.clangCompilerPath


### PR DESCRIPTION
Fix some test failures which occur when using XCODE_ONLY_PLATFORM_FAMILY_NAMES to prevent plugins from registering new platforms.

rdar://175558887