### PR TITLE
Allow extending explicit modulemap contents with the Swift generated header

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1108,6 +1108,7 @@ public final class BuiltinMacros {
     public static let SWIFT_INDEX_STORE_ENABLE = BuiltinMacros.declareBooleanMacro("SWIFT_INDEX_STORE_ENABLE")
     public static let SWIFT_INDEX_STORE_PATH = BuiltinMacros.declarePathMacro("SWIFT_INDEX_STORE_PATH")
     public static let SWIFT_INSTALL_OBJC_HEADER = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALL_OBJC_HEADER")
+    public static let SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS = BuiltinMacros.declareBooleanMacro("SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS")
     public static let SWIFT_INSTALLAPI_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_INSTALLAPI_LAZY_TYPECHECK")
     public static let SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK = BuiltinMacros.declareBooleanMacro("SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK")
     public static let SWIFT_DISABLE_HEADERMAPS = BuiltinMacros.declareBooleanMacro("SWIFT_DISABLE_HEADERMAPS")
@@ -2382,6 +2383,7 @@ public final class BuiltinMacros {
         SWIFT_INDEX_STORE_ENABLE,
         SWIFT_INDEX_STORE_PATH,
         SWIFT_INSTALL_OBJC_HEADER,
+        SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS,
         SWIFT_INSTALLAPI_LAZY_TYPECHECK,
         SWIFT_PREPARE_FOR_INDEX_LAZY_TYPECHECK,
         SWIFT_LIBRARIES_ONLY,

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -1346,7 +1346,8 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
 
         // ... and thus the module is Swift only iff the target isn't generating a module map.
         assert(createsModuleMap || exportsSwiftObjCAPI || hasExplicitModuleMapContents)
-        let forSwiftOnly = !createsModuleMap
+        let extendsProvidedModuleMap = scope.evaluate(BuiltinMacros.SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS)
+        let forSwiftOnly = !createsModuleMap && !(extendsProvidedModuleMap && hasExplicitModuleMapContents && exportsSwiftObjCAPI)
 
         // Compute the paths for the module map files for this target in the staging location in $(TARGET_TEMP_DIR).  These copies will be included in the VFS so that we have a simple, defined location for where to have the VFS look for module map entries.  The ModuleInfo object contains these paths so that tasks created by other task producers can depend on them.
 

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ModuleMapTaskProducer.swift
@@ -238,7 +238,14 @@ final class ModuleMapTaskProducer: PhasedTaskProducer, TaskProducer {
                 // If we were provided the modulemap contents, then just use those.
                 let moduleMapContents = scope.evaluate(BuiltinMacros.MODULEMAP_FILE_CONTENTS)
                 if !moduleMapContents.isEmpty {
-                    contents = ByteString(encodingAsUTF8: moduleMapContents)
+                    let providedContents = ByteString(encodingAsUTF8: moduleMapContents)
+                    if scope.evaluate(BuiltinMacros.SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS),
+                       let moduleMapExtension = try swiftModuleMapContents(moduleInfo: moduleInfo, scope: scope) {
+                        contents = ByteString(providedContents.bytes + moduleMapExtension.bytes)
+                        originalModuleMapContents = providedContents
+                    } else {
+                        contents = providedContents
+                    }
                 } else {
                     let swiftModuleMapContents = try swiftModuleMapContents(moduleInfo: moduleInfo, scope: scope)
 

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -69,6 +69,7 @@ extension ProjectModel {
             case SUPPORTS_MACCATALYST
             case SWIFT_SERIALIZE_DEBUGGING_OPTIONS
             case SWIFT_INSTALL_OBJC_HEADER
+            case SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS
             case SWIFT_OBJC_INTERFACE_HEADER_NAME
             case SWIFT_OBJC_INTERFACE_HEADER_DIR
             case SWIFT_OPTIMIZATION_LEVEL


### PR DESCRIPTION
This is needed to support SwiftPM targets which mix Swift/C sources