### PR TITLE
Remove stale .swiftmodule bundles across build descriptions

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -501,6 +501,39 @@ package final class BuildOperation: BuildSystemOperation {
         let serializationQueue = buildDatabaseSerializationQueue(for: databaseDirectory)
         do {
             return try await serializationQueue.withOperation { [buildEnvironment] in
+
+                if request.enableStaleFileRemoval && request.buildCommand.shouldEnableStaleFileRemoval {
+                    // Group the modules expected by this build description by their platform directory.
+                    var expectedByPlatformDir: [Path: Set<Path>] = [:]
+                    for moduleDir in buildDescription.swiftModuleOutputDirectories {
+                        let platformDir = moduleDir.dirname
+                        expectedByPlatformDir[platformDir, default: []].insert(moduleDir)
+                    }
+
+                    // Remove any .swiftmodule bundles that exist on disk but are no longer
+                    // produced by the current build description.
+                    for (platformDir, expectedModules) in expectedByPlatformDir {
+                        // Skip directories that haven't been created yet 
+                        guard fs.exists(platformDir) else { continue }
+
+                        do {
+                            let contents = try fs.listdir(platformDir)
+                            for item in contents {
+                                guard item.hasSuffix(".swiftmodule") else { continue }
+
+                                let foundPath = platformDir.join(item)
+
+                                if !expectedModules.contains(foundPath) {
+                                    try fs.remove(foundPath)
+                                    buildOutputDelegate.note("Removed stale cross-build swiftmodule: \(foundPath.str)")
+                                }
+                            }
+                        } catch {
+                            buildOutputDelegate.note("Skipped stale swiftmodule cleanup in \(platformDir.str): \(error)")
+                        }
+                    }
+                }
+
                 // If we use a cached build system, be sure to release it on build completion.
                 if userPreferences.enableBuildSystemCaching {
                     // Get the build system to use, keyed by the directory containing the (sole) database.

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -143,6 +143,9 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     /// The set of all (non-virtual) paths produced by tasks in the build description.
     private let allOutputPaths: Set<Path>
 
+    /// The set of planned top-level `.swiftmodule` directory paths.
+    package let swiftModuleOutputDirectories: Set<Path>
+
     private let rootPathsPerTarget: [ConfiguredTarget: [Path]]
     private let moduleCachePathsPerTarget: [ConfiguredTarget: [Path]]
 
@@ -209,11 +212,12 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     package let emitFrontendCommandLines: Bool
 
     /// Load a build description from the given path.
-    fileprivate init(inDir dir: Path, signature: BuildDescriptionSignature, taskStore: FrozenTaskStore, allOutputPaths: Set<Path>, rootPathsPerTarget: [ConfiguredTarget: [Path]], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo], casValidationInfos: [CASValidationInfo], settingsPerTarget: [ConfiguredTarget: Settings], enableStaleFileRemoval: Bool = true, taskActionMap: [String: TaskAction.Type], targetTaskCounts: [ConfiguredTarget: Int], moduleSessionFilePath: Path?, diagnostics: [ConfiguredTarget?: [Diagnostic]], fs: any FSProxy, invalidationPaths: [Path], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult], copiedPathMap: [String: String], targetDependencies: [TargetDependencyRelationship], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>], bypassActualTasks: Bool, targetsBuildInParallel: Bool, emitFrontendCommandLines: Bool) throws {
+    fileprivate init(inDir dir: Path, signature: BuildDescriptionSignature, taskStore: FrozenTaskStore, allOutputPaths: Set<Path>, rootPathsPerTarget: [ConfiguredTarget: [Path]], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo], casValidationInfos: [CASValidationInfo], settingsPerTarget: [ConfiguredTarget: Settings], enableStaleFileRemoval: Bool = true, taskActionMap: [String: TaskAction.Type], targetTaskCounts: [ConfiguredTarget: Int], moduleSessionFilePath: Path?, diagnostics: [ConfiguredTarget?: [Diagnostic]], fs: any FSProxy, invalidationPaths: [Path], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult], copiedPathMap: [String: String], targetDependencies: [TargetDependencyRelationship], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>], bypassActualTasks: Bool, targetsBuildInParallel: Bool, emitFrontendCommandLines: Bool, swiftModuleOutputDirectories: Set<Path>) throws {
         self.dir = dir
         self.signature = signature
         self.taskStore = taskStore
         self.allOutputPaths = allOutputPaths
+        self.swiftModuleOutputDirectories = swiftModuleOutputDirectories
         self.rootPathsPerTarget = rootPathsPerTarget
         self.moduleCachePathsPerTarget = moduleCachePathsPerTarget
         self.artifactInfoPerTarget = artifactInfoPerTarget
@@ -345,7 +349,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     package func serialize<T: Serializer>(to serializer: T) {
         guard serializer.delegate is BuildDescriptionSerializerDelegate else { fatalError("delegate must be a BuildDescriptionSerializerDelegate") }
 
-        serializer.beginAggregate(21)
+        serializer.beginAggregate(22)
         serializer.serialize(dir)
         serializer.serialize(signature)
         // Serialize the tasks first so we can index into this array during deserialization.
@@ -379,6 +383,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         serializer.serialize(targetsBuildInParallel)
         serializer.serialize(emitFrontendCommandLines)
         serializer.serialize(casValidationInfos)
+        serializer.serialize(swiftModuleOutputDirectories)
         serializer.endAggregate()
     }
 
@@ -386,7 +391,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         // Check that we have the appropriate delegate.
         guard let delegate = deserializer.delegate as? BuildDescriptionDeserializerDelegate else { throw DeserializerError.invalidDelegate("delegate must be a BuildDescriptionDeserializerDelegate") }
 
-        try deserializer.beginAggregate(21)
+        try deserializer.beginAggregate(22)
         self.dir = try deserializer.deserialize()
         self.signature = try deserializer.deserialize()
         self.allOutputPaths = try deserializer.deserialize()
@@ -423,6 +428,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         }
         self.taskStore = taskStore
         self.casValidationInfos = try deserializer.deserialize()
