### PR TITLE
Display dynamic targets in the target dependency graph

### DIFF
--- a/Sources/SWBBuildService/PlanningOperation.swift
+++ b/Sources/SWBBuildService/PlanningOperation.swift
@@ -74,9 +74,6 @@ package final class PlanningOperation: Sendable {
 
             delegate.emit(diagnostic: graph.targetBuildOrderDiagnostic, for: activity, signature: "compute_target_graph")
 
-            // Emit a log item containing the resolved dependencies for all targets being built.
-            delegate.emit(diagnostic: graph.dependencyGraphDiagnostic, for: activity, signature: "compute_target_graph")
-
             return graph
         }
 

--- a/Sources/SWBCore/TargetDependencyResolver.swift
+++ b/Sources/SWBCore/TargetDependencyResolver.swift
@@ -190,38 +190,6 @@ public struct TargetBuildGraph: TargetGraph, Sendable {
         }
     }
 
-    /// Computes and returns a hierarchical diagnostic representing the build graph.
-    public var dependencyGraphDiagnostic: Diagnostic {
-        return _dependencyGraphDiagnostic.getValue(self)
-    }
-    private var _dependencyGraphDiagnostic: LazyCache<TargetBuildGraph, Diagnostic> = LazyCache { instance in
-        // .allTargets is sorted in topological order. Reverse this so that targets appear before their dependencies in the list.
-        return Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("Target dependency graph (\(instance.allTargets.count) target" + (instance.allTargets.count > 1 ? "s" : "") + ")"), childDiagnostics: instance.allTargets.reversed().map { configuredTarget in
-            let project = instance.workspaceContext.workspace.project(for: configuredTarget.target)
-            let resolvedDependencies = instance.resolvedDependencies(of: configuredTarget)
-            let parts = [
-                "Target '\(configuredTarget.target.name)' in project '\(project.name)'",
-                instance.buildRequest.shouldSkipExecution(target: configuredTarget.target) ? " (skipped due to 'Skip Dependencies' scheme option)" : "",
-                resolvedDependencies.isEmpty ? " (no dependencies)" : "",
-            ]
-            return Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData(parts.joined(separator: "")), childDiagnostics: resolvedDependencies.map { dependency in
-                let project = instance.workspaceContext.workspace.project(for: dependency.target.target)
-                let dependencyDescription = "target '\(dependency.target.target.name)' in project '\(project.name)'"
-                let dependencyString: String
-                switch dependency.reason {
-                case .explicit:
-                    dependencyString = "Explicit dependency on \(dependencyDescription)"
-                case .implicitBuildPhaseLinkage(filename: let filename, buildableItem: _, buildPhase: let buildPhase):
-                    dependencyString = "Implicit dependency on \(dependencyDescription) via file '\(filename)' in build phase '\(buildPhase)'"
-                case .implicitBuildSetting(settingName: let settingName, options: let options):
-                    dependencyString = "Implicit dependency on \(dependencyDescription) via options '\(options.joined(separator: " "))' in build setting '\(settingName)'"
-                case .impliedByTransitiveDependencyViaRemovedTargets(let intermediateTargetName):
-                    dependencyString = "Dependency on \(dependencyDescription) via transitive dependency through '\(intermediateTargetName)'"
-                }
-                return Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("➜ " + dependencyString))
-            })
-        })
-    }
 }
 
 extension TargetBuildGraph {

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -144,6 +144,74 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
         .sorted(by: \.target.guid)
     }
 
