### PR TITLE
Preserve Android deployment target in Swift module filenames

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -879,9 +879,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         func destinationModuleFileName(_ triple: LLVMTriple) -> String {
             switch self {
             case .generateModule(let moduleTriple, _):
-                return moduleTriple.unversioned.description
+                return moduleTriple.moduleFileNameDescription
             default:
-                return triple.unversioned.description
+                return triple.moduleFileNameDescription
             }
         }
 
@@ -3743,6 +3743,15 @@ extension SwiftDiscoveredCommandLineToolSpecInfo {
 
         // Get the info from the global cache.
         return try await discoveredSwiftCompilerInfo(producer, delegate, at: toolPath, blocklistsPathOverride: userSpecifiedBlocklists)
+    }
+}
+
+extension LLVMTriple {
+    @_spi(Testing) public var moduleFileNameDescription: String {
+        if system == "linux" && environment?.hasPrefix("android") == true {
+            return description
+        }
+        return unversioned.description
     }
 }
 

--- a/Tests/SWBCoreTests/SwiftCompilerTests.swift
+++ b/Tests/SWBCoreTests/SwiftCompilerTests.swift
@@ -698,4 +698,15 @@ fileprivate final class TestSwiftParserDelegate: TaskOutputParserDelegate, Senda
                                                                                Path("/path/to/b.dia")])
         }
     }
+
+    @Test
+    func destinationModuleFileNameTriples() throws {
+        let androidTriple = try LLVMTriple("aarch64-unknown-linux-android28.0.0")
+        let appleTriple = try LLVMTriple("arm64-apple-ios15.0")
+        let linuxTriple = try LLVMTriple("x86_64-unknown-linux-gnu")
+
+        #expect(androidTriple.moduleFileNameDescription == "aarch64-unknown-linux-android28.0.0")
+        #expect(appleTriple.moduleFileNameDescription == "arm64-apple-ios")
+        #expect(linuxTriple.moduleFileNameDescription == "x86_64-unknown-linux-gnu")
+    }
 }


### PR DESCRIPTION
Fixes #1167 

Preserve deployment target in Android module filenames. Android module filenames must retain the deployment target because it is part of the target triple used for module lookup. Other platforms continue to use the unversioned triple. Adds a regression test covering Android, Apple, and Linux triples.