### PR TITLE
Run build-phase storyboardc bundles through the postprocessor (rdar://50701007)

### DIFF
--- a/Sources/SWBApplePlatform/CMakeLists.txt
+++ b/Sources/SWBApplePlatform/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(SWBApplePlatform
   ResMergerLinkerSpec.swift
   SceneKitToolSpec.swift
   StoryboardLinker.swift
+  StoryboardPostprocessor.swift
   XCStringsCompiler.swift
   ActoolInputFileGroupingStrategy.swift
   AssetCatalogCompilerOutputParser.swift

--- a/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SWBUtil
+public import SWBUtil
 public import SWBCore
 public import SWBMacro
 import Synchronization
@@ -80,7 +80,13 @@ public class IbtoolCompilerSpec : GenericCompilerSpec, IbtoolCompilerSupport, @u
             outputs = buildPhaseInfo.filterOutputFiles(outputs, inputs: inputs)
         }
         for output in outputs {
-            delegate.declareOutput(FileToBuild(absolutePath: output.path, inferringTypeUsing: cbc.producer))
+            let fileToBuild: FileToBuild
+            if let fileType = declaredOutputFileType(forOutputAt: output.path, cbc) {
+                fileToBuild = FileToBuild(absolutePath: output.path, fileType: fileType)
+            } else {
+                fileToBuild = FileToBuild(absolutePath: output.path, inferringTypeUsing: cbc.producer)
+            }
+            delegate.declareOutput(fileToBuild)
         }
 
         // FIXME: Add the output paths for the .strings files.  I think this is a little tricky because ibtool will lay down strings files for .xibs, but not for .storyboards; instead the storyboard linker will put the .strings files in place.  I'm not certain about that, though.
@@ -152,6 +158,15 @@ public final class IbtoolCompilerSpecNIB: IbtoolCompilerSpec, SpecIdentifierType
 
 public final class IbtoolCompilerSpecStoryboard: IbtoolCompilerSpec, SpecIdentifierType, @unchecked Sendable {
     public static let identifier = "com.apple.xcode.tools.ibtool.storyboard.compiler"
+
+    override public func declaredOutputFileType(forOutputAt path: Path, _ cbc: CommandBuildContext) -> FileTypeSpec? {
+        // Mark the compiled `.storyboardc` bundle with the refined type so it routes to the storyboard linker
+        // rather than back through the postprocessor (which handles only unprocessed build-phase inputs).
+        if path.fileExtension == "storyboardc" {
+            return cbc.producer.lookupFileType(identifier: "wrapper.storyboardc.compiled")
+        }
+        return nil
+    }
 
     override public func environmentFromSpec(_ cbc: CommandBuildContext, _ delegate: any DiagnosticProducingDelegate, lookup: ((MacroDeclaration) -> MacroExpression?)? = nil) -> [(String, String)] {
         let cachingEnabled = cbc.scope.evaluate(BuiltinMacros.ENABLE_GENERIC_TASK_CACHING)

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -140,6 +140,7 @@ struct ApplePlatformSpecsExtension: SpecificationsExtension {
             CopyXCAppExtensionPointsFileSpec.self,
             DittoToolSpec.self,
             IBStoryboardLinkerCompilerSpec.self,
+            IBStoryboardPostprocessorSpec.self,
             IIGCompilerSpec.self,
             IbtoolCompilerSpecNIB.self,
             IbtoolCompilerSpecStoryboard.self,

--- a/Sources/SWBApplePlatform/Specs/IBStoryboardLinker.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBStoryboardLinker.xcspec
@@ -25,7 +25,7 @@
             "--print-diagnostic-categories",
         );
         InputFileTypes = (
-            "wrapper.storyboardc",
+            "wrapper.storyboardc.compiled",
         );
         InputFileGroupings = (
             tool,

--- a/Sources/SWBApplePlatform/Specs/IBStoryboardPostprocessor.xcspec
+++ b/Sources/SWBApplePlatform/Specs/IBStoryboardPostprocessor.xcspec
@@ -24,8 +24,9 @@
         ProgressDescription = "Postprocessing $(CommandProgressByType) Storyboardc files";
         SynthesizeBuildRule = YES;
         IsArchitectureNeutral = YES;
+        // Output to the temporary resources directory (not the product) so the stripped bundle is fed into the storyboard linker, which places the final bundle in the product. See rdar://50701007.
         Outputs = (
-            "$(ProductResourcesDir)/$(InputFileBase).storyboardc",
+            "$(TempResourcesDir)/$(InputFileBase).storyboardc",
         );
         InputFileTypes = (
             "wrapper.storyboardc",
@@ -68,11 +69,11 @@
                 CommandLineArgs = {
                     YES = (
                         "--strip",
-                        "$(ProductResourcesDir)/$(InputFileBase).storyboardc",
+                        "$(TempResourcesDir)/$(InputFileBase).storyboardc",
                     );
                     NO = (
                         "--write",
-                        "$(ProductResourcesDir)/$(InputFileBase).storyboardc",
+                        "$(TempResourcesDir)/$(InputFileBase).storyboardc",
                     );
                 };
             },

--- a/Sources/SWBApplePlatform/Specs/InterfaceBuilderFileTypes.xcspec
+++ b/Sources/SWBApplePlatform/Specs/InterfaceBuilderFileTypes.xcspec
@@ -62,4 +62,14 @@
         Type = FileType;
         UTI = "com.apple.dt.interfacebuilder.document.storyboard.package";
     },
+    {
+        // A compiled storyboard package produced by the storyboard compiler or postprocessor, as opposed to a `wrapper.storyboardc` added directly to a build phase.
+        //
+        // This type deliberately declares no extensions: an on-disk `.storyboardc` bundle is inferred as the base `wrapper.storyboardc` type (and thus routed to the postprocessor), while this refined type is only ever stamped programmatically on the outputs of the compiler and postprocessor (and thus routed to the linker). Because the storyboard linker's synthesized build rule accepts this refined type exactly and the postprocessor's accepts the base type exactly, the exact-vs-conformance priority in build rule matching disambiguates the two without a special case. See rdar://50701007.
+        AppliesToBuildRules = YES;
+        BasedOn = "wrapper.storyboardc";
+        Identifier = "wrapper.storyboardc.compiled";
+        Name = "Compiled Interface Builder Storyboard Package";
+        Type = FileType;
+    },
 )

--- a/Sources/SWBApplePlatform/StoryboardPostprocessor.swift
+++ b/Sources/SWBApplePlatform/StoryboardPostprocessor.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBUtil
+public import SWBCore
+public import SWBMacro
+
+/// The storyboard postprocessor strips design-time content from a `.storyboardc` bundle that was added directly to a build phase (as opposed to one produced by the storyboard compiler), reducing its deployment size.
+///
+/// Its input is the unprocessed `wrapper.storyboardc` type, and its output is marked as the refined `wrapper.storyboardc.compiled` type so that the stripped bundle routes to the storyboard linker rather than being fed back into the postprocessor. See rdar://50701007.
+public final class IBStoryboardPostprocessorSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
+    public static let identifier = "com.apple.xcode.tools.ibtool.storyboard.postprocessor"
+
+    override public func declaredOutputFileType(forOutputAt path: Path, _ cbc: CommandBuildContext) -> FileTypeSpec? {
+        if path.fileExtension == "storyboardc" {
+            return cbc.producer.lookupFileType(identifier: "wrapper.storyboardc.compiled")
+        }
+        return nil
+    }
+}

--- a/Sources/SWBCore/BuildRuleSet.swift
+++ b/Sources/SWBCore/BuildRuleSet.swift
@@ -117,11 +117,6 @@ public final class DisambiguatingBuildRuleSet: BuildRuleSet {
 
                     let identifiers = matches.map { $0.first }
 
-                    // <rdar://50701007> Ignore a known problem case -- the linker and postprocessor rules conflict and we always choose the linker rule, so the postprocessor rule is effectively ignored. We need to find a way to generalize some conflict resolution and/or ordering mechanism.
-                    if identifiers == ["com.apple.xcode.tools.ibtool.storyboard.linker", "com.apple.xcode.tools.ibtool.storyboard.postprocessor"] {
-                        return []
-                    }
-
                     // FIXME: COMBINE_HIDPI_IMAGES is a bit of a special case in the build system...
                     if identifiers == ["com.apple.compilers.tiffutil", "com.apple.build-tasks.copy-png-file"] || identifiers == ["com.apple.compilers.tiffutil", "com.apple.build-tasks.copy-tiff-file"] {
                         return []

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -854,6 +854,13 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         return true
     }
 
+    /// The file type to declare for a generated output at `path`, or `nil` to infer it from the path extension.
+    ///
+    /// Subclasses can override this to stamp a refined file type on a generated output so it routes to a different downstream build rule than an unprocessed input with the same extension would. The storyboard compiler and postprocessor use this to mark their compiled `.storyboardc` bundles with `wrapper.storyboardc.compiled` so they route to the storyboard linker rather than back through the postprocessor. See rdar://50701007.
+    open func declaredOutputFileType(forOutputAt path: Path, _ cbc: CommandBuildContext) -> FileTypeSpec? {
+        return nil
+    }
+
     /// Constructs the "rule info" and command line arguments for a task, and then instructs the task generation delegate to create the task with that information.
     open func constructTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate) async {
         await constructTasks(cbc, delegate, specialArgs: [])
@@ -930,7 +937,11 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
         }
 
         for output in outputs {
-            delegate.declareOutput(FileToBuild(absolutePath: output.path, inferringTypeUsing: cbc.producer, indexingInputReplacement: indexingInputReplacement))
+            if let fileType = declaredOutputFileType(forOutputAt: output.path, cbc) {
+                delegate.declareOutput(FileToBuild(absolutePath: output.path, fileType: fileType, indexingInputReplacement: indexingInputReplacement))
+            } else {
+                delegate.declareOutput(FileToBuild(absolutePath: output.path, inferringTypeUsing: cbc.producer, indexingInputReplacement: indexingInputReplacement))
+            }
         }
 
         // Add the additional outputs defined by the spec.  These are not declared as outputs but should be processed by the tool separately.

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -266,6 +266,8 @@ package final class TestFile: TestInternalStructureItem, CustomStringConvertible
             return "wrapper.scncache"
         case ".storyboard":
             return "file.storyboard"
+        case ".storyboardc":
+            return "wrapper.storyboardc"
         case ".strings":
             return "text.plist.strings"
         case ".stringsdict":

--- a/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ResourceTaskConstructionTests.swift
@@ -630,6 +630,105 @@ fileprivate struct ResourcesTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    /// Check that a pre-compiled `.storyboardc` bundle added directly to a build phase (i.e. not produced by the storyboard compiler) is run through the storyboard postprocessor and then linked, rather than being linked directly.
+    ///
+    /// This is a regression test for rdar://50701007, where the storyboard linker and postprocessor rules conflicted on the `wrapper.storyboardc` input type and the postprocessor was silently ignored.
+    @Test(.requireSDKs(.macOS))
+    func interfaceBuilderStoryboardPostprocessing() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("Info.plist"),
+                    TestFile("prebuilt.storyboardc"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "App",
+                    type: .application,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug",
+                                               buildSettings: [
+                                                "CODE_SIGN_IDENTITY": "",
+                                                "SDKROOT": "macosx",
+                                                "IBC_EXEC": ibtoolPath.str,
+                                                "INFOPLIST_FILE": "Sources/Info.plist",
+                                               ]),
+                    ],
+                    buildPhases: [
+                        TestResourcesBuildPhase([
+                            "prebuilt.storyboardc",
+                        ]),
+                    ])
+            ])
+        let core = try await getCore()
+        let tester = try TaskConstructionTester(core, testProject)
+        let SRCROOT = tester.workspace.projects[0].sourceRoot.str
+
+        let ibtoolPath = try await self.ibtoolPath
+
+        await tester.checkBuild(runDestination: .macOS) { results in
+            // Ignore all the auxiliary file tasks.
+            results.checkTasks(.matchRuleType("WriteAuxiliaryFile")) { tasks in }
+            // Ignore all the mkdir and touch tasks.
+            results.checkTasks(.matchRuleType("MkDir")) { tasks in }
+            results.checkTasks(.matchRuleType("Touch")) { tasks in }
+            // Ignore all Gate tasks.
+            results.checkTasks(.matchRuleType("Gate")) { _ in }
+            // Ignore all RegisterWithLaunchServices tasks.
+            results.checkTasks(.matchRuleType("RegisterWithLaunchServices")) { _ in }
+            results.checkTasks(.matchRuleType("RegisterExecutionPolicyException")) { _ in }
+            // Ignore all build directory tasks.
+            results.checkTasks(.matchRuleType("CreateBuildDirectory")) { _ in }
+            // Ignore info plist processing.
+            results.checkTasks(.matchRuleType("ProcessInfoPlistFile")) { _ in }
+
+            results.checkTarget("App") { target in
+                // The pre-compiled storyboardc should be postprocessed (stripped) into the temporary resources directory.
+                results.checkTask(.matchTarget(target), .matchRuleType("StripStoryboard")) { task in
+                    task.checkRuleInfo(["StripStoryboard", "\(SRCROOT)/Sources/prebuilt.storyboardc"])
+                    task.checkInputs([
+                        .path("\(SRCROOT)/Sources/prebuilt.storyboardc"),
+                        .namePattern(.and(.prefix("target"), .suffix("Producer"))),
+                        .namePattern(.prefix("target-"))])
+                    task.checkOutputs([
+                        .path("\(SRCROOT)/build/aProject.build/Debug/App.build/prebuilt.storyboardc"),
+                    ])
+                }
+
+                // The postprocessed storyboardc should then be linked into the product.
+                results.checkTask(.matchTarget(target), .matchRuleType("LinkStoryboards")) { task in
+                    task.checkRuleInfo(["LinkStoryboards"])
+                    task.checkInputs([
+                        .path("\(SRCROOT)/build/aProject.build/Debug/App.build/prebuilt.storyboardc"),
+                        .namePattern(.and(.prefix("target"), .suffix("Producer"))),
+                        .namePattern(.prefix("target-"))
+                    ])
+                    task.checkOutputs([
+                        .path("\(SRCROOT)/build/Debug/App.app/Contents/Resources/prebuilt.storyboardc"),
+                    ])
+                }
+            }
+
+            // Skip the validate task.
+            results.checkTasks(.matchRuleType("Validate")) { _ in }
+
+            // Check there are no other tasks.
+            results.checkNoTask()
+
+            // Check there are no diagnostics.
+            results.checkNoDiagnostics()
+        }
+    }
+
     /// Check the behavior of the IB compile tools when building with multiple variants.
     @Test(.requireSDKs(.macOS))
     func interfaceBuilderCompilers_MultiVariant() async throws {


### PR DESCRIPTION
## Summary

Fixes rdar://50701007: storyboard postprocessing was completely ignored by the build system.

The storyboard **linker** and **postprocessor** both synthesized build rules on the same `wrapper.storyboardc` input type, producing an unresolvable match tie. The build-rule engine hard-coded that pair (`DisambiguatingBuildRuleSet`) to suppress the ambiguity diagnostic and always pick the linker, so the postprocessor rule never produced a task.

## Approach

Rather than threading file provenance into the matcher, this gives compiled storyboard bundles a refined file type and lets the **existing** exact-vs-conformance match priority do the disambiguation:

- New file type `wrapper.storyboardc.compiled` (`BasedOn` `wrapper.storyboardc`, **no extension** — so on-disk `.storyboardc` bundles still infer the base type and the refined type is only ever stamped programmatically).
- The compiler and postprocessor stamp their `.storyboardc` outputs with the refined type, via a new overridable `declaredOutputFileType(forOutputAt:_:)` hook on `CommandLineToolSpec` (default returns `nil` → infer, so every other tool is unchanged).
- The postprocessor now writes to `$(TempResourcesDir)` instead of `$(ProductResourcesDir)` so its stripped output feeds the linker, and is backed by a small `IBStoryboardPostprocessorSpec` class.
- The linker accepts `wrapper.storyboardc.compiled`.
- The hard-coded workaround in `BuildRuleSet.swift` is removed.

Routing now falls out of priority matching with no collisions:

- on-disk `.storyboardc` added to a build phase (base type, exact match) → **postprocess** → temp → **link**
- `.storyboard` source → **compile** → temp → **link**
- compiler/postprocessor outputs (`.compiled`, exact match) → **link**

## Testing

- New `interfaceBuilderStoryboardPostprocessing` test: a pre-compiled `.storyboardc` added to a build phase is now stripped into the temp resources dir and then linked into the product (previously it was linked directly, with no postprocessing).
- All existing storyboard/localization/watch/installloc task-construction tests pass unchanged (the source→compile→link path is unaffected).
- Full `SWBTaskConstructionTests` suite passes except one pre-existing, unrelated Android build-directory-naming failure.

Also adds a `.storyboardc` → `wrapper.storyboardc` mapping to the test workspace helper so such bundles can be referenced in tests.