### PR TITLE
#bundle should error when used from a static framework

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2261,6 +2261,13 @@ private class SettingsBuilder: ProjectMatchLookup {
             table.push(BuiltinMacros.INFOPLIST_KEY_WKApplication, literal: true)
         }
 
+        // Static frameworks will not get expected results from #bundle since they do not have any easy-to-grab handle into their resource bundle.
+        // Setting SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE causes #bundle to produce an error when used.
+        // Mergeable libraries, on the other hand, DO support #bundle. See addSecondaryTargetDerivedSettings(…).
+        if scope.isFramework && scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "staticlib" {
+            table.push(BuiltinMacros.SWIFT_ACTIVE_COMPILATION_CONDITIONS, BuiltinMacros.namespace.parseStringList(["$(inherited)", "SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"]))
+        }
+
         return table
     }
 

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -4587,6 +4587,66 @@ import SWBTestSupport
         let settings6 = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters.mergingOverrides(["SWIFT_VERSION": "6.0"]), project: testProject, target: testTarget)
         #expect(settings6.globalScope.evaluateAsString(try #require(settings5.userNamespace.lookupMacroDeclaration("SWIFT_UPCOMING_FEATURE_CONCISE_MAGIC_FILE"))) == "YES")
     }
+
+    @Test
+    func frameworkPoundBundleAvailability() async throws {
+        let testWorkspace = try await TestWorkspace(
+            "Workspace",
+            projects: [TestProject(
+                "aProject",
+                groupTree: TestGroup("SomeFiles", children: [TestFile("Code.swift")]),
+                buildConfigurations:[
+                    TestBuildConfiguration("Debug")
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "SomeTarget",
+                        type: .framework,
+                        buildConfigurations: [TestBuildConfiguration("Debug")],
+                        buildPhases: [TestSourcesBuildPhase(["Code.swift"])]
+                    )
+                ]
+            )])
+            .load(getCore())
+
+        var context = try await contextForTestData(testWorkspace)
+        var buildRequestContext = BuildRequestContext(workspaceContext: context)
+        var testProject = context.workspace.projects[0]
+        var testTarget = testProject.targets[0]
+
+        let parameters = BuildParameters(action: .build, configuration: "Debug")
+        var settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testTarget)
+        #expect(!settings.globalScope.evaluateAsString(try #require(settings.userNamespace.lookupMacroDeclaration("SWIFT_ACTIVE_COMPILATION_CONDITIONS"))).contains("SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"))
+
+        let testStaticWorkspace = try await TestWorkspace(
+            "Workspace",
+            projects: [TestProject(
+                "aProject",
+                groupTree: TestGroup("SomeFiles", children: [TestFile("Code.swift")]),
+                buildConfigurations:[
+                    TestBuildConfiguration("Debug")
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "SomeTarget",
+                        type: .framework,
+                        buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: [
+                            "MACH_O_TYPE": "staticlib"
+                        ])],
+                        buildPhases: [TestSourcesBuildPhase(["Code.swift"])]
+                    )
+                ]
+            )])
+            .load(getCore())
+
+        context = try await contextForTestData(testStaticWorkspace)
+        buildRequestContext = BuildRequestContext(workspaceContext: context)
+        testProject = context.workspace.projects[0]
+        testTarget = testProject.targets[0]
+
+        settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: testTarget)
+        #expect(settings.globalScope.evaluateAsString(try #require(settings.userNamespace.lookupMacroDeclaration("SWIFT_ACTIVE_COMPILATION_CONDITIONS"))).contains("SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"))
+    }
 }
 
 @Suite fileprivate struct SettingsEditorTests: CoreBasedTests {


### PR DESCRIPTION
Set `SWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE` for static frameworks so that `#bundle` produces an error rather than silently doing the wrong thing.

Unlike mergeable libraries, a regular framework with its `MACH_O_TYPE` set to `staticlib` does not provide a bundle hook that `#bundle` could use to get access to the resources.
