### PR TITLE
Drop x86_64 from simulator builds at deployment targets 27+

### DIFF
--- a/Sources/SWBApplePlatform/Specs/iOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/iOSSimulator.xcspec
@@ -30,6 +30,7 @@
         Identifier = x86_64;
         PerArchBuildSettingName = "Intel 64-bit";
         SortNumber = 106;
+        DeploymentTargetRange = ( "0", "27" );
     },
 
     {

--- a/Sources/SWBApplePlatform/Specs/tvOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/tvOSSimulator.xcspec
@@ -30,6 +30,7 @@
         Identifier = x86_64;
         PerArchBuildSettingName = "Intel 64-bit";
         SortNumber = 106;
+        DeploymentTargetRange = ( "0", "27" );
     },
 
 

--- a/Sources/SWBApplePlatform/Specs/watchOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/watchOSSimulator.xcspec
@@ -38,6 +38,7 @@
         Identifier = x86_64;
         PerArchBuildSettingName = "Intel 64-bit";
         SortNumber = 106;
+        DeploymentTargetRange = ( "0", "27" );
     },
 
     {

--- a/Sources/SWBApplePlatform/Specs/xrOSSimulator.xcspec
+++ b/Sources/SWBApplePlatform/Specs/xrOSSimulator.xcspec
@@ -30,6 +30,7 @@
         Identifier = x86_64;
         PerArchBuildSettingName = "Intel 64-bit";
         SortNumber = 106;
+        DeploymentTargetRange = ( "0", "27" );
     },
 
     {

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -4961,6 +4961,25 @@ import SWBTestSupport
         }
     }
 
+    @Test(.requireSDKs(.iOS), .requireXcode27())
+    func activeRunDestination_Simulator_x86_64ClampedAtDefaultDeploymentTarget() async throws {
+        // Build all standard archs. The clamp then drops x86_64 from a simulator build at the
+        // default (>= 27) deployment target.
+        try await testActiveRunDestinationiOS(extraBuildSettings: [
+            "ONLY_ACTIVE_ARCH": "NO",
+        ], runDestination: .iOSSimulator) { context, settings, scope throws in
+            #expect(settings.errors == [])
+            #expect(settings.warnings == [])
+            #expect(scope.evaluate(BuiltinMacros.PLATFORM_NAME) == "iphonesimulator")
+            #expect(scope.evaluate(BuiltinMacros.PLATFORM_FAMILY_NAME) == "iOS")
+            #expect(scope.evaluate(BuiltinMacros.SDKROOT) == context.sdkRegistry.lookup("iphonesimulator")?.path)
+            #expect(!scope.evaluate(BuiltinMacros.ONLY_ACTIVE_ARCH))
+            #expect(scope.evaluate(BuiltinMacros.ARCHS) == ["arm64"])
+            try #require(scope.evaluate(try scope.namespace.declareStringMacro("x86_64")) == "")
+            try #require(scope.evaluate(try scope.namespace.declareStringMacro("arm64")) == "YES")
+        }
+    }
+
     @Test(.requireSDKs(.macOS), .requireXcode26())
     func activeRunDestination_ONLY_ACTIVE_ARCH_interaction() async throws {
         // Prefer the run destination's targetArchitecture


### PR DESCRIPTION
Mirrors the existing macOS x86_64 clamp for the iOS, tvOS, watchOS, and visionOS simulators. Adds a test covering the clamped behavior.

resolves: rdar://179972645

assisted by Claude Opus 4.8