+    /// Computes and returns a hierarchical diagnostic representing the build graph.
+    package var dependencyGraphDiagnostic: Diagnostic {
+        .init(
+            behavior: .note,
+            location: .unknown,
+            data: .init(
+                "Target dependency graph (\(planRequest.buildGraph.allTargets.count) target" + (
+                    planRequest.buildGraph.allTargets.count > 1 ? "s" : ""
+                ) + ")"
+            ),
+            childDiagnostics: planRequest.buildGraph.allTargets.reversed().map {
+                let project = planRequest.workspaceContext.workspace.project(
+                    for: $0.target
+                )
+                let resolvedDependencies = planRequest.buildGraph.resolvedDependencies(
+                    of: $0
+                )
+                let isDynamic = getTargetSettings($0).globalScope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib"
+                    || dynamicallyBuildingTargetsWithDiamondLinkage[$0.target] != nil
+
+                return .init(
+                    behavior: .note,
+                    location: .unknown,
+                    data: .init(
+                        [
+                            "Target '\($0.target.name)' in project '\(project.name)'",
+                            planRequest.buildRequest.shouldSkipExecution(
+                                target: $0.target
+                            ) ? " (skipped due to 'Skip Dependencies' scheme option)" : "",
+                            {
+                                switch (resolvedDependencies.isEmpty, isDynamic) {
+                                case (true, true): " (no dependencies, Dynamic)"
+                                case (true, false): " (no dependencies)"
+                                case (false, true): " (Dynamic)"
+                                case (false, false): ""
+                                }
+                            }(),
+                        ]
+                        .joined()
+                    ),
+                    childDiagnostics: resolvedDependencies.map {
+                        let project = planRequest.workspaceContext.workspace
+                            .project(for: $0.target.target)
+
+                        return .init(
+                            behavior: .note,
+                            location: .unknown,
+                            data: .init(
+                                "➜ " + {
+                                    switch $0.reason {
+                                    case .explicit:
+                                        "Explicit dependency on \($1)"
+                                    case .implicitBuildPhaseLinkage(filename: let filename, buildableItem: _, buildPhase: let buildPhase):
+                                        "Implicit dependency on \($1) via file '\(filename)' in build phase '\(buildPhase)'"
+                                    case .implicitBuildSetting(settingName: let settingName, options: let options):
+                                        "Implicit dependency on \($1) via options '\(options.joined(separator: " "))' in build setting '\(settingName)'"
+                                    case .impliedByTransitiveDependencyViaRemovedTargets(let name):
+                                        "Dependency on \($1) via transitive dependency through '\(name)'"
+                                    }
+                                }($0, "target '\($0.target.target.name)' in project '\(project.name)'")
+                            )
+                        )
+                    }
+                )
+            }
+        )
+    }
+
     package func resolvedDependencies(of target: ConfiguredTarget) -> [ResolvedTargetDependency] {
         // Use the static target for lookup if necessary.
         let configuredTarget: ConfiguredTarget

--- a/Sources/SWBTaskExecution/BuildDescription.swift
+++ b/Sources/SWBTaskExecution/BuildDescription.swift
@@ -181,6 +181,9 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     /// The list of task construction diagnostics. They are getting serialized.
     package let diagnostics: [ConfiguredTarget?: [Diagnostic]]
 
+    /// A hierarchical diagnostic representing the target dependency graph.
+    package let dependencyGraphDiagnostic: Diagnostic
+
     package var hadErrors: Bool {
         for diagnostics in diagnostics.values {
             for diagnostic in diagnostics {
@@ -209,7 +212,32 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     package let emitFrontendCommandLines: Bool
 
     /// Load a build description from the given path.
-    fileprivate init(inDir dir: Path, signature: BuildDescriptionSignature, taskStore: FrozenTaskStore, allOutputPaths: Set<Path>, rootPathsPerTarget: [ConfiguredTarget: [Path]], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo], casValidationInfos: [CASValidationInfo], settingsPerTarget: [ConfiguredTarget: Settings], enableStaleFileRemoval: Bool = true, taskActionMap: [String: TaskAction.Type], targetTaskCounts: [ConfiguredTarget: Int], moduleSessionFilePath: Path?, diagnostics: [ConfiguredTarget?: [Diagnostic]], fs: any FSProxy, invalidationPaths: [Path], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult], copiedPathMap: [String: String], targetDependencies: [TargetDependencyRelationship], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>], bypassActualTasks: Bool, targetsBuildInParallel: Bool, emitFrontendCommandLines: Bool) throws {
+    fileprivate init(
+        inDir dir: Path,
+        signature: BuildDescriptionSignature,
+        taskStore: FrozenTaskStore,
+        allOutputPaths: Set<Path>,
+        rootPathsPerTarget: [ConfiguredTarget: [Path]],
+        moduleCachePathsPerTarget: [ConfiguredTarget: [Path]],
+        artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo],
+        casValidationInfos: [CASValidationInfo],
+        settingsPerTarget: [ConfiguredTarget: Settings],
+        enableStaleFileRemoval: Bool = true,
+        taskActionMap: [String: TaskAction.Type],
+        targetTaskCounts: [ConfiguredTarget: Int],
+        moduleSessionFilePath: Path?,
+        diagnostics: [ConfiguredTarget?: [Diagnostic]],
+        dependencyGraphDiagnostic: Diagnostic,
+        fs: any FSProxy,
+        invalidationPaths: [Path],
+        recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult],
+        copiedPathMap: [String: String],
+        targetDependencies: [TargetDependencyRelationship],
+        definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>],
+        bypassActualTasks: Bool,
+        targetsBuildInParallel: Bool,
+        emitFrontendCommandLines: Bool
+    ) throws {
         self.dir = dir
         self.signature = signature
         self.taskStore = taskStore
@@ -224,6 +252,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         self.targetsByGuid = try Self.targetsByGuidMap(targetTaskCounts.keys)
         self.moduleSessionFilePath = moduleSessionFilePath
         self.diagnostics = diagnostics
+        self.dependencyGraphDiagnostic = dependencyGraphDiagnostic
         self.isBuildDirectoryCache = .init()
         self.invalidationPaths = invalidationPaths
         self.invalidationSignature = fs.filesSignature(invalidationPaths)
@@ -345,7 +374,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
     package func serialize<T: Serializer>(to serializer: T) {
         guard serializer.delegate is BuildDescriptionSerializerDelegate else { fatalError("delegate must be a BuildDescriptionSerializerDelegate") }
 
-        serializer.beginAggregate(21)
+        serializer.beginAggregate(22)
         serializer.serialize(dir)
         serializer.serialize(signature)
         // Serialize the tasks first so we can index into this array during deserialization.
@@ -368,6 +397,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         // Force the diagnostics to be ordered deterministically in the description.
         let diagnostics = self.diagnostics.mapValues { $0.sorted(by: { $0.formatLocalizedDescription(.debug) < $1.formatLocalizedDescription(.debug) }) }
         serializer.serialize(diagnostics)
+        serializer.serialize(dependencyGraphDiagnostic)
 
         serializer.serialize(invalidationPaths)
         serializer.serialize(invalidationSignature)
@@ -386,7 +416,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         // Check that we have the appropriate delegate.
         guard let delegate = deserializer.delegate as? BuildDescriptionDeserializerDelegate else { throw DeserializerError.invalidDelegate("delegate must be a BuildDescriptionDeserializerDelegate") }
 
-        try deserializer.beginAggregate(21)
+        try deserializer.beginAggregate(22)
         self.dir = try deserializer.deserialize()
         self.signature = try deserializer.deserialize()
         self.allOutputPaths = try deserializer.deserialize()
@@ -408,6 +438,7 @@ package final class BuildDescription: Serializable, Sendable, Encodable, Cacheab
         self.targetsByGuid = try Self.targetsByGuidMap(targetTaskCounts.keys)
         self.moduleSessionFilePath = try deserializer.deserialize()
         self.diagnostics = try deserializer.deserialize()
+        self.dependencyGraphDiagnostic = try deserializer.deserialize()
         self.isBuildDirectoryCache = .init()
         self.invalidationPaths = try deserializer.deserialize()
         self.invalidationSignature = try deserializer.deserialize()
@@ -540,6 +571,8 @@ package final class BuildDescriptionBuilder {
     /// The diagnostics engine for task construction.
     fileprivate var diagnosticsEngines = [ConfiguredTarget?: DiagnosticsEngine]()
 
+    private let dependencyGraphDiagnostic: Diagnostic
+
     /// Additional paths which invalidate the build description because they provide significant input to the build, e.g.
     /// user-provided module maps.
     private let invalidationPaths: [Path]
@@ -580,7 +613,33 @@ package final class BuildDescriptionBuilder {
     /// - Parameters:
     ///   - path: The path of a directory to store the build description to.
     ///   - bypassActualTasks: If enabled, replace tasks with fake ones (`/usr/bin/true`).
-    init(path: Path, signature: BuildDescriptionSignature, buildCommand: BuildCommand, taskAdditionalInputs: [Ref<any PlannedTask>: NodeList], mutatedNodes: Set<Ref<any PlannedNode>>, mutatingTasks: [Ref<any PlannedTask>: MutatingTaskInfo], bypassActualTasks: Bool, targetsBuildInParallel: Bool, emitFrontendCommandLines: Bool, moduleSessionFilePath: Path?, invalidationPaths: [Path], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult], copiedPathMap: [String: String], outputPathsPerTarget: [ConfiguredTarget?: [Path]], allOutputPaths: Set<Path>, rootPathsPerTarget: [ConfiguredTarget: [Path]], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo], casValidationInfos: [BuildDescription.CASValidationInfo], staleFileRemovalIdentifierPerTarget: [ConfiguredTarget?: String], settingsPerTarget: [ConfiguredTarget: Settings], targetDependencies: [TargetDependencyRelationship], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>], workspace: Workspace) {
+    init(
+        path: Path,
+        signature: BuildDescriptionSignature,
+        buildCommand: BuildCommand,
+        taskAdditionalInputs: [Ref<any PlannedTask>: NodeList],
+        mutatedNodes: Set<Ref<any PlannedNode>>,
+        mutatingTasks: [Ref<any PlannedTask>: MutatingTaskInfo],
+        bypassActualTasks: Bool,
+        targetsBuildInParallel: Bool,
+        emitFrontendCommandLines: Bool,
+        moduleSessionFilePath: Path?,
+        invalidationPaths: [Path],
+        recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult],
+        copiedPathMap: [String: String],
+        outputPathsPerTarget: [ConfiguredTarget?: [Path]],
+        allOutputPaths: Set<Path>,
+        rootPathsPerTarget: [ConfiguredTarget: [Path]],
+        moduleCachePathsPerTarget: [ConfiguredTarget: [Path]],
+        artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo],
+        casValidationInfos: [BuildDescription.CASValidationInfo],
+        staleFileRemovalIdentifierPerTarget: [ConfiguredTarget?: String],
+        settingsPerTarget: [ConfiguredTarget: Settings],
+        targetDependencies: [TargetDependencyRelationship],
+        definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>],
+        dependencyGraphDiagnostic: Diagnostic,
+        workspace: Workspace
+    ) {
         self.path = path
         self.signature = signature
         self.taskAdditionalInputs = taskAdditionalInputs
@@ -603,6 +662,7 @@ package final class BuildDescriptionBuilder {
         self.settingsPerTarget = settingsPerTarget
         self.targetDependencies = targetDependencies
         self.definingTargetsByModuleName = definingTargetsByModuleName
+        self.dependencyGraphDiagnostic = dependencyGraphDiagnostic
         self.taskStore = TaskStore()
     }
 
@@ -710,7 +770,33 @@ package final class BuildDescriptionBuilder {
         // Create the build description.
         let buildDescription: BuildDescription
         do {
-            buildDescription = try BuildDescription(inDir: path, signature: signature, taskStore: frozenTaskStore, allOutputPaths: allOutputPaths, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos, settingsPerTarget: settingsPerTarget, taskActionMap: taskActionMap, targetTaskCounts: targetTaskCounts, moduleSessionFilePath: moduleSessionFilePath, diagnostics: diagnosticsEngines.mapValues { engine in engine.diagnostics }, fs: fs, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, bypassActualTasks: bypassActualTasks, targetsBuildInParallel: targetsBuildInParallel, emitFrontendCommandLines: emitFrontendCommandLines)
+            buildDescription = try BuildDescription(
+                inDir: path,
+                signature: signature,
+                taskStore: frozenTaskStore,
+                allOutputPaths: allOutputPaths,
+                rootPathsPerTarget: rootPathsPerTarget,
+                moduleCachePathsPerTarget: moduleCachePathsPerTarget,
+                artifactInfoPerTarget: artifactInfoPerTarget,
+                casValidationInfos: casValidationInfos,
+                settingsPerTarget: settingsPerTarget,
+                taskActionMap: taskActionMap,
+                targetTaskCounts: targetTaskCounts,
+                moduleSessionFilePath: moduleSessionFilePath,
+                diagnostics: diagnosticsEngines.mapValues {
+                    engine in engine.diagnostics
+                },
+                dependencyGraphDiagnostic: dependencyGraphDiagnostic,
+                fs: fs,
+                invalidationPaths: invalidationPaths,
+                recursiveSearchPathResults: recursiveSearchPathResults,
+                copiedPathMap: copiedPathMap,
+                targetDependencies: targetDependencies,
+                definingTargetsByModuleName: definingTargetsByModuleName,
+                bypassActualTasks: bypassActualTasks,
+                targetsBuildInParallel: targetsBuildInParallel,
+                emitFrontendCommandLines: emitFrontendCommandLines
+            )
         }
         catch {
             throw StubError.error("unable to create build description: \(error)")
@@ -1044,7 +1130,38 @@ extension BuildDescription {
     // FIXME: Bypass actual tasks should go away, eventually.
     //
     // FIXME: This layering isn't working well, we are plumbing a bunch of stuff through here just because we don't want to talk to TaskConstruction.
-    static package func construct(workspace: Workspace, tasks: [any PlannedTask], path: Path, signature: BuildDescriptionSignature, buildCommand: BuildCommand, diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:], indexingInfo: [(forTarget: ConfiguredTarget?, path: Path, indexingInfo: any SourceFileIndexingInfo)] = [], fs: any FSProxy = localFS, bypassActualTasks: Bool = false, targetsBuildInParallel: Bool = true, emitFrontendCommandLines: Bool = false, moduleSessionFilePath: Path? = nil, invalidationPaths: [Path] = [], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [], copiedPathMap: [String: String] = [:], rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:], casValidationInfos: [BuildDescription.CASValidationInfo] = [], staleFileRemovalIdentifierPerTarget: [ConfiguredTarget?: String] = [:], settingsPerTarget: [ConfiguredTarget: Settings] = [:], delegate: any BuildDescriptionConstructionDelegate, targetDependencies: [TargetDependencyRelationship] = [], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>], userPreferences: UserPreferences) async throws -> BuildDescription? {
+    static package func construct(
+        workspace: Workspace,
+        tasks: [any PlannedTask],
+        path: Path,
+        signature: BuildDescriptionSignature,
+        buildCommand: BuildCommand,
+        diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:],
+        dependencyGraphDiagnostic: Diagnostic,
+        indexingInfo: [(
+            forTarget: ConfiguredTarget?,
+            path: Path,
+            indexingInfo: any SourceFileIndexingInfo
+        )] = [],
+        fs: any FSProxy = localFS,
+        bypassActualTasks: Bool = false,
+        targetsBuildInParallel: Bool = true,
+        emitFrontendCommandLines: Bool = false,
+        moduleSessionFilePath: Path? = nil,
+        invalidationPaths: [Path] = [],
+        recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [],
+        copiedPathMap: [String: String] = [:],
+        rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:],
+        moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:],
+        artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:],
+        casValidationInfos: [BuildDescription.CASValidationInfo] = [],
+        staleFileRemovalIdentifierPerTarget: [ConfiguredTarget?: String] = [:],
+        settingsPerTarget: [ConfiguredTarget: Settings] = [:],
+        delegate: any BuildDescriptionConstructionDelegate,
+        targetDependencies: [TargetDependencyRelationship] = [],
+        definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>],
+        userPreferences: UserPreferences
+    ) async throws -> BuildDescription? {
         var diagnostics = diagnostics
 
         // We operate on the sorted tasks here to ensure that the list of task additional inputs is deterministic.
@@ -1310,7 +1427,39 @@ extension BuildDescription {
         }
 
         // Create the builder.
-        let builder = BuildDescriptionBuilder(path: path, signature: signature, buildCommand: buildCommand, taskAdditionalInputs: taskAdditionalInputs, mutatedNodes: Set(mutableNodes.keys), mutatingTasks: mutatingTasks, bypassActualTasks: bypassActualTasks, targetsBuildInParallel: targetsBuildInParallel, emitFrontendCommandLines: emitFrontendCommandLines, moduleSessionFilePath: moduleSessionFilePath, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, outputPathsPerTarget: outputPathsPerTarget, allOutputPaths: Set(producers.keys.map { $0.instance.path }), rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos, staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget, settingsPerTarget: settingsPerTarget, targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, workspace: workspace)
+        let builder = BuildDescriptionBuilder(
+            path: path,
+            signature: signature,
+            buildCommand: buildCommand,
+            taskAdditionalInputs: taskAdditionalInputs,
+            mutatedNodes: Set(
+                mutableNodes.keys
+            ),
+            mutatingTasks: mutatingTasks,
+            bypassActualTasks: bypassActualTasks,
+            targetsBuildInParallel: targetsBuildInParallel,
+            emitFrontendCommandLines: emitFrontendCommandLines,
+            moduleSessionFilePath: moduleSessionFilePath,
+            invalidationPaths: invalidationPaths,
+            recursiveSearchPathResults: recursiveSearchPathResults,
+            copiedPathMap: copiedPathMap,
+            outputPathsPerTarget: outputPathsPerTarget,
+            allOutputPaths: Set(
+                producers.keys.map {
+                    $0.instance.path
+                }
+            ),
+            rootPathsPerTarget: rootPathsPerTarget,
+            moduleCachePathsPerTarget: moduleCachePathsPerTarget,
+            artifactInfoPerTarget: artifactInfoPerTarget,
+            casValidationInfos: casValidationInfos,
+            staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget,
+            settingsPerTarget: settingsPerTarget,
+            targetDependencies: targetDependencies,
+            definingTargetsByModuleName: definingTargetsByModuleName,
+            dependencyGraphDiagnostic: dependencyGraphDiagnostic,
+            workspace: workspace
+        )
         for (target, diagnostics) in diagnostics {
             let engine = builder.diagnosticsEngines.getOrInsert(target, { DiagnosticsEngine() })
             for diag in diagnostics {

--- a/Sources/SWBTaskExecution/BuildDescriptionManager.swift
+++ b/Sources/SWBTaskExecution/BuildDescriptionManager.swift
@@ -272,6 +272,7 @@ package final class BuildDescriptionManager: Sendable {
             signature: signature,
             buildCommand: planRequest.buildRequest.buildCommand,
             diagnostics: planningDiagnostics,
+            dependencyGraphDiagnostic: plan.globalProductPlan.dependencyGraphDiagnostic,
             indexingInfo: [],
             fs: fs,
             bypassActualTasks: bypassActualTasks,
@@ -438,6 +439,26 @@ package final class BuildDescriptionManager: Sendable {
                     inMemoryCachedBuildDescriptions[signature] = buildDescription
                 }
             }.value
+        }
+
+        if case .newOrCached = request {
+            let signature = ByteString(
+                encodingAsUTF8: "report_target_dependency_graph"
+            )
+            constructionDelegate.withActivity(
+                ruleInfo: "ReportTargetDependencyGraph",
+                executionDescription: "Report target dependency graph",
+                signature: signature,
+                target: nil,
+                parentActivity: nil
+            ) {
+                constructionDelegate.emit(
+                    diagnostic: buildDescription.dependencyGraphDiagnostic,
+                    for: $0,
+                    signature: signature
+                )
+                return .succeeded
+            }
         }
 
         // Touch the serialized file to denote its use (if we didn't just create it)
@@ -620,7 +641,7 @@ package final class BuildDescriptionManager: Sendable {
         }
 
         // Also get the target build graph's display representation.  In the future we would like to emit structured data (e.g. JSON) here instead, although perhaps with the display string embedded in it for human readability.
-        let buildGraphString = request.buildGraph.dependencyGraphDiagnostic.formatLocalizedDescription(.debugWithoutBehaviorAndLocation)
+        let buildGraphString = buildDescription.dependencyGraphDiagnostic.formatLocalizedDescription(.debugWithoutBehaviorAndLocation)
 
         // Write the data to disk.
         do {

--- a/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
+++ b/Sources/SWBTestSupport/TaskExecutionTestSupport.swift
@@ -94,8 +94,67 @@ package struct TestManifest: Sendable {
 
 extension BuildDescription {
     /// Convenience testing method which omits the `capturedBuildInfo:` parameter.
-    static package func construct(workspace: Workspace, tasks: [any PlannedTask], path: Path, signature: BuildDescriptionSignature, buildCommand: BuildCommand, diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:], indexingInfo: [(forTarget: ConfiguredTarget?, path: Path, indexingInfo: any SourceFileIndexingInfo)] = [], fs: any FSProxy = localFS, bypassActualTasks: Bool = false, moduleSessionFilePath: Path? = nil, invalidationPaths: [Path] = [], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [], copiedPathMap: [String: String] = [:], rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:], casValidationInfos: [BuildDescription.CASValidationInfo] = [], staleFileRemovalIdentifierPerTarget: [ConfiguredTarget: String] = [:], settingsPerTarget: [ConfiguredTarget: Settings] = [:], delegate: any BuildDescriptionConstructionDelegate, targetDependencies: [TargetDependencyRelationship] = [], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>] = [:]) async throws -> BuildDescription? {
-        return try await construct(workspace: workspace, tasks: tasks, path: path, signature: signature, buildCommand: buildCommand, diagnostics: diagnostics, indexingInfo: indexingInfo, fs: fs, bypassActualTasks: bypassActualTasks, moduleSessionFilePath: moduleSessionFilePath, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, casValidationInfos: casValidationInfos, staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget, settingsPerTarget: settingsPerTarget, delegate: delegate, targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, userPreferences: .defaultForTesting)
+    static package func construct(
+        workspace: Workspace,
+        tasks: [any PlannedTask],
+        path: Path,
+        signature: BuildDescriptionSignature,
+        buildCommand: BuildCommand,
+        diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:],
+        dependencyGraphDiagnostic: Diagnostic = Diagnostic(
+            behavior: .note,
+            location: .unknown,
+            data: DiagnosticData(
+                "Target dependency graph (0 targets)"
+            )
+        ),
+        indexingInfo: [(
+            forTarget: ConfiguredTarget?,
+            path: Path,
+            indexingInfo: any SourceFileIndexingInfo
+        )] = [],
+        fs: any FSProxy = localFS,
+        bypassActualTasks: Bool = false,
+        moduleSessionFilePath: Path? = nil,
+        invalidationPaths: [Path] = [],
+        recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [],
+        copiedPathMap: [String: String] = [:],
+        rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:],
+        moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:],
+        artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:],
+        casValidationInfos: [BuildDescription.CASValidationInfo] = [],
+        staleFileRemovalIdentifierPerTarget: [ConfiguredTarget: String] = [:],
+        settingsPerTarget: [ConfiguredTarget: Settings] = [:],
+        delegate: any BuildDescriptionConstructionDelegate,
+        targetDependencies: [TargetDependencyRelationship] = [],
+        definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>] = [:]
+    ) async throws -> BuildDescription? {
+        return try await construct(
+            workspace: workspace,
+            tasks: tasks,
+            path: path,
+            signature: signature,
+            buildCommand: buildCommand,
+            diagnostics: diagnostics,
+            dependencyGraphDiagnostic: dependencyGraphDiagnostic,
+            indexingInfo: indexingInfo,
+            fs: fs,
+            bypassActualTasks: bypassActualTasks,
+            moduleSessionFilePath: moduleSessionFilePath,
+            invalidationPaths: invalidationPaths,
+            recursiveSearchPathResults: recursiveSearchPathResults,
+            copiedPathMap: copiedPathMap,
+            rootPathsPerTarget: rootPathsPerTarget,
+            moduleCachePathsPerTarget: moduleCachePathsPerTarget,
+            artifactInfoPerTarget: artifactInfoPerTarget,
+            casValidationInfos: casValidationInfos,
+            staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget,
+            settingsPerTarget: settingsPerTarget,
+            delegate: delegate,
+            targetDependencies: targetDependencies,
+            definingTargetsByModuleName: definingTargetsByModuleName,
+            userPreferences: .defaultForTesting
+        )
     }
 }
 

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -749,7 +749,15 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
                     Diagnostic(behavior: .error, location: .unknown, data: DiagnosticData("Test")),
                 ]
             ]
