### PR TITLE
Adopt -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls when preparing for indexing

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1109,6 +1109,7 @@ public final class BuiltinMacros {
     public static let SWIFT_INDEX_STORE_PATH = BuiltinMacros.declarePathMacro("SWIFT_INDEX_STORE_PATH")
     public static let SWIFT_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALL_OBJC_HEADER")
     public static let SWIFT_INSTALLAPI_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALLAPI_LAZY_TYPECHECK")
+    public static let SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK")
     public static let SWIFT_DISABLE_HEADERMAPS = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_HEADERMAPS")
     public static let SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_DEFAULT_SEARCH_PATHS_IN_HEADER_SEARCH_PATHS")
     public static let SWIFT_DISABLE_PARSE_AS_LIBRARY = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_PARSE_AS_LIBRARY")
@@ -2382,6 +2383,7 @@ public final class BuiltinMacros {
         SWIFT_INDEX_STORE_PATH,
         SWIFT_INSTALL_OBJC_HEADER,
         SWIFT_INSTALLAPI_LAZY_TYPECHECK,
+        SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK,
         SWIFT_LIBRARIES_ONLY,
         SWIFT_LIBRARY_LEVEL,
         SWIFT_LIBRARY_PATH,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1337,6 +1337,14 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                 let skipFlag = toolSpecInfo.toolFeatures.has(.experimentalSkipAllFunctionBodies) ? "-experimental-skip-all-function-bodies" : "-experimental-skip-non-inlinable-function-bodies"
                 args += ["-Xfrontend", skipFlag]
 
+                if cbc.scope.evaluate(BuiltinMacros.SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK) {
+                    args += ["-Xfrontend", "-experimental-lazy-typecheck"]
+                    if !cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_TESTABILITY) {
+                        // `-enable-testing` is not compatible with '-experimental-skip-non-exportable-decls'.
+                        args += ["-Xfrontend", "-experimental-skip-non-exportable-decls"]
+                    }
+                }
+
                 let allowErrors = toolSpecInfo.toolFeatures.has(.experimentalAllowModuleWithCompilerErrors)
                 if allowErrors {
                     args += ["-Xfrontend", "-experimental-allow-module-with-compiler-errors"]

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -109,6 +109,11 @@
                 DefaultValue = YES;
             },
             {
+                Name = "SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK";
+                Type = Boolean;
+                DefaultValue = YES;
+            },
+            {
                 Name = "SWIFT_SKIP_INSTALLED_HEADER_INTERFACE_VERIFICATION";
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/IndexBuildTaskConstructionTests.swift
@@ -608,6 +608,51 @@ fileprivate struct IndexBuildTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS), .requireXcode26(), arguments: [true, false])
+    func swiftPrepareForIndexLazyTypecheck(enabled: Bool) async throws {
+        let project = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [TestFile("main.swift")]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "CODE_SIGN_IDENTITY": "",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "ALWAYS_SEARCH_USER_PATHS": "NO",
+                    "SWIFT_EXEC": swiftCompilerPath.str,
+                    "SWIFT_VERSION": swiftVersion,
+                    "SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK" : enabled ? "YES" : "NO"
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "AppTarget",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug")
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["main.swift"])
+                    ]),
+            ])
+
+        let tester = try await TaskConstructionTester(getCore(), project)
+        try await tester.checkIndexBuild() { results in
+            results.checkTask(.matchTargetName("AppTarget"), .matchRuleItem("SwiftDriver Compilation Requirements")) { task in
+                if enabled {
+                    task.checkCommandLineContains(["-Xfrontend", "-experimental-lazy-typecheck"])
+                    task.checkCommandLineContains(["-Xfrontend", "-experimental-skip-non-exportable-decls"])
+                } else {
+                    task.checkCommandLineDoesNotContain("-experimental-lazy-typecheck")
+                    task.checkCommandLineDoesNotContain("-experimental-skip-non-exportable-decls")
+                }
+            }
+            results.checkNoDiagnostics()
+        }
+    }
+
     @Test(.requireSDKs(.macOS))
     func swiftIndexBuildWithoutOptimizationOverride() async throws {
         let buildSettings: [String: String] = try await [


### PR DESCRIPTION
SourceKit-LSP's builtin SwiftPM prepare-for-indexing operation has been using these options for a while, introduce an on-by-default setting to match that behavior and roll them out more widely.