### PR TITLE
Include WORKSPACE_DIR when configuring prefix mapping

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleVerifierTaskProducer.swift
@@ -320,6 +320,7 @@ final class ModuleVerifierTaskProducer: PhasedTaskProducer, TaskProducer {
         passthrough(BuiltinMacros.PROJECT_DIR)
         passthrough(BuiltinMacros.PROJECT_TEMP_DIR)
         passthrough(BuiltinMacros.BUILT_PRODUCTS_DIR)
+        passthrough(BuiltinMacros.WORKSPACE_DIR)
 
         // Module cache: with explicit modules we have a strict context hash that ensures correctness. For implicit modules create a separate cache for each target to prevent cache-correctness issues from leaking into validation. This matches the external modules-verifier tool, which always creates a separate cache.
         if scope.evaluate(BuiltinMacros.CLANG_ENABLE_EXPLICIT_MODULES) || scope.evaluate(BuiltinMacros._EXPERIMENTAL_CLANG_EXPLICIT_MODULES) {

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
@@ -118,6 +118,7 @@ final class CompilationCachingConfigFileTaskProducer: StandardTaskProducer, Task
                         prefixMaps["/^src"] = scope.evaluate(BuiltinMacros.PROJECT_DIR).str
                         prefixMaps["/^derived"] = scope.evaluate(BuiltinMacros.PROJECT_TEMP_DIR).str
                         prefixMaps["/^built"] = scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR).str
+                        prefixMaps["/^workspace"] = scope.evaluate(BuiltinMacros.WORKSPACE_DIR)
                     }
                     prefixMaps.merge(extraMaps, uniquingKeysWith: { _, new in new })
 

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3362,6 +3362,7 @@
                         "-fdepscan-prefix-map=$(PROJECT_DIR)=/^src",
                         "-fdepscan-prefix-map=$(PROJECT_TEMP_DIR)=/^derived",
                         "-fdepscan-prefix-map=$(BUILT_PRODUCTS_DIR)=/^built",
+                        "-fdepscan-prefix-map=$(WORKSPACE_DIR)=/^workspace",
                     );
                     NO = ();
                 };

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1504,6 +1504,7 @@
                         "-scanner-prefix-map", "$(PROJECT_DIR)=/^src",
                         "-scanner-prefix-map", "$(PROJECT_TEMP_DIR)=/^derived",
                         "-scanner-prefix-map", "$(BUILT_PRODUCTS_DIR)=/^built",
+                        "-scanner-prefix-map", "$(WORKSPACE_DIR)=/^workspace",
                     );
                     NO = ();
                 };

--- a/Tests/SWBCoreTests/CommandLineSpecTests.swift
+++ b/Tests/SWBCoreTests/CommandLineSpecTests.swift
@@ -1975,6 +1975,7 @@ import SWBMacro
         let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
         let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
         let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
+        let workspaceDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("WORKSPACE_DIR") as? StringMacroDeclaration)
 
         func test(caching: Bool, prefixMapping: Bool, completeMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             var table = MacroValueAssignmentTable(namespace: core.specRegistry.internalMacroNamespace)
@@ -1986,6 +1987,7 @@ import SWBMacro
             table.push(srcDir, literal: "/source")
             table.push(projectTmpDir, literal: "/build")
             table.push(builtDir, literal: "/products")
+            table.push(workspaceDir, literal: "/workspace")
             let mockScope = MacroEvaluationScope(table: table)
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
@@ -2020,6 +2022,7 @@ import SWBMacro
                 "-fdepscan-prefix-map=/source=/^src",
                 "-fdepscan-prefix-map=/build=/^derived",
                 "-fdepscan-prefix-map=/products=/^built",
+                "-fdepscan-prefix-map=/workspace=/^workspace",
             ])
         })
         try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b", "/c=/d"], completion: { args in
@@ -2047,6 +2050,7 @@ import SWBMacro
         let srcDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_DIR") as? PathMacroDeclaration)
         let projectTmpDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("PROJECT_TEMP_DIR") as? PathMacroDeclaration)
         let builtDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("BUILT_PRODUCTS_DIR") as? PathMacroDeclaration)
+        let workspaceDir = try #require(core.specRegistry.internalMacroNamespace.lookupMacroDeclaration("WORKSPACE_DIR") as? StringMacroDeclaration)
 
         func test(caching: Bool, prefixMapping: Bool, completeMapping: Bool, extraMaps: [String], completion: ([String]) throws -> Void) async throws {
             // Create the mock table.
@@ -2071,6 +2075,7 @@ import SWBMacro
             table.push(srcDir, literal: "/source")
             table.push(projectTmpDir, literal: "/build")
             table.push(builtDir, literal: "/products")
+            table.push(workspaceDir, literal: "/workspace")
             let mockScope = MacroEvaluationScope(table: table)
             let producer = try MockCommandProducer(core: core, productTypeIdentifier: "com.apple.product-type.framework", platform: "macosx")
             let delegate = try CapturingTaskGenerationDelegate(producer: producer, userPreferences: .defaultForTesting)
@@ -2113,6 +2118,7 @@ import SWBMacro
                 "-scanner-prefix-map", "/source=/^src",
                 "-scanner-prefix-map", "/build=/^derived",
                 "-scanner-prefix-map", "/products=/^built",
+                "-scanner-prefix-map", "/workspace=/^workspace",
             ])
         })
         try await test(caching: true, prefixMapping: true, completeMapping: false, extraMaps: ["/a=/b", "/c=/d"], completion: { args in


### PR DESCRIPTION
Swift packages use the shared WORKSPACE_DIR as a shared CWD for compiles to maximize module reuse. This path is a parent of PROJECT_DIR, so it need to be prefix mapped to ensure we can get cache hits when cloning a package + dependencies at two different paths. Identified while working on https://github.com/swiftlang/swift-package-manager/pull/10246