### PR TITLE
Add EXECUTABLE_INSTALL_NAME to BuildSettings

### DIFF
--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -963,6 +963,7 @@ public enum PIF {
         public var ENTITLEMENTS_REQUIRED: String?
         public var EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES: [String]?
         public var EXECUTABLE_NAME: String?
+        public var EXECUTABLE_INSTALL_NAME: String?
         public var FRAMEWORK_SEARCH_PATHS: [String]?
         public var GENERATE_INFOPLIST_FILE: String?
         public var GCC_C_LANGUAGE_STANDARD: String?

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -94,6 +94,7 @@ extension ProjectModel {
             case COREML_CODEGEN_LANGUAGE
             case COREML_COMPILER_CONTAINER
             case EXECUTABLE_NAME
+            case EXECUTABLE_INSTALL_NAME
             case GENERATE_EMBED_IN_CODE_ACCESSORS
             case INSTALLAPI_COPY_PHASE
             case INSTALLHDRS_COPY_PHASE


### PR DESCRIPTION
This is split off of #1545, which will provide a default for this setting and will switch to the new setting as the default for LD_DYLIB_INSTALL_NAME.

This change needs to land first, followed by adoption of an override in the swift-pm PIF-builder, and only then can #1545 be merged.