### PR TITLE
Only declare DocC symbol-graph inputs for cohort base archs

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2460,7 +2460,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
 
     /// Gets the paths to the symbol graph files for the Swift module for all architectures and variants.
     static func mainSymbolGraphFiles(_ cbc: CommandBuildContext) -> [Path] {
-        let archSpecificSubScopes = cbc.scope.evaluate(BuiltinMacros.ARCHS).map { arch in
+        // ARCHS_BASE is the set of archs we actually compile, and therefore emit symbol graphs for.
+        let archSpecificSubScopes = cbc.scope.evaluate(BuiltinMacros.ARCHS_BASE).map { arch in
             return cbc.scope.subscope(binding: BuiltinMacros.archCondition, to: arch)
         }
 

--- a/Tests/SWBTaskConstructionTests/CohortArchTests.swift
+++ b/Tests/SWBTaskConstructionTests/CohortArchTests.swift
@@ -981,4 +981,90 @@ fileprivate struct CohortArchTests: CoreBasedTests {
         }
     }
 
+    /// DocC depends on symbol graphs for exactly the archs that are compiled: only base archs when cohorts are folded, all archs when built separately.
+    @Test(.requireSDKs(.iOS))
+    func testCohortArchSymbolGraphForDocumentation() async throws {
+        try await withTemporaryDirectory(fs: localFS) { (tmpDir: NamedTemporaryDirectory) in
+            let core = try await makeCore(tmpDir)
+            let doccToolPath = try await self.doccToolPath
+
+            let docTargetName = "DocFramework"
+            let testProject = try await TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    path: "Sources",
+                    children: [
+                        TestFile("SwiftFile.swift"),
+                        TestFile("DocFramework.docc"),
+                    ]
+                ),
+                buildConfigurations: [TestBuildConfiguration(
+                    CONFIGURATION,
+                    buildSettings: [
+                        "AD_HOC_CODE_SIGNING_ALLOWED": "YES",
+                        "ARCHS": "",        // Will be filled in by the build request
+                        "CODE_SIGN_IDENTITY": "-",
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "iphoneos",
+                        "SWIFT_EXEC": swiftCompilerPath.str,
+                        "SWIFT_VERSION": swiftVersion,
+                        "DOCC_EXEC": doccToolPath.str,
+                    ]
+                )],
+                targets: [
+                    TestStandardTarget(
+                        docTargetName,
+                        type: .framework,
+                        buildConfigurations: [TestBuildConfiguration(CONFIGURATION)],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                "SwiftFile.swift",
+                                "DocFramework.docc",
+                            ]),
+                        ]
+                    ),
+                ]
+            )
+            let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+            let tester = try TaskConstructionTester(core, testWorkspace)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            let fs = PseudoFS()
+            let sourcesFolder = Path(SRCROOT).join("Sources")
+            try fs.createDirectory(sourcesFolder, recursive: true)
+            try fs.write(sourcesFolder.join("SwiftFile.swift"), contents: "/* Some Swift content */\n")
+            let docsCatalog = sourcesFolder.join("DocFramework.docc")
+            try fs.createDirectory(docsCatalog, recursive: true)
+            try fs.write(docsCatalog.join("DocFramework.md"), contents: "# ``DocFramework``")
+
+            let archs = [baseArch, cohortArch]
+            let runDestination = RunDestinationInfo(platform: "iphoneos", sdk: "iphoneos", sdkVariant: "iphoneos", targetArchitecture: baseArch, supportedArchitectures: archs, disableOnlyActiveArch: true)
+
+            // DocC depends on a symbol graph for each compiled arch: just the base arch when folded, every arch otherwise.
+            func checkSymbolGraphInputs(enableCohortArchs: Bool, expectCohortMemberInput: Bool) async throws {
+                let parameters = BuildParameters(action: .docBuild, configuration: CONFIGURATION, overrides: [
+                    "ARCHS": archs.joined(separator: " "),
+                    "ENABLE_COHORT_ARCHS": enableCohortArchs ? "YES" : "NO",
+                ])
+                let target = try #require(tester.workspace.projects[0].targets.first.map({ BuildRequest.BuildTargetInfo(parameters: parameters, target: $0) }))
+                let request = BuildRequest(parameters: parameters, buildTargets: [target], continueBuildingAfterErrors: false, useParallelTargets: true, useImplicitDependencies: true, useDryRun: false)
+                await tester.checkBuild(runDestination: runDestination, buildRequest: request, fs: fs) { results in
+                    results.checkNoDiagnostics()
+                    results.checkTask(.matchRuleItem("CompileDocumentation")) { task in
+                        let inputs = task.inputs.map(\.path.str).filter { $0.contains("/symbol-graph/swift/") }
+                        #expect(inputs.contains { $0.contains("/symbol-graph/swift/\(baseArch)-") },
+                                "Expected a base-arch symbol graph input, found: \(inputs)")
+                        #expect(inputs.contains { $0.contains("/symbol-graph/swift/\(cohortArch)-") } == expectCohortMemberInput,
+                                "Cohort member symbol graph input: expected \(expectCohortMemberInput), found: \(inputs)")
+                    }
+                }
+            }
+
+            try await checkSymbolGraphInputs(enableCohortArchs: true, expectCohortMemberInput: false)
+            try await checkSymbolGraphInputs(enableCohortArchs: false, expectCohortMemberInput: true)
+        }
+    }
+
 }


### PR DESCRIPTION
Cohort member archs fold into their base arch's compile via -target-arch-variant and emit no symbol graph, so iterate ARCHS_BASE rather than ARCHS when declaring DocC inputs to avoid referencing a *.symbols.json that nothing produces.
