### PR TITLE
[ssaf] Integrate clang-ssaf-analyzer into the SSAF build pipeline

### DIFF
--- a/Sources/SWBApplePlatform/CMakeLists.txt
+++ b/Sources/SWBApplePlatform/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(SWBApplePlatform
   PluginDCLT.swift
   RealityAssetsTaskProducer.swift
   RegisterExecutionPolicyException.swift
+  SsafAnalyzerTool.swift
   StringCatalogCompilerOutputParser.swift
   StubBinaryTaskProducer.swift
   XCStringsInputFileGroupingStrategy.swift)
@@ -112,6 +113,7 @@ SwiftBuild_Bundle(MODULE SWBApplePlatform FILES
   Specs/SceneKitFileTypes.xcspec
   Specs/SceneKitTools.xcspec
   Specs/SpriteKitFileTypes.xcspec
+  Specs/SsafAnalyzer.xcspec
   Specs/StripSymbolsDarwin.xcspec
   Specs/TiffUtil.xcspec
   Specs/tvOSDevice.xcspec

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -131,6 +131,8 @@ struct ApplePlatformSpecsExtension: SpecificationsExtension {
         [
             AppExtensionPlistGeneratorSpec.self,
             AppIntentsMetadataCompilerSpec.self,
+            EntityLinkerToolSpec.self,
+            SsafAnalyzerToolSpec.self,
             AppIntentsSSUTrainingCompilerSpec.self,
             ExtensionPointExtractorSpec.self,
             ActoolCompilerSpec.self,

--- a/Sources/SWBApplePlatform/Specs/SsafAnalyzer.xcspec
+++ b/Sources/SWBApplePlatform/Specs/SsafAnalyzer.xcspec
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+(
+    {
+        Type = Compiler;
+        Identifier = com.apple.build-tools.clang-ssaf-analyzer;
+        ExecPath = "clang-ssaf-analyzer";
+        Name = "SSAF Analyzer Tool";
+        Description = "Analyzes linked entity summary files";
+        CommandLine = "clang-ssaf-analyzer [special-args] [inputs] -o $(OutputPath)";
+        RuleName = "AnalyzeSSAF $(OutputPath)";
+        ExecDescription = "Analyzing Summary files";
+        ProgressDescription = "Analyzing $(OutputPath)";
+        InputFileTypes = ();
+        CommandOutputParser = XCGenericCommandOutputParser;
+        InputFileGroupings = ();
+        SynthesizeBuildRule = YES;
+        IsArchitectureNeutral = NO;
+    }
+)

--- a/Sources/SWBApplePlatform/SsafAnalyzerTool.swift
+++ b/Sources/SWBApplePlatform/SsafAnalyzerTool.swift
@@ -16,19 +16,19 @@ public import SWBCore
 public import SWBMacro
 
 
-public final class EntityLinkerToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
-    public static let identifier = "com.apple.build-tools.clang-ssaf-linker"
+public final class SsafAnalyzerToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
+    public static let identifier = "com.apple.build-tools.clang-ssaf-analyzer"
     required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
         super.init(parser, basedOnSpec)
     }
 
-    public struct DiscoveredEntityLinkerToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
+    public struct DiscoveredSsafAnalyzerToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
         public let toolPath: Path
         public var toolVersion: Version?
     }
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
-        let toolPath = self.resolveExecutablePath(producer, Path("clang-ssaf-linker"))
-        return DiscoveredEntityLinkerToolSpecInfo(toolPath: toolPath, toolVersion: nil)
+        let toolPath = self.resolveExecutablePath(producer, Path("clang-ssaf-analyzer"))
+        return DiscoveredSsafAnalyzerToolSpecInfo(toolPath: toolPath, toolVersion: nil)
     }
 }

