### PR TITLE
Add attachments for builds run using the CoreQualificationTester.

### DIFF
--- a/Sources/SWBTestSupport/BuildOperationTester.swift
+++ b/Sources/SWBTestSupport/BuildOperationTester.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -1446,12 +1446,12 @@ package final class BuildOperationTester {
     /// This variant of `checkBuild()` differs from the main versiion in these ways:
     /// - Does not have a `operationBuildRequest` parameter.
     /// - Has a default value of the `performBuild` parameter which performs a nortmal build.
-    @discardableResult package func checkBuild<T>(_ name: String? = nil, parameters: BuildParameters? = nil, runDestination: RunDestinationInfo?, buildRequest inputBuildRequest: BuildRequest? = nil, buildCommand: BuildCommand? = nil, schemeCommand: SchemeCommand? = .launch, persistent: Bool = false, serial: Bool = false, buildOutputMap: [String:String]? = nil, signableTargets: Set<String> = [], signableTargetInputs: [String: ProvisioningTaskInputs] = [:], attachBuildArifacts: Bool = true, clientDelegate: (any ClientDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, body: (BuildResults) async throws -> T) async throws -> T {
-        try await checkBuild(name, parameters: parameters, runDestination: runDestination, buildRequest: inputBuildRequest, buildCommand: buildCommand, schemeCommand: schemeCommand, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, signableTargets: signableTargets, signableTargetInputs: signableTargetInputs, attachBuildArifacts: attachBuildArifacts, clientDelegate: clientDelegate, sourceLocation: sourceLocation, body: body, performBuild: { try await $0.buildWithTimeout() })
+    @discardableResult package func checkBuild<T>(_ name: String? = nil, parameters: BuildParameters? = nil, runDestination: RunDestinationInfo?, buildRequest inputBuildRequest: BuildRequest? = nil, buildCommand: BuildCommand? = nil, schemeCommand: SchemeCommand? = .launch, persistent: Bool = false, serial: Bool = false, buildOutputMap: [String:String]? = nil, signableTargets: Set<String> = [], signableTargetInputs: [String: ProvisioningTaskInputs] = [:], attachBuildArtifacts: Bool = true, clientDelegate: (any ClientDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, body: (BuildResults) async throws -> T) async throws -> T {
+        try await checkBuild(name, parameters: parameters, runDestination: runDestination, buildRequest: inputBuildRequest, buildCommand: buildCommand, schemeCommand: schemeCommand, persistent: persistent, serial: serial, buildOutputMap: buildOutputMap, signableTargets: signableTargets, signableTargetInputs: signableTargetInputs, attachBuildArtifacts: attachBuildArtifacts, clientDelegate: clientDelegate, sourceLocation: sourceLocation, body: body, performBuild: { try await $0.buildWithTimeout() })
     }
 
     /// Construct the tasks for the given build parameters, and test the result.
-    @discardableResult package func checkBuild<T>(_ name: String? = nil, parameters: BuildParameters? = nil, runDestination: RunDestinationInfo?, buildRequest inputBuildRequest: BuildRequest? = nil, operationBuildRequest: BuildRequest? = nil, buildCommand: BuildCommand? = nil, schemeCommand: SchemeCommand? = .launch, persistent: Bool = false, serial: Bool = false, buildOutputMap: [String:String]? = nil, signableTargets: Set<String> = [], signableTargetInputs: [String: ProvisioningTaskInputs] = [:], attachBuildArifacts: Bool = true, clientDelegate: (any ClientDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, body: (BuildResults) async throws -> T, performBuild: @escaping (any BuildSystemOperation) async throws -> Void) async throws -> T {
+    @discardableResult package func checkBuild<T>(_ name: String? = nil, parameters: BuildParameters? = nil, runDestination: RunDestinationInfo?, buildRequest inputBuildRequest: BuildRequest? = nil, operationBuildRequest: BuildRequest? = nil, buildCommand: BuildCommand? = nil, schemeCommand: SchemeCommand? = .launch, persistent: Bool = false, serial: Bool = false, buildOutputMap: [String:String]? = nil, signableTargets: Set<String> = [], signableTargetInputs: [String: ProvisioningTaskInputs] = [:], attachBuildArtifacts: Bool = true, clientDelegate: (any ClientDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, body: (BuildResults) async throws -> T, performBuild: @escaping (any BuildSystemOperation) async throws -> Void) async throws -> T {
         try await checkBuildDescription(parameters, runDestination: runDestination, buildRequest: inputBuildRequest, buildCommand: buildCommand, schemeCommand: schemeCommand, persistent: persistent, serial: serial, signableTargets: signableTargets, signableTargetInputs: signableTargetInputs, clientDelegate: clientDelegate) { results throws in
             // Check that there are no duplicate task identifiers - it is a fatal error if there are, unless `continueBuildingAfterErrors` is set.
             var tasksByTaskIdentifier: [TaskIdentifier: Task] = [:]
@@ -1532,7 +1532,7 @@ package final class BuildOperationTester {
             let results = try BuildResults(core: core, workspace: workspace, buildDescriptionResults: results, tasksByTaskIdentifier: delegate.tasksByTaskIdentifier.merging(delegate.dynamicTasksByTaskIdentifier, uniquingKeysWith: { a, b in a }), fs: fs, events: events, dynamicTaskDependencies: dynamicDependencies, buildDatabasePath: persistent ? results.buildDescription.buildDatabasePath : nil)
 
             // TODO: <rdar://59432231> Longer term, we should find a way to share code with CoreQualificationTester, which has a number of APIs for emitting build operation debug info.
-            if attachBuildArifacts {
+            if attachBuildArtifacts {
                 Attachment.record(results.buildTranscript, named: "Build Transcript" + (name.map({ " for Build Operation \"\($0)\"" }) ?? ""))
                 if localFS.exists(results.buildDescription.packagePath) {
                     Attachment.record(results.buildDescription.packagePath.str, named: "Build Description" + (name.map({ " for Build Operation \"\($0)\"" }) ?? ""))

--- a/Sources/SwiftBuildTestSupport/CoreQualificationTester.swift
+++ b/Sources/SwiftBuildTestSupport/CoreQualificationTester.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -43,17 +43,17 @@ final package class CoreQualificationTester: Sendable {
     package func invalidate() async throws {
     }
 
-    package func checkBuild(_ buildParameters: SWBBuildParameters? = nil, _ buildRequest: SWBBuildRequest? = nil, delegate: (any SWBPlanningOperationDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
+    package func checkBuild(name: String? = nil, _ buildParameters: SWBBuildParameters? = nil, _ buildRequest: SWBBuildRequest? = nil, delegate: (any SWBPlanningOperationDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
         guard let project = testWorkspace.projects.first else {
             throw StubError.error("Workspace has no projects; explicitly specify target name to build")
         }
         guard let targetName = project.targets.first?.name else {
             throw StubError.error("Workspace has no targets; explicitly specify target name to build")
         }
-        return try await checkBuild(buildParameters, buildRequest, target: targetName, project: project.name, delegate: delegate, sourceLocation: sourceLocation, block)
+        return try await checkBuild(name: name, buildParameters, buildRequest, target: targetName, project: project.name, delegate: delegate, sourceLocation: sourceLocation, block)
     }
 
-    package func checkBuild(_ buildParameters: SWBBuildParameters? = nil, _ buildRequest: SWBBuildRequest? = nil, target: String, project: String? = nil, delegate: (any SWBPlanningOperationDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
+    package func checkBuild(name: String? = nil, _ buildParameters: SWBBuildParameters? = nil, _ buildRequest: SWBBuildRequest? = nil, target: String, project: String? = nil, delegate: (any SWBPlanningOperationDelegate)? = nil, sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
         let delegate = delegate ?? TestBuildOperationDelegate()
 
         var request = buildRequest ?? SWBBuildRequest()
@@ -66,41 +66,39 @@ final package class CoreQualificationTester: Sendable {
 
         let events = try await testSession.runBuildOperation(request: request, delegate: delegate)
 
-        try await checkResults(events: events, block)
+        try await checkResults(name: name, events: events, block)
     }
 
-    package func checkResults(events: [SwiftBuildMessage], sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
-        //try await XCTContext.runActivity(named: "Analyze Build Results") { activity in
-            var loggedEvents: [String] = []
-            var diagnostics: [LoggedDiagnostic] = []
-            for event in events {
-                switch event {
-                case let .diagnostic(message):
-                    diagnostics.append(.init(message))
-                default:
-                    break
-                }
-                try loggedEvents.append(String(decoding: JSONEncoder(outputFormatting: [.sortedKeys, .withoutEscapingSlashes]).encode(event), as: UTF8.self))
+    package func checkResults(name: String? = nil, events: [SwiftBuildMessage], sourceLocation: SourceLocation = #_sourceLocation, _ block: (CoreQualificationTesterResults) async throws -> Void) async throws {
+        var loggedEvents: [String] = []
+        var diagnostics: [LoggedDiagnostic] = []
+        for event in events {
+            switch event {
+            case let .diagnostic(message):
+                diagnostics.append(.init(message))
+            default:
+                break
             }
+            try loggedEvents.append(String(decoding: JSONEncoder(outputFormatting: [.sortedKeys, .withoutEscapingSlashes]).encode(event), as: UTF8.self))
+        }
 
-            // TODO: <rdar://59432231> Longer term, we should find a way to share code with BuildOperationTester, which has a number of APIs for building up a human readable build transcript.
-            //activity.attach(name: "Event Log", plistObject: loggedEvents)
-            //activity.attach(name: "Diagnostics", plistObject: diagnostics.map { $0.description })
-            //activity.attach(name: "Output", string: events.allOutput().bytes.unsafeStringValue)
+        // TODO: <rdar://59432231> Longer term, we should find a way to share code with BuildOperationTester, which has a number of APIs for building up a human readable build transcript.
+        Attachment.record(ByteString(encodingAsUTF8: loggedEvents.joined(separator: "\n")).bytes, named: "Event Log" + (name.map({ " for Build Operation \"\($0)\"" }) ?? ""))
+        Attachment.record(ByteString(encodingAsUTF8: diagnostics.map({ $0.description }).joined(separator: "\n")).bytes, named: "Diagnostics" + (name.map({ " for Build Operation \"\($0)\"" }) ?? ""))
+        Attachment.record(events.allOutput().bytes.bytes, named: "Output" + (name.map({ " for Build Operation \"\($0)\"" }) ?? ""))
 
-            let results = CoreQualificationTesterResults(events: events, diagnostics: diagnostics, fs: fs)
+        let results = CoreQualificationTesterResults(events: events, diagnostics: diagnostics, fs: fs)
 
-            defer {
-                let validationResults = results.validate(sourceLocation: sourceLocation)
+        defer {
+            let validationResults = results.validate(sourceLocation: sourceLocation)
 
-                // Print the event log in the case of unchecked errors/warnings, which is useful on platforms where XCTAttachment doesn't exist
-                if validationResults.hadUncheckedErrors || validationResults.hadUncheckedWarnings {
-                    Issue.record("Build failed with unchecked errors and/or warnings; event log follows:\n\n\(loggedEvents.joined(separator: "\n"))", sourceLocation: sourceLocation)
-                }
+            // Print the event log in the case of unchecked errors/warnings, which is useful on platforms where XCTAttachment doesn't exist
+            if validationResults.hadUncheckedErrors || validationResults.hadUncheckedWarnings {
+                Issue.record("Build failed with unchecked errors and/or warnings; event log follows:\n\n\(loggedEvents.joined(separator: "\n"))", sourceLocation: sourceLocation)
             }
+        }
 
-            try await block(results)
-        //}
+        try await block(results)
     }
 }
 
@@ -430,6 +428,10 @@ extension Array where Element == SwiftBuildMessage {
             case let .output(message):
                 if let output = _filterDiagnostic(message: String(decoding: message.data, as: UTF8.self)) {
                     consoleOutput <<< output
+                    // If this event doesn't end with a newline then add one, so the output text doesn't end up with a unrelated elements together on a single line.
+                    if let lastChar = output.last, lastChar != "\n" {
+                        consoleOutput  <<< "\n"
+                    }
                 }
             default:
                 break

--- a/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -232,7 +232,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
                 let startBuilds = WaitCondition()
                 let buildsDone = WaitCondition()
 
-                // The threads this test spawns to run the build can outlive the lifetime of the test itself, so it passed attachBuildArifacts = false since if that happens then the test might crash because the reporter needed to add the attachments will no longer exist.
+                // The threads this test spawns to run the build can outlive the lifetime of the test itself, so it passed attachBuildArtifacts = false since if that happens then the test might crash because the reporter needed to add the attachments will no longer exist.
 
                 // build1 cancels immediately
                 _Concurrency.Task<Void, Never> {
@@ -241,7 +241,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
                         tester.userPreferences = prefs
 
-                        try await tester.checkBuild(runDestination: .host, attachBuildArifacts: false, body: { results in
+                        try await tester.checkBuild(runDestination: .host, attachBuildArtifacts: false, body: { results in
                             results.checkCapstoneEvents(last: .buildCancelled)
                         }) { operation in
                             build1Ready.signal()
@@ -269,7 +269,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
 
                         tester.userPreferences = prefs
 
-                        try await tester.checkBuild(runDestination: .host, attachBuildArifacts: false, body: { results in
+                        try await tester.checkBuild(runDestination: .host, attachBuildArtifacts: false, body: { results in
                             #expect(results.events.first! == .buildStarted)
 
                             let waitTask = try #require(results.getTask(.matchRule(["wait"])))
@@ -333,7 +333,7 @@ fileprivate struct BuildTaskBehaviorTests: CoreBasedTests {
                 tester2.userPreferences = prefs
 
                 func runBuild(_ tester: BuildOperationTester, started: WaitCondition, waits: WaitCondition) async throws {
-                    try await tester.checkBuild(runDestination: .host, attachBuildArifacts: false, body: { results in
+                    try await tester.checkBuild(runDestination: .host, attachBuildArtifacts: false, body: { results in
                         // Each build must run its wait task to completion (i.e. it
                         // actually drove the engine, rather than being cancelled).
                         let waitTask = try #require(results.getTask(.matchRule(["wait"])))

--- a/Tests/SwiftBuildTests/DriverKitTests.swift
+++ b/Tests/SwiftBuildTests/DriverKitTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -91,7 +91,7 @@ fileprivate struct DriverKitTests: CoreBasedTests {
                 try fs.createDirectory(SRCROOT.join("aProject"), recursive: true)
                 try fs.write(SRCROOT.join("aProject/foo.c"), contents: "int main() { return 0; }")
 
-                try await tester.checkBuild(SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyMac, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
+                try await tester.checkBuild(name: "Any Mac", SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyMac, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
                     results.checkNoDiagnostics()
                     results.checkNoFailedTasks()
 
@@ -105,7 +105,7 @@ fileprivate struct DriverKitTests: CoreBasedTests {
                     }
                 }
 
-                try await tester.checkBuild(SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyiOSDevice, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
+                try await tester.checkBuild(name: "Any iOS Device", SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyiOSDevice, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
                     results.checkNoDiagnostics()
                     results.checkNoFailedTasks()
 
@@ -119,7 +119,7 @@ fileprivate struct DriverKitTests: CoreBasedTests {
                     }
                 }
 
-                try await tester.checkBuild(SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyiOSSimulator, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
+                try await tester.checkBuild(name: "Any iOS Simulator", SWBBuildParameters(configuration: "Debug", activeRunDestination: .anyiOSSimulator, overrides: ["AD_HOC_CODE_SIGNING_ALLOWED": "YES"]), delegate: DriverKitBuildOperationDelegate()) { results in
                     results.checkNoDiagnostics()
                     results.checkNoFailedTasks()
 


### PR DESCRIPTION
Also add a name parameter so tests which run multiple builds can disambiguate their attachments.

And fix typo in `BuildOperationTester.checkBuild()` parameter `attachBuildArifacts`.