### PR TITLE
[CAS] Serialize remote service path into .cas-config and unify plugin options

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -58,8 +58,8 @@ private struct BuildCacheInfoMsg: MessageHandler {
         } else if message.pluginEnabled, case .xcode(let xcodeDeveloperDir) = core.developerPath {
             casOptions.setPluginPath(xcodeDeveloperDir.join(Path("usr/lib/libToolchainCASPlugin.dylib")).str)
         }
-        if let remoteServicePath = message.remoteServicePath, !remoteServicePath.isEmpty {
-            casOptions.setPluginOption(name: "remote-service-path", value: remoteServicePath)
+        if let (name, value) = CASOptions.getRemoteServicePluginOption(remoteServicePath: message.remoteServicePath) {
+            casOptions.setPluginOption(name: name, value: value)
         }
 
         let casDatabases = try ClangCASDatabases(options: casOptions)

--- a/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
+++ b/Sources/SWBCore/LibSwiftDriver/LibSwiftDriver.swift
@@ -700,10 +700,7 @@ extension SwiftModuleDependencyGraph {
             guard let path else { return nil }
             return try AbsolutePath(validating: path)
         }
-        var pluginOpts = [(String, String)]()
-        if casOptions.hasRemoteCache, let servicePath = casOptions.remoteServicePath {
-            pluginOpts.append(("remote-service-path", servicePath.str))
-        }
+        let pluginOpts = casOptions.pluginOptions(useRemote: true)
         let key = SwiftModuleDependencyGraph.OracleRegistryKey(compilerLocation: compilerLocation, casOpts: casOptions)
         guard let oracle = oracleRegistry[key] else {
             throw StubError.error("can't find created dependency scanning oracle from compiler location \(compilerLocation)")

--- a/Sources/SWBCore/Settings/CASOptions.swift
+++ b/Sources/SWBCore/Settings/CASOptions.swift
@@ -120,6 +120,24 @@ public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
         return remoteServicePath != nil
     }
 
+    /// The options to pass to the CAS plugin, as `(name, value)` pairs.
+    ///
+    /// - Parameter useRemote: Whether the remote service path (if any) should be
+    ///   configured. Pass `false` for CAS instances that must not use the remote cache.
+    public func pluginOptions(useRemote: Bool) -> [(String, String)] {
+        var options: [(String, String)] = []
+        if useRemote, let remoteServiceOption = Self.getRemoteServicePluginOption(remoteServicePath: remoteServicePath?.str) {
+            options.append(remoteServiceOption)
+        }
+        return options
+    }
+
+    /// The CAS plugin option used to configure the remote cache service, or `nil` if `remoteServicePath` is not set.
+    public static func getRemoteServicePluginOption(remoteServicePath: String?) -> (String, String)? {
+        guard let remoteServicePath, !remoteServicePath.isEmpty else { return nil }
+        return ("remote-service-path", remoteServicePath)
+    }
+
     public init(
         casPath: Path,
         pluginPath: Path?,
@@ -168,7 +186,8 @@ public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
 
     public static func create(
         _ scope: MacroEvaluationScope,
-        _ purpose: Purpose
+        _ purpose: Purpose,
+        delegate: (any DiagnosticProducingDelegate)? = nil
     ) throws -> CASOptions {
         func isLanguageSupportedForRemoteCaching() -> Bool {
             switch purpose {
@@ -207,6 +226,9 @@ public struct CASOptions: Hashable, Serializable, Encodable, Sendable {
             }
             pluginPath = nil
             remoteServicePath = nil
+            if !scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SERVICE_PATH).isEmpty {
+                delegate?.warning("\(BuiltinMacros.COMPILATION_CACHE_REMOTE_SERVICE_PATH.name) is set but \(BuiltinMacros.COMPILATION_CACHE_ENABLE_PLUGIN.name) is not enabled; the remote CAS service will not be used")
+            }
         }
 
         let limitingStrategy: CASOptions.SizeLimitingStrategy = try {

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -1011,7 +1011,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
                 let casOptions: CASOptions? = {
                     guard cachedBuild else { return nil }
                     do {
-                        return try CASOptions.create(cbc.scope, .compiler(language))
+                        return try CASOptions.create(cbc.scope, .compiler(language), delegate: delegate)
                     } catch {
                         delegate.error(error.localizedDescription)
                         return nil

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1470,7 +1470,7 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             // Add caching related configurations.
             let casOptions: CASOptions?
             do {
-                casOptions = isCachingEnabled ? (try CASOptions.create(cbc.scope, .compiler(.other(dialectName: "swift")))) : nil
+                casOptions = isCachingEnabled ? (try CASOptions.create(cbc.scope, .compiler(.other(dialectName: "swift")), delegate: delegate)) : nil
                 if let casOpts = casOptions {
                     args.append("-cache-compile-job")
                     args += ["-cas-path", casOpts.casPath.str]

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CompilationCachingConfigFileTaskProducer.swift
@@ -59,10 +59,13 @@ final class CompilationCachingConfigFileTaskProducer: StandardTaskProducer, Task
                     struct CASConfig: Encodable {
                         let CASPath: String
                         let PluginPath: String?
+                        let PluginOptions: [[String: String]]
                     }
                     let encoder = JSONEncoder()
                     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-                    let casConfigContent = try encoder.encode(CASConfig(CASPath: casOpts.casPath.str, PluginPath: casOpts.pluginPath?.str))
+                    // Serialize each plugin option as a single-key object to match the format expected by LLVM's CAS configuration reader.
+                    let pluginOptions = casOpts.pluginOptions(useRemote: true).map { [$0.0: $0.1] }
+                    let casConfigContent = try encoder.encode(CASConfig(CASPath: casOpts.casPath.str, PluginPath: casOpts.pluginPath?.str, PluginOptions: pluginOptions))
 
                     var prefixXcode = false
                     var prefixProject = false

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
@@ -248,8 +248,8 @@ package final class ClangModuleDependencyGraph {
                                 if let pluginPath = casOptions.pluginPath {
                                     casOpts.setPluginPath(pluginPath.str)
                                 }
-                                if let remotePath = casOptions.remoteServicePath, !ignoreRemote {
-                                    casOpts.setPluginOption(name: "remote-service-path", value: remotePath.str)
+                                for (name, value) in casOptions.pluginOptions(useRemote: !ignoreRemote) {
+                                    casOpts.setPluginOption(name: name, value: value)
                                 }
                                 return casOpts
                             }

--- a/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/CompilationCachingTaskConstructionTests.swift
@@ -134,6 +134,119 @@ fileprivate struct CompilationCachingTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS, comment: "Caching requires explicit modules, which requires libclang and is only available on macOS"))
+    func casConfigFileContainsRemoteServiceAsPluginOption() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("SourceFile.m"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "CC": clangCompilerPath.str,
+                    "CLANG_ENABLE_MODULES": "YES",
+                    "CLANG_ENABLE_COMPILE_CACHE": "YES",
+                    "COMPILATION_CACHE_ENABLE_PLUGIN": "YES",
+                    "COMPILATION_CACHE_REMOTE_SERVICE_PATH": "/tmp/cc",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Tool",
+                    type: .commandLineTool,
+                    buildConfigurations: [TestBuildConfiguration("Debug")],
+                    buildPhases: [TestSourcesBuildPhase(["SourceFile.m"])]
+                ),
+            ])
+        let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+        let tester = try await TaskConstructionTester(getCore(), testWorkspace)
+
+        try await tester.checkBuild(runDestination: .macOS) { results in
+            // The `.cas-config` file should carry the remote service path as a
+            // plugin option so external tools (e.g. dsymutil, lldb) can connect
+            // to the same remote cache.
+            results.checkWriteAuxiliaryFileTask(.matchRuleType("WriteCASConfig")) { _, contents in
+                #expect(contents.asString.contains(#""remote-service-path":"/tmp/cc""#))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS, comment: "Caching requires explicit modules, which requires libclang and is only available on macOS"))
+    func casConfigFileWithoutRemoteService() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("SourceFile.m"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "CC": clangCompilerPath.str,
+                    "CLANG_ENABLE_MODULES": "YES",
+                    "CLANG_ENABLE_COMPILE_CACHE": "YES",
+                    "COMPILATION_CACHE_ENABLE_PLUGIN": "YES",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Tool",
+                    type: .commandLineTool,
+                    buildConfigurations: [TestBuildConfiguration("Debug")],
+                    buildPhases: [TestSourcesBuildPhase(["SourceFile.m"])]
+                ),
+            ])
+        let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+        let tester = try await TaskConstructionTester(getCore(), testWorkspace)
+
+        try await tester.checkBuild(runDestination: .macOS) { results in
+            // With no remote service configured, `PluginOptions` should be empty.
+            results.checkWriteAuxiliaryFileTask(.matchRuleType("WriteCASConfig")) { _, contents in
+                #expect(contents.asString.contains(#""PluginOptions":[]"#))
+                #expect(!contents.asString.contains("remote-service-path"))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS, comment: "Caching requires explicit modules, which requires libclang and is only available on macOS"))
+    func remoteServiceWithoutPluginEmitsWarning() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "SomeFiles",
+                children: [
+                    TestFile("SourceFile.m"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "CC": clangCompilerPath.str,
+                    "CLANG_ENABLE_MODULES": "YES",
+                    "CLANG_ENABLE_COMPILE_CACHE": "YES",
+                    // Remote service is set but the plugin is not enabled.
+                    "COMPILATION_CACHE_REMOTE_SERVICE_PATH": "/tmp/cc",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Tool",
+                    type: .commandLineTool,
+                    buildConfigurations: [TestBuildConfiguration("Debug")],
+                    buildPhases: [TestSourcesBuildPhase(["SourceFile.m"])]
+                ),
+            ])
+        let testWorkspace = TestWorkspace("aWorkspace", projects: [testProject])
+        let tester = try await TaskConstructionTester(getCore(), testWorkspace)
+
+        try await tester.checkBuild(runDestination: .macOS) { results in
+            results.checkWarning(.contains("COMPILATION_CACHE_REMOTE_SERVICE_PATH is set but COMPILATION_CACHE_ENABLE_PLUGIN is not enabled"))
+        }
+    }
+
     @Test(.requireSDKs(.host))
     func imageFormatMCCASSupport() async throws {
         let core = try await getCore()


### PR DESCRIPTION
Centralize CAS plugin-option computation on `CASOptions` so the clang and
Swift caching paths, the `BuildCacheInfo` message handler, and the
`.cas-config` file all share a single source of truth:

- Add `CASOptions.pluginOptions(useRemote:)` and the static
  `getRemoteServicePluginOption(remoteServicePath:)` helper, replacing the
  duplicated remote-service-path logic in ClangModuleDependencyGraph,
  LibSwiftDriver, and Messages.
- Write `PluginOptions` (including the remote service path) into
  `.cas-config`, matching the format LLVM's CASConfiguration reader expects,
  so external tools (dsymutil, lldb) can reach the same remote cache.
- Emit a warning from `CASOptions.create` when a remote service path is set
  but the CAS plugin is not enabled.

Add task-construction tests covering the serialized plugin options and the
new warning.