--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1033,6 +1033,7 @@ public final class BuiltinMacros {
     public static let RUN_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("RUN_CLANG_STATIC_ANALYZER")
     public static let INVOKE_SSAF = BuiltinMacros.declareBooleanMacro("INVOKE_SSAF")
     public static let EXTRACT_SUMMARIES = BuiltinMacros.declareStringMacro("EXTRACT_SUMMARIES")
+    public static let STOP_AT_LU_SUMMARY_GENERATION = BuiltinMacros.declareStringListMacro("STOP_AT_LU_SUMMARY_GENERATION")
     public static let SWIFT_API_DIGESTER_MODE = BuiltinMacros.declareEnumMacro("SWIFT_API_DIGESTER_MODE") as EnumMacroDeclaration<SwiftAPIDigesterMode>
     public static let RUN_SWIFT_ABI_CHECKER_TOOL = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL")
     public static let RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL_DRIVER")
@@ -2263,6 +2264,7 @@ public final class BuiltinMacros {
         RUN_CLANG_STATIC_ANALYZER,
         INVOKE_SSAF,
         EXTRACT_SUMMARIES,
+        STOP_AT_LU_SUMMARY_GENERATION,
         RUN_DOCUMENTATION_COMPILER,
         SKIP_BUILDING_DOCUMENTATION,
         RUN_SYMBOL_GRAPH_EXTRACT,

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1376,7 +1376,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         if cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true {
             let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
             let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".ssaf-tu.json")
-            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-tu-summary-file=\(jsonPath.str)"]
+            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-compilation-unit-id=\(outputNode.path.str)", "--ssaf-tu-summary-file=\(jsonPath.str)"]
             extraOutputs.append(delegate.createNode(jsonPath))
         }
 

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -150,6 +150,7 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     var clangStaticAnalyzerSpec: ClangCompilerSpec { get }
 
     var entityLinkerToolSpec: CommandLineToolSpec { get }
+    var ssafAnalyzerToolSpec: CommandLineToolSpec { get }
 
     /// The Clang modules verifier tool spec to use.
     var clangModuleVerifierSpec: ClangCompilerSpec { get }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1025,6 +1025,16 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                         let output = Path(binaryOutput.str + ".linked-summaries.json")
                         await context.entityLinkerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: ssafInputs, output: output), delegate)
                     }
+                    await appendGeneratedTasks(&perArchTasks) { delegate in
+                        let linkedSummariesInput = Path(binaryOutput.str + ".linked-summaries.json")
+                        let analyzerOutput = Path(binaryOutput.str + ".ssaf-analysis.json")
+                        let analysisName = scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
+                        let stopAtAnalyses = Set(scope.evaluate(BuiltinMacros.STOP_AT_LU_SUMMARY_GENERATION))
+                        let specialArgs = analysisName.split(separator: ",")
+                            .filter { !stopAtAnalyses.contains(String($0)) }
+                            .flatMap { ["-a", "\($0)AnalysisResult"] }
+                        await context.ssafAnalyzerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: linkedSummariesInput)], output: analyzerOutput), delegate, specialArgs: specialArgs)
+                    }
                 }
 
                 // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -234,6 +234,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     public let clangPreprocessorSpec: ClangCompilerSpec
     public let clangStaticAnalyzerSpec: ClangCompilerSpec
     public let entityLinkerToolSpec: CommandLineToolSpec
+    public let ssafAnalyzerToolSpec: CommandLineToolSpec
     public let clangModuleVerifierSpec: ClangCompilerSpec
     private let _clangStatCacheSpec: Result<ClangStatCacheSpec, any Error>
     var clangStatCacheSpec: ClangStatCacheSpec? { return specForResult(_clangStatCacheSpec) }
@@ -358,6 +359,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.clangPreprocessorSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-linker", domain: domain, ofType: CommandLineToolSpec.self)
+        self.ssafAnalyzerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-analyzer", domain: domain, ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
         self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }
         self.codesignSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain, ofType: CodesignToolSpec.self)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -128,6 +128,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.clangPreprocessorSpec = try getSpec(ofType: ClangPreprocessorSpec.self)
         self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-linker", ofType: CommandLineToolSpec.self)
+        self.ssafAnalyzerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-analyzer", ofType: CommandLineToolSpec.self)
         self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
         self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
         self.stripSpec = try getSpec("com.apple.build-tools.strip", ofType: StripToolSpec.self)
@@ -169,6 +170,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package let clangPreprocessorSpec: ClangCompilerSpec
     package let clangStaticAnalyzerSpec: ClangCompilerSpec
     package let entityLinkerToolSpec: CommandLineToolSpec
