### PR TITLE
[6.4] Add SWIFTC_DISABLE_SANDBOX Swift compiler xcspec settings

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1204,6 +1204,17 @@
             },
 
             {
+                Name = "SWIFTC_DISABLE_SANDBOX";
+                Type = Boolean;
+                DefaultValue = NO;
+                CommandLineArgs = {
+                    YES = (
+                        "-disable-sandbox",
+                    );
+                    NO = ();
+                };
+            },
+            {
                 Name = "ENABLE_CODESIZE_PROFILE";
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4855,6 +4855,88 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    @Test(
+        .requireSDKs(.host),
+    )
+    func swiftcDisableSandboxSetting() async throws {
+        let targetName = "targetName"
+        let swiftCompilerPath = try await self.swiftCompilerPath
+        let swiftVersion = try await self.swiftVersion
+        let libtoolPath = try await self.libtoolPath
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir.join("srcroot"),
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.swift"),
+                    ],
+                ),
+                targets: [
+                    TestStandardTarget(
+                        targetName,
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "LIBTOOL": libtoolPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                ],
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(
+                                [
+                                    TestBuildFile("File1.swift"),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+
+            // Default (setting unset) should not pass -disable-sandbox.
+            await tester.checkBuild(
+                BuildParameters(configuration: "Debug"),
+                runDestination: .host,
+            ) { results in
+                results.checkTarget(targetName) { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineDoesNotContain("-disable-sandbox")
+                    }
+                }
+            }
+
+            await tester.checkBuild(
+                BuildParameters(configuration: "Debug", overrides: ["SWIFTC_DISABLE_SANDBOX": "YES"]),
+                runDestination: .host,
+            ) { results in
+                results.checkTarget(targetName) { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineContains(["-disable-sandbox"])
+                    }
+                }
+            }
+
+            await tester.checkBuild(
+                BuildParameters(configuration: "Debug", overrides: ["SWIFTC_DISABLE_SANDBOX": "NO"]),
+                runDestination: .host,
+            ) { results in
+                results.checkTarget(targetName) { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
+                        task.checkCommandLineDoesNotContain("-disable-sandbox")
+                    }
+                }
+            }
+        }
+    }
+
     @Test(.requireSDKs(.macOS))
     func layoutStringValueWitnesses() async throws {
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
Some package systems (e.g: HomeBrew, Nix) use a custom build sandbox. Within the outer sandbox, Swift Toolchain should not create their own sandbox, which is why SwiftPM offers a `--disable-sandbox` options.

Add a Swift compiler XCSpec setting that, when set, passes the respective command line argument to the swiftc compiler.

Relates to: swiftlang/swift-package-manager#7098
Issue: rdar://179641209
Issue: rdar://FB23149934 (Customer Feedback)