### PR TITLE
Fix unused withLock result warnings

### DIFF
--- a/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
+++ b/Sources/SWBApplePlatform/InterfaceBuilderCompiler.swift
@@ -26,7 +26,11 @@ public class IbtoolCompilerSpec : GenericCompilerSpec, IbtoolCompilerSupport, @u
             guard ftb.fileType.identifier == "file.xib" else {
                 return
             }
-            allInputFilenames.withLock{ $0.insert(ftb.absolutePath.basenameWithoutSuffix) }
+            allInputFilenames.withLock {
+                _ = $0.insert(
+                    ftb.absolutePath.basenameWithoutSuffix
+                )
+            }
         }
 
         func filterOutputFiles(_ outputs: [any PlannedNode], inputs: [Path]) -> [any PlannedNode] {

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -113,7 +113,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
 
     /// Registers a path accessed during task construction.
     func access(path: Path) {
-        state.withLock { $0.accessedPaths.insert(path) }
+        state.withLock { _ = $0.accessedPaths.insert(path) }
     }
 
     /// Paths accessed during task construction that invalidate the build description.


### PR DESCRIPTION
## Summary

Explicitly discard the results of `Set.insert` calls inside `withLock` closures.

The closures implicitly returned the results of `Set.insert`, triggering the following warning:

```
result of call to 'withLock' is unused
```

## Changes

- Discard the `Set.insert` result in `IbtoolCompilerSpec.BuildPhaseInfo.addToContext(_:)`
- Discard the `Set.insert` result in `TaskProducerContext.access(path:)`

This change does not affect behavior.