### PR TITLE
Port ModuleVerifierModuleMap to use Swift's Regex

### DIFF
--- a/Sources/SWBCore/ClangModuleVerifier/ModuleVerifierModuleMap.swift
+++ b/Sources/SWBCore/ClangModuleVerifier/ModuleVerifierModuleMap.swift
@@ -12,9 +12,7 @@
 
 public import SWBUtil
 
-// FIXME: Port to Regex
-import struct Foundation.NSRange
-import class Foundation.NSRegularExpression
+import Foundation
 
 @_spi(Testing)
 public enum ModuleMapKind: String {
@@ -47,14 +45,11 @@ public struct ModuleVerifierModuleMap: Hashable {
         excludedHeaderNames = findHeaders(withSpecifierPattern: "exclude")
         privateHeaderNames = findHeaders(withSpecifierPattern: "private(?:\\s+textual)?")
 
-        // This is what you would call "quick and dirty". Real dirty. :(
         func findHeaders(withSpecifierPattern specifierPattern: String) -> [String] {
-            let pattern = specifierPattern + "\\s+header\\s+\"(.*?)(?<!\\\\)\""
-            let regularExpression = try! NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
-            // The range conversions are all real awkward, <rdar://78800247&78800081&78800042>.
-            let wholeString = NSRange(moduleContents.startIndex..., in: moduleContents)
-            return regularExpression.matches(in: moduleContents, range: wholeString).map {match in
-                return String(moduleContents[Range(match.range(at: 1), in: moduleContents)!])
+            let pattern = specifierPattern + #"\s+header\s+"((?:[^"\\]|\\.)*)""#
+            let regex = try! Regex(pattern).dotMatchesNewlines()
+            return moduleContents.matches(of: regex).compactMap { match in
+                match.output[1].substring.map(String.init)
             }
         }
 

--- a/Sources/SWBCore/ClangModuleVerifier/ModuleVerifierModuleMap.swift
+++ b/Sources/SWBCore/ClangModuleVerifier/ModuleVerifierModuleMap.swift
@@ -42,15 +42,15 @@ public struct ModuleVerifierModuleMap: Hashable {
             self.kind = .privateModule
         }
 
-        excludedHeaderNames = findHeaders(withSpecifierPattern: "exclude")
-        privateHeaderNames = findHeaders(withSpecifierPattern: "private(?:\\s+textual)?")
+        let excludedHeaderRegex = #/exclude\s+header\s+"(?<header>(?:[^"\\]|\\.)*)"/#
+        let privateHeaderRegex = #/private(?:\s+textual)?\s+header\s+"(?<header>(?:[^"\\]|\\.)*)"/#
 
-        func findHeaders(withSpecifierPattern specifierPattern: String) -> [String] {
-            let pattern = specifierPattern + #"\s+header\s+"((?:[^"\\]|\\.)*)""#
-            let regex = try! Regex(pattern).dotMatchesNewlines()
-            return moduleContents.matches(of: regex).compactMap { match in
-                match.output[1].substring.map(String.init)
-            }
+        excludedHeaderNames = moduleContents.matches(of: excludedHeaderRegex).map {
+            String($0.output.header)
+        }
+
+        privateHeaderNames = moduleContents.matches(of: privateHeaderRegex).map {
+            String($0.output.header)
         }
 
         // Even quicker and dirtier. D:


### PR DESCRIPTION
_[Put a one line description of your change into the PR title, please be specific]_

The `ModuleVerifierModuleMap` used to use old `NSRegularExpression` API from `Foundation`. With this PR, it now uses the Swift's Regex type from Swift's stdlib. The foundation module is imported because `modulesDeclared` function in the file requires it.

The more important change is that the regex itself has been changed. Rather than relying on a lazy match with a negative lookbehind to find the closing quote, it now explicitly matches the contents of a quoted string by treating ordinary characters and escape sequences separately.

I ran the tests for it with `swift test --filter ModuleVerifierModuleMapTests` and all passed. But running all the tests with `swift test` failed in settings module. I am worried if i have done something wrong while setting up swift-build.

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

This was part of the swift mentorship program, where owen assigned this task for me to get familiar with the contribution process.

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
