### PR TITLE
[6.4] GHA: Add a build-verdicts workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -130,3 +130,33 @@ jobs:
         uses: actions/checkout@v4
       - name: Run space format check
         run: cat .github/scripts/format-check.sh | bash
+
+  build-verdicts:
+    name: Build Verdicts
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - tests_without_docker
+      - cmake-smoke-test
+      - wasm-integration-tests
+      - static-linux-sdk-integration-tests
+      - swiftpm-self-hosted-tests
+      - soundness
+      - space-format-check
+    if: always()  # Runs even if previous jobs fail so it can evaluate them
+    steps:
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends coreutils jq
+      - name: Check upstream job statuses
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed=$(printf '%s' "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result != "success")) | .[] | "\(.key): \(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "The following required jobs did not succeed:"
+            printf '%s\n' "$failed"
+            exit 1
+          fi
+          echo "All required jobs passed successfully!"


### PR DESCRIPTION
Add a build-verdict workflow that will emit a message to the console when all required jobs have failed.  Doing so will allow the define a single job as required in the project settings.