### PR TITLE
Restrict fine grained compilation caching to supported object file formats

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1048,6 +1048,7 @@ public final class BuiltinMacros {
     public static let PLATFORM_REQUIRES_SWIFT_MODULEWRAP = BuiltinMacros.declareBooleanMacro("PLATFORM_REQUIRES_SWIFT_MODULEWRAP")
     public static let RPATH_ORIGIN = BuiltinMacros.declareStringMacro("RPATH_ORIGIN")
     public static let PLATFORM_USES_DSYMS = BuiltinMacros.declareBooleanMacro("PLATFORM_USES_DSYMS")
+    public static let PLATFORM_SUPPORTS_MCCAS = BuiltinMacros.declareBooleanMacro("PLATFORM_SUPPORTS_MCCAS")
     public static let SWIFTC_PASS_SDKROOT = BuiltinMacros.declareBooleanMacro("SWIFTC_PASS_SDKROOT")
     public static let SWIFTC_PASS_SYSROOT = BuiltinMacros.declareBooleanMacro("SWIFTC_PASS_SYSROOT")
     public static let SWIFT_ABI_CHECKER_BASELINE_DIR = BuiltinMacros.declareStringMacro("SWIFT_ABI_CHECKER_BASELINE_DIR")
@@ -2312,6 +2313,7 @@ public final class BuiltinMacros {
         PLATFORM_REQUIRES_SWIFT_MODULEWRAP,
         RPATH_ORIGIN,
         PLATFORM_USES_DSYMS,
+        PLATFORM_SUPPORTS_MCCAS,
         SWIFTC_PASS_SDKROOT,
         SWIFTC_PASS_SYSROOT,
         SWIFT_ABI_CHECKER_BASELINE_DIR,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2742,6 +2742,7 @@ private class SettingsBuilder: ProjectMatchLookup {
                 sdkTable.push(BuiltinMacros.RPATH_ORIGIN, literal: origin)
             }
             sdkTable.push(BuiltinMacros.PLATFORM_USES_DSYMS, literal: imageFormat.usesDsyms)
+            sdkTable.push(BuiltinMacros.PLATFORM_SUPPORTS_MCCAS, literal: imageFormat.supportsMCCAS)
         }
 
         // Add additional SDK default settings.

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1363,7 +1363,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             additionalSignatureData += "|\(explicitModulesSignatureData)"
         }
 
-        let fineGrainedCacheEnabled = cbc.scope.evaluate(BuiltinMacros.CLANG_CACHE_FINE_GRAINED_OUTPUTS) == .enabled
+        let fineGrainedCacheEnabled = cbc.scope.evaluate(BuiltinMacros.CLANG_CACHE_FINE_GRAINED_OUTPUTS) == .enabled && cbc.scope.evaluate(BuiltinMacros.PLATFORM_SUPPORTS_MCCAS)
 
         if fineGrainedCacheEnabled, let casOptions = explicitModulesPayload?.casOptions, !casOptions.hasRemoteCache {
             commandLine += ["-Xclang", "-fcas-backend"]

--- a/Sources/SWBUtil/ProcessInfo.swift
+++ b/Sources/SWBUtil/ProcessInfo.swift
@@ -426,6 +426,15 @@ extension ImageFormat {
             return false
         }
     }
+
+    public var supportsMCCAS: Bool {
+        switch self {
+        case .macho:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 extension FixedWidthInteger {

--- a/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
@@ -133,4 +133,47 @@ fileprivate struct CompilationCachingTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.host))
+    func imageFormatMCCASSupport() async throws {
+        let core = try await getCore()
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("SourceFile.c"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "CC": clangCompilerPath.str,
+                    "CLANG_ENABLE_MODULES": "YES",
+                    "CLANG_ENABLE_COMPILE_CACHE": "YES",
+                    "CLANG_CACHE_FINE_GRAINED_OUTPUTS": "YES",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Tool",
+                    type: .commandLineTool,
+                    buildConfigurations: [TestBuildConfiguration("Debug")],
+                    buildPhases: [TestSourcesBuildPhase(["SourceFile.c"])]
+                ),
+            ])
+        let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+        let tester = try TaskConstructionTester(core, testWorkspace)
+
+        try await tester.checkBuild(runDestination: .host) { results in
+            try results.checkTarget("Tool") { target in
+                try results.checkTask(.matchTarget(target), .matchRuleType("CompileC")) { task in
+                    if core.hostOperatingSystem == .macOS {
+                        task.checkCommandLineContainsUninterrupted(["-Xclang", "-fcas-backend"])
+                    } else {
+                        task.checkCommandLineDoesNotContain("-fcas-backend")
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Otherwise it gets enabled by default and the compiler errors out when passed a non-MachO triple