### PR TITLE
Fix two trivial build warnings in SWBCore and SWBBuildSystemTests

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/GenerateEmbedInCodeAccessor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/GenerateEmbedInCodeAccessor.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import SWBUtil
+import SWBUtil
 import SWBMacro
 
 /// Generates the `embedded_resources.swift` accessor for resources marked `embedInCode`.

--- a/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftDriverTests.swift
@@ -5451,7 +5451,7 @@ fileprivate struct SwiftDriverTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
     func basicsSwift4_2() async throws {
         try await withTemporaryDirectory { tmpDirPath in
-            let testWorkspace = try TestWorkspace(
+            let testWorkspace = TestWorkspace(
                 "Test",
                 sourceRoot: tmpDirPath.join("Test"),
                 projects: [


### PR DESCRIPTION
  - GenerateEmbedInCodeAccessor: demote unused `public import SWBUtil` to a plain import. No SWBUtil type appears in the file's public API, so the public import only triggered an "unused public import" warning.
  - SwiftDriverTests.basicsSwift4_2: drop a redundant `try` on the non-throwing TestWorkspace(...) initializer.

rdar://175924223
rdar://175556492
