### PR TITLE
Modernize simulator test run destinations to arm64

### DIFF
--- a/Sources/SWBTestSupport/RunDestinationTestSupport.swift
+++ b/Sources/SWBTestSupport/RunDestinationTestSupport.swift
@@ -43,7 +43,7 @@ extension _RunDestinationInfo {
 
     /// A generic run destination targeting iOS Simulator, using the public SDK.
     package static var anyiOSSimulator: Self {
-        return generic(sdk: "iphonesimulator", supportedArchitectures: ["arm64", "i386", "x86_64"])
+        return generic(sdk: "iphonesimulator", supportedArchitectures: ["arm64"])
     }
 
     /// A generic run destination targeting tvOS, using the public SDK.
@@ -53,7 +53,7 @@ extension _RunDestinationInfo {
 
     /// A generic run destination targeting tvOS Simulator, using the public SDK.
     package static var anytvOSSimulator: Self {
-        return generic(sdk: "appletvsimulator", supportedArchitectures: ["arm64", "x86_64"])
+        return generic(sdk: "appletvsimulator", supportedArchitectures: ["arm64"])
     }
 
     /// A generic run destination targeting watchOS, using the public SDK.
@@ -63,7 +63,7 @@ extension _RunDestinationInfo {
 
     /// A generic run destination targeting watchOS Simulator, using the public SDK.
     package static var anywatchOSSimulator: Self {
-        return generic(sdk: "watchsimulator", supportedArchitectures: ["arm64", "i386", "x86_64"])
+        return generic(sdk: "watchsimulator", supportedArchitectures: ["arm64"])
     }
 
     /// A generic run destination targeting xrOS, using the public SDK.
@@ -73,7 +73,7 @@ extension _RunDestinationInfo {
 
     /// A generic run destination targeting xrOS Simulator, using the public SDK.
     package static var anyxrOSSimulator: Self {
-        return generic(sdk: "xrsimulator", supportedArchitectures: ["arm64", "x86_64"])
+        return generic(sdk: "xrsimulator", supportedArchitectures: ["arm64"])
     }
 
     /// A generic run destination targeting DriverKit, using the public SDK.
@@ -173,7 +173,7 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting iOS Simulator generic device, using the public SDK.
     package static var iOSSimulator: Self {
-        return .init(platform: "iphonesimulator", sdk: "iphonesimulator", sdkVariant: "iphonesimulator", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+        return .init(platform: "iphonesimulator", sdk: "iphonesimulator", sdkVariant: "iphonesimulator", targetArchitecture: "arm64", supportedArchitectures: ["arm64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting watchOS generic device, using the public SDK.
@@ -183,7 +183,7 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting watchOS Simulator generic device, using the public SDK.
     package static var watchOSSimulator: Self {
-        return .init(platform: "watchsimulator", sdk: "watchsimulator", sdkVariant: "watchsimulator", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+        return .init(platform: "watchsimulator", sdk: "watchsimulator", sdkVariant: "watchsimulator", targetArchitecture: "arm64", supportedArchitectures: ["arm64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting tvOS generic device, using the public SDK.
@@ -193,7 +193,7 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting tvOS Simulator generic device, using the public SDK.
     package static var tvOSSimulator: Self {
-        return .init(platform: "appletvsimulator", sdk: "appletvsimulator", sdkVariant: "appletvsimulator", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+        return .init(platform: "appletvsimulator", sdk: "appletvsimulator", sdkVariant: "appletvsimulator", targetArchitecture: "arm64", supportedArchitectures: ["arm64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting xrOS generic device, using the public SDK.
@@ -203,7 +203,7 @@ extension _RunDestinationInfo {
 
     /// A run destination targeting xrOS Simulator generic device, using the public SDK.
     package static var xrOSSimulator: Self {
-        return .init(platform: "xrsimulator", sdk: "xrsimulator", sdkVariant: "xrsimulator", targetArchitecture: "x86_64", supportedArchitectures: ["x86_64"], disableOnlyActiveArch: false)
+        return .init(platform: "xrsimulator", sdk: "xrsimulator", sdkVariant: "xrsimulator", targetArchitecture: "arm64", supportedArchitectures: ["arm64"], disableOnlyActiveArch: false)
     }
 
     /// A run destination targeting DriverKit, using the public SDK.

--- a/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/IndexBuildOperationTests.swift
@@ -469,6 +469,7 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                     TestBuildConfiguration("Debug", buildSettings: [
                         "SDKROOT": "iphonesimulator",
                         "SUPPORTED_PLATFORMS": "iphonesimulator",
+                        "IPHONEOS_DEPLOYMENT_TARGET": "18.0",
                     ])
                 ],
                 buildPhases: [
@@ -623,7 +624,8 @@ fileprivate struct IndexBuildOperationTests: CoreBasedTests {
                     "SDK_VARIANT": "auto",
                     "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
                     "SWIFT_VERSION": swiftVersion,
-                    "MACOSX_DEPLOYMENT_TARGET": "26.0"
+                    "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                    "IPHONEOS_DEPLOYMENT_TARGET": "26.0"
                 ])
             ], buildPhases: [TestSourcesBuildPhase(["test.swift"])])
 

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -117,7 +117,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
             try await tester.checkBuild(parameters: buildParameters, runDestination: .iOSSimulator, buildCommand: .build(style: .buildOnly, skipDependencies: false), signableTargets: Set(provisioningInputs.keys), signableTargetInputs: provisioningInputs) { results in
                 results.checkNoDiagnostics()
                 results.checkNote(.equal("Emplaced \(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/Assets.car (for task: [\"LinkAssetCatalog\", \"\(srcRoot.str)/Sources/Assets.xcassets\"])"))
-                results.checkNote(.equal("Using stub executor library with Swift entry point. (for task: [\"ConstructStubExecutorLinkFileList\", \"\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt\"])"))
+                results.checkNote(.equal("Using stub executor library with Swift entry point. (for task: [\"ConstructStubExecutorLinkFileList\", \"\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt\"])"))
                 results.checkNoNotes()
 
                 results.checkTasks(.matchRuleItemPattern(.prefix("Swift"))) { _ in }
@@ -140,7 +140,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                 results.checkTask(.matchRule(["Ld", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget.debug.dylib", "normal"])) { _ in }
 
                 // We should construct the stub executor link file list
-                results.checkTask(.matchRule(["ConstructStubExecutorLinkFileList", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt"])) { _ in }
+                results.checkTask(.matchRule(["ConstructStubExecutorLinkFileList", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt"])) { _ in }
 
                 // We should have the normal link task, which is the preview shim, and it should link the bootstrap static library
                 results.checkTask(.matchRule(["Ld", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget", "normal"])) { task in
@@ -162,7 +162,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "-e", "___debug_blank_executor_main",
                                 "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_dylib", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibPath-normal-\(results.runDestinationTargetArchitecture).txt",
                                 "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_instlnm", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibInstallName-normal-\(results.runDestinationTargetArchitecture).txt",
-                                "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt",
+                                "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt",
                                 "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__entitlements", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent",
                                 "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__ents_der", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent.der",
                                 "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget.debug.dylib",
@@ -186,7 +186,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                             "-Xlinker", "-e", "-Xlinker", "___debug_blank_executor_main",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_dylib", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibPath-normal-\(results.runDestinationTargetArchitecture).txt",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_instlnm", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibInstallName-normal-\(results.runDestinationTargetArchitecture).txt",
-                            "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt",
+                            "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__entitlements", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__ents_der", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent.der",
                             "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget.debug.dylib",
@@ -250,6 +250,8 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.selection.preview-thunk.dia",
                                 "-target",
                                 "\(results.runDestinationTargetArchitecture)-apple-ios\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)-simulator",
+                                "-Xllvm",
+                                "-aarch64-use-tbi",
                                 "-enable-objc-interop",
                                 "-sdk",
                                 "\(core.loadSDK(.iOSSimulator).path.str)",
@@ -561,6 +563,8 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                                 "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/File1.selection.preview-thunk.dia",
                                 "-target",
                                 "\(results.runDestinationTargetArchitecture)-apple-ios\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)-simulator",
+                                "-Xllvm",
+                                "-aarch64-use-tbi",
                                 "-enable-objc-interop",
                                 "-sdk",
                                 "\(core.loadSDK(.iOSSimulator).path.str)",
@@ -705,6 +709,11 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
             let buildParameters = BuildParameters(configuration: "Debug", overrides: [
                 // And XOJIT previews enabled, which should be passed when the workspace setting is on
                 "ENABLE_XOJIT_PREVIEWS": "YES",
+                // Exercise the multi-arch (universal binary) preview path. x86_64 simulators are
+                // invalid at recent deployment targets, so pin low enough that x86_64 is still valid
+                // and re-add it to VALID_ARCHS.
+                "VALID_ARCHS": "$(inherited) x86_64",
+                "IPHONEOS_DEPLOYMENT_TARGET": "18.0",
             ])
 
             try await tester.checkBuild(parameters: buildParameters, runDestination: .anyiOSSimulator, buildCommand: .build(style: .buildOnly, skipDependencies: false)) { results in
@@ -816,7 +825,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_dylib", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppExTarget.build/AppExTarget-DebugDylibPath-normal-\(results.runDestinationTargetArchitecture).txt",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_entry", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppExTarget.build/AppExTarget-DebugEntryPoint-normal-\(results.runDestinationTargetArchitecture).txt",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_instlnm", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppExTarget.build/AppExTarget-DebugDylibInstallName-normal-\(results.runDestinationTargetArchitecture).txt",
-                            "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppExTarget.build/AppExTarget-ExecutorLinkFileList-normal-x86_64.txt",
+                            "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppExTarget.build/AppExTarget-ExecutorLinkFileList-normal-arm64.txt",
                             "\(srcRoot.str)/build/Debug-iphonesimulator/AppExTarget.appex/AppExTarget.debug.dylib",
                             "-o", "\(srcRoot.str)/build/Debug-iphonesimulator/AppExTarget.appex/AppExTarget"
                         ]

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -4922,9 +4922,9 @@ import SWBTestSupport
             #expect(scope.evaluate(BuiltinMacros.PLATFORM_FAMILY_NAME) == "iOS")
             #expect(scope.evaluate(BuiltinMacros.SDKROOT) == context.sdkRegistry.lookup("iphonesimulator")?.path)
             #expect(scope.evaluate(BuiltinMacros.ONLY_ACTIVE_ARCH))
-            #expect(scope.evaluate(BuiltinMacros.ARCHS) == ["x86_64"])
-            try #require(scope.evaluate(try scope.namespace.declareStringMacro("x86_64")) == "YES")
-            try #require(scope.evaluate(try scope.namespace.declareStringMacro("arm64")) == "")
+            #expect(scope.evaluate(BuiltinMacros.ARCHS) == ["arm64"])
+            try #require(scope.evaluate(try scope.namespace.declareStringMacro("arm64")) == "YES")
+            try #require(scope.evaluate(try scope.namespace.declareStringMacro("x86_64")) == "")
         }
     }
 
@@ -4946,7 +4946,9 @@ import SWBTestSupport
     @Test(.requireSDKs(.watchOS))
     func activeRunDestination_Simulator_Device_Different_Platform() async throws {
         // If a target supports both device+sim and the run destination is a simulator, we should build the target for its supported simulator
-        try await testActiveRunDestinationiOS(runDestination: .watchOSSimulator) { context, settings, scope throws in
+        try await testActiveRunDestinationiOS(extraBuildSettings: [
+            "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
+        ], runDestination: .watchOSSimulator) { context, settings, scope throws in
             #expect(settings.errors == [])
             #expect(settings.warnings == [])
             #expect(scope.evaluate(BuiltinMacros.PLATFORM_NAME) == "iphonesimulator")
@@ -5039,6 +5041,8 @@ import SWBTestSupport
                 "SDKROOT": "iphonesimulator",
                 "VALID_ARCHS": "foo bar x86_64 baz x86_64h qux",
                 "ARCHS": "$(VALID_ARCHS)",
+                // x86_64 is only valid for older simulator deployment targets, so pin low enough to keep x86_64 in ARCHS for this multi-arch case.
+                "IPHONEOS_DEPLOYMENT_TARGET": "26.0",
             ],
             runDestination: nil,
             activeArchitecture: nil,

--- a/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
+++ b/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
@@ -367,7 +367,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                 "Debug",
                                 buildSettings: [
                                     "SDKROOT": "iphoneos",
-                                    "ARCHS": "arm64 x86_64",
+                                    "ARCHS": "arm64",
                                     "ONLY_ACTIVE_ARCH": "NO",
                                     "SWIFT_EXEC": swiftCompilerPath.str,
                                     // Set the real TAPI tool path so that we can check its version to determine what version of the "headers info" JSON file to pass to `tapi extractapi`.
@@ -547,7 +547,7 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                 results.checkNoDiagnostics()
 
                 results.checkTarget("iOS App") { target in
-                    for arch in ["x86_64", "arm64"] {
+                    for arch in ["arm64"] {
                         let sdkdbFile = "/tmp/Test/aProject/build/aProject.build/Debug-iphonesimulator/iOS App.build/symbol-graph/clang/\(arch)-apple-ios\(results.runDestinationSDK.version)-simulator/iOS App.sdkdb"
                         let symbolGraphFile = "/tmp/Test/aProject/build/aProject.build/Debug-iphonesimulator/iOS App.build/symbol-graph/clang/\(arch)-apple-ios\(results.runDestinationSDK.version)-simulator/iOS_App.symbols.json"
 

--- a/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PlatformTaskConstructionTests.swift
@@ -270,7 +270,7 @@ fileprivate struct PlatformTaskConstructionTests: CoreBasedTests {
             }
 
             results.checkTarget("AppTarget") { target in
-                results.checkTask(.matchTarget(target), .matchRuleType("CompileC"), .matchRuleItemBasename("main.m"), .matchRuleItem("x86_64")) { task in
+                results.checkTask(.matchTarget(target), .matchRuleType("CompileC"), .matchRuleItemBasename("main.m"), .matchRuleItem("arm64")) { task in
                     task.checkRuleInfo([.equal("CompileC"), .suffix("main.o"), .suffix("main.m"), .equal("normal"), .equal(results.runDestinationTargetArchitecture), .equal("objective-c"), .any])
                     task.checkCommandLineLastArgumentEqual("\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/AppTarget.build/Objects-normal/\(results.runDestinationTargetArchitecture)/main.o")
                 }

--- a/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PreviewsTaskConstructionTests.swift
@@ -916,10 +916,10 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                         .namePattern(.and(.prefix("target-AppTarget-T-AppTarget-"), .suffix("--begin-linking"))),
                     ])
                     task.checkOutputs([
-                        .path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt"),
+                        .path("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt"),
                     ])
                     task.checkRuleInfo([
-                        "ConstructStubExecutorLinkFileList", .suffix("AppTarget-ExecutorLinkFileList-normal-x86_64.txt")
+                        "ConstructStubExecutorLinkFileList", .suffix("AppTarget-ExecutorLinkFileList-normal-arm64.txt")
                     ])
                     task.checkCommandLineMatches(
                         [
@@ -928,7 +928,7 @@ fileprivate struct PreviewsTaskConstructionTests: CoreBasedTests {
                             .suffix("/Developer/usr/lib/libPreviewsJITStubExecutor_no_swift_entry_point.a"),
                             .suffix("/Developer/usr/lib/libPreviewsJITStubExecutor.a"),
                             .equal("--output"),
-                            .equal("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt"),
+                            .equal("\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-arm64.txt"),
                         ]
                     )
                 }

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -2691,6 +2691,7 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
                         "DEVELOPMENT_TEAM": "",
                         "CODE_SIGN_IDENTITY": "-",
                         "CODE_SIGN_STYLE": "Automatic",
+                        "WATCHOS_DEPLOYMENT_TARGET": "11.0",
                         "SDKROOT": "watchsimulator"].addingContents(of: extraSettings))],
                 targets: [
                     TestAggregateTarget("All",

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -1028,7 +1028,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     "Debug",
                     buildSettings: [
                         "ARCHS[sdk=watchos*]": "arm64_32",
-                        "ARCHS[sdk=watchsimulator*]": "x86_64",
+                        "ARCHS[sdk=watchsimulator*]": "arm64",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "-",
                         "CODE_SIGN_ENTITLEMENTS": "Entitlements.plist",
@@ -1304,7 +1304,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     "Debug",
                     buildSettings: [
                         "ARCHS[sdk=watchos*]": "arm64_32",
-                        "ARCHS[sdk=watchsimulator*]": "x86_64",
+                        "ARCHS[sdk=watchsimulator*]": "arm64",
                         "PRODUCT_NAME": "$(TARGET_NAME)",
                         "CODE_SIGN_IDENTITY": "-",
                         "CODE_SIGN_ENTITLEMENTS": "Entitlements.plist",
@@ -2954,7 +2954,7 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
         try await fs.writeXCTRunnerApp(deviceXctrunnerPath, archs: ["arm64", "arm64e"], platform: .iOS, infoLookup: core)
 
         let simXctrunnerPath = core.developerPath.path.join("Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/XCTRunner.app")
-        try await fs.writeXCTRunnerApp(simXctrunnerPath, archs: ["x86_64"], platform: .iOSSimulator, infoLookup: core)
+        try await fs.writeXCTRunnerApp(simXctrunnerPath, archs: ["arm64"], platform: .iOSSimulator, infoLookup: core)
 
         // Check a debug build for the device.
         await tester.checkBuild(runDestination: .macOS, fs: fs) { results in

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -105,7 +105,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
                                                 "ARCHS[sdk=watchos*]": "arm64_32",
-                                                "ARCHS[sdk=watchsimulator*]": "x86_64",
+                                                "ARCHS[sdk=watchsimulator*]": "arm64",
                                                 "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
                                                 "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                                                 "INFOPLIST_FILE": "Sources/watchosApp/Info.plist",
@@ -134,7 +134,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
                                                 "ARCHS[sdk=watchos*]": "arm64_32",
-                                                "ARCHS[sdk=watchsimulator*]": "x86_64",
+                                                "ARCHS[sdk=watchsimulator*]": "arm64",
                                                 "ASSETCATALOG_COMPILER_COMPLICATION_NAME": "Complication",
                                                 "ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS": "YES",
                                                 "INFOPLIST_FILE": "Sources/watchosExtension/Info.plist",
@@ -164,7 +164,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                         TestBuildConfiguration("Debug",
                                                buildSettings: [
                                                 "ARCHS[sdk=watchos*]": "arm64_32",
-                                                "ARCHS[sdk=watchsimulator*]": "x86_64",
+                                                "ARCHS[sdk=watchsimulator*]": "arm64",
                                                 "ASSETCATALOG_COMPILER_COMPLICATION_NAME": "Complication",
                                                 "INFOPLIST_FILE": "Sources/watchosExtension/Info.plist",
                                                 "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
@@ -529,7 +529,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
             // Check the watchOS extension
             results.checkTarget("Watchable WatchKit Extension") { target in
-                let arch = "x86_64"
+                let arch = "arm64"
                 let variant = "normal"
 
                 // There should be one clang and one swiftc task.
@@ -546,7 +546,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
                     task.checkRuleInfo(["SwiftDriver Compilation", "Watchable WatchKit Extension", .equal(variant), .equal(arch), .equal("com.apple.xcode.tools.swift.compiler")])
                     let responseFilePath = "@\(SRCROOT)/build/aProject.build/Debug-watchsimulator/\(target.target.name).build/Objects-\(variant)/\(arch)/\(target.target.name).SwiftFileList"
-                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOSSimulator).path.str, "-target", "x86_64-apple-watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)-simulator"])
+                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOSSimulator).path.str, "-target", "arm64-apple-watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)-simulator"])
                 }
 
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements"))
@@ -555,7 +555,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                     let expectedCommandLine: [String] = [
                         ["clang"],
-                        ["-target", "x86_64-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)-simulator"],
+                        ["-target", "arm64-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)-simulator"],
                         ["-isysroot", core.loadSDK(.watchOSSimulator).path.str, "-Xlinker", "-rpath", "-Xlinker", "@executable_path/Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../../Frameworks"],
                         ["-fapplication-extension", "\(SRCROOT)/build/Debug-watchsimulator/Watchable WatchKit Extension.appex/Watchable WatchKit Extension"]
                     ].reduce([], +)
@@ -563,11 +563,11 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 }
 
                 // There should be tasks to copy the associated Swift files.
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftdoc"), .matchRuleItemBasename("x86_64-apple-watchos-simulator.swiftdoc")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftdoc"), .matchRuleItemBasename("arm64-apple-watchos-simulator.swiftdoc")) { _ in }
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftMergeGeneratedHeaders"), .matchRuleItemBasename("Watchable_WatchKit_Extension-Swift.h"), .matchRuleItemBasename("Watchable_WatchKit_Extension-Swift.h")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftmodule"), .matchRuleItemBasename("x86_64-apple-watchos-simulator.swiftmodule")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftsourceinfo"), .matchRuleItemBasename("x86_64-apple-watchos-simulator.swiftsourceinfo")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.abi.json"), .matchRuleItemBasename("x86_64-apple-watchos-simulator.abi.json")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftmodule"), .matchRuleItemBasename("arm64-apple-watchos-simulator.swiftmodule")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.swiftsourceinfo"), .matchRuleItemBasename("arm64-apple-watchos-simulator.swiftsourceinfo")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable_WatchKit_Extension.abi.json"), .matchRuleItemBasename("arm64-apple-watchos-simulator.abi.json")) { _ in }
 
                 // There should be two actool tasks
                 for variant in ["thinned", "unthinned"] {
@@ -690,14 +690,14 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 let builtHostIOSAppPath = "\(SRCROOT)/build/Debug-iphonesimulator/Watchable.app"
 
                 // We should have one clang, one swiftc, and link task per arch.
-                for arch in ["x86_64"] {
+                for arch in ["arm64"] {
                     // CompileC
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileC"), .matchRuleItemBasename("main.m"), .matchRuleItem(arch)) { task in
                         task.checkRuleInfo([.equal("CompileC"), .suffix("main.o"), .suffix("main.m"), .equal("normal"), .equal(arch), .equal("objective-c"), .any])
                         let expectedCommandLine: [String] = [
                             ["clang"],
                             ["-target", "\(arch)-apple-ios\(IPHONEOS_DEPLOYMENT_TARGET)-simulator"],
-                            ["-isysroot", core.loadSDK(.iOSSimulator).path.str, "-fasm-blocks"],
+                            ["-isysroot", core.loadSDK(.iOSSimulator).path.str],
                             ["-o", "\(SRCROOT)/build/aProject.build/Debug-iphonesimulator/Watchable.build/Objects-normal/\(arch)/main.o"]
                         ].reduce([], +)
                         task.checkCommandLineContains(expectedCommandLine)
@@ -737,11 +737,11 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 }
 
                 // There should be tasks to copy the associated Swift files.
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftdoc"), .matchRuleItemBasename("x86_64-apple-ios-simulator.swiftdoc")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftdoc"), .matchRuleItemBasename("arm64-apple-ios-simulator.swiftdoc")) { _ in }
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftMergeGeneratedHeaders"), .matchRuleItemBasename("Watchable-Swift.h"), .matchRuleItemBasename("Watchable-Swift.h")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftmodule"), .matchRuleItemBasename("x86_64-apple-ios-simulator.swiftmodule")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftsourceinfo"), .matchRuleItemBasename("x86_64-apple-ios-simulator.swiftsourceinfo")) { _ in }
-                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.abi.json"), .matchRuleItemBasename("x86_64-apple-ios-simulator.abi.json")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftmodule"), .matchRuleItemBasename("arm64-apple-ios-simulator.swiftmodule")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.swiftsourceinfo"), .matchRuleItemBasename("arm64-apple-ios-simulator.swiftsourceinfo")) { _ in }
+                results.checkTask(.matchTarget(target), .matchRuleType("Copy"), .matchRuleItemBasename("Watchable.abi.json"), .matchRuleItemBasename("arm64-apple-ios-simulator.abi.json")) { _ in }
 
                 // There should be a process Info.plist task.
                 results.checkTask(.matchTarget(target), .matchRuleType("ProcessInfoPlistFile")) { _ in }

--- a/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
+++ b/Tests/SwiftBuildTests/ArenaIndexingInfoTests.swift
@@ -88,6 +88,9 @@ struct ArenaIndexingInfoTests: CoreBasedTests {
                                     "PRODUCT_NAME": "$(TARGET_NAME)",
                                     "ALWAYS_SEARCH_USER_PATHS": "NO",
                                     "MACOSX_DEPLOYMENT_TARGET": "26.0",
+                                    // Pin only the simulator below the x86_64 simulator clamp so x86_64 stays valid
+                                    // for the simulator index info, without disturbing the device/Mac Catalyst cases.
+                                    "IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator*]": "26.0",
                                 ])],
                         targets: [
                             macApp,


### PR DESCRIPTION
Flip the simulator run destinations to arm64 and update the affected test expectations accordingly.

Tests whose simulator arch derives from `ARCHS_STANDARD` (rather than the active arch) would otherwise break once x86_64 is clamped out of the simulators at newer deployment targets; pin an explicit deployment target for those.

Assisted by Claude Opus 4.8