### PR TITLE
Enable IPI library level verification

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -116,7 +116,7 @@
             {
                 Name = "SWIFT_ENABLE_IPI_LIBRARY_LEVEL";
                 Type = Boolean;
-                DefaultValue = NO;
+                DefaultValue = YES;
             },
             {
                 Name = "SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES";

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4141,9 +4141,10 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             task.checkCommandLineContains(["-library-level", "ipi"])
         }
 
-        // Don't infer "ipi" from SKIP_INSTALL when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is NO (default).
+        // Don't infer "ipi" from SKIP_INSTALL when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is explicitly NO.
         try await checkLibraryLevelForConfig(targetType: .framework,
-                                             buildSettings: ["SKIP_INSTALL" : "YES"]) { task in
+                                             buildSettings: ["SKIP_INSTALL" : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "NO"]) { task in
             task.checkCommandLineDoesNotContain("-library-level")
         }
 


### PR DESCRIPTION
Currently, incorrect imports are diagnosed as warning; this feature is not source breaking.

rdar://181266286

_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
