### PR TITLE
Update two tests in TaskConstructionTests.swift for Xcode 27.

### DIFF
--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -4958,7 +4958,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
     }
 
     /// Check recursive header search paths.
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .requireXcode26())
     func recursiveHeaderSearchPaths() async throws {
         let testProject = TestProject(
             "aProject",
@@ -4977,6 +4977,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         "HEADER_SEARCH_PATHS": "System/**",
                         "FRAMEWORK_SEARCH_PATHS": "Framework/**",
                         "CLANG_USE_RESPONSE_FILE": "NO",
+                        // Workaround for CI which have Intel hosts.
+                        "MACOSX_DEPLOYMENT_TARGET": "26.0",
                     ]),
             ],
             targets: [

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -1670,14 +1670,14 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         let MACOSX_DEPLOYMENT_TARGET = "26.0"
 
         // MacOS is the only platform where we can create universal binaries
-        let architectures = runDestination == .macOS ?  ["arm64", "x86_64"] : [runDestination.targetArchitecture]
+        let architectures = runDestination.platform == "macosx" ?  ["arm64", "x86_64"] : [runDestination.targetArchitecture]
 
         // Check the debug build.
         let overrides = [
             "ARCHS": architectures.joined(separator: " "),
         ]
 
-        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides), runDestination: runDestination == .macOS ? .anyMac: .host) { results in
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: overrides), runDestination: runDestination.platform == "macosx" ? .anyMac: .host) { results in
             results.consumeTasksMatchingRuleTypes(["CreateBuildDirectory", "Gate", "MkDir", "Touch", "RegisterExecutionPolicyException"])
             results.checkTarget("Tool") { target in
                 let effectivePlatformName = results.builtProductsDirSuffix(target)
@@ -1781,7 +1781,8 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                             task.checkRuleInfo(["Libtool", targetBuildDir.join(libSupportFileName).str, "normal"])
                         }
                         switch runDestination {
-                        case .macOS:
+                        // There are multiple macOS run destinations and not all of them match .macOS, so we check the platform instead.
+                        case _ where runDestination.platform == "macosx":
                             task.checkCommandLine([libtoolPath.str, "-static", "-arch_only", arch, "-D", "-syslibroot", core.loadSDK(.macOS).path.str,
                                                    "-L\(SRCROOT)/build/Debug", "-filelist", targetObjectsPerArchBuildDir.join("Support.LinkFileList").str,
                                                    "-dependency_info", targetObjectsPerArchBuildDir.join("Support_libtool_dependency_info.dat").str,
@@ -1807,7 +1808,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                         ]
                         task.checkInputs(versioningSupported ? inputFiles: Array(inputFiles[1...]))
 
-                        if runDestination == .macOS {
+                        if runDestination.platform == "macosx" {
                             task.checkOutputs([
                                 .path(architectures.count > 1 ? targetObjectsPerArchBuildDir.join("Binary/\(libSupportFileName)").str : targetBuildDir.join(libSupportFileName).str),
                                 .path(targetObjectsPerArchBuildDir.join("Support_libtool_dependency_info.dat").str)
@@ -1858,7 +1859,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
         }
 
         // Check an install release build, with signing enabled.
-        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: .host) { results in
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: runDestination) { results in
             results.checkTarget("Tool") { target in
                 let effectivePlatformName = results.builtProductsDirSuffix(target)
                 let targetBuildDir = Path("\(SRCROOT)/build/Release\(effectivePlatformName)")
@@ -1878,7 +1879,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     }
                 }
 
-                if runDestination == .macOS {
+                if runDestination.platform == "macosx" {
                     // There should be an Info.plist processing task, and associated Preprocess (we explicitly enable it).
                     results.checkTask(.matchTarget(target), .matchRuleType("Preprocess")) { task in
                         task.checkRuleInfo(["Preprocess", targetPerArchBuildBaseDir.join("\(results.runDestinationTargetArchitecture)/Preprocessed-Info.plist").str, "\(SRCROOT)/Tool.plist"])


### PR DESCRIPTION
- Update TaskConstructionTests.toolBasics() for Xcode 27.

    rdar://179852268

- Update TaskConstructionTests.recursiveHeaderSearchPaths() for Xcode 27

    rdar://179852239