### PR TITLE
Fix indexStorePath/indexDatabasePath being transposed in BSP response

### DIFF
--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -36,12 +36,14 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
     private var buildDescriptionID: SWBBuildDescriptionID? = nil
 
     private var indexStorePath: String? {
-        buildRequest.parameters.arenaInfo?.indexDataStoreFolderPath.map {
-            Path($0).dirname.join("index-store").str
-        }
+        // The directory containing index store info written by the compilers.
+        buildRequest.parameters.arenaInfo?.indexDataStoreFolderPath
     }
     private var indexDatabasePath: String? {
-        buildRequest.parameters.arenaInfo?.indexDataStoreFolderPath
+        // This is where a BSP client (e.g. SourceKit-LSP) may create its own IndexStoreDB.
+        buildRequest.parameters.arenaInfo?.indexDataStoreFolderPath.map {
+            Path($0).dirname.join("IndexStoreDB").str
+        }
     }
 
     public let messageHandlingHelper = QueueBasedMessageHandlerHelper(

--- a/Tests/SwiftBuildTests/BuildServerTests.swift
+++ b/Tests/SwiftBuildTests/BuildServerTests.swift
@@ -53,7 +53,7 @@ extension Connection {
     }
 }
 
-fileprivate func withBuildServerConnection(setup: (Path) async throws -> (TestWorkspace, SWBBuildRequest), body: (any Connection, CollectingMessageHandler, Path) async throws -> Void) async throws {
+fileprivate func withBuildServerConnection(setup: (Path) async throws -> (TestWorkspace, SWBBuildRequest), body: (any Connection, CollectingMessageHandler, Path, InitializeBuildResponse) async throws -> Void) async throws {
     try await withTemporaryDirectory { (temporaryDirectory: NamedTemporaryDirectory) in
         try await withAsyncDeferrable { deferrable in
             let tmpDir = temporaryDirectory.path
@@ -74,7 +74,7 @@ fileprivate func withBuildServerConnection(setup: (Path) async throws -> (TestWo
 
             connectionToServer.start(handler: buildServer)
             connectionToClient.start(handler: collectingMessageHandler)
-            _ = try await connectionToServer.send(
+            let initializeResponse = try await connectionToServer.send(
                 InitializeBuildRequest(
                     displayName: "test-bsp-client",
                     version: "1.0.0",
@@ -86,7 +86,7 @@ fileprivate func withBuildServerConnection(setup: (Path) async throws -> (TestWo
             connectionToServer.send(OnBuildInitializedNotification())
             _ = try await connectionToServer.send(WorkspaceWaitForBuildSystemUpdatesRequest())
 
-            try await body(connectionToServer, collectingMessageHandler, tmpDir)
+            try await body(connectionToServer, collectingMessageHandler, tmpDir, initializeResponse)
 
             _ = try await connectionToServer.send(BuildShutdownRequest())
             connectionToServer.send(OnBuildExitNotification())
@@ -185,7 +185,7 @@ fileprivate struct BuildServerTests: CoreBasedTests {
             request.parameters.activeRunDestination = .host
 
             return (testWorkspace, request)
-        }) { connection, handler, _ in
+        }) { connection, handler, _, _ in
             #expect(handler.notifications.withLock { notifications in
                 notifications.contains { notification in
                     notification is OnBuildTargetDidChangeNotification
@@ -257,7 +257,7 @@ fileprivate struct BuildServerTests: CoreBasedTests {
             request.parameters.activeRunDestination = .host
 
             return (testWorkspace, request)
-        }) { connection, _, tmpDir in
+        }) { connection, _, tmpDir, _ in
             let targetsResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             let target = try #require(targetsResponse.targets.only)
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [target.id]))
@@ -361,7 +361,7 @@ fileprivate struct BuildServerTests: CoreBasedTests {
             """)
 
             return (testWorkspace, request)
-        }) { connection, collector, tmpDir in
+        }) { connection, collector, tmpDir, _ in
             let targetsResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             let target = try #require(targetsResponse.targets.filter { $0.displayName == "Target2" }.only)
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [target.id]))
@@ -514,6 +514,74 @@ fileprivate struct BuildServerTests: CoreBasedTests {
                 connectionToServer.send(OnBuildExitNotification())
                 connectionToServer.close()
             }
+        }
+    }
+
+    /// Regression test for `indexStorePath`/`indexDatabasePath` being transposed in the `build/initialize` response.
+    @Test(.requireSDKs(.host))
+    func indexStoreAndDatabasePathsAreNotTransposed() async throws {
+        try await withBuildServerConnection(setup: { tmpDir in
+            let testWorkspace = TestWorkspace(
+                "aWorkspace",
+                sourceRoot: tmpDir.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        defaultConfigurationName: "Debug",
+                        groupTree: TestGroup(
+                            "Foo",
+                            children: [
+                                TestFile("a.swift"),
+                            ]
+                        ),
+                        targets: [
+                            TestStandardTarget(
+                                "Target",
+                                type: .dynamicLibrary,
+                                buildConfigurations: [
+                                    TestBuildConfiguration("Debug", buildSettings: [
+                                        "SDKROOT": "auto",
+                                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                    ])
+                                ],
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "a.swift"
+                                    ])
+                                ]
+                            ),
+                        ]
+                    )
+                ])
+
+            var request = SWBBuildRequest()
+            request.parameters = SWBBuildParameters()
+            request.parameters.action = "build"
+            request.parameters.configurationName = "Debug"
+            for target in testWorkspace.projects.flatMap({ $0.targets }) {
+                request.add(target: SWBConfiguredTarget(guid: target.guid))
+            }
+            request.parameters.activeRunDestination = .host
+
+            let derivedDataPath = tmpDir.join("out").str
+            request.parameters.arenaInfo = SWBArenaInfo(
+                derivedDataPath: derivedDataPath,
+                buildProductsPath: derivedDataPath + "/Products",
+                buildIntermediatesPath: derivedDataPath + "/Intermediates.noindex",
+                pchPath: derivedDataPath + "/PCH",
+                indexRegularBuildProductsPath: nil,
+                indexRegularBuildIntermediatesPath: nil,
+                indexPCHPath: derivedDataPath,
+                indexDataStoreFolderPath: derivedDataPath,
+                indexEnableDataStore: true
+            )
+
+            return (testWorkspace, request)
+        }) { _, _, tmpDir, initializeResponse in
+            let data = try #require(SourceKitInitializeBuildResponseData(fromLSPAny: initializeResponse.data))
+
+            #expect(data.indexStorePath == tmpDir.join("out").str)
+            #expect(data.indexDatabasePath == tmpDir.join("IndexStoreDB").str)
         }
     }
 }


### PR DESCRIPTION
Fixes swiftlang/swift-package-manager#10350

**Note:** the linked issue was filed against `swift-package-manager`, but the root cause is in `swift-build`'s BSP server implementation, so the fix lives here.

## Summary
`indexStorePath` and `indexDatabasePath` in `SWBBuildServer`'s BSP `build/initialize` response were transposed:

- `indexStorePath` derived a sibling directory (`dirname(indexDataStoreFolderPath)/index-store`) that nothing ever writes to.
- `indexDatabasePath` returned `indexDataStoreFolderPath` directly — i.e. the *real* index store location — mislabeled as a database path.

Any BSP client that trusts `indexStorePath` (e.g. SourceKit-LSP with `swiftPM.buildSystem: "swiftbuild"`) opens a valid-but-empty store and silently returns no results for cross-file queries.

## Fix
- `indexStorePath` now returns `arenaInfo.indexDataStoreFolderPath` directly — the actual directory the build writes index data into.
- `indexDatabasePath` now derives a sibling directory (`DataStoreDB`, following the naming convention already used for adjacent Index.noindex paths in `SWBTestSupport/Misc.swift`: `DataStore`, `PrecompiledHeaders`, `Build`) so a client can safely create its own IndexStoreDB without colliding with the raw store.

## Verification
Reproduced and confirmed with a real package, using the `swiftbuild` backend end-to-end:
1. Captured the real `-index-store-path` from a verbose `swift build --build-system swiftbuild -v` compile invocation.
2. Queried `swift package experimental-build-server --build-system swiftbuild` directly over stdio with a raw `build/initialize` request and confirmed the advertised paths didn't match the real one (before fix).
3. After the fix, rebuilt and re-queried: `indexStorePath` now matches the real store path, and `.build/out/v5/{units,records}` are confirmed present exactly where `indexStorePath` claims.
4. `indexDatabasePath` now points at a distinct, non-colliding sibling path.

## Testing
Added `indexStoreAndDatabasePathsAreNotTransposed` in `BuildServerTests.swift`, which constructs a build request with an explicit `SWBArenaInfo` and asserts `indexStorePath` matches the real derived-data path while `indexDatabasePath` remains distinct from it. Verified the test fails without the fix and passes with it.