### PR TITLE
[6.4.x] Fix product type checks in package diamond resolution

### DIFF
--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -866,7 +866,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                 }
                 // Check whether this actually links statically.
                 let settings = getTargetSettings(packageTargetTarget)
-                return settings.productType?.identifier == "com.apple.product-type.objfile"
+                return settings.productType?.conformsTo(identifier: "com.apple.product-type.objfile") == true
             }
 
             for product in linkedPackageProducts {
@@ -881,7 +881,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                     return false
                 }
                 // Check whether this actually links statically.
-                return getTargetSettings($0.target).productType?.identifier == "com.apple.product-type.objfile"
+                return getTargetSettings($0.target).productType?.conformsTo(identifier: "com.apple.product-type.objfile") == true
             }
 
             for target in linkedPackageTargets {

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -925,6 +925,7 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
         case framework
         case staticFramework
         case staticLibrary
+        case swiftPMStaticTarget
         case objectFile
         case commonObject
         case objectLibrary
@@ -968,6 +969,8 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
                 return "com.apple.product-type.framework.static"
             case .staticLibrary:
                 return "com.apple.product-type.library.static"
+            case .swiftPMStaticTarget:
+                return "org.swift.product-type.library.static"
             case .objectFile:
                 return "com.apple.product-type.objfile"
             case .commonObject:
@@ -1041,7 +1044,7 @@ package final class TestStandardTarget: TestInternalTarget, Sendable {
                 return "\(name).framework"
             case .staticLibrary:
                 return "lib\(name).a"
-            case .objectFile:
+            case .objectFile, .swiftPMStaticTarget:
                 return "\(name).o"
             case .commonObject:
                 return "$(EXECUTABLE_NAME)"

--- a/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildDescriptionConstructionTests.swift
@@ -340,7 +340,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
             ),
         ] + ((packageTarget != nil) ? [] : [
             TestStandardTarget("\(packageTargetName)",
-                               type: .objectFile,
+                               type: .swiftPMStaticTarget,
                                buildConfigurations: [
                                 // Targets need to opt-in to specialization.
                                 TestBuildConfiguration("Debug", buildSettings: [
@@ -505,7 +505,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                     TestBuildFile(.target("PackageLib")), TestBuildFile(.target("Utility")), TestBuildFile(.target("PackageLibProduct2")), TestBuildFile(.target("Mock"))]) ],
                                 dependencies: ["PackageLib", "Utility", "PackageLibProduct2", "Mock"]
                             ),
-                            TestStandardTarget("PackageLib", type: .objectFile),
+                            TestStandardTarget("PackageLib", type: .swiftPMStaticTarget),
                             TestStandardTarget(
                                 "PackageLibProduct2",
                                 type: .framework,
@@ -521,8 +521,8 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                     TestBuildFile(.target("PackageLib2")), TestBuildFile(.target("Utility"))]) ],
                                 dependencies: ["PackageLib2", "Utility"]
                             ),
-                            TestStandardTarget("PackageLib2", type: .objectFile),
-                            TestStandardTarget("Utility", type: .objectFile, buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: ["PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME": (conflictsWithPackageProduct ? "YES" : "NO")])], dynamicTargetVariantName: offerDynamicVariant ? "Utility-dynamic" : ""),
+                            TestStandardTarget("PackageLib2", type: .swiftPMStaticTarget),
+                            TestStandardTarget("Utility", type: .swiftPMStaticTarget, buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: ["PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME": (conflictsWithPackageProduct ? "YES" : "NO")])], dynamicTargetVariantName: offerDynamicVariant ? "Utility-dynamic" : ""),
                             TestStandardTarget("Utility-dynamic", type: .framework),
                             TestPackageProductTarget("Mock", frameworksBuildPhase: TestFrameworksBuildPhase()),
                         ]
@@ -714,7 +714,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                                     dependencies: ["PackageLib", "SecondPackageLibProduct"]
                                                 ),
                                                 TestStandardTarget(
-                                                    "PackageLib", type: .objectFile,
+                                                    "PackageLib", type: .swiftPMStaticTarget,
                                                     buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "PackageLib",])],
                                                     buildPhases: [TestFrameworksBuildPhase([
                                                         TestBuildFile(.target("SecondPackageLibProduct"))]),
@@ -735,7 +735,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                                     ],
                                                     dependencies: ["SecondPackageLib"]
                                                 ),
-                                                TestStandardTarget("SecondPackageLib", type: .objectFile,
+                                                TestStandardTarget("SecondPackageLib", type: .swiftPMStaticTarget,
                                                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "SecondPackageLib",])], buildPhases: [TestSourcesBuildPhase([TestBuildFile("test.c")])]),
                                             ]
                                                               ),
@@ -837,7 +837,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                                                     ],
                                                                     dependencies: ["SecondPackageLib"]
                                                                 ),
-                                                                TestStandardTarget("SecondPackageLib", type: .objectFile,
+                                                                TestStandardTarget("SecondPackageLib", type: .swiftPMStaticTarget,
                                                                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "SecondPackageLib",])], buildPhases: [TestSourcesBuildPhase([TestBuildFile("test.c")])]),
                                                                ]
                                                               )]
@@ -928,7 +928,7 @@ fileprivate struct BuildDescriptionConstructionTests: CoreBasedTests {
                                                                 ],
                                                                 dependencies: ["PackageLib"]
                                                             ),
-                                                            TestStandardTarget("PackageLib", type: .objectFile),
+                                                            TestStandardTarget("PackageLib", type: .swiftPMStaticTarget),
                                                         ])
                                                     ])
             let tester = try await BuildOperationTester(getCore(), workspace, simulated: true)


### PR DESCRIPTION
SwiftPM PIF generation now uses a product type which inherits from "com.apple.product-type.objfile" instead, but diamond resolution was checking for an exact match. Instead, this needs to be a conforms-to check to ensure we correctly use dynamic variant when needed. 

This was found during code review in https://github.com/swiftlang/swift-build/pull/1424. This backports a minimal version of the change to 6.4 