+    package let ssafAnalyzerToolSpec: CommandLineToolSpec
     package let clangModuleVerifierSpec: ClangCompilerSpec
     package let diffSpec: CommandLineToolSpec
     package let stripSpec: StripToolSpec

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3501,13 +3501,11 @@
             {   Name = EXTRACT_SUMMARIES;
                     Type = String;
                     DefaultValue = "";
-                    Condition = "$(INVOKE_SSAF)";
                     Category = "SAPolicy";
             },
             {   Name = STOP_AT_LU_SUMMARY_GENERATION;
                     Type = StringList;
                     DefaultValue = "";
-                    Condition = "$(INVOKE_SSAF)";
                     Category = "SAPolicy";
             },
             // This entry exists for string expansion in 'RuleName'.

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3501,6 +3501,13 @@
             {   Name = EXTRACT_SUMMARIES;
                     Type = String;
                     DefaultValue = "";
+                    Condition = "$(INVOKE_SSAF)";
+                    Category = "SAPolicy";
+            },
+            {   Name = STOP_AT_LU_SUMMARY_GENERATION;
+                    Type = StringList;
+                    DefaultValue = "";
+                    Condition = "$(INVOKE_SSAF)";
                     Category = "SAPolicy";
             },
             // This entry exists for string expansion in 'RuleName'.

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -395,8 +395,8 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
-    func invokeSsafCommandLineFlags() async throws {
-        func makeTestWorkspace(_ tmpDirPath: Path, invokeSSAF: String, extractSummaries: String = "") -> TestWorkspace {
+    func invokeSsafCommandLineFlagsCallGraph() async throws {
+        func makeTestWorkspace(_ tmpDirPath: Path, invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "") -> TestWorkspace {
             TestWorkspace(
                 "Test",
                 sourceRoot: tmpDirPath.join("Test"),
@@ -410,6 +410,7 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                                 "PRODUCT_NAME": "$(TARGET_NAME)",
                                 "INVOKE_SSAF": invokeSSAF,
                                 "EXTRACT_SUMMARIES": extractSummaries,
+                                "STOP_AT_LU_SUMMARY_GENERATION": stopAtLUSummaryGeneration,
                                 // Uncomment to test with a local build of clang
                                 // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
                                 "CODE_SIGNING_ALLOWED": "NO",
@@ -426,7 +427,7 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
         // INVOKE_SSAF=YES: both flags are present and the summary file path is co-located with
         // the object file, sharing the same basename but with a .json extension.
         try await withTemporaryDirectory { tmpDirPath in
-            let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "YES", extractSummaries: "CallGraph"), simulated: false)
+            let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "YES", extractSummaries: "CallGraph", stopAtLUSummaryGeneration: "CallGraph"), simulated: false)
             try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/File1.cpp")) {
                 $0 <<< "void foo() {}\n"
                 $0 <<< "\n"
@@ -446,6 +447,7 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     let objectPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".o") })
                     let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
+                    task.checkCommandLineContains(["--ssaf-compilation-unit-id=\(objectPath.str)"])
                     task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
 
                     let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
@@ -459,11 +461,10 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     let linkedSummaryBytes = try tester.fs.read(linkedSummaryPath)
                     #expect(!linkedSummaryBytes.isEmpty)
                 }
-                results.checkNoDiagnostics()
             }
         }
 
-        // INVOKE_SSAF=NO: neither SSAF flag is present.
+        // INVOKE_SSAF=NO: No SSAF flag is present.
         try await withTemporaryDirectory { tmpDirPath in
             let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "NO"), simulated: false)
             try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/File1.cpp")) {