-            guard let description = try await BuildDescription.construct(workspace: testWorkspace, tasks: [], path: Path.root.join("tmp"), signature: ByteString([]), diagnostics: diagnostics, fs: PseudoFS())?.buildDescription else {
+            let dependencyGraphDiagnostic = Diagnostic(
+                behavior: .note,
+                location: .unknown,
+                data: DiagnosticData("Target dependency graph (1 target)"),
+                childDiagnostics: [
+                    Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("Target 'Target1' in project 'Project1' (no dependencies)")),
+                ]
+            )
+            guard let description = try await BuildDescription.construct(workspace: testWorkspace, tasks: [], path: Path.root.join("tmp"), signature: ByteString([]), diagnostics: diagnostics, dependencyGraphDiagnostic: dependencyGraphDiagnostic, fs: PseudoFS())?.buildDescription else {
                 Issue.record("Expected to be able to construct a build description.")
                 return
             }
@@ -769,6 +777,7 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
             deserializerDelegate.taskStore = taskStore
             let deserializer = MsgPackDeserializer(serializedBuildDescription, delegate: deserializerDelegate)
             let deserializedDescription: BuildDescription = try deserializer.deserialize()
+            #expect(deserializedDescription.dependencyGraphDiagnostic == description.dependencyGraphDiagnostic)
 
             func dump(_ description: BuildDescription) throws -> String {
                 var s = ""
@@ -810,8 +819,67 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
 }
 
 private extension BuildDescription {
-    static func construct(workspace: Workspace, tasks: [any PlannedTask], path: Path, signature: BuildDescriptionSignature, buildCommand: BuildCommand? = nil, diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:], indexingInfo: [(forTarget: ConfiguredTarget?, path: Path, indexingInfo: any SourceFileIndexingInfo)] = [], fs: any FSProxy = localFS, bypassActualTasks: Bool = false, moduleSessionFilePath: Path? = nil, invalidationPaths: [Path] = [], recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [], copiedPathMap: [String: String] = [:], rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:], moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:], artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:], staleFileRemovalIdentifierPerTarget: [ConfiguredTarget: String] = [:], settingsPerTarget: [ConfiguredTarget: Settings] = [:], targetDependencies: [TargetDependencyRelationship] = [], definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>] = [:]) async throws -> BuildDescriptionDiagnosticResults? {
-        let buildDescription = try await construct(workspace: workspace, tasks: tasks, path: path, signature: signature, buildCommand: buildCommand ?? .build(style: .buildOnly, skipDependencies: false), diagnostics: diagnostics, indexingInfo: indexingInfo, fs: fs, bypassActualTasks: bypassActualTasks, moduleSessionFilePath: moduleSessionFilePath, invalidationPaths: invalidationPaths, recursiveSearchPathResults: recursiveSearchPathResults, copiedPathMap: copiedPathMap, rootPathsPerTarget: rootPathsPerTarget, moduleCachePathsPerTarget: moduleCachePathsPerTarget, artifactInfoPerTarget: artifactInfoPerTarget, staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget, settingsPerTarget: settingsPerTarget, delegate: MockTestBuildDescriptionConstructionDelegate(), targetDependencies: targetDependencies, definingTargetsByModuleName: definingTargetsByModuleName, userPreferences: .defaultForTesting)
+    static func construct(
+        workspace: Workspace,
+        tasks: [any PlannedTask],
+        path: Path,
+        signature: BuildDescriptionSignature,
+        buildCommand: BuildCommand? = nil,
+        diagnostics: [ConfiguredTarget?: [Diagnostic]] = [:],
+        dependencyGraphDiagnostic: Diagnostic = Diagnostic(
+            behavior: .note,
+            location: .unknown,
+            data: DiagnosticData(
+                "Target dependency graph (0 targets)"
+            )
+        ),
+        indexingInfo: [(
+            forTarget: ConfiguredTarget?,
+            path: Path,
+            indexingInfo: any SourceFileIndexingInfo
+        )] = [],
+        fs: any FSProxy = localFS,
+        bypassActualTasks: Bool = false,
+        moduleSessionFilePath: Path? = nil,
+        invalidationPaths: [Path] = [],
+        recursiveSearchPathResults: [RecursiveSearchPathResolver.CachedResult] = [],
+        copiedPathMap: [String: String] = [:],
+        rootPathsPerTarget: [ConfiguredTarget:[Path]] = [:],
+        moduleCachePathsPerTarget: [ConfiguredTarget: [Path]] = [:],
+        artifactInfoPerTarget: [ConfiguredTarget: ArtifactInfo] = [:],
+        staleFileRemovalIdentifierPerTarget: [ConfiguredTarget: String] = [:],
+        settingsPerTarget: [ConfiguredTarget: Settings] = [:],
+        targetDependencies: [TargetDependencyRelationship] = [],
+        definingTargetsByModuleName: [String: OrderedSet<ConfiguredTarget>] = [:]
+    ) async throws -> BuildDescriptionDiagnosticResults? {
+        let buildDescription = try await construct(
+            workspace: workspace,
+            tasks: tasks,
+            path: path,
+            signature: signature,
+            buildCommand: buildCommand ?? .build(
+                style: .buildOnly,
+                skipDependencies: false
+            ),
+            diagnostics: diagnostics,
+            dependencyGraphDiagnostic: dependencyGraphDiagnostic,
+            indexingInfo: indexingInfo,
+            fs: fs,
+            bypassActualTasks: bypassActualTasks,
+            moduleSessionFilePath: moduleSessionFilePath,
+            invalidationPaths: invalidationPaths,
+            recursiveSearchPathResults: recursiveSearchPathResults,
+            copiedPathMap: copiedPathMap,
+            rootPathsPerTarget: rootPathsPerTarget,
+            moduleCachePathsPerTarget: moduleCachePathsPerTarget,
+            artifactInfoPerTarget: artifactInfoPerTarget,
+            staleFileRemovalIdentifierPerTarget: staleFileRemovalIdentifierPerTarget,
+            settingsPerTarget: settingsPerTarget,
+            delegate: MockTestBuildDescriptionConstructionDelegate(),
+            targetDependencies: targetDependencies,
+            definingTargetsByModuleName: definingTargetsByModuleName,
+            userPreferences: .defaultForTesting
+        )
         return buildDescription.map { BuildDescriptionDiagnosticResults(buildDescription: $0, workspace: workspace) } ?? nil
     }
 }

--- a/Tests/SwiftBuildTests/BuildLogTests.swift
+++ b/Tests/SwiftBuildTests/BuildLogTests.swift
@@ -332,6 +332,403 @@ struct BuildLogTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS))
+    func targetDependencyGraphWithOneTarget() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let testSession = try await TestSWBSession(
+                    temporaryDirectory: temporaryDirectory
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let target = TestAggregateTarget("aTarget")
+                let testWorkspace = TestWorkspace(
+                    "Workspace",
+                    sourceRoot: temporaryDirectory.path.join("Test"),
+                    projects: [
+                        TestProject(
+                            "Project",
+                            groupTree: TestGroup("Sources"),
+                            targets: [target]
+                        ),
+                    ]
+                )
+
+                let tester = try await CoreQualificationTester(
+                    testWorkspace,
+                    testSession
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await tester.invalidate()
+                    }
+                }
+
+                let (events, _) = try await testSession
+                    .runBuildDescriptionCreationOperation(
+                        request: {
+                            var request = SWBBuildRequest()
+                            request.parameters = SWBBuildParameters()
+                            request.parameters.action = "build"
+                            request.parameters.configurationName = "Debug"
+                            request.add(
+                                target: SWBConfiguredTarget(
+                                    guid: target.guid,
+                                    parameters: nil
+                                )
+                            )
+                            return request
+                        }(),
+                        delegate: TestBuildOperationDelegate()
+                    )
+
+                try await tester.checkResults(events: events) { results in
+                    results.checkNote(
+                        .equal("Target dependency graph (1 target)")
+                    ) { diagnostic in
+                        let actual = (
+                            [diagnostic.message]
+                            + diagnostic.childDiagnostics.map(\.message)
+                        ).joined(separator: "\n")
+
+                        #expect(actual == """
+                            Target dependency graph (1 target)
+                            Target 'aTarget' in project 'Project' (no dependencies)
+                            """
+                        )
+
+                        return true
+                    }
+
+                    results.checkNoDiagnostics()
+                    results.checkNoFailedTasks()
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func targetDependencyGraphWithDynamicTargets() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let testSession = try await TestSWBSession(
+                    temporaryDirectory: temporaryDirectory
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let app = TestStandardTarget(
+                    "App",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "CODE_SIGNING_ALLOWED": "NO",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SDKROOT": "macosx",
+                            ]
+                        ),
+                    ],
+                    buildPhases: [
+                        TestFrameworksBuildPhase([
+                            TestBuildFile(.target("DynamicLinkPackageProduct")),
+                            TestBuildFile(.target("PackageLibProduct2")),
+                        ]),
+                    ],
+                    dependencies: ["DynamicLinkPackageProduct", "PackageLibProduct2"]
+                )
+                let testWorkspace = TestWorkspace(
+                    "Workspace",
+                    sourceRoot: temporaryDirectory.path.join("Test"),
+                    projects: [
+                        TestProject(
+                            "AppProject",
+                            groupTree: TestGroup("Sources"),
+                            targets: [app]
+                        ),
+                        TestPackageProject(
+                            "Modules",
+                            groupTree: TestGroup("Sources"),
+                            buildConfigurations: [
+                                TestBuildConfiguration(
+                                    "Debug",
+                                    buildSettings: [
+                                        "ALWAYS_SEARCH_USER_PATHS": "NO",
+                                        "CODE_SIGNING_ALLOWED": "NO",
+                                        "GENERATE_INFOPLIST_FILE": "YES",
+                                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                                        "SDKROOT": "auto",
+                                        "SDK_VARIANT": "auto",
+                                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                    ]
+                                ),
+                            ],
+                            targets: [
+                                TestStandardTarget(
+                                    "DynamicLinkPackageProduct",
+                                    type: .framework,
+                                    buildPhases: [
+                                        TestFrameworksBuildPhase([
+                                            TestBuildFile(.target("PackageLib")),
+                                        ]),
+                                    ],
+                                    dependencies: ["PackageLib"]
+                                ),
+                                TestStandardTarget(
+                                    "PackageLib",
+                                    type: .objectFile,
+                                    dependencies: ["Common"]
+                                ),
+                                TestPackageProductTarget(
+                                    "PackageLibProduct2",
+                                    frameworksBuildPhase: TestFrameworksBuildPhase([
+                                        TestBuildFile(.target("PackageLib2")),
+                                    ]),
+                                    dependencies: ["PackageLib2"]
+                                ),
+                                TestStandardTarget(
+                                    "PackageLib2",
+                                    type: .objectFile,
+                                    dependencies: ["Common"]
+                                ),
+                                TestStandardTarget(
+                                    "Common",
+                                    type: .objectFile,
+                                    dynamicTargetVariantName: "Common-dynamic"
+                                ),
+                                TestStandardTarget(
+                                    "Common-dynamic",
+                                    type: .framework
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+
+                let tester = try await CoreQualificationTester(
+                    testWorkspace,
+                    testSession
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await tester.invalidate()
+                    }
+                }
+
+                let (events, _) = try await testSession
+                    .runBuildDescriptionCreationOperation(
+                        request: {
+                            var request = SWBBuildRequest()
+                            request.parameters = SWBBuildParameters()
+                            request.parameters.action = "build"
+                            request.parameters.configurationName = "Debug"
+                            request.add(
+                                target: SWBConfiguredTarget(
+                                    guid: app.guid,
+                                    parameters: nil
+                                )
+                            )
+                            return request
+                        }(),
+                        delegate: TestBuildOperationDelegate()
+                    )
+
+                try await tester.checkResults(events: events) { results in
+                    results.checkNote(
+                        .prefix("Target dependency graph")
+                    ) { diagnostic in
+                        let actual = (
+                            [diagnostic.message]
+                            + diagnostic.childDiagnostics.flatMap {
+                                [$0.message] + $0.childDiagnostics.map(\.message)
+                            }
+                        ).joined(separator: "\n")
+
+                        #expect(actual == """
+                            Target dependency graph (6 targets)
+                            Target 'App' in project 'AppProject'
+                            ➜ Explicit dependency on target 'DynamicLinkPackageProduct' in project 'Modules'
+                            ➜ Explicit dependency on target 'PackageLibProduct2' in project 'Modules'
+                            Target 'PackageLibProduct2' in project 'Modules'
+                            ➜ Explicit dependency on target 'PackageLib2' in project 'Modules'
+                            Target 'PackageLib2' in project 'Modules'
+                            ➜ Explicit dependency on target 'Common' in project 'Modules'
+                            Target 'DynamicLinkPackageProduct' in project 'Modules' (Dynamic)
+                            ➜ Explicit dependency on target 'PackageLib' in project 'Modules'
+                            Target 'PackageLib' in project 'Modules'
+                            ➜ Explicit dependency on target 'Common' in project 'Modules'
+                            Target 'Common' in project 'Modules' (no dependencies, Dynamic)
+                            """
+                        )
+
+                        return true
+                    }
+
+                    results.checkNoDiagnostics()
+                    results.checkNoFailedTasks()
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
+    func targetDependencyGraphWithNonExplicitDependencies() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let testSession = try await TestSWBSession(
+                    temporaryDirectory: temporaryDirectory
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                let target = TestStandardTarget(
+                    "aTarget",
+                    type: .framework,
+                    buildConfigurations: [
+                        TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "OTHER_LDFLAGS": "-framework buildSettingDependency",
+                            ]
+                        ),
+                    ],
+                    buildPhases: [
+                        TestFrameworksBuildPhase([
+                            TestBuildFile("buildPhaseDependency.framework"),
+                        ]),
+                    ],
+                    dependencies: ["removedTarget"]
+                )
+                let buildPhaseDependency = TestStandardTarget(
+                    "buildPhaseDependency",
+                    type: .framework
+                )
+                let buildSettingDependency = TestStandardTarget(
+                    "buildSettingDependency",
+                    type: .framework
+                )
+                let removedTarget = TestAggregateTarget(
+                    "removedTarget",
+                    dependencies: ["transitiveDependency"]
+                )
+                let transitiveDependency = TestStandardTarget(
+                    "transitiveDependency",
+                    type: .framework
+                )
+                let testWorkspace = TestWorkspace(
+                    "Workspace",
+                    sourceRoot: temporaryDirectory.path.join("Test"),
+                    projects: [
+                        TestProject(
+                            "Project",
+                            groupTree: TestGroup(
+                                "Sources",
+                                children: [
+                                    TestFile("buildPhaseDependency.framework"),
+                                ]
+                            ),
+                            buildConfigurations: [
+                                TestBuildConfiguration(
+                                    "Debug",
+                                    buildSettings: [
+                                        "CODE_SIGNING_ALLOWED": "NO",
+                                        "GENERATE_INFOPLIST_FILE": "YES",
+                                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                                        "SDKROOT": "macosx",
+                                    ]
+                                ),
+                            ],
+                            targets: [
+                                target,
+                                buildPhaseDependency,
+                                buildSettingDependency,
+                                removedTarget,
+                                transitiveDependency,
+                            ]
+                        ),
+                    ]
+                )
+
+                let tester = try await CoreQualificationTester(
+                    testWorkspace,
+                    testSession
+                )
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await tester.invalidate()
+                    }
+                }
+
+                let (events, _) = try await testSession
+                    .runBuildDescriptionCreationOperation(
+                        request: {
+                            var request = SWBBuildRequest()
+                            request.parameters = SWBBuildParameters()
+                            request.parameters.action = "build"
+                            request.parameters.configurationName = "Debug"
+                            request.useImplicitDependencies = true
+                            request.dependencyScope = .buildRequest
+                            for target in [
+                                target,
+                                buildPhaseDependency,
+                                buildSettingDependency,
+                                transitiveDependency,
+                            ] {
+                                request.add(
+                                    target: SWBConfiguredTarget(
+                                        guid: target.guid,
+                                        parameters: nil
+                                    )
+                                )
+                            }
+                            return request
+                        }(),
+                        delegate: TestBuildOperationDelegate()
+                    )
+
+                try await tester.checkResults(events: events) { results in
+                    results.checkNote(
+                        .equal("Target dependency graph (4 targets)")
+                    ) { diagnostic in
+                        let actual = (
+                            [diagnostic.message]
+                            + diagnostic.childDiagnostics.flatMap {
+                                [$0.message] + $0.childDiagnostics.map(\.message)
+                            }
+                        ).joined(separator: "\n")
+
+                        #expect(actual.contains(
+                            "➜ Implicit dependency on target 'buildPhaseDependency' in project 'Project' via file 'buildPhaseDependency.framework' in build phase 'Link Binary'"
+                        ))
+                        #expect(actual.contains(
+                            "➜ Implicit dependency on target 'buildSettingDependency' in project 'Project' via options '-framework buildSettingDependency' in build setting 'OTHER_LDFLAGS'"
+                        ))
+                        #expect(actual.contains(
+                            "➜ Dependency on target 'transitiveDependency' in project 'Project' via transitive dependency through 'removedTarget'"
+                        ))
+
+                        return true
+                    }
+
+                    results.checkNoDiagnostics()
+                    results.checkNoFailedTasks()
+                }
+            }
+        }
+    }
+
     /// Test functionality that's only present when `EnableDebugActivityLogs` is on.
     @Test(.requireSDKs(.macOS))
     func enableDebugActivityLogs() async throws {

--- a/Tests/SwiftBuildTests/BuildOperationTests.swift
+++ b/Tests/SwiftBuildTests/BuildOperationTests.swift
@@ -381,6 +381,9 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                                 ])
                             }
                         }
+                        results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { task in
+                            #expect(task.executionDescription == "Report target dependency graph")
+                        }
                         results.checkNoTask()
 
                         results.checkNoDiagnostics()
@@ -410,6 +413,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                             results.checkTask(.matchRule(["GatherProvisioningInputs"])) { task in
                                 #expect(task.executionDescription == "Gather provisioning inputs")
                             }
+                            results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { _ in }
                             results.checkNoTask()
                         })
                     }
@@ -428,6 +432,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                             results.checkTask(.matchRule(["GatherProvisioningInputs"])) { task in
                                 #expect(task.executionDescription == "Gather provisioning inputs")
                             }
+                            results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { _ in }
                             results.checkNoTask()
                         })
                     }
@@ -539,6 +544,9 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                                     "Discovering version info for ld"
                                 ])
                             }
+                        }
+                        results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { task in
+                            #expect(task.executionDescription == "Report target dependency graph")
                         }
                         results.checkNoTask()
                     }
@@ -987,6 +995,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         results.checkNoDiagnostics()
                         results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs", "PruneExplicitPrecompiledModules"])
                         results.checkTasks(.matchRuleType("ClangStatCache")) { _ in }
+                        results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { _ in }
                         results.checkNoTask()
 
                         results.checkNoFailedTasks()
@@ -1017,6 +1026,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
                         results.checkTask(.matchRule(["CreateBuildDescription"])) { task in
                             #expect(task.executionDescription == "Create build description")
                         }
+                        results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { _ in }
                         results.checkNoTask()
 
                         results.checkNote(.equal("Building targets in dependency order"))
@@ -1032,6 +1042,7 @@ fileprivate struct BuildOperationTests: CoreBasedTests {
 
                     try await tester.checkResults(events: events) { results in
                         results.consumeTasksMatchingRuleTypes(["ComputeTargetDependencyGraph", "GatherProvisioningInputs", "WriteAuxiliaryFile", "ClangStatCache", "ProcessInfoPlistFile", "CodeSign", "PruneExplicitPrecompiledModules"])
+                        results.checkTask(.matchRule(["ReportTargetDependencyGraph"])) { _ in }
                         results.checkNoTask()
 
                         results.checkNote(.equal("Building targets in dependency order"))


### PR DESCRIPTION
Implements #1535.

## Motivation

The target dependency graph currently emitted by Swift Build in the build log and `target-graph.txt` does not indicate whether each target will be built dynamically.

In particular, the existing output does not identify targets that are replaced with dynamic variants as a result of resolving the diamond dependency problem.

This change appends `(Dynamic)` to targets that will be built dynamically.
This applies both to targets that are explicitly configured as dynamic and to targets that become dynamic as a result of resolving the diamond dependency problem.

This makes it possible to verify at a relatively early stage of the build, and at low cost, whether each target will be built with the intended linkage.

## Changes

### Change where the dependency graph diagnostic is computed

The existing implementation computes the dependency graph diagnostic before resolving the diamond dependency problem.
At that point, Swift Build cannot determine which targets will be replaced with dynamic variants.

This change makes the following updates:

- Remove the existing log emission from `PlanningOperation`
- Remove the dependency graph diagnostic computation from `TargetDependencyResolver`
- Compute `dependencyGraphDiagnostic` in `GlobalProductPlan`
  - `GlobalProductPlan` holds the result of resolving the diamond dependency problem, allowing it to determine which targets will be built dynamically

### Share the diagnostic between log and file output

- Add `dependencyGraphDiagnostic` to `BuildDescription`
  - This carries the diagnostic computed by `GlobalProductPlan` to the existing file output point
- Serialize `dependencyGraphDiagnostic` together with `BuildDescription`
  - This allows the same diagnostic to be used when restoring a `BuildDescription` from the on-disk cache

### Log output

- Add a `ReportTargetDependencyGraph` activity and associate the dependency graph diagnostic with it
  - A separate activity is used because using the existing `CreateBuildDescription` activity would require substantial changes to where that activity begins and ends
- Emit the diagnostic only for `.newOrCached` requests
  - This preserves the behavior of the existing log output

### File output

- Preserve the existing output timing for `target-graph.txt`
- Change the diagnostic used by `BuildDescriptionManager.serializeBuildDescription` from the `TargetBuildGraph` diagnostic to `BuildDescription.dependencyGraphDiagnostic`

### Tests

- Add a unit test for dependency graph log output with a single target
- Add a unit test for the Dynamic annotation when an existing dynamic framework is present and another target becomes dynamic as a result of resolving the diamond dependency problem
- Add a unit test for dependency graph log output with non-explicit dependencies
- Make minor adjustments to the existing `BuildDescription` tests