### PR TITLE
Failures in AppShortcutsStringsValidationTests.appShortcutsStringsValidation()

### DIFF
--- a/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
@@ -215,8 +215,8 @@ fileprivate struct AppShortcutsStringsValidationTests: CoreBasedTests {
                 }
                 // 2 Errors for missing application name as the phrases in the app shortcut are combined with the
                 // with the phrases in the strings file.
-                results.checkError(.contains("Invalid Utterance. Every App Shortcut utterance should have one '${applicationName}' in it."))
-                results.checkError(.contains("Invalid Utterance. Every App Shortcut utterance should have one '${applicationName}' in it."))
+                results.checkError(.regex(#/'\${applicationName}'/#))
+                results.checkError(.regex(#/'\${applicationName}'/#))
                 results.checkError(.contains("Command ValidateAppShortcutStringsMetadata failed."), failIfNotFound: false)
             }
 


### PR DESCRIPTION
Switch from comparing the entire string to regex for the required token, to work both before/after the diagnostic string was changed.

Resolves rdar://177031942.