### PR TITLE
Serialize llbuild builds per database directory to prevent concurrent engines

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -158,6 +158,60 @@ package extension BuildSystemOperation {
     }
 }
 
+/// Process-global serialization of builds by on-disk build-database directory.
+///
+/// The same database must never be driven by two llbuild engines concurrently.
+/// A per-`SystemCacheEntry` queue can only enforce this while two builds share
+/// the *same* cache entry; it breaks down when an entry is evicted (e.g.
+/// `clearCachedBuildSystem` on cycle detection or by `CleanOperation`) and a
+/// restart re-inserts a fresh entry, or when two builds come from different
+/// caches. Keying serialization on the database directory —
+/// independent of cache-entry lifetime and of which build-system cache drove the
+/// build — guarantees at most one engine operates a given database at a time,
+/// which two engines over one database would otherwise corrupt. rdar://176791560.
+private let buildDatabaseSerializationQueues = SWBMutex<[Path: AsyncOperationQueue]>([:])
+
+/// Returns the serialization queue (concurrency 1) for `databaseDirectory`,
+/// creating it on first use. Queues persist for the lifetime of the process so
+/// they survive cache-entry eviction/recreation.
+private func buildDatabaseSerializationQueue(for databaseDirectory: Path) -> AsyncOperationQueue {
+    buildDatabaseSerializationQueues.withLock { queues in
+        if let existing = queues[databaseDirectory] {
+            return existing
+        }
+        let queue = AsyncOperationQueue(concurrentTasks: 1)
+        queues[databaseDirectory] = queue
+        return queue
+    }
+}
+
+/// Enforces the serialization invariant above: at most one llbuild engine may be
+/// actively building a given database directory at a time. This is a hard
+/// `precondition` (active in release too) — two engines on one database means
+/// the serialization has failed, and crashing deterministically here is strictly
+/// better than the nondeterministic heap corruption it would otherwise cause.
+/// rdar://176791560.
+private let activeBuildDatabases = SWBMutex<[Path: Int]>([:])
+
+private func enterActiveBuildDatabase(_ databaseDirectory: Path) {
+    let count = activeBuildDatabases.withLock { active -> Int in
+        let n = (active[databaseDirectory] ?? 0) + 1
+        active[databaseDirectory] = n
+        return n
+    }
+    precondition(count == 1, "rdar://176791560: \(count) concurrent llbuild build engines on database '\(databaseDirectory.str)'")
+}
+
+private func leaveActiveBuildDatabase(_ databaseDirectory: Path) {
+    activeBuildDatabases.withLock { active in
+        if let n = active[databaseDirectory], n > 1 {
+            active[databaseDirectory] = n - 1
+        } else {
+            active[databaseDirectory] = nil
+        }
+    }
+}
+
 /// An in-flight build operation created in response to a build request.
 package final class BuildOperation: BuildSystemOperation {
     /// Statistics on an executing operation.
@@ -439,22 +493,28 @@ package final class BuildOperation: BuildSystemOperation {
         // The build environment given to llbuild should always be non-nil so that it never inherits the calling environment.
         let buildEnvironment = self.environment ?? [:]
 
-        // If we use a cached build system, be sure to release it on build completion.
-        if userPreferences.enableBuildSystemCaching {
-            // Get the build system to use, keyed by the directory containing the (sole) database.
-            let entry = cachedBuildSystems.getOrInsert(buildDescription.buildDatabasePath.dirname, { SystemCacheEntry() })
-            do {
-                return try await entry.serializationQueue.withOperation { [buildEnvironment] in
+        // Serialize all builds against the same on-disk build-database directory
+        // process-globally, so two llbuild engines can never operate the same
+        // database concurrently — even across cache eviction/recreation or across
+        // different build-system caches. rdar://176791560.
+        let databaseDirectory = buildDescription.buildDatabasePath.dirname
+        let serializationQueue = buildDatabaseSerializationQueue(for: databaseDirectory)
+        do {
+            return try await serializationQueue.withOperation { [buildEnvironment] in
+                // If we use a cached build system, be sure to release it on build completion.
+                if userPreferences.enableBuildSystemCaching {
+                    // Get the build system to use, keyed by the directory containing the (sole) database.
+                    let entry = cachedBuildSystems.getOrInsert(databaseDirectory, { SystemCacheEntry() })
                     return await _build(cacheEntry: entry, dbPath: dbPath, traceFile: traceFile, debuggingDataPath: debuggingDataPath, buildEnvironment: buildEnvironment, priorBuildDescription: priorBuildDescription)
+                } else {
+                    return await _build(cacheEntry: nil, dbPath: dbPath, traceFile: traceFile, debuggingDataPath: debuggingDataPath, buildEnvironment: buildEnvironment, priorBuildDescription: priorBuildDescription)
                 }
-            } catch is CancellationError {
-                return .cancelled
-            } catch {
-                assertionFailure("withOperation was expected to only throw in case of cancellation, but threw unexpected error: \(error)")
-                return .failed
             }
-        } else {
-            return await _build(cacheEntry: nil, dbPath: dbPath, traceFile: traceFile, debuggingDataPath: debuggingDataPath, buildEnvironment: buildEnvironment, priorBuildDescription: priorBuildDescription)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            assertionFailure("withOperation was expected to only throw in case of cancellation, but threw unexpected error: \(error)")
+            return .failed
         }
     }
 
@@ -538,6 +598,12 @@ package final class BuildOperation: BuildSystemOperation {
 
         // Dispatch the build.
         let result: Bool
+        // Assert no other engine is building this same database directory
+        // concurrently. The `defer` keeps the count balanced on every exit.
+        // rdar://176791560.
+        let buildDatabaseDir = buildDescription.buildDatabasePath.dirname
+        enterActiveBuildDatabase(buildDatabaseDir)
+        defer { leaveActiveBuildDatabase(buildDatabaseDir) }
         do {
             let isCancelled: Bool = await queue.sync {
                 self.system = system

--- a/Sources/SWBBuildSystem/BuildSystemCache.swift
+++ b/Sources/SWBBuildSystem/BuildSystemCache.swift
@@ -25,9 +25,6 @@ extension HeavyCache: BuildSystemCache where Key == Path, Value == SystemCacheEn
 }
 
 package final class SystemCacheEntry: CacheableValue {
-    /// Queue that must be used by the active operation using this cache entry.
-    let serializationQueue = AsyncOperationQueue(concurrentTasks: 1)
-
     /// The environment in use.
     var environment: [String: String]? = nil
 

--- a/Sources/SWBUtil/AsyncOperationQueue.swift
+++ b/Sources/SWBUtil/AsyncOperationQueue.swift
@@ -38,13 +38,6 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                 return id
             }
         }
-
-        var continuation: WaitingContinuation? {
-            guard case .waiting(_, let continuation) = self else {
-                return nil
-            }
-            return continuation
-        }
     }
 
     /// Creates an `AsyncOperationQueue` with a specified number of concurrent tasks.
@@ -108,13 +101,20 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                             waitingTasks.remove(at: index)
                             return .cancel(continuation)
                         case .creating, .running, .waiting:
-                            // A task may have completed since we initially checked if we should wait. Check again in this locked
-                            // section and if we can start it, remove it from the waiting tasks and start it immediately.
-                            if waitingTasks.count >= concurrentTasks {
+                            // A task may have completed since we initially checked if we should wait. Re-check here, but
+                            // count only the *running* tasks: this task is currently in `waitingTasks` as `.creating`, so
+                            // counting the whole array would count it against itself and could leave it parked with no
+                            // running task left to ever resume it. If a slot is free, mark this task as running in place
+                            // (keeping it in `waitingTasks` so it continues to occupy a concurrency slot until it
+                            // completes) and start it immediately.
+                            let runningCount = waitingTasks.reduce(into: 0) { count, task in
+                                if case .running = task { count += 1 }
+                            }
+                            if runningCount >= concurrentTasks {
                                 waitingTasks[index] = .waiting(taskId, continuation)
                                 return nil
                             } else {
-                                waitingTasks.remove(at: index)
+                                waitingTasks[index] = .running(taskId)
                                 return .start(continuation)
                             }
                     }
@@ -143,10 +143,15 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                         // continuation for the waiting task with a `CancellationError`. Return the continuation
                         // here so it can be resumed once the `waitingTasksLock` is released.
                         return continuation
-                    case .creating, .running:
+                    case .creating:
                         // If the task was still being created, mark it as cancelled in `waitingTasks` so that
                         // the handler for `withCheckedThrowingContinuation` can immediately cancel it.
                         self.waitingTasks[taskIndex] = .cancelled(taskId)
+                        return nil
+                    case .running:
+                        // The task has already been promoted and started running, so it is no longer waiting on
+                        // its continuation. Leave it in place to keep occupying its slot; it will observe the
+                        // cancellation cooperatively and be removed by `signalCompletion` when it completes.
                         return nil
                     case .cancelled:
                         preconditionFailure("Attempting to cancel a task that was already cancelled")
@@ -164,48 +169,38 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                 return nil
             }
 
-            // Remove the completed task from the list to decrement the active task count.
+            // Remove the completed task from the list to free its concurrency slot.
             if let taskIndex = self.waitingTasks.firstIndex(where: { $0.id == taskId }) {
                 waitingTasks.remove(at: taskIndex)
             }
 
-            // We cannot remove elements from `waitingTasks` while iterating over it, so we make
-            // a pass to collect operations and then apply them after the loop.
-            func createTaskListOperations() -> (CollectionDifference<WorkTask>?, WaitingContinuation?) {
-                var changes: [CollectionDifference<WorkTask>.Change] = []
-                for (index, task) in waitingTasks.enumerated() {
-                    switch task {
-                    case .running:
-                        // Skip tasks that are already running, looking for the first one that is waiting or creating.
-                        continue
-                    case .creating:
-                        // If the next task is in the process of being created, let the
-                        // creation code in the `withCheckedThrowingContinuation` in `waitIfNeeded`
-                        // handle starting the task.
-                        break
-                    case .waiting:
-                        // Begin the next waiting task
-                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
-                        return (CollectionDifference<WorkTask>(changes), task.continuation)
-                    case .cancelled:
-                        // If the next task is cancelled, continue removing cancelled
-                        // tasks until we find one that hasn't run yet, or we exaust the list of waiting tasks.
-                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
-                        continue
-                    }
+            // Find the next task to start, removing any cancelled tombstones we pass along the way.
+            var index = 0
+            while index < waitingTasks.count {
+                switch waitingTasks[index] {
+                case .running:
+                    // Already occupying a slot; keep looking for a task that hasn't started yet.
+                    index += 1
+                case .creating:
+                    // The task is in the process of being created, i.e. it is between reserving its slot and
+                    // registering its continuation. We cannot resume it here (it has no continuation yet), but we
+                    // must keep looking for a waiting task behind it to promote: relying on the creating task to
+                    // start itself would strand those waiting tasks if it is cancelled before it ever runs. It is
+                    // safe to promote a later waiting task because the running-count re-check in `waitIfNeeded` will
+                    // make this creating task park once it observes the slot is taken.
+                    index += 1
+                case .waiting(let id, let continuation):
+                    // Promote the next waiting task to running in place so it keeps occupying a concurrency slot
+                    // until it completes, then resume its continuation once the lock is released.
+                    waitingTasks[index] = .running(id)
+                    return continuation
+                case .cancelled:
+                    // Drop cancelled tasks and keep looking for one that still needs to run.
+                    waitingTasks.remove(at: index)
                 }
-                return (CollectionDifference<WorkTask>(changes), nil)
             }
 
-            let (collectionOperations, continuation) = createTaskListOperations()
-            if let operations = collectionOperations {
-                guard let appliedDiff = waitingTasks.applying(operations) else {
-                    preconditionFailure("Failed to apply changes to waiting tasks")
-                }
-                waitingTasks = appliedDiff
-            }
-
-            return continuation
+            return nil
         }
 
         continuationToResume?.resume()

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -312,6 +312,50 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
         }
     }
 
+    /// Two builds that both fully execute against the *same* on-disk build
+    /// database directory must be serialized: never driven by two llbuild engines
+    /// at once. This is the deterministic counterpart to `stressConcurrentCancellation`
+    /// (neither build cancels, so both run their engine to completion). With the
+    /// serialization in place they run one-at-a-time and both succeed; without it,
+    /// the at-most-one-engine-per-database invariant in `BuildOperation` trips.
+    /// rdar://176791560.
+    @Test(.requireSDKs(.host), .skipHostOS(.windows, "no /usr/bin/true"))
+    func concurrentBuildsOnSameDatabaseAreSerialized() async throws {
+        let prefs = UserPreferences.defaultForTesting.with(enableBuildDebugging: false, enableBuildSystemCaching: true)
+
+        // Reuse one temporary directory so both builds resolve to the same
+        // build-database directory (and, like the real bug, separate caches).
+        try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) async throws -> Void in
+            for i in 1...5 {
+                let (tester1, waits1, started1) = try await self.createBuildOperationTesterForCancellation(temporaryDirectory: temporaryDirectory, contents: "a\(i)")
+                let (tester2, waits2, started2) = try await self.createBuildOperationTesterForCancellation(temporaryDirectory: temporaryDirectory, contents: "b\(i)")
+                tester1.userPreferences = prefs
+                tester2.userPreferences = prefs
+
+                func runBuild(_ tester: BuildOperationTester, started: WaitCondition, waits: WaitCondition) async throws {
+                    try await tester.checkBuild(runDestination: .host, attachBuildArifacts: false, body: { results in
+                        // Each build must run its wait task to completion (i.e. it
+                        // actually drove the engine, rather than being cancelled).
+                        let waitTask = try #require(results.getTask(.matchRule(["wait"])))
+                        results.check(event: .taskHadEvent(waitTask, event: .started), precedes: .taskHadEvent(waitTask, event: .completed))
+                    }) { operation in
+                        // Let the wait task finish as soon as it has started, so the
+                        // build completes and releases the database for the other build.
+                        _Concurrency.Task<Void, Never> {
+                            await started.wait()
+                            waits.signal()
+                        }
+                        await operation.build()
+                    }
+                }
+
+                async let build1: Void = runBuild(tester1, started: started1, waits: waits1)
+                async let build2: Void = runBuild(tester2, started: started2, waits: waits2)
+                _ = try await (build1, build2)
+            }
+        }
+    }
+
     /// Check that we honor specs which are unsafe to interrupt.
     @Test(.requireSDKs(.host), .skipHostOS(.windows, "no bash shell"), .skipHostOS(.freebsd, "Currently hangs on FreeBSD"))
     func unsafeToInterrupt() async throws {


### PR DESCRIPTION

SWBBuildService could crash with heap corruption inside llbuild::core::BuildEngine::build when two builds drove the same on-disk build database with two llbuild engines at once. Mutual exclusion was provided by SystemCacheEntry.serializationQueue, which only serializes builds that share the same cache entry; that breaks down when the cached build system is evicted and recreated between builds (cycle detection or a clean, or any other eviction of the entry), letting a restart run concurrently with the build it replaced.

Serialize builds with a process-global AsyncOperationQueue (concurrency 1) keyed by the build-database directory, so mutual exclusion survives cache eviction/recreation and holds across caches. Remove the now-unused SystemCacheEntry.serializationQueue. Add a debug-only invariant assert that trips if two engines ever build one database, and a deterministic regression test.

Also mirror the AsyncOperationQueue concurrency-limit and deadlock fix from swift-package-manager (the file is maintained in both repos): once a parked task was promoted it was removed from waitingTasks, so the admission gate under-counted running tasks and admitted extra ones; the continuation re-check also counted the .creating task against itself and could deadlock. Promote tasks to .running in place, re-check against the running-task count only, and stop onCancel from tombstoning an already-running task.

rdar://176791560
