### PR TITLE
WebAssembly should use object libraries in place of relocatable objects

### DIFF
--- a/Sources/SWBWebAssemblyPlatform/Specs/WebAssembly.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WebAssembly.xcspec
@@ -26,12 +26,6 @@
     {
         Domain = webassembly;
         Type = ProductType;
-        Identifier = org.swift.product-type.common.object;
-        BasedOn = com.apple.product-type.library.static;
-    },
-    {
-        Domain = webassembly;
-        Type = ProductType;
         Identifier = com.apple.product-type.tool;
         BasedOn = default:com.apple.product-type.tool;
         DefaultBuildProperties = {
@@ -49,7 +43,7 @@
         Domain = webassembly;
         Type = ProductType;
         Identifier = com.apple.product-type.bundle.unit-test;
-        BasedOn = org.swift.product-type.common.object;
+        BasedOn = com.apple.product-type.library.static;
         DefaultBuildProperties = {
             ENABLE_TESTING_SEARCH_PATHS = YES;
             // Index store data is required to discover XCTest tests
@@ -69,5 +63,17 @@
             EXECUTABLE_SUFFIX = ".$(EXECUTABLE_EXTENSION)";
             EXECUTABLE_EXTENSION = "wasm";
         };
+    },
+    {
+        Domain = webassembly;
+        Type = ProductType;
+        Identifier = org.swift.product-type.common.object;
+        BasedOn = org.swift.product-type.library.object;
+    },
+    {
+        Domain = webassembly;
+        Type = ProductType;
+        Identifier = org.swift.product-type.library.static;
+        BasedOn = org.swift.product-type.library.object;
     },
 )

--- a/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
+++ b/Tests/SWBWebAssemblyPlatformTests/SWBWebAssemblyPlatformTests.swift
@@ -127,6 +127,96 @@ fileprivate struct SWBWebAssemblyPlatformTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host), .requirePlatform("webassembly"))
+    func wasmCommonObjectUsesObjectLibraryAssembler() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let clangCompilerPath = try await self.clangCompilerPath
+            let swiftCompilerPath = try await self.swiftCompilerPath
+            let swiftVersion = try await self.swiftVersion
+            let testProject = try await TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("SourceFile.c"),
+                        TestFile("SwiftFile.swift"),
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "MyObject",
+                        type: .commonObject,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug",
+                                                   buildSettings: [
+                                                    "GENERATE_INFOPLIST_FILE": "YES",
+                                                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                                                    "SDKROOT": "auto",
+                                                    "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                                    "CLANG_ENABLE_MODULES": "YES",
+                                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                                    "SWIFT_VERSION": swiftVersion,
+                                                    "CC": clangCompilerPath.str,
+                                                    "CLANG_EXPLICIT_MODULES_LIBCLANG_PATH": libClangPath.str,
+                                                    "CLANG_USE_RESPONSE_FILE": "NO",
+                                                   ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("SourceFile.c"),
+                                TestBuildFile("SwiftFile.swift"),
+                            ]),
+                        ]),
+                ])
+            // Use a dedicated core for this test so the SDKs it registers do not impact other tests
+            let core = try await Self.makeCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            // Swift SDK contents
+            let sdkManifestContents = """
+            {
+                "schemaVersion" : "4.0",
+                "targetTriples" : {
+                    "wasm32-unknown-wasip1" : {
+                        "sdkRootPath" : "WASI.sdk",
+                        "swiftResourcesPath" : "swift.xctoolchain/usr/lib/swift_static",
+                        "swiftStaticResourcesPath" : "swift.xctoolchain/usr/lib/swift_static",
+                        "toolsetPaths" : [
+                            "toolset.json"
+                        ]
+                    }
+                }
+            }
+            """
+            let sdkManifestDir = tmpDir
+            try localFS.createDirectory(sdkManifestDir)
+            let sdkManifestPath = sdkManifestDir.join("swift-sdk.json")
+            try await localFS.writeFileContents(sdkManifestDir.join("swift-sdk.json"), waitForNewTimestamp: false, body: { $0.write(sdkManifestContents) })
+            try await localFS.writeFileContents(sdkManifestDir.join("toolset.json"), waitForNewTimestamp: false, body: { stream in
+                stream.write("""
+                {
+                    "rootPath" : "swift.xctoolchain/usr/bin",
+                    "schemaVersion" : "1.0",
+                    "swiftCompiler" : {
+                        "extraCLIOptions" : [
+                            "-static-stdlib"
+                        ]
+                    }
+                }
+                """)
+            })
+
+            let destination = try RunDestinationInfo(sdkManifestPath: sdkManifestPath, triple: "wasm32-unknown-wasip1", targetArchitecture: "wasm32", supportedArchitectures: ["wasm32"], disableOnlyActiveArch: false, core: core)
+            let parameters = BuildParameters(configuration: "Debug", activeRunDestination: destination)
+            await tester.checkBuild(parameters, runDestination: nil, fs: localFS) { results in
+                results.checkTask(.matchTargetName("MyObject"), .matchRuleType("AssembleObjectLibrary")) { task in
+                    task.checkCommandLineContains(["builtin-ObjectLibraryAssembler"])
+                }
+                results.checkNoTask(.matchTargetName("MyObject"), .matchRuleType("Ld"))
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
     /// Regression test: a wasm app target depending on a library with platform specialization
     /// must not fail with `unable to find sdk 'webassembly'`.
     @Test(.requireSDKs(.host))


### PR DESCRIPTION
This is consistent with how we handle other platforms like linux-musl and hews closer to SwiftPM's native build system behavior. It's also beneficial for code size reasons, and sidesteps the issue described in https://github.com/swiftlang/llvm-project/pull/13431#pullrequestreview-4736072242.

I have a paired PR I'll post later which also improves the SwiftPM-side integration testing coverage to include more relevant cases.

Closes https://github.com/swiftlang/swift-build/issues/1552