@@ -486,6 +487,77 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
                     task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
                 }
                 results.checkNoTask(.matchRuleType("LinkEntity"))
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
+    func invokeSsafCommandLineFlagsUnsafeBuffer() async throws {
+        func makeTestWorkspace(_ tmpDirPath: Path, invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "") -> TestWorkspace {
+            TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup("Sources", children: [TestFile("File1.cpp")]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "INVOKE_SSAF": invokeSSAF,
+                                "EXTRACT_SUMMARIES": extractSummaries,
+                                "STOP_AT_LU_SUMMARY_GENERATION": stopAtLUSummaryGeneration,
+                                // Uncomment to test with a local build of clang
+                                // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
+                                "CODE_SIGNING_ALLOWED": "NO",
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Test",
+                                type: .dynamicLibrary,
+                                buildPhases: [TestSourcesBuildPhase(["File1.cpp"])])
+                        ])
+                ])
+        }
+
+        try await withTemporaryDirectory { tmpDirPath in
+            let tester = try await BuildOperationTester(getCore(), makeTestWorkspace(tmpDirPath, invokeSSAF: "YES", extractSummaries: "UnsafeBufferUsage"), simulated: false)
+            try await tester.fs.writeFileContents(tmpDirPath.join("Test/aProject/File1.cpp")) {
+                $0 <<< "void foo(int *p) {\n"
+                $0 <<< "  p[1] = 1;\n"
+                $0 <<< "}\n"
+            }
+            try await tester.checkBuild(runDestination: .host) { results in
+                try results.checkTask(.matchRuleType("CompileC")) { task throws in
+                    let objectPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".o") })
+                    let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=UnsafeBufferUsage"])
+                    task.checkCommandLineContains(["--ssaf-compilation-unit-id=\(objectPath.str)"])
+                    task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
+
+                    let jsonBytes = try tester.fs.read(Path(expectedJsonPath))
+                    #expect(!jsonBytes.isEmpty)
+                }
+                // The entity linker should receive File1.ssaf-tu.json as input and produce a .linked-summaries.json file.
+                try results.checkTask(.matchRuleType("LinkEntity")) { task throws in
+                    #expect(task.inputPaths.contains(where: { $0.str.hasSuffix("File1.ssaf-tu.json") }))
+                    let linkedSummaryPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".linked-summaries.json") })
+                    #expect(tester.fs.exists(linkedSummaryPath))
+                    let linkedSummaryBytes = try tester.fs.read(linkedSummaryPath)
+                    #expect(!linkedSummaryBytes.isEmpty)
+                }
+                // The SSAF analyzer should run against the linked summaries and request the
+                // UnsafeBufferUsageAnalysisResult analysis, producing a non-empty analysis file.
+                try results.checkTask(.matchRuleType("AnalyzeSSAF")) { task throws in
+                    task.checkCommandLineContains(["-a", "UnsafeBufferUsageAnalysisResult"])
+                    #expect(task.inputPaths.contains(where: { $0.str.hasSuffix(".linked-summaries.json") }))
+                    let analysisPath = try #require(task.outputPaths.first { $0.str.hasSuffix(".ssaf-analysis.json") })
+                    #expect(tester.fs.exists(analysisPath))
+                    let analysisBytes = try tester.fs.read(analysisPath)
+                    #expect(!analysisBytes.isEmpty)
+                }
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -450,7 +450,7 @@ fileprivate struct ClangTests: CoreBasedTests {
 
     @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
     func invokeSsafOptions() async throws {
-        func getTestProject(invokeSSAF: String, extractSummaries: String = "") -> TestProject {
+        func getTestProject(invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "") -> TestProject {
             TestProject(
                 "aProject",
                 groupTree: TestGroup(
@@ -465,6 +465,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                             "PRODUCT_NAME": "$(TARGET_NAME)",
                             "INVOKE_SSAF": invokeSSAF,
                             "EXTRACT_SUMMARIES": extractSummaries,
+                            "STOP_AT_LU_SUMMARY_GENERATION": stopAtLUSummaryGeneration,
                             // Uncomment to test with a local build of clang
                             // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
                         ]),
@@ -485,10 +486,10 @@ fileprivate struct ClangTests: CoreBasedTests {
         // When INVOKE_SSAF is YES, the extract-summaries value and a .ssaf-tu.json summary file path are added.
         // The summary file is co-located with the object file: same directory, same basename, .ssaf-tu.json extension.
         do {
-            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph"))
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph,UnsafeBufferUsage", stopAtLUSummaryGeneration: "CallGraph"))
             await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC")) { task in
-                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph,UnsafeBufferUsage"])
                     if let objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") }) {
                         let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
                         task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
@@ -507,6 +508,18 @@ fileprivate struct ClangTests: CoreBasedTests {
                     }
                     #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".linked-summaries.json") }))
                 }
+                //
+                results.checkTask(.matchRuleType("AnalyzeSSAF")) { task in
+                    task.checkCommandLineDoesNotContain("CallGraphAnalysisResult")
+                    task.checkCommandLineContains(["-a", "UnsafeBufferUsageAnalysisResult"])
+                    let jsonInputs = task.inputs.filter { $0.path.str.hasSuffix(".linked-summaries.json") }
+                    if let jsonInput = jsonInputs.first {
+                        #expect(jsonInput.path.basename == "Test.dylib.linked-summaries.json")
+                    } else {
+                        Issue.record("Expected Test.dylib.linked-summaries.json as input to the AnalyzeSSAF task")
+                    }
+                    #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".ssaf-analysis.json") }))
+                }
                 results.checkNoDiagnostics()
             }
         }
@@ -520,16 +533,17 @@ fileprivate struct ClangTests: CoreBasedTests {
                     task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
                 }
                 results.checkNoTask(.matchRuleType("LinkEntity"))
+                results.checkNoTask(.matchRuleType("AnalyzeSSAF"))
                 results.checkNoDiagnostics()
             }
         }
 
         // The value of EXTRACT_SUMMARIES is passed through verbatim to --ssaf-extract-summaries.
         do {
-            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph"))
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph,UnsafeBufferUsage"))
             await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC")) { task in
-                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph"])
+                    task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph,UnsafeBufferUsage"])
                 }
                 results.checkNoDiagnostics()
             }


### PR DESCRIPTION
Add a new AnalyzeSSAF task that runs clang-ssaf-analyzer over the entity linker's output.
Add a new build setting STOP_AT_LU_SUMMARY_GENERATION (string list) to let specific summaries be excluded from whole-program analysis while still being extracted per-TU.

rdar://176927646