### PR TITLE
Fix PIFParsingError Sendable warning by making PIFStringEnum Sendable.

### DIFF
--- a/Sources/SWBCore/ProjectModel/ProjectModelItem.swift
+++ b/Sources/SWBCore/ProjectModel/ProjectModelItem.swift
@@ -260,7 +260,7 @@ func ==(lhs: UnownedProjectModelItem, rhs: UnownedProjectModelItem) -> Bool
 
 // MARK: PIF value constant definitions
 
-public protocol PIFStringEnum {
+public protocol PIFStringEnum: Sendable {
     init?(rawValue: String)
     static var logicalTypeName: String { get }
     static var allRawValues: [String] { get }


### PR DESCRIPTION
`PIFParsingError.invalidEnumValue` produces a Sendable warning.

This can be addressed by making `PIFStringEnum` conform to `Sendable`.