### PR TITLE
SWBBuildServer - fix override to allow index preparation with optimization enabled

### DIFF
--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -117,6 +117,7 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
             updatedBuildRequest.configuredTargets[targetIndex].parameters?.action = "indexbuild"
             var overridesTable = updatedBuildRequest.configuredTargets[targetIndex].parameters?.overrides.commandLine ?? SWBSettingsTable()
             overridesTable.set(value: "YES", for: "ONLY_ACTIVE_ARCH")
+            overridesTable.set(value: "NO", for: "INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE")
             updatedBuildRequest.configuredTargets[targetIndex].parameters?.overrides.commandLine = overridesTable
         }
 


### PR DESCRIPTION
INDEX_ENABLE_OPTIMIZATION_LEVEL_OVERRIDE also needs to appear in the per-target build request overrides