### PR TITLE
Generate XOJIT preview thunks for source files reached through a symlink

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3237,7 +3237,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // See the related `previewXOJITThunkInfoResolvesSymlinkedSourcePath` test.
             func resolvedPath(_ path: Path) -> Path { (try? fs.realpath(path)) ?? path }
             let realSourceFile = resolvedPath(sourceFile)
-            selectedInputPath = originalInputs.first { resolvedPath($0) == realSourceFile } ?? sourceFile
+            selectedInputPath = originalInputs.only { resolvedPath($0) == realSourceFile } ?? sourceFile
 
             if let driverPayload = payload.driverPayload {
                 do {

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3224,13 +3224,29 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         if payload.previewStyle == .xojit {
             // Also pass the auxiliary Swift files.
             commandLine.append(contentsOf: originalInputs.map(\.str))
-            selectedInputPath = sourceFile
+
+            // Fixes rdar://176386125. The package PIF builder may symlink-resolve source paths in
+            // the build description (eg, /tmp -> /private/tmp) so they match what the index service stores.
+            // The previews client, however, asks us to thunk the *unresolved* path, so a plain `sourceFile` won't
+            // match the command's inputs and libSwiftDriver returns no command line -> `noPreviewInfos`.
+            //
+            // Use the spelling that actually appears in the command's inputs, matched by realpath,
+            // and key the output-file-map / VFS overlay on it. No-op when the paths already agree
+            // (eg, the legacy package PIF builder available in Xcode).
+            //
+            // See the related `previewXOJITThunkInfoResolvesSymlinkedSourcePath` test.
+            func resolvedPath(_ path: Path) -> Path { (try? fs.realpath(path)) ?? path }
+            let realSourceFile = resolvedPath(sourceFile)
+            selectedInputPath = originalInputs.first { resolvedPath($0) == realSourceFile } ?? sourceFile
 
             if let driverPayload = payload.driverPayload {
                 do {
                     // Inject the thunk source into the output file map
                     let pchPath = driverPayload.tempDirPath.join(driverPayload.outputPrefix + "-primary-Bridging-header.pch")
-                    let map = SwiftOutputFileMap(files: [sourceFile.str: .init(object: outputPath.str), "": .init(pch: pchPath.str)])
+                    let map = SwiftOutputFileMap(files: [
+                        selectedInputPath.str: SwiftOutputFileMap.Entry(object: outputPath.str),
+                        "": SwiftOutputFileMap.Entry(pch: pchPath.str)
+                    ])
                     let newOutputFileMap = driverPayload.tempDirPath.join(UUID().uuidString)
                     try fs.createDirectory(newOutputFileMap.dirname, recursive: true)
                     try fs.write(newOutputFileMap, contents: ByteString(JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(map)))
@@ -3238,7 +3254,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
                     // rdar://127735418 ([JIT] Emit a vfsoverlay for JIT preview thunk compiler arguments so clients can specify the original file path when substituting contents)
                     let vfs = VFS()
-                    vfs.addMapping(sourceFile, externalContents: inputPath)
+                    vfs.addMapping(selectedInputPath, externalContents: inputPath)
                     newVFSOverlayPath = driverPayload.tempDirPath.join("vfsoverlay-\(inputPath.basename).json")
                     try fs.createDirectory(newOutputFileMap.dirname, recursive: true)
                     let overlay = try vfs.toVFSOverlay().propertyListItem.asJSONFragment().asString

--- a/Sources/SWBUtil/Collection.swift
+++ b/Sources/SWBUtil/Collection.swift
@@ -17,9 +17,26 @@ public extension Collection {
     }
 
     /// Return the only element in the collection, if it has exactly one element.
-    /// - complexity: O(1).
+    ///
+    /// **Complexity**. O(1).
     var only: Iterator.Element? {
         return !isEmpty && index(after: startIndex) == endIndex ? self.first : nil
+    }
+
+    /// Returns the single element of the sequence satisfying `predicate`,
+    /// or `nil`if no element — or more than one element — satisfies it.
+    ///
+    /// Unlike `first(where:)`, multiple matches yield `nil`;
+    /// iteration stops as soon as a second match is found.
+    ///
+    /// **Complexity**.  O(n), where n is the length of the sequence.
+    func only(where predicate: (Element) throws -> Bool) rethrows -> Element? {
+        var onlyMatch: Element?
+        for candidate in self where try predicate(candidate) {
+            guard onlyMatch == nil else { return nil }
+            onlyMatch = candidate
+        }
+        return onlyMatch
     }
 
     /// Returns the elements of the sequence, sorted using the given key path as the comparison between elements.

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -1122,6 +1122,113 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
         }
     }
 
+    /// Regression test for rdar://176386125: `generatePreviewInfo(.thunkInfo)` must match the
+    /// requested source file against the compile command's inputs by *resolved* path, not by unresolved path.
+    ///
+    /// For standalone Swift packages, the OSS (ie, new) *package PIF builder* bakes the
+    /// symlink-resolved source path (eg, `/private/tmp/foo/main.swift`) into the compile
+    /// command so it matches what the *index service* stores, while the previews client requests a thunk
+    /// for the unresolved path (eg, `/tmp/foo/main.swift`). The two paths resolve to the same file but differ,
+    /// so the broken code — which compared them literally — found no matching input, libSwiftDriver
+    /// produced no command line, and the request came back empty, which clients report as `noPreviewInfos`.
+    ///
+    /// We reproduce that path mismatch without a real package by introducing a single symlink `srcRootSymlink`.
+    /// Before the fix this returns zero preview infos; after the fix it returns one, and the resulting
+    /// compile command line refers to the build's spelling (`srcRoot`), never the request's symlink.
+    @Test(.requireSDKs(.iOS))
+    func previewXOJITThunkInfoResolvesSymlinkedSourcePath() async throws {
+        try await withTemporaryDirectory { (tmpDirPath: Path) in
+            // The real source directory. The build references `main.swift` through it, so
+            // this is the spelling that ends up baked into the compile command's inputs.
+            let srcRoot = tmpDirPath.join("srcroot")
+
+            // A symlink that points at `srcRoot`.
+            // The preview request references `main.swift` through it.
+            let srcRootSymlink = tmpDirPath.join("srcroot-symlink")
+
+            let sourceFile = TestFile("main.swift")
+            let testProject = TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "Sources", path: "Sources",
+                    children: [sourceFile]
+                ),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "iphoneos",
+                        "SWIFT_VERSION": "5.0",
+                        "SWIFT_OPTIMIZATION_LEVEL": "-Onone"
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "AppTarget",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile(sourceFile.name)])
+                        ]
+                    )
+                ]
+            )
+
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            try tester.fs.createDirectory(srcRoot.join("Sources"), recursive: true)
+            try tester.fs.write(srcRoot.join("Sources").join(sourceFile.name), contents: "")
+
+            // The build references the source through `srcRoot`; the preview request references it
+            // through `srcRootSymlink`, a symlink to the same directory. Same file, different spelling.
+            try tester.fs.symlink(srcRootSymlink, target: srcRoot)
+            let buildSourceFile = srcRoot.join("Sources").join(sourceFile.name)
+            let requestedSourceFile = srcRootSymlink.join("Sources").join(sourceFile.name)
+
+            // Sanity check the setup: the two spellings differ as strings but resolve to the same file.
+            try #require(requestedSourceFile != buildSourceFile)
+            try #require(try tester.fs.realpath(requestedSourceFile) == tester.fs.realpath(buildSourceFile))
+
+            let buildParameters = BuildParameters(
+                configuration: "Debug",
+                overrides: ["ENABLE_XOJIT_PREVIEWS": "YES"]
+            )
+
+            try await tester.checkBuild(
+                parameters: buildParameters,
+                runDestination: .iOSSimulator,
+                buildCommand: .build(style: .buildOnly, skipDependencies: false)
+            ) { results in
+                results.checkNoErrors()
+
+                let buildDescription = results.buildDescription
+                let appTarget = try #require(buildDescription.allConfiguredTargets.first { $0.target.name == "AppTarget" })
+
+                let previewInfoInput = TaskGeneratePreviewInfoInput.thunkInfo(
+                    sourceFile: requestedSourceFile,
+                    thunkVariantSuffix: "selection"
+                )
+                let previewInfos = buildDescription.generatePreviewInfoForTesting(
+                    for: [appTarget],
+                    workspaceContext: tester.workspaceContext,
+                    buildRequestContext: results.buildRequestContext,
+                    input: previewInfoInput
+                )
+
+                // The crux: before the fix this was empty (-> `noPreviewInfos`), because the requested
+                // symlinked path didn't match the resolved path baked into the compile command.
+                #expect(previewInfos.count == 1)
+                let compileCommandLine: [String] = try #require(previewInfos.only?.thunkInfo?.compileCommandLine)
+
+                // And the command we hand back references the spelling that actually appears in the
+                // build (`srcRoot`), not the symlinked path the client happened to ask with.
+                #expect(compileCommandLine.contains(buildSourceFile.str))
+                #expect(!compileCommandLine.contains(requestedSourceFile.str))
+            }
+        }
+    }
+
     private enum LinkStyle {
         case dylib
         case bundleLoader


### PR DESCRIPTION
### Context

When SwiftUI Previews run in XOJIT mode, the previews client asks Swift Build — per source file — for the compile command that builds that file's "preview thunk", via `generatePreviewInfo(.thunkInfo)`, identifying the file by path. In `SwiftCompilerSpec.generatePreviewInfo`, Swift Build locates that path among the target's compile inputs and hands it to `LibSwiftDriver.frontendCommandLine` as the primary input, which produces the `swift-frontend` invocation for the thunk.

That lookup compares paths by exact string. If the source file was recorded in the build description under a different — but equivalent — spelling than the one in the request, nothing matches: `frontendCommandLine` returns no command line, `generatePreviewInfo` returns an empty result, and the client reports `noPreviewInfos`, so the preview never renders.

This happens for standalone Swift packages whose sources live under a symlinked directory. On macOS, temporary directories such as `/tmp` are symlinks to `/private/tmp`, and SwiftPM's new package PIF builder symlink-resolves source paths (to match what the index store records). The compile command then holds `/private/tmp/.../View.swift` while the preview request still carries the unresolved `/tmp/.../View.swift` — the same file, a different spelling, no match.

### Fix

In the XOJIT branch of `SwiftCompilerSpec.generatePreviewInfo`, match the requested source file against the command's inputs by resolved path (ie, `FSProxy.realpath`), and use the spelling that actually appears in the command as the primary input. The output-file-map and the VFS overlay are keyed on that same spelling so they line up with what the driver resolves. When the requested and recorded paths already agree — e.g. the legacy package PIF builder, which doesn't resolve symlinks — this is a no-op.

### Testing

Adds `previewXOJITThunkInfoResolvesSymlinkedSourcePath` to `PreviewsBuildOperationTests`. Rather than standing up a real package, it reproduces the spelling mismatch with a single symlink: it builds a one-file app under a real directory and then requests the preview thunk through a symlink to that directory, so the requested path and the build's input path resolve to the same file but differ as strings. It asserts that exactly one preview info comes back and that the returned compile command references the real (build) spelling, never the symlinked request path.

Without the fix the test returns zero preview infos (ie, the `noPreviewInfos` condition); with it one, as expected.

Fixes rdar://176386125 (and related to rdar://179887248).