### PR TITLE
fix(build): ignore compiler verbosity in task signatures

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -823,6 +823,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         "-fdiagnostics-parseable-fixits",
         "-fno-elide-type",
         "-fdiagnostics-show-template-tree",
+        "-v",
 
         // https://clang.llvm.org/docs/ClangCommandLineReference.html
         "-fdiagnostics-show-note-include-stack",

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -722,6 +722,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         case invalid
     }
 
+    static let outputAgnosticCompilerArguments = Set<ByteString>([
+        "-v"
+    ])
+
     static let outputAgnosticCompilerArgumentsWithValues = Set<ByteString>([
         "-index-store-path",
         "-index-unit-output-path",
@@ -732,7 +736,8 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
     ])
 
     static func isOutputAgnosticCommandLineArgument(_ argument: ByteString, prevArgument: ByteString?) -> Bool {
-        if SwiftCompilerSpec.outputAgnosticCompilerArgumentsWithValues.contains(argument) {
+        if SwiftCompilerSpec.outputAgnosticCompilerArguments.contains(argument) ||
+           SwiftCompilerSpec.outputAgnosticCompilerArgumentsWithValues.contains(argument) {
             return true
         }
 

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -2708,6 +2708,8 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
 
             try await tester.checkNullBuild(parameters: BuildParameters(configuration: "Debug", commandLineOverrides: ["OTHER_CFLAGS": "-index-store-path \"\(tmpDirPath.join("IndexDataStore"))\""]), runDestination: .macOS, persistent: true, excludedTasks: ["ClangStatCache"])
 
+            try await tester.checkNullBuild(parameters: BuildParameters(configuration: "Debug", commandLineOverrides: ["OTHER_CFLAGS": "-v", "OTHER_SWIFT_FLAGS": "-v"]), runDestination: .macOS, persistent: true, excludedTasks: ["ClangStatCache"])
+
             // Check that the next build is NOT null.
             try await tester.checkBuild(parameters: BuildParameters(configuration: "Debug", commandLineOverrides: ["OTHER_CFLAGS": "-DFOO=\"删除所有的\""]), runDestination: .macOS, persistent: true) { results in
 


### PR DESCRIPTION
Fixes swiftlang/swift-package-manager#9299

## Summary

Prevent compiler verbosity flags from invalidating Clang and Swift compiler task signatures.

SwiftPM forwards `-v` to the compiler when `--very-verbose` logging is enabled. Although this flag only changes diagnostic output, SwiftBuild included it when computing compiler task signatures. Adding `--very-verbose` to an otherwise unchanged build therefore caused compiler tasks and their downstream dependents to run again.

SwiftBuild already treats linker verbosity as output-agnostic. This change extends that behavior to Clang and Swift compiler invocations.

## Changes

- Treat Clang’s `-v` argument as output-agnostic when computing compiler task signatures.
- Treat Swift’s `-v` argument as output-agnostic when computing compiler task signatures.
- Add persistent-build regression coverage for `OTHER_CFLAGS=-v` and `OTHER_SWIFT_FLAGS=-v`.
- Verify that changing only compiler verbosity produces a null build.

## Alternatives considered

Removing `-v` from SwiftPM’s very-verbose build settings was rejected because it would prevent genuinely executed compiler tasks from producing the requested verbose output.

Filtering `-v` globally for every command-line tool was also considered. The change remains compiler-specific because `-v` is not necessarily output-agnostic for every tool, and the existing compiler specifications already provide the appropriate signature-normalization mechanism.

Handling only the linker flags is insufficient because Clang and Swift compiler task signatures still change and cause their downstream linker tasks to run.

## Notes

The flag remains present on the actual compiler command line. It is removed only from the command-line representation used to compute the task signature, so verbose compiler output continues to work whenever compilation is otherwise required.

After this change lands, SwiftPM will need to update its pinned SwiftBuild revision before removing the known-issue quarantine for the corresponding regression test.

## Testing

- `swift test --filter outputAgnosticsFlagsRebuild` — passed.
- `bash .github/scripts/format-check.sh` — passed.
- Verified that the regression test fails without the compiler normalization, reporting signature changes for both the Clang and Swift compilation tasks.