### PR TITLE
[6.4]Always use clang when linking a preview shim

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -940,7 +940,9 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
     }
 
     public func constructPreviewShimLinkerTasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, libraries: [LibrarySpecifier], usedTools: [CommandLineToolSpec: Set<FileTypeSpec>], rpaths: [String], ldflags: [String]?) async {
-        let resolvedLinkerDriver = Self.resolveLinkerDriver(cbc, usedTools: usedTools)
+        // Always use clang to link the preview shim, because it will never contain code compiled
+        // using swiftc, and we don't want the driver to force load static compat libs.
+        let resolvedLinkerDriver = LinkerDriverChoice.clang
         let linkerDriverLookup: ((MacroDeclaration) -> MacroStringExpression?) = { macro in
             switch macro {
             case BuiltinMacros.LINKER_DRIVER:

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -144,46 +144,20 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
 
                 // We should have the normal link task, which is the preview shim, and it should link the bootstrap static library
                 results.checkTask(.matchRule(["Ld", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget", "normal"])) { task in
-                    switch linkerDriver {
-                    case "clang":
-                        task.checkCommandLine(
-                            [
-                                "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang",
-                                "-Xlinker", "-reproducible",
-                                "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)-simulator",
-                                "-isysroot", core.loadSDK(.iOSSimulator).path.str,
-                                "-Os",
-                                "-Xlinker", "-no_warn_duplicate_libraries",
-                                "-L\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-F\(srcRoot.str)/build/Debug-iphonesimulator",
-                                "-Xlinker", "-rpath", "-Xlinker", "@executable_path",
-                                "-rdynamic",
-                                "-Xlinker", "-objc_abi_version", "-Xlinker", "2",
-                                "-e", "___debug_blank_executor_main",
-                                "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_dylib", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibPath-normal-\(results.runDestinationTargetArchitecture).txt",
-                                "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_instlnm", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibInstallName-normal-\(results.runDestinationTargetArchitecture).txt",
-                                "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt",
-                                "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__entitlements", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent",
-                                "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__ents_der", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget.app-Simulated.xcent.der",
-                                "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget.debug.dylib",
-                                "-Xlinker", "-no_adhoc_codesign",
-                                "-o", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget"
-                            ]
-                        )
-                    case "auto":
-                        task.checkCommandLine([
-                            "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
+                    task.checkCommandLine(
+                        [
+                            "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang",
                             "-Xlinker", "-reproducible",
                             "-target", "\(results.runDestinationTargetArchitecture)-apple-ios\(core.loadSDK(.iOSSimulator).defaultDeploymentTarget)-simulator",
-                            "-emit-executable",
-                            "-sdk", core.loadSDK(.iOSSimulator).path.str,
+                            "-isysroot", core.loadSDK(.iOSSimulator).path.str,
+                            "-Os",
                             "-Xlinker", "-no_warn_duplicate_libraries",
                             "-L\(srcRoot.str)/build/Debug-iphonesimulator",
                             "-F\(srcRoot.str)/build/Debug-iphonesimulator",
                             "-Xlinker", "-rpath", "-Xlinker", "@executable_path",
-                            "-Xclang-linker", "-rdynamic",
+                            "-rdynamic",
                             "-Xlinker", "-objc_abi_version", "-Xlinker", "2",
-                            "-Xlinker", "-e", "-Xlinker", "___debug_blank_executor_main",
+                            "-e", "___debug_blank_executor_main",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_dylib", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibPath-normal-\(results.runDestinationTargetArchitecture).txt",
                             "-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__debug_instlnm", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-DebugDylibInstallName-normal-\(results.runDestinationTargetArchitecture).txt",
                             "-Xlinker", "-filelist", "-Xlinker", "\(srcRoot.str)/build/ProjectName.build/Debug-iphonesimulator/AppTarget.build/AppTarget-ExecutorLinkFileList-normal-x86_64.txt",
@@ -192,10 +166,8 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                             "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget.debug.dylib",
                             "-Xlinker", "-no_adhoc_codesign",
                             "-o", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/AppTarget"
-                        ])
-                    default:
-                        Issue.record("test invoked with unexpected linker driver")
-                    }
+                        ]
+                    )
                 }
 
                 results.checkTask(.matchRule(["Ld", "\(srcRoot.str)/build/Debug-iphonesimulator/AppTarget.app/__preview.dylib", "normal"])) { _ in }


### PR DESCRIPTION
The preview shim will never contain code compiled with swiftc. Use clang to link it so we never force load the Swift compatibility libraries, which would fail to resolve symbols in the standard library.

rdar://181404607