### PR TITLE
Fix SWBBuildService when Swift incremental cleanup diagnostics emitted after build request completes

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1601,7 +1601,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
 
     /// Wait for all status activity to be complete before returning.
     func waitForCompletion(buildSucceeded: Bool) async {
-        let completionToken = await dynamicOperationContext.waitForCompletion()
+        _ = await dynamicOperationContext.waitForCompletion()
         if await validateCompilationCachePostBuild() == .succeeded {
             cleanupCompilationCache()
         }
@@ -1625,7 +1625,14 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
                     }
                 }
             }
+        }
 
+        // cleanUpForAllKeys above tears down Swift driver state asynchronously and emits
+        // incremental-build diagnostics.  We have to drain those diagnostics while the build's request
+        // is still open.
+        let completionToken = await dynamicOperationContext.waitForCompletion()
+
+        await queue.sync {
             // Reset the DynamicOperationContext to free cached info from the finished build.
             self.dynamicOperationContext.reset(completionToken: completionToken)
         }

--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -1601,7 +1601,7 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
 
     /// Wait for all status activity to be complete before returning.
     func waitForCompletion(buildSucceeded: Bool) async {
-        _ = await dynamicOperationContext.waitForCompletion()
+        let completionToken = await dynamicOperationContext.waitForCompletion()
         if await validateCompilationCachePostBuild() == .succeeded {
             cleanupCompilationCache()
         }
@@ -1619,20 +1619,11 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
             // If the build failed, make sure we flush any pending incremental build records.
             // Usually, driver instances are cleaned up and write out their incremental build records when a target finishes building. However, this won't necessarily be the case if the build fails. Ensure we write out any pending records before tearing down the graph so we don't use a stale record on a subsequent build.
             if !buildSucceeded {
-                self.dynamicOperationContext.swiftModuleDependencyGraph.cleanUpForAllKeys { [buildOutputDelegate = self.buildOutputDelegate] diagnostics in
-                    for diagnostic in diagnostics {
-                        buildOutputDelegate.emit(diagnostic)
-                    }
+                for diagnostic in self.dynamicOperationContext.swiftModuleDependencyGraph.cleanUpForAllKeys() {
+                    self.buildOutputDelegate.emit(diagnostic)
                 }
             }
-        }
 
-        // cleanUpForAllKeys above tears down Swift driver state asynchronously and emits
-        // incremental-build diagnostics.  We have to drain those diagnostics while the build's request
-        // is still open.
-        let completionToken = await dynamicOperationContext.waitForCompletion()
-
-        await queue.sync {
             // Reset the DynamicOperationContext to free cached info from the finished build.
             self.dynamicOperationContext.reset(completionToken: completionToken)
         }
@@ -1873,10 +1864,8 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
         // First, give it a chance to write out incremental state
         let driverIdentifiers = operation.buildDescription.taskStore.tasksForTarget(target).compactMap { ($0.payload as? SwiftTaskPayload)?.driverPayload?.uniqueID }
         for identifier in Set(driverIdentifiers) {
-            dynamicOperationContext.swiftModuleDependencyGraph.cleanUp(key: identifier) { [buildOutputDelegate] diagnostics in
-                for diagnostic in diagnostics {
-                    buildOutputDelegate.emit(diagnostic)
-                }
+            for diagnostic in dynamicOperationContext.swiftModuleDependencyGraph.cleanUp(key: identifier) {
+                buildOutputDelegate.emit(diagnostic)
             }
         }
     }

--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -252,27 +252,18 @@ public final class SwiftModuleDependencyGraph: SwiftGlobalExplicitDependencyGrap
     }
 
     /// Serialize incremental build state for the given key and removes its state from memory
-    public func cleanUpForAllKeys(diagnosticsHandler: (([SWBUtil.Diagnostic]) -> Void)?) {
-        registryQueue.async {
-            for driver in self.registry.values {
-                let diagnostics = driver.writeIncrementalBuildInformation()
-                if !diagnostics.isEmpty {
-                    diagnosticsHandler?(diagnostics)
-                }
-            }
-            self.registry.removeAll()
+    public func cleanUpForAllKeys() -> [SWBUtil.Diagnostic] {
+        registryQueue.blocking_sync {
+            defer { self.registry.removeAll() }
+            return self.registry.values.flatMap { $0.writeIncrementalBuildInformation() }
         }
     }
 
     /// Serialize incremental build state for the given key and removes its state from memory
-    public func cleanUp(key: String, diagnosticsHandler: (([SWBUtil.Diagnostic]) -> Void)?) {
-        registryQueue.async {
-            if let driver = self.registry.removeValue(forKey: key) {
-                let diagnostics = driver.writeIncrementalBuildInformation()
-                if !diagnostics.isEmpty {
-                    diagnosticsHandler?(diagnostics)
-                }
-            }
+    public func cleanUp(key: String) -> [SWBUtil.Diagnostic] {
+        registryQueue.blocking_sync {
+            guard let driver = self.registry.removeValue(forKey: key) else { return [] }
+            return driver.writeIncrementalBuildInformation()
         }
     }
 


### PR DESCRIPTION
Fix SWBBuildService when Swift incremental cleanup diagnostics emitted after build request completes

SWBBuildService could crash with a precondition failure in Request.send at the end of a build. The crash originated on the SwiftModuleDependencyGraph queue when emitting a swift-driver incremental-build diagnostic after the Request had already been completed.

