### PR TITLE
[6.4]Respect -use-ld in toolset swift options as an ALTERNATE_LINKER override

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2894,6 +2894,13 @@ private class SettingsBuilder: ProjectMatchLookup {
                             // directory. We should fix the SDK and then enforce consistency here.
                             case "-wmo", "-whole-module-optimization":
                                 table.push(BuiltinMacros.SWIFT_COMPILATION_MODE, literal: "wholemodule")
+                            case _  where option.hasPrefix("-use-ld="):
+                                // Some existing toolsets put '-use-ld' in the Swift options, assuming that swiftc
+                                // will always be used as the linker driver. However, clang/clang++ may be used
+                                // for targets which only contain C-family sources. Map these flags to an
+                                // ALTERNATE_LINKER override which applies to any linker driver.
+                                let alternateLinker = String(option.dropFirst("-use-ld=".count))
+                                table.push(BuiltinMacros.ALTERNATE_LINKER, literal: alternateLinker)
                             default:
                                 break
                             }

--- a/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/ToolsetTaskConstructionTests.swift
@@ -568,6 +568,84 @@ fileprivate struct ToolsetTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.host))
+    func toolsetSwiftUseLdAppliesToAllLinkerDrivers() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let core = try await getCore()
+
+            let toolsetPath = tmpDir.join("toolset.json")
+            let toolset = SwiftSDK.Toolset(
+                swiftCompiler: .init(extraCLIOptions: ["-use-ld=lld"])
+            )
+            let toolsetData = try JSONEncoder().encode(toolset)
+            try localFS.createDirectory(toolsetPath.dirname, recursive: true)
+            try localFS.write(toolsetPath, contents: ByteString(toolsetData))
+
+            let testProject = TestProject(
+                "aProject",
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("file.c"),
+                        TestFile("file.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SWIFT_VERSION": try await swiftVersion,
+                        "CLANG_USE_RESPONSE_FILE": "NO",
+                        "SWIFT_SDK_TOOLSETS": toolsetPath.strWithPosixSlashes,
+                    ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "SwiftLinked",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "LINKER_DRIVER": "swiftc",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.swift"]),
+                        ],
+                        dependencies: ["ClangLinked"]
+                    ),
+                    TestStandardTarget(
+                        "ClangLinked",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "LINKER_DRIVER": "clang",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["file.c"]),
+                        ]
+                    ),
+                ])
+
+            let tester = try TaskConstructionTester(core, testProject)
+
+            await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .host, fs: localFS) { results in
+                results.checkNoDiagnostics()
+
+                results.checkTarget("SwiftLinked") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-use-ld=lld"])
+                    }
+                }
+
+                results.checkTarget("ClangLinked") { target in
+                    results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
+                        task.checkCommandLineContains(["-fuse-ld=lld"])
+                        task.checkCommandLineDoesNotContain("-use-ld=lld")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host))
     func toolsetInBuildRequestOverrides() async throws {
         try await withTemporaryDirectory { tmpDir in
             let core = try await getCore()


### PR DESCRIPTION
* Explanation: Some existing Swift SDK toolsets specify -use-ld= in _Swift compiler_ options without specifying a linker path override, assuming that only swiftc will ever be used to link. Map these options to an ALTERNATE_LINKER override so they also apply to linking of C-family targets.
* Scope: Cross compilation using toolsets with -use-ld
* Issues: https://github.com/swiftlang/swift-build/issues/1574
* Risk:
      Low, this is a narrowly targeted change to toolset settings
* Testing: Added unit test, manual testing of the example from the issue


Closes https://github.com/swiftlang/swift-build/issues/1574