### PR TITLE
Update BuildBacktraceTests.backtracesForDeletedOutputs() for Xcode 27

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildBacktraceTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -310,13 +310,14 @@ fileprivate struct BuildBacktraceTests: CoreBasedTests {
                     """
             }
 
-            try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
+            let runDestination = RunDestinationInfo.macOS
+            try await tester.checkBuild(runDestination: runDestination, buildRequest: buildRequest, persistent: true) { results in
                 results.checkNoDiagnostics()
             }
 
-            try tester.fs.remove(SRCROOT.join("build/aProject.build/Debug/TargetFoo.build/Objects-normal/\(RunDestinationInfo.host.targetArchitecture)/foo.o"))
+            try tester.fs.remove(SRCROOT.join("build/aProject.build/Debug/TargetFoo.build/Objects-normal/\(runDestination.targetArchitecture)/foo.o"))
 
-            try await tester.checkBuild(runDestination: .macOS, buildRequest: buildRequest, persistent: true) { results in
+            try await tester.checkBuild(runDestination: runDestination, buildRequest: buildRequest, persistent: true) { results in
                 results.checkNoDiagnostics()
                 results.checkTask(.matchTargetName("TargetFoo"), .matchRuleType("CompileC")) { task in
                     results.checkBacktrace(task, [


### PR DESCRIPTION
rdar://179852131