### PR TITLE
[6.4] GitHub actions CI cleanup

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
     needs: [soundness, space-format-check]
     with:
       enable_cross_pr_testing: true
-      linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
+      linux_os_versions: '["bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_build_command: 'swift test --no-parallel'
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
@@ -102,6 +102,7 @@ jobs:
     name: Test SwiftPM
     needs: [soundness, space-format-check]
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.10
+    timeout-minutes: 90
     with:
       linux_os_versions: '["jammy"]'
       linux_swift_versions: '["nightly-main"]'


### PR DESCRIPTION
- Drop Amazon Linux 2 CI jobs
- Increase the timeout a bit for the SwiftPM tests, which are the longest running jobs