### PR TITLE
Fix several build warnings due to import scoping.

### DIFF
--- a/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
+++ b/Sources/SWBCore/Extensions/SettingsBuilderExtension.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
-public import struct SWBProtocol.RunDestinationInfo
+import struct SWBProtocol.RunDestinationInfo
 public import SWBMacro
 
 /// An extension point for services.

--- a/Sources/SWBMacro/MacroValueAssignmentTable.swift
+++ b/Sources/SWBMacro/MacroValueAssignmentTable.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public import SWBUtil
-public import Synchronization
+package import Synchronization
 
 /// A mapping from macro declarations to corresponding macro value assignments, each of which is a linked list of macro expressions in precedence order.  At the moment it doesn’t support conditional assignments, but that functionality will be implemented soon.
 public struct MacroValueAssignmentTable: Serializable, Sendable {

--- a/Sources/SWBTestSupport/SwiftSDK.swift
+++ b/Sources/SWBTestSupport/SwiftSDK.swift
@@ -13,7 +13,7 @@
 import Foundation
 public import SWBUtil
 @_spi(Testing) public import SWBProtocol
-@_spi(Testing) public import SWBCore
+@_spi(Testing) import SWBCore
 
 extension SwiftSDK {
     /// The default location storing Swift SDKs installed by SwiftPM.

--- a/Sources/SwiftBuildTestSupport/TestBuildOperationDelegate.swift
+++ b/Sources/SwiftBuildTestSupport/TestBuildOperationDelegate.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import SWBUtil
+import SWBUtil
 package import SwiftBuild
 import SWBTestSupport
 package import Synchronization


### PR DESCRIPTION
## Summary

Fixes several build warnings caused by overly broad import visibility.

Some imports were declared as `public` or `package` even though the imported modules are not used in public or package declarations. This updates those imports to the narrowest required visibility.

