### PR TITLE
Introduce a new linux-musl platform and avoid linking relocatable objects when we target it

### DIFF
--- a/Sources/SWBGenericUnixPlatform/Plugin.swift
+++ b/Sources/SWBGenericUnixPlatform/Plugin.swift
@@ -89,6 +89,7 @@ struct GenericUnixPlatformSpecsExtension: SpecificationsExtension {
     func specificationDomains() -> [String: [String]] {
         [
             "linux": ["generic-unix"],
+            "staticlinux": ["linux"],
             "freebsd": ["generic-unix"],
             "openbsd": ["generic-unix"],
         ]
@@ -97,7 +98,7 @@ struct GenericUnixPlatformSpecsExtension: SpecificationsExtension {
 
 struct GenericUnixPlatformInfoExtension: PlatformInfoExtension {
     func additionalPlatforms(context: any PlatformInfoExtensionAdditionalPlatformsContext) throws -> [(path: Path, data: [String: PropertyListItem])] {
-        return try OperatingSystem.createFallbackSystemToolchains.compactMap { operatingSystem in
+        var platforms: [(path: Path, data: [String: PropertyListItem])] = try OperatingSystem.createFallbackSystemToolchains.compactMap { operatingSystem in
             // Only create platforms if the host OS allows a fallback toolchain, or we're cross compiling.
             guard operatingSystem.createFallbackSystemToolchain || operatingSystem != context.hostOperatingSystem else {
                 return nil
@@ -112,14 +113,28 @@ struct GenericUnixPlatformInfoExtension: PlatformInfoExtension {
                 "IsDeploymentPlatform": .plString("YES"),
             ])
         }
+        platforms.append(
+            (.root, [
+                "Type": .plString("Platform"),
+                "Name": .plString("staticlinux"),
+                "Identifier": .plString("staticlinux"),
+                "Description": .plString("staticlinux"),
+                "FamilyName": .plString("Static Linux"),
+                "FamilyIdentifier": .plString("staticlinux"),
+                "IsDeploymentPlatform": .plString("YES"),
+            ])
+        )
+        return platforms
     }
 
     func platformName(triple: LLVMTriple) -> String? {
         switch triple.system {
-        case "linux" where triple.environment?.hasPrefix("gnu") == true || triple.environment == "musl",
+        case "linux" where triple.environment?.hasPrefix("gnu") == true,
             "freebsd",
             "openbsd":
             return triple.system
+        case "linux" where triple.environment == "musl":
+            return "staticlinux"
         default:
             return nil
         }

--- a/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/Unix.xcspec
@@ -92,5 +92,19 @@
         Extensions = (so);
         IsLibrary = YES;
         IsDynamicLibrary = YES;
-    }
+    },
+
+    {
+        Domain = staticlinux;
+        Type = ProductType;
+        Identifier = org.swift.product-type.common.object;
+        BasedOn = org.swift.product-type.library.object;
+    },
+
+    {
+        Domain = staticlinux;
+        Type = ProductType;
+        Identifier = org.swift.product-type.library.static;
+        BasedOn = org.swift.product-type.library.object;
+    },
 )

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -926,6 +926,7 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
         case staticFramework
         case staticLibrary
         case objectFile
+        case commonObject
         case objectLibrary
         case dynamicLibrary
         case bundle
@@ -969,6 +970,8 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
                 return "com.apple.product-type.library.static"
             case .objectFile:
                 return "com.apple.product-type.objfile"
+            case .commonObject:
+                return "org.swift.product-type.common.object"
             case .objectLibrary:
                 return "org.swift.product-type.library.object"
             case .dynamicLibrary:
@@ -1040,6 +1043,8 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
                 return "lib\(name).a"
             case .objectFile:
                 return "\(name).o"
+            case .commonObject:
+                return "$(EXECUTABLE_NAME)"
             case .objectLibrary:
                 return "\(name).objlib"
             case .dynamicLibrary:

--- a/Tests/SWBBuildServiceTests/BuildServiceTests.swift
+++ b/Tests/SWBBuildServiceTests/BuildServiceTests.swift
@@ -69,7 +69,7 @@ fileprivate struct BuildServiceTests: CoreBasedTests {
 
         // Linux
         .init(triple: "aarch64-unknown-linux-gnu", platformName: "linux", buildProductsDirectorySuffix: "-linux-aarch64", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
-        .init(triple: "x86_64-unknown-linux-musl", platformName: "linux", buildProductsDirectorySuffix: "-linux-x86_64", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
+        .init(triple: "x86_64-unknown-linux-musl", platformName: "staticlinux", buildProductsDirectorySuffix: "-staticlinux-x86_64", sdkVariant: nil, deploymentTargetSettingName: nil, deploymentTarget: nil),
 
         // Android
         .init(triple: "aarch64-unknown-linux-android24", platformName: "android", buildProductsDirectorySuffix: "-android-aarch64", sdkVariant: nil, deploymentTargetSettingName: "ANDROID_DEPLOYMENT_TARGET", deploymentTarget: "24"),

--- a/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/HostBuildToolTaskConstructionTests.swift
@@ -283,7 +283,7 @@ fileprivate struct HostBuildToolTaskConstructionTests: CoreBasedTests {
                             "Debug",
                             buildSettings: [
                                 "SDKROOT": "auto",
-                                "SUPPORTED_PLATFORMS": "linux"
+                                "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)"
                             ]),
                     ], buildPhases: [
                         TestSourcesBuildPhase(["frame.swift"])

--- a/Tests/StaticLinuxSDKIntegrationTests/StaticLinuxSDKIntegrationTests.swift
+++ b/Tests/StaticLinuxSDKIntegrationTests/StaticLinuxSDKIntegrationTests.swift
@@ -97,10 +97,141 @@ fileprivate struct StaticLinuxSDKIntegrationTests: CoreBasedTests {
                     return
                 }
 
-                let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug-linux-\(hostArch)").join("tool").str), arguments: [])
+                let executionResult = try await Process.getOutput(url: URL(fileURLWithPath: projectDir.join("build").join("Debug-staticlinux-\(hostArch)").join("tool").str), arguments: [])
                 #expect(executionResult.exitStatus == .exit(0))
                 #expect(String(decoding: executionResult.stdout, as: UTF8.self) == "Hello from Static Linux!\n")
                 #expect(String(decoding: executionResult.stderr, as: UTF8.self) == "")
+            }
+        }
+    }
+
+    // Regression test for https://github.com/swiftlang/swift-package-manager/issues/10237
+    @Test(.requireSDKs(.host), .requiresStaticLinuxSwiftSDK, .skipXcodeToolchain)
+    func cxxabiStaticLinking() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let testProject = try await TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("main.swift"),
+                        TestFile("bridging.h"),
+                        TestFile("cxx1.cpp"),
+                        TestFile("cxx2.cpp"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "auto",
+                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                        "SWIFT_VERSION": swiftVersion,
+                        "LINKER_DRIVER": "auto",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "tool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "SWIFT_OBJC_BRIDGING_HEADER": "$(SRCROOT)/bridging.h",
+                            ])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                            TestFrameworksBuildPhase([
+                                TestBuildFile(.target("cxx1")),
+                                TestBuildFile(.target("cxx2")),
+                            ])
+                        ],
+                        dependencies: [
+                            "cxx1",
+                            "cxx2",
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "cxx1",
+                        type: .commonObject,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug")
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["cxx1.cpp"]),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "cxx2",
+                        type: .commonObject,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug")
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["cxx2.cpp"]),
+                        ]
+                    ),
+                ])
+
+            let core = try await Self.getSwiftSDKIntegrationTestingCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("main.swift")) { stream in
+                stream <<< """
+                    #if canImport(Musl)
+                    print("Hello from Static Linux! \\(cxx1() + cxx2())")
+                    #else
+                    #error("should not be active")
+                    #endif
+                """
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("bridging.h")) { stream in
+                stream <<< """
+                    int cxx1(void);
+                    int cxx2(void);
+                """
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("cxx1.cpp")) { stream in
+                stream <<< """
+                    extern "C" int cxx1() {
+                        try {
+                            throw 1;
+                        } catch (...) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                """
+            }
+
+            try await tester.fs.writeFileContents(projectDir.join("cxx2.cpp")) { stream in
+                stream <<< """
+                    extern "C" int cxx2() {
+                        try {
+                            throw 2;
+                        } catch (...) {
+                            return 2;
+                        }
+                        return 0;
+                    }
+                """
+            }
+
+            let hostArch = try {
+                let arch = try #require(Architecture.hostStringValue)
+                if arch == "arm64" {
+                    return "aarch64"
+                }
+                return arch
+            }()
+            let triple = "\(hostArch)-swift-linux-musl"
+            let swiftSDK = try #require(await core.findStaticLinuxSwiftSDK())
+            let destination = try RunDestinationInfo(sdkManifestPath: swiftSDK.manifestPath, triple: triple, targetArchitecture: hostArch, supportedArchitectures: [hostArch], disableOnlyActiveArch: false, core: core)
+            try await tester.checkBuild(runDestination: destination) { results in
+                results.checkNoErrors()
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift-package-manager/issues/10237

Use a distinct platform for targeting linux-musl triples, whose spec domain inherits from the existing linux platform. This allows us to override some of the product types, and should also make it easier to model linux -> linux cross compilation in some edge cases.

In the immediate term, this change is motivated by the fact that the linux-musl triple unconditionally configures clang to include -lc++abi on link lines, which is incompatible with linking relocatable objects. Instead, we build object libraries for SwiftPM targets like we're already doing on a few other platforms.

Targeting this to main for now, and I'll cherrypick to 6.4 later unless we come up with a better approach