### PR TITLE
Don't add -target-variant to compiler response files.

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -714,7 +714,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             var previousArg: ByteString? = nil
             while let arg = iterator.next() {
                 let argAsByteString = ByteString(encodingAsUTF8: arg)
-                if arg == "-target" || arg == "-target-arch-variant" {
+                if arg == "-target" || arg == "-target-variant" || arg == "-target-arch-variant" {
                     // Exclude -target and similar options from the response file to make reading the build log easier.
                     regularCommandLine.append(arg)
                     if let nextArg = iterator.next() {


### PR DESCRIPTION
As with `-target` and `-target-arch-variant`, having all of the triple-related options directly in the command line makes it easier to diagnose certain kinds of issues.