+        self.swiftModuleOutputDirectories = try deserializer.deserialize()
     }
 
     package var cost: Int {
@@ -555,6 +561,9 @@ package final class BuildDescriptionBuilder {
 
     private let allOutputPaths: Set<Path>
 
+    /// The set of planned top-level `.swiftmodule` directory paths.
+    package let swiftModuleOutputDirectories: Set<Path>
+
     // The map of root paths per configured target.
     private let rootPathsPerTarget: [ConfiguredTarget: [Path]]
 
@@ -595,6 +604,15 @@ package final class BuildDescriptionBuilder {
         self.copiedPathMap = copiedPathMap
         self.outputPathsPerTarget = outputPathsPerTarget
         self.allOutputPaths = allOutputPaths
+        var moduleDirs = Set<Path>()
+        for path in allOutputPaths {
+            if path.dirname.basename.hasSuffix(".swiftmodule") {
+                moduleDirs.insert(path.dirname)
+            } else if path.basename.hasSuffix(".swiftmodule") {
+                moduleDirs.insert(path)
+            }
+        }
+        self.swiftModuleOutputDirectories = moduleDirs
         self.rootPathsPerTarget = rootPathsPerTarget
         self.moduleCachePathsPerTarget = moduleCachePathsPerTarget
         self.artifactInfoPerTarget = artifactInfoPerTarget
@@ -710,7 +728,7 @@ package final class BuildDescriptionBuilder {
         // Create the build description.
         let buildDescription: BuildDescription
         do {
-            buildDescription = try BuildDescription(inDir: path, signature: signature, taskStore: frozenTaskStore, allOutputPaths: allOutputPaths, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos, settingsPerTarget: settingsPerTarget, taskActionMap: taskActionMap, targetTaskCounts: targetTaskCounts, moduleSessionFilePath: moduleSessionFilePath, diagnostics: diagnosticsEngines.mapValues { engine in engine.diagnostics }, fs: fs, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, bypassActualTasks: bypassActualTasks, targetsBuildInParallel: targetsBuildInParallel, emitFrontendCommandLines: emitFrontendCommandLines)
+            buildDescription = try BuildDescription(inDir: path, signature: signature, taskStore: frozenTaskStore, allOutputPaths: allOutputPaths, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos, settingsPerTarget: settingsPerTarget, taskActionMap: taskActionMap, targetTaskCounts: targetTaskCounts, moduleSessionFilePath: moduleSessionFilePath, diagnostics: diagnosticsEngines.mapValues { engine in engine.diagnostics }, fs: fs, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, bypassActualTasks: bypassActualTasks, targetsBuildInParallel: targetsBuildInParallel, emitFrontendCommandLines: emitFrontendCommandLines, swiftModuleOutputDirectories: self.swiftModuleOutputDirectories)
         }
         catch {
             throw StubError.error("unable to create build description: \(error)")

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -8190,4 +8190,124 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
             }
         }
     }
+
+    @Test(.requireSDKs(.host))
+    func staleSwiftModuleBundlesAreCleanedBetweenBuildDescriptions() async throws {
+        try await withTemporaryDirectory { tmpDirPath async throws -> Void in
+            let core = try await getCore()
+            let sourceRoot = tmpDirPath.join("Test")
+            let projectDir = sourceRoot.join("aProject")
+
+            func makeWorkspace(includeIntermediateTargets: Bool) async throws -> TestWorkspace {
+                let settings: [String: String] = await [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "SWIFT_VERSION": try swiftVersion,
+                    "DEFINES_MODULE": "YES",
+                    "SDKROOT": "$(HOST_PLATFORM)",
+                    "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                    "CODE_SIGNING_ALLOWED": "NO"
+                ]
+
+                return TestWorkspace(
+                    "Test",
+                    sourceRoot: sourceRoot,
+                    projects: [
+                        TestProject(
+                            "aProject",
+                            groupTree: TestGroup(
+                                "Sources",
+                                children: [
+                                    TestFile("App.swift"),
+                                    TestFile("Middle.swift"),
+                                    TestFile("Leaf.swift"),
+                                ]
+                            ),
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug", buildSettings: settings)
+                            ],
+                            targets: includeIntermediateTargets ? [
+                                TestStandardTarget(
+                                    "App",
+                                    type: .commandLineTool,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: settings)],
+                                    buildPhases: [TestSourcesBuildPhase(["App.swift"])],
+                                    dependencies: ["MiddleLib"]
+                                ),
+                                TestStandardTarget(
+                                    "MiddleLib",
+                                    type: .staticLibrary,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: settings)],
+                                    buildPhases: [TestSourcesBuildPhase(["Middle.swift"])],
+                                    dependencies: ["LeafLib"]
+                                ),
+                                TestStandardTarget(
+                                    "LeafLib",
+                                    type: .staticLibrary,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: settings)],
+                                    buildPhases: [TestSourcesBuildPhase(["Leaf.swift"])]
+                                ),
+                            ] : [
+                                TestStandardTarget(
+                                    "App",
+                                    type: .commandLineTool,
+                                    buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: settings)],
+                                    buildPhases: [TestSourcesBuildPhase(["App.swift"])]
+                                )
+                            ]
+                        )
+                    ]
+                )
+            }
+
+            try localFS.createDirectory(projectDir, recursive: true)
+
+            try await localFS.writeFileContents(projectDir.join("App.swift")) { stream in
+                stream <<< """
+                #if canImport(MiddleLib)
+                import MiddleLib
+                #endif
+
+                @main
+                struct Main {
+                    static func main() {}
+                }
+                """
+            }
+
+            try await localFS.writeFileContents(projectDir.join("Middle.swift")) { stream in
+                stream <<< """
+                import LeafLib
+
+                public func middle() {}
+                """
+            }
+
+            try await localFS.writeFileContents(projectDir.join("Leaf.swift")) { stream in
+                stream <<< """
+                public func leaf() {}
+                """
+            }
+
+            let destination: RunDestinationInfo = .host
+            let tester1 = try await BuildOperationTester(core, try makeWorkspace(includeIntermediateTargets: true), simulated: false)
+            try await tester1.checkBuild(runDestination: destination, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            let productsDir = projectDir.join("build").join("Debug\(destination.builtProductsDirSuffix(core: core))")
+            let middleModuleDir = productsDir.join("MiddleLib.swiftmodule")
+            let leafModuleDir = productsDir.join("LeafLib.swiftmodule")
+
+            #expect(tester1.fs.exists(middleModuleDir))
+            #expect(tester1.fs.exists(leafModuleDir))
+
+            let tester2 = try await BuildOperationTester(core, try makeWorkspace(includeIntermediateTargets: false), simulated: false)
+            try await tester2.checkBuild(runDestination: destination, persistent: true) { results in
+                results.checkNoErrors()
+            }
+
+            #expect(!tester2.fs.exists(middleModuleDir))
+            #expect(!tester2.fs.exists(leafModuleDir))
+        }
+    }
 }

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -786,6 +786,11 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
                 return s
             }
 
+            #expect(
+                description.swiftModuleOutputDirectories ==
+                deserializedDescription.swiftModuleOutputDirectories
+            )
+
             let s1 = try dump(description)
             let s2 = try dump(deserializedDescription)
             #expect(s1 == s2)


### PR DESCRIPTION
Fixes #1171 

Clean up stale .swiftmodule bundles between build descriptions by recording the set of expected module output directories during build description construction and removing obsolete module bundles before starting a new build. This prevents stale cross-build artifacts from remaining in shared product directories when the target graph changes, while treating cleanup failures as non-fatal. Add a regression test covering consecutive builds with different dependency graphs to verify that obsolete .swiftmodule bundles are removed correctly.