### PR TITLE
Build LinkageDependencyResolver product-name maps lazily

### DIFF
--- a/Sources/SWBCore/LinkageDependencyResolver.swift
+++ b/Sources/SWBCore/LinkageDependencyResolver.swift
@@ -73,35 +73,49 @@ fileprivate extension LinkageDependencyResolver {
 }
 
 actor LinkageDependencyResolver {
-    /// Sets of targets mapped by product name.
-    private let targetsByProductName: [String: Set<StandardTarget>]
-
-    /// Sets of targets mapped by product name stem.
-    private let targetsByProductNameStem: [String: Set<StandardTarget>]
+    /// Lazily-built target lookup maps, keyed by (evaluated) product name and by product-name stem.
+    ///
+    /// Building these forces `getCachedSettings` — and thus `Settings` construction — for every workspace
+    /// target whose product-reference name is a build setting expression, which for SwiftPM packages is
+    /// *every* module target (`$(EXECUTABLE_NAME)`/`$(WRAPPER_NAME)`). The maps are only consulted during
+    /// implicit-dependency resolution (`implicitDependency(forProductName:)` / `forProductNameStem:`), so
+    /// projects that use only explicit dependencies (all SwiftPM packages) never need them. Build them
+    /// lazily on first use to avoid that per-target `Settings` construction on every build — it was the
+    /// dominant cost of a no-change build for large packages. See <rdar://182737643>.
+    private struct ProductNameMaps: Sendable {
+        let byProductName: [String: Set<StandardTarget>]
+        let byProductNameStem: [String: Set<StandardTarget>]
+    }
+    private let productNameMapsCache = SWBMutex<ProductNameMaps?>(nil)
 
     internal let resolver: DependencyResolver
 
     init(workspaceContext: WorkspaceContext, buildRequest: BuildRequest, buildRequestContext: BuildRequestContext, delegate: any TargetDependencyResolverDelegate) {
-        var targetsByProductName = [String: Set<StandardTarget>]()
-        var targetsByProductNameStem = [String: Set<StandardTarget>]()
-        for case let target as StandardTarget in workspaceContext.workspace.allTargets {
-            // The product reference name may itself be a build setting expression, so evaluate it to obtain the concrete basename that lookups (which use resolved build file paths) will match against.
-            let productName = target.productReference.evaluatedName(computeSettings: { buildRequestContext.getCachedSettings(buildRequest.parameters, target: target) })
-
-            // Add to the mapping by the full product name.
-            targetsByProductName[productName, default: []].insert(target)
-
-            // Add to the mapping by the name stem, if different from the full product name; if it is the same, then lookups should instead end up using the full-name table we created above.
-            if let stem = Path(productName).stem, stem != productName {
-                targetsByProductNameStem[stem, default: []].insert(target)
-            }
-        }
-
-        // Remember the mappings we created.
-        self.targetsByProductName = targetsByProductName
-        self.targetsByProductNameStem = targetsByProductNameStem
-
         resolver = DependencyResolver(workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, delegate: delegate)
+    }
+
+    /// The target lookup maps, built on first access (see `ProductNameMaps`).
+    nonisolated private func productNameMaps() -> ProductNameMaps {
+        productNameMapsCache.withLock { cached in
+            if let cached { return cached }
+            var byProductName = [String: Set<StandardTarget>]()
+            var byProductNameStem = [String: Set<StandardTarget>]()
+            for case let target as StandardTarget in workspaceContext.workspace.allTargets {
+                // The product reference name may itself be a build setting expression, so evaluate it to obtain the concrete basename that lookups (which use resolved build file paths) will match against.
+                let productName = target.productReference.evaluatedName(computeSettings: { buildRequestContext.getCachedSettings(buildRequest.parameters, target: target) })
+
+                // Add to the mapping by the full product name.
+                byProductName[productName, default: []].insert(target)
+
+                // Add to the mapping by the name stem, if different from the full product name; if it is the same, then lookups should instead end up using the full-name table we created above.
+                if let stem = Path(productName).stem, stem != productName {
+                    byProductNameStem[stem, default: []].insert(target)
+                }
+            }
+            let maps = ProductNameMaps(byProductName: byProductName, byProductNameStem: byProductNameStem)
+            cached = maps
+            return maps
+        }
     }
 
     fileprivate func computeGraph() async -> (allTargets: OrderedSet<ConfiguredTarget>, targetDependencies: [ConfiguredTarget: [ResolvedTargetDependency]]) {
@@ -450,7 +464,7 @@ actor LinkageDependencyResolver {
 
     /// Search for an implicit dependency by full product name.
     nonisolated private func implicitDependency(forProductName productName: String, from configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, source: ImplicitDependencySource) async -> ConfiguredTarget? {
-        let candidateConfiguredTargets = await (targetsByProductName[productName] ?? []).asyncMap { [self] candidateTarget -> ConfiguredTarget? in
+        let candidateConfiguredTargets = await (productNameMaps().byProductName[productName] ?? []).asyncMap { [self] candidateTarget -> ConfiguredTarget? in
             // Prefer overriding build parameters from the build request, if present.
             let buildParameters = resolver.buildParametersByTarget[candidateTarget] ?? configuredTarget.parameters
 
@@ -469,7 +483,7 @@ actor LinkageDependencyResolver {
 
     /// Search for an implicit dependency by product name stem.
     nonisolated private func implicitDependency(forProductNameStem stem: String, buildFilePath: Path, from configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, source: ImplicitDependencySource) async -> ConfiguredTarget? {
-        let candidateConfiguredTargets = await (targetsByProductNameStem[stem] ?? []).asyncMap { [self] candidateStandardTarget -> ConfiguredTarget? in
+        let candidateConfiguredTargets = await (productNameMaps().byProductNameStem[stem] ?? []).asyncMap { [self] candidateStandardTarget -> ConfiguredTarget? in
             // Prefer overriding build parameters from the build request, if present.
             let buildParameters = resolver.buildParametersByTarget[candidateStandardTarget] ?? configuredTarget.parameters
 

--- a/Sources/SWBCore/LinkageDependencyResolver.swift
+++ b/Sources/SWBCore/LinkageDependencyResolver.swift
@@ -86,36 +86,31 @@ actor LinkageDependencyResolver {
         let byProductName: [String: Set<StandardTarget>]
         let byProductNameStem: [String: Set<StandardTarget>]
     }
-    private let productNameMapsCache = SWBMutex<ProductNameMaps?>(nil)
+    private let productNameMapsCache = LazyCache { (resolver: LinkageDependencyResolver) -> ProductNameMaps in
+        var byProductName = [String: Set<StandardTarget>]()
+        var byProductNameStem = [String: Set<StandardTarget>]()
+        for case let target as StandardTarget in resolver.workspaceContext.workspace.allTargets {
+            // The product reference name may itself be a build setting expression, so evaluate it to obtain the concrete basename that lookups (which use resolved build file paths) will match against.
+            let productName = target.productReference.evaluatedName(computeSettings: { resolver.buildRequestContext.getCachedSettings(resolver.buildRequest.parameters, target: target) })
+
+            // Add to the mapping by the full product name.
+            byProductName[productName, default: []].insert(target)
+
+            // Add to the mapping by the name stem, if different from the full product name; if it is the same, then lookups should instead end up using the full-name table we created above.
+            if let stem = Path(productName).stem, stem != productName {
+                byProductNameStem[stem, default: []].insert(target)
+            }
+        }
+        return ProductNameMaps(byProductName: byProductName, byProductNameStem: byProductNameStem)
+    }
+
+    /// The target lookup maps, built on first access (see `ProductNameMaps`).
+    private nonisolated var productNameMaps: ProductNameMaps { productNameMapsCache.getValue(self) }
 
     internal let resolver: DependencyResolver
 
     init(workspaceContext: WorkspaceContext, buildRequest: BuildRequest, buildRequestContext: BuildRequestContext, delegate: any TargetDependencyResolverDelegate) {
         resolver = DependencyResolver(workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, delegate: delegate)
-    }
-
-    /// The target lookup maps, built on first access (see `ProductNameMaps`).
-    nonisolated private func productNameMaps() -> ProductNameMaps {
-        productNameMapsCache.withLock { cached in
-            if let cached { return cached }
-            var byProductName = [String: Set<StandardTarget>]()
-            var byProductNameStem = [String: Set<StandardTarget>]()
-            for case let target as StandardTarget in workspaceContext.workspace.allTargets {
-                // The product reference name may itself be a build setting expression, so evaluate it to obtain the concrete basename that lookups (which use resolved build file paths) will match against.
-                let productName = target.productReference.evaluatedName(computeSettings: { buildRequestContext.getCachedSettings(buildRequest.parameters, target: target) })
-
-                // Add to the mapping by the full product name.
-                byProductName[productName, default: []].insert(target)
-
-                // Add to the mapping by the name stem, if different from the full product name; if it is the same, then lookups should instead end up using the full-name table we created above.
-                if let stem = Path(productName).stem, stem != productName {
-                    byProductNameStem[stem, default: []].insert(target)
-                }
-            }
-            let maps = ProductNameMaps(byProductName: byProductName, byProductNameStem: byProductNameStem)
-            cached = maps
-            return maps
-        }
     }
 
     fileprivate func computeGraph() async -> (allTargets: OrderedSet<ConfiguredTarget>, targetDependencies: [ConfiguredTarget: [ResolvedTargetDependency]]) {
@@ -464,7 +459,7 @@ actor LinkageDependencyResolver {
 
     /// Search for an implicit dependency by full product name.
     nonisolated private func implicitDependency(forProductName productName: String, from configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, source: ImplicitDependencySource) async -> ConfiguredTarget? {
-        let candidateConfiguredTargets = await (productNameMaps().byProductName[productName] ?? []).asyncMap { [self] candidateTarget -> ConfiguredTarget? in
+        let candidateConfiguredTargets = await (productNameMaps.byProductName[productName] ?? []).asyncMap { [self] candidateTarget -> ConfiguredTarget? in
             // Prefer overriding build parameters from the build request, if present.
             let buildParameters = resolver.buildParametersByTarget[candidateTarget] ?? configuredTarget.parameters
 
@@ -483,7 +478,7 @@ actor LinkageDependencyResolver {
 
     /// Search for an implicit dependency by product name stem.
     nonisolated private func implicitDependency(forProductNameStem stem: String, buildFilePath: Path, from configuredTarget: ConfiguredTarget, imposedParameters: SpecializationParameters?, source: ImplicitDependencySource) async -> ConfiguredTarget? {
-        let candidateConfiguredTargets = await (productNameMaps().byProductNameStem[stem] ?? []).asyncMap { [self] candidateStandardTarget -> ConfiguredTarget? in
+        let candidateConfiguredTargets = await (productNameMaps.byProductNameStem[stem] ?? []).asyncMap { [self] candidateStandardTarget -> ConfiguredTarget? in
             // Prefer overriding build parameters from the build request, if present.
             let buildParameters = resolver.buildParametersByTarget[candidateStandardTarget] ?? configuredTarget.parameters
 


### PR DESCRIPTION
### Summary

`LinkageDependencyResolver.init` eagerly builds `targetsByProductName` / `targetsByProductNameStem` over **every** workspace target, calling `evaluatedName` on each. Since every SwiftPM module target's product-reference name is a build setting expression (`$(EXECUTABLE_NAME)` / `$(WRAPPER_NAME)`), that forces `getCachedSettings` — and thus full `Settings` construction — for every target on **every** build, including no-change builds.

Those maps are only consulted during **implicit**-dependency resolution (`implicitDependency(forProductName:)` / `forProductNameStem:`). Packages that use only **explicit** dependencies — i.e. all SwiftPM packages — never trigger that path, so building the maps eagerly is pure overhead.

This PR builds the maps **lazily on first use**. They are byte-identical when built, so behavior is unchanged; explicit-dependency projects simply never pay to build them.

### Motivation

`rdar://182737643` — large SwiftPM packages regressed ~13% on no-change ("null") builds. The delta is entirely in the out-of-process `Build operation` phase. Root-causing with a compiler-fixed A/B (swap only `SWBBuildService` via `XCBBUILDSERVICE_PATH`, keep the toolchain constant) attributed the whole regression to the eager map build.
