### PR TITLE
pipe2/dup3 O_CLOEXEC

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -502,7 +502,7 @@ if useLocalDependencies {
 
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.5.0")),
+        .package(url: "https://github.com/apple/swift-system.git", .upToNextMajor(from: "1.7.3")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.3"),
         .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", branch: relatedDependenciesBranch),
     ]

--- a/Sources/SWBCLibc/include/SWBCLibc.h
+++ b/Sources/SWBCLibc/include/SWBCLibc.h
@@ -26,3 +26,16 @@ typedef struct {
 
 int dladdr(void *addr, Dl_info *info);
 #endif
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+
+// Duplicates `fd` onto the lowest-numbered unused file descriptor, atomically
+// setting the close-on-exec flag. Unlike a `dup()` followed by a separate
+// `fcntl(F_SETFD, FD_CLOEXEC)`, this cannot race against a concurrent
+// `fork()`/`exec()` in another thread. Returns the new descriptor, or -1 with
+// `errno` set.
+static inline int swb_dup_cloexec(int fd) {
+    return fcntl(fd, F_DUPFD_CLOEXEC, 0);
+}
+#endif

--- a/Sources/SWBServiceCore/ServiceEntryPoint.swift
+++ b/Sources/SWBServiceCore/ServiceEntryPoint.swift
@@ -34,7 +34,7 @@ extension Service {
         // Immediately capture those into distinct file descriptors, and close the originals.
         let inputFD: FileDescriptor
         do {
-            inputFD = try FileDescriptor.standardInput.duplicate()
+            inputFD = try FileDescriptor.standardInput.safeDuplicate()
         } catch {
             throw StubError.error("unable to dup input stream: \(error)")
         }
@@ -42,7 +42,7 @@ extension Service {
         // Rewire stdout to a stable file descriptor.
         let outputFD: FileDescriptor
         do {
-            outputFD = try FileDescriptor.standardOutput.duplicate()
+            outputFD = try FileDescriptor.standardOutput.safeDuplicate()
         } catch {
             throw StubError.error("unable to dup output stream: \(error)")
         }
@@ -60,14 +60,14 @@ extension Service {
         let nullPath = Path.null
         let nullFd: FileDescriptor
         do {
-            nullFd = try FileDescriptor.open(FilePath(nullPath.str), .readOnly)
+            nullFd = try FileDescriptor.safeOpen(FilePath(nullPath.str), .readOnly)
         } catch {
             throw StubError.error("unable to open \(nullPath.str): \(error)")
         }
 
         // (dup2 closes its 2nd parameter)
         do {
-            _ = try nullFd.duplicate(as: .standardInput)
+            _ = try nullFd.safeDuplicate(as: .standardInput)
         } catch {
             throw StubError.error("unable to dup \(nullPath.str) to stdin: \(error)")
         }
@@ -75,7 +75,7 @@ extension Service {
         // Now remap stdout to stderr, so normal print statements go to the console output stream.
         // (dup2 closes its 2nd parameter)
         do {
-            _ = try FileDescriptor.standardError.duplicate(as: .standardOutput)
+            _ = try FileDescriptor.standardError.safeDuplicate(as: .standardOutput)
         } catch {
             throw StubError.error("unable to dup stderr to stdout: \(error)")
         }

--- a/Sources/SWBUtil/FSProxy.swift
+++ b/Sources/SWBUtil/FSProxy.swift
@@ -503,7 +503,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
     func read(_ path: Path) throws -> ByteString {
         do {
-            let fd = try FileDescriptor.open(FilePath(path.str), .readOnly)
+            let fd = try FileDescriptor.safeOpen(FilePath(path.str), .readOnly)
             return try fd.closeAfter {
                 let data = OutputByteStream()
                 let tmpBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 1 << 12, alignment: 1)
@@ -529,7 +529,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
 
     private func _write(_ path: Path, contents: ByteString, mode: FileDescriptor.AccessMode, options: FileDescriptor.OpenOptions, permissions: FilePermissions?) throws {
         do {
-            let fd = try FileDescriptor.open(FilePath(path.str), mode, options: options, permissions: permissions)
+            let fd = try FileDescriptor.safeOpen(FilePath(path.str), mode, options: options, permissions: permissions)
             _ = try fd.closeAfter {
                 try fd.writeAll(contents)
             }
@@ -547,7 +547,7 @@ class LocalFS: FSProxy, @unchecked Sendable {
     }
 
     func write(_ path: Path, contents: (FileDescriptor) async throws -> Void) async throws {
-        let fd = try FileDescriptor.open(FilePath(path.str), .writeOnly, options: [.create, .truncate], permissions: defaultFilePermissions)
+        let fd = try FileDescriptor.safeOpen(FilePath(path.str), .writeOnly, options: [.create, .truncate], permissions: defaultFilePermissions)
         return try await fd.closeAfter {
             try await contents(fd)
         }

--- a/Sources/SWBUtil/FileDescriptor.swift
+++ b/Sources/SWBUtil/FileDescriptor.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+private import SWBLibc
+
+#if canImport(System)
+public import System
+#else
+public import SystemPackage
+#endif
+
+extension FileDescriptor {
+    /// Opens or creates a file for reading or writing, always marking the
+    /// descriptor close-on-exec so that it is not leaked into child processes.
+    ///
+    /// This is a thin wrapper over `FileDescriptor.open(_:_:options:permissions:retryOnInterrupt:)`
+    /// which forces `.closeOnExec`.
+    public static func safeOpen(_ path: FilePath, _ mode: FileDescriptor.AccessMode, options: FileDescriptor.OpenOptions = FileDescriptor.OpenOptions(), permissions: FilePermissions? = nil, retryOnInterrupt: Bool = true) throws -> FileDescriptor {
+        var options = options
+        options.insert(.closeOnExec)
+        return try open(path, mode, options: options, permissions: permissions, retryOnInterrupt: retryOnInterrupt)
+    }
+
+    /// Creates a pipe, atomically marking both ends close-on-exec where the
+    /// platform supports doing so.
+    ///
+    /// The atomic `pipe2`-based API is used wherever it is available: on non-Apple
+    /// platforms (including Windows) via swift-system's `SystemPackage`, and on
+    /// Apple platforms running an OS new enough to vend the underlying `pipe2`
+    /// syscall via the SDK's `System` framework. On older Apple OSes we fall back
+    /// to a plain `pipe`, which does not set close-on-exec.
+    public static func safePipe() throws -> (readEnd: FileDescriptor, writeEnd: FileDescriptor) {
+        #if canImport(System)
+        // TODO: Enable once we can build against the macOS 27 SDK, which vends
+        // FileDescriptor.pipe(options:).
+        #if false
+        if #available(macOS 27, iOS 27, tvOS 27, watchOS 27, visionOS 27, *) {
+            return try pipe(options: .closeOnExec)
+        }
+        #endif
+        return try pipe()
+        #else
+        return try pipe(options: .closeOnExec)
+        #endif
+    }
+
+    /// Duplicates this file descriptor onto `target`, atomically marking the new
+    /// descriptor close-on-exec where the platform supports doing so.
+    ///
+    /// The atomic `dup3`-based API is used wherever it is available: on non-Apple
+    /// platforms (excluding Windows) via swift-system's `SystemPackage`, and on
+    /// Apple platforms running an OS new enough to vend the underlying `dup3`
+    /// syscall via the SDK's `System` framework. Elsewhere — older Apple OSes and
+    /// Windows, which has no `dup3` — we fall back to a plain `dup2`, which does
+    /// not set close-on-exec.
+    public func safeDuplicate(as target: FileDescriptor, retryOnInterrupt: Bool = true) throws -> FileDescriptor {
+        #if canImport(System)
+        // TODO: Enable once we can build against the macOS 27 SDK, which vends
+        // FileDescriptor.duplicate(as:options:).
+        #if false
+        if #available(macOS 27, iOS 27, tvOS 27, watchOS 27, visionOS 27, *) {
+            return try duplicate(as: target, options: .closeOnExec, retryOnInterrupt: retryOnInterrupt)
+        }
+        #endif
+        return try duplicate(as: target, retryOnInterrupt: retryOnInterrupt)
+        #elseif os(Windows)
+        return try duplicate(as: target, retryOnInterrupt: retryOnInterrupt)
+        #else
+        return try duplicate(as: target, options: .closeOnExec, retryOnInterrupt: retryOnInterrupt)
+        #endif
+    }
+
+    /// Duplicates this file descriptor onto the lowest-numbered unused descriptor,
+    /// marking the new descriptor close-on-exec where the platform supports it.
+    ///
+    /// On non-Windows platforms this uses `fcntl(F_DUPFD_CLOEXEC)`, which obtains
+    /// the new descriptor and sets close-on-exec atomically — a plain `dup()`
+    /// followed by `fcntl(F_SETFD, FD_CLOEXEC)` would race against a concurrent
+    /// `fork()`/`exec()`. On Windows, which has no `F_DUPFD_CLOEXEC`, we fall back
+    /// to a plain `dup`, which does not set close-on-exec.
+    public func safeDuplicate(retryOnInterrupt: Bool = true) throws -> FileDescriptor {
+        #if os(Windows)
+        return try duplicate(retryOnInterrupt: retryOnInterrupt)
+        #else
+        while true {
+            let newValue = swb_dup_cloexec(self.rawValue)
+            if newValue >= 0 {
+                return FileDescriptor(rawValue: newValue)
+            }
+            let error = Errno(rawValue: errno)
+            guard retryOnInterrupt && error == .interrupted else { throw error }
+        }
+        #endif
+    }
+}

--- a/Sources/SWBUtil/IO.swift
+++ b/Sources/SWBUtil/IO.swift
@@ -23,7 +23,7 @@ public struct IOPipe: Sendable {
     public let writeEnd: FileDescriptor
 
     public init() throws {
-        let (readEnd, writeEnd) = try FileDescriptor.pipe()
+        let (readEnd, writeEnd) = try FileDescriptor.safePipe()
         self.readEnd = readEnd
         self.writeEnd = writeEnd
     }

--- a/Sources/SWBUtil/LineReader.swift
+++ b/Sources/SWBUtil/LineReader.swift
@@ -29,7 +29,7 @@ public final class LineReader {
     public init(forReadingFrom url: URL, delimiter: String = "\n", bufferSize: Int = 1024) throws {
         self.delimiter = Data(delimiter.utf8)
         self.bufferSize = bufferSize
-        fileHandle = try FileDescriptor.open(FilePath(url.filePath.str), .readOnly)
+        fileHandle = try FileDescriptor.safeOpen(FilePath(url.filePath.str), .readOnly)
         buffer = Data(capacity: bufferSize)
     }
 

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -157,7 +157,7 @@ fileprivate func isStrippable(_ first_four_bytes: UInt32, _ second_four_bytes: U
 }
 
 fileprivate func isMacho(_ path: Path) throws -> Bool {
-    let src_fd = try FileDescriptor.open(FilePath(path.str), .readOnly)
+    let src_fd = try FileDescriptor.safeOpen(FilePath(path.str), .readOnly)
     let ret = try src_fd.closeAfter { () throws -> Bool in
         return try withUnsafeTemporaryAllocation(byteCount: 16, alignment: 8) { buffer in
             // Read the first chunk of data.  We're assuming we can get the entire Mach-O magic word (4 bytes) in a single read operation (a pretty safe assumption).
@@ -309,9 +309,9 @@ func _copyFile(_ srcPath: Path, _ dstPath: Path) throws {
             // attempting to customize it is unnecessary and will likely be incorrect as security descriptors are far more complex than a simple bitset.
             permissions = nil
         }
-        let dstFd = try FileDescriptor.open(FilePath(dstPath.str), .writeOnly, options: [.create, .truncate], permissions: permissions)
+        let dstFd = try FileDescriptor.safeOpen(FilePath(dstPath.str), .writeOnly, options: [.create, .truncate], permissions: permissions)
         try dstFd.closeAfter {
-            let srcFd = try FileDescriptor.open(FilePath(srcPath.str), .readOnly)
+            let srcFd = try FileDescriptor.safeOpen(FilePath(srcPath.str), .readOnly)
             try srcFd.closeAfter {
                 let tmpBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 1 << 16, alignment: 1)
                 defer { tmpBuffer.deallocate() }

--- a/Sources/SWBUtil/XCBuildDataArchive.swift
+++ b/Sources/SWBUtil/XCBuildDataArchive.swift
@@ -49,10 +49,10 @@ public final class XCBuildDataArchive: Sendable {
         let exists: Bool
         let fd: FileDescriptor
         do {
-            fd = try FileDescriptor.open(FilePath(archiveFilePath.str), .writeOnly, options: [.create, .exclusiveCreate, .exclusiveLock], permissions: FilePermissions([.ownerReadWrite, .groupRead, .otherRead]))
+            fd = try FileDescriptor.safeOpen(FilePath(archiveFilePath.str), .writeOnly, options: [.create, .exclusiveCreate, .exclusiveLock], permissions: FilePermissions([.ownerReadWrite, .groupRead, .otherRead]))
             exists = false
         } catch Errno.fileExists {
-            fd = try FileDescriptor.open(FilePath(archiveFilePath.str), .readWrite, options: [.exclusiveLock])
+            fd = try FileDescriptor.safeOpen(FilePath(archiveFilePath.str), .readWrite, options: [.exclusiveLock])
             exists = true
         }
 


### PR DESCRIPTION
Add `safeOpen` / `safePipe` / `safeDuplicate` helpers on `FileDescriptor` that always request close-on-exec, so descriptors created by the build system are not leaked into the child processes it spawns. They route through the swift-system pipe2/dup3 wrappers where those are available:

- `safePipe` uses `FileDescriptor.pipe(options: .closeOnExec)` on non-Apple platforms (including Windows), and on Apple platforms running OS 27 or later via the SDK's `System` framework; older Apple OSes fall back to a plain `pipe()`.
- `safeDuplicate(as:)` uses `FileDescriptor.duplicate(as:options:)` on non-Apple platforms (dup3 is unavailable on Windows) and on Apple OS 27 or later; elsewhere it falls back to a plain `dup2()`.
- `safeDuplicate()` (no target) uses `fcntl(F_DUPFD_CLOEXEC)` to atomically obtain the lowest-numbered unused descriptor with close-on-exec set; on Windows, which has no `F_DUPFD_CLOEXEC`, it falls back to a plain `dup()`.
- `safeOpen` forces `OpenOptions.closeOnExec`.

Adopt these wrappers in `FSProxy`, `PbxCp`, `XCBuildDataArchive`, `LineReader`, and the build service entry point, and require swift-system 1.7.3 (which exposes `OpenOptions.closeOnExec` on Windows).
