### PR TITLE
Use top-level framework dir for ExtractAPI

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift
@@ -71,15 +71,36 @@ final class TAPISymbolExtractorTaskProducer: PhasedTaskProducer, TaskProducer {
         }
 
         // For Objective-C targets that `@import` their dependencies we need to know the locations of the module maps for those targets.
-        // This search needs to be done recursively since, for example with SwiftPM the target will depend on the PACKAGE:PRODUCT target
+        // These are registered explicitly with `-fmodule-map-file=` because a module map is not always discoverable, e.g.:
+        //
+        // - Swift package dependencies generate their module map into build intermediates
+        // - A target may point `MODULEMAP_PATH` at a custom location
+        //
+        // This search needs to be done recursively since, for example, with SwiftPM, the target will depend on the PACKAGE:PRODUCT target
         // which in turn depends on the PACKAGE:TARGET target that generates the module map.
+        // rdar://93921653
         var dependenciesModuleMaps = OrderedSet<Path>()
         if let configuredTarget = context.configuredTarget {
             let transitiveClosure = transitiveClosure([configuredTarget], successors: { context.globalProductPlan.dependencies(of: $0) }).result
             for dependencyTarget in transitiveClosure {
                 let settings = context.globalProductPlan.getTargetSettings(dependencyTarget)
                 if let moduleInfo = context.globalProductPlan.getModuleInfo(dependencyTarget) {
-                    dependenciesModuleMaps.append(moduleInfo.moduleMapPaths.builtPath)
+                    var moduleMapPath = moduleInfo.moduleMapPaths.builtPath
+                    // A framework generates its module map at `TARGET_BUILD_DIR/MODULES_FOLDER_PATH`,
+                    // which is nested under `Foo.framework/Versions/A/Modules` for versioned frameworks.
+                    // Clang only treats a module map as belonging to a framework when the `Modules`
+                    // directory sits directly inside `.framework`, so point at the top-level
+                    // `Foo.framework/Modules` symlink instead if `MODULEMAP_PATH` is not provided.
+                    // rdar://176811346
+                    let depScope = settings.globalScope
+                    if settings.productType is FrameworkProductTypeSpec,
+                       depScope.evaluate(BuiltinMacros.MODULEMAP_PATH).isEmpty {
+                        moduleMapPath = depScope.evaluate(BuiltinMacros.TARGET_BUILD_DIR)
+                            .join(depScope.evaluate(BuiltinMacros.WRAPPER_NAME))
+                            .join(depScope.evaluate(BuiltinMacros.MODULES_FOLDER_PATH).basename)
+                            .join(moduleMapPath.basename)
+                    }
+                    dependenciesModuleMaps.append(moduleMapPath)
                 } else if let moduleMapPath = settings.globalScope.evaluate(BuiltinMacros.MODULEMAP_PATH).nilIfEmpty {
                     dependenciesModuleMaps.append(Path(moduleMapPath))
                 }

--- a/Tests/SWBTaskConstructionTests/DocumentationTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/DocumentationTaskConstructionTests.swift
@@ -53,6 +53,88 @@ fileprivate struct DocumentationTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    // For versioned frameworks, the module map path must use the top-level symlink
+    // (`Foo.framework/Modules/module.modulemap`) instead of the versioned path
+    // (`Foo.framework/Versions/A/Modules/module.modulemap`).
+    /// rdar://176811346
+    @Test(.requireSDKs(.macOS))
+    func extractAPIUsesTopLevelPathForVersionedFrameworkModuleMap() async throws {
+        try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {
+            let core = try await getCore()
+            let swiftExec = try await swiftCompilerPath.str
+            let tapiExec = try await tapiToolPath.str
+            let libtool = try await libtoolPath.str
+            let docc = try await doccToolPath.str
+
+            func frameworkTarget(_ name: String, dependencies: [TestTargetDependency] = []) -> TestStandardTarget {
+                TestStandardTarget(
+                    name,
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "ARCHS": "arm64",
+                                "ONLY_ACTIVE_ARCH": "YES",
+                                "SWIFT_EXEC": swiftExec,
+                                "TAPI_EXEC": tapiExec,
+                                "LIBTOOL": libtool,
+                                "DOCC_EXEC": docc,
+                                "INFOPLIST_FILE": "SomeFiles/Info.plist",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "DEFINES_MODULE": "YES",
+                                "TAPI_EXTRACT_API_ENABLE_MODULES": "YES",
+                                "EAGER_LINKING": "NO",
+                            ]
+                        )
+                    ],
+                    buildPhases: [
+                        TestHeadersBuildPhase([TestBuildFile("\(name).h", headerVisibility: .public)]),
+                        TestSourcesBuildPhase([TestBuildFile("\(name).m")]),
+                    ],
+                    dependencies: dependencies
+                )
+            }
+
+            let testProject = TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("Info.plist"),
+                        TestFile("MainFramework.h"),
+                        TestFile("MainFramework.m"),
+                        TestFile("DepFramework.h"),
+                        TestFile("DepFramework.m"),
+                    ]
+                ),
+                targets: [
+                    frameworkTarget("MainFramework", dependencies: [TestTargetDependency("DepFramework")]),
+                    frameworkTarget("DepFramework"),
+                ]
+            )
+
+            let tester = try TaskConstructionTester(core, testProject)
+            let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+            let fs = PseudoFS()
+            let folder = Path(SRCROOT).join("SomeFiles")
+            try fs.createDirectory(folder, recursive: true)
+            try fs.write(folder.join("Info.plist"), contents: "Test")
+            for name in ["MainFramework", "DepFramework"] {
+                try fs.write(folder.join("\(name).h"), contents: "/* Some Objective-C content */\n")
+                try fs.write(folder.join("\(name).m"), contents: "/* Some Objective-C content */\n")
+            }
+
+            await tester.checkBuild(BuildParameters(action: .docBuild, configuration: "Debug"), runDestination: .anyMac, fs: fs) { results in
+                results.checkTask(.matchTargetName("MainFramework"), .matchRuleItem("ExtractAPI")) { task in
+                    task.checkCommandLineMatches([.anySequence, .and(.prefix("-fmodule-map-file="), .suffix("DepFramework.framework/Modules/module.modulemap")), .anySequence])
+                    task.checkCommandLineNoMatch([.anySequence, .contains("DepFramework.framework/Versions/A/Modules"), .anySequence])
+                }
+            }
+        }
+    }
+
     @Test(.requireSDKs(.macOS), .requireXcode26())
     func buildWithAllFilesExcludedDoesNotBuildDocumentation() async throws {
         try await ObjectiveCSymbolExtractorImplementationSelector.runWithAllImplementations {

--- a/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
+++ b/Tests/SWBTaskConstructionTests/ObjectiveCSymbolExtractorTests.swift
@@ -757,8 +757,9 @@ fileprivate struct ObjectiveCSymbolExtractorTests: CoreBasedTests {
                                 task.checkCommandLineContains([
                                     // Check custom MODULEMAP_PATH values. This would for example be the generated module map.
                                     "-fmodule-map-file=/tmp/Test/aProject/dependency_custom_module_map_file_path",
-                                    // Check that module maps from dependencies' dependencies are also passed.
-                                    "-fmodule-map-file=/tmp/Test/aProject/build/Debug/SwiftSubDependency.framework/Versions/A/Modules/module.modulemap"
+                                    // Check that module maps from dependencies' dependencies are also passed
+                                    // using the top-level symlink to the versioned framework path
+                                    "-fmodule-map-file=/tmp/Test/aProject/build/Debug/SwiftSubDependency.framework/Modules/module.modulemap"
                                 ])
 
                                 if SWBFeatureFlag.enableClangExtractAPI.value && clangFeatures.has(.extractAPIIgnores) {


### PR DESCRIPTION
The documentation build passes each dependency's module map to Clang via `-fmodule-map-file=`. Clang only treats a module map as belonging to the framework if the `Modules` dir is present directly inside the `.frameworks` dir. However, it is possible that a framework nests the modules inside a versioned subdirectory. This patch updates the ExtractAPI task to normalise the path and use the top-level symlink (`Foo.framework/Modules/module.modulemap`) instead of the versioned path (`Foo.framework/Versions/A/Modules/module.modulemap`).

rdar://176811346