### PR TITLE
[6.4.x] Fix link command line filtering when using dynamic replacement previews with swiftc as the linker driver

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -1176,20 +1176,59 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
 
         var commandLine = Array(task.commandLineAsStrings)
 
-        let argPrefix = "-Xlinker"
+        let linkerPrefix = "-Xlinker"
+        let clangLinkerPrefix = "-Xclang-linker"
 
         // Args without parameters (-Xlinker-prefixed, e.g. -Xlinker)
-        for arg in ["-export_dynamic", "-sdk_imports_each_object", "-dead_strip"] {
+        for arg in ["-export_dynamic", "-sdk_imports_each_object", "-dead_strip", "-bundle", "-r"] {
             while let index = commandLine.firstIndex(of: arg) {
-                guard index > 0, commandLine[index - 1] == argPrefix else { break }
+                guard index > 0, commandLine[index - 1] == linkerPrefix else { break }
                 commandLine.removeSubrange(index - 1 ... index)
             }
         }
 
-        // Args without parameters
-        for arg in ["-dynamiclib", "-bundle", "-r", "-dead_strip", "-nostdlib", "-rdynamic"] {
+        // Args without parameters (-Xclang-linker prefixed)
+        for arg in ["-nostdlib", "-rdynamic"] {
+            while let index = commandLine.firstIndex(of: arg) {
+                guard index > 0, commandLine[index - 1] == clangLinkerPrefix else { break }
+                commandLine.removeSubrange(index - 1 ... index)
+            }
+        }
+
+        // Args without parameters, unprefixed
+        for arg in ["-dynamiclib", "-emit-library", "-emit-executable", "-bundle", "-r", "-dead_strip", "-nostdlib", "-rdynamic"] {
             while let index = commandLine.firstIndex(of: arg) {
                 commandLine.remove(at: index)
+            }
+        }
+
+        // Args with a parameter (-Xlinker-prefixed, e.g. -Xlinker arg -Xlinker param)
+        for arg in ["-object_path_lto", "-add_ast_path", "-dependency_info", "-map", "-order_file", "-final_output", "-allowable_client", "-sdk_imports"] {
+            while let index = commandLine.firstIndex(of: arg) {
+                guard index > 0,
+                    index + 2 < commandLine.count,
+                    commandLine[index - 1] == linkerPrefix,
+                    commandLine[index + 1] == linkerPrefix
+                    else {
+                        break
+                }
+
+                commandLine.removeSubrange(index - 1 ... index + 2)
+            }
+        }
+
+        // Args with a parameter (-Xclang-linker-prefixed)
+        for arg in ["-install_name"] {
+            while let index = commandLine.firstIndex(of: arg) {
+                guard index > 0,
+                    index + 2 < commandLine.count,
+                    commandLine[index - 1] == clangLinkerPrefix,
+                    commandLine[index + 1] == clangLinkerPrefix
+                    else {
+                        break
+                }
+
+                commandLine.removeSubrange(index - 1 ... index + 2)
             }
         }
 
@@ -1204,35 +1243,44 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
             }
         }
 
-        // Args with a parameter (-Xlinker-prefixed, e.g. -Xlinker arg -Xlinker param)
-        for arg in ["-object_path_lto", "-add_ast_path", "-dependency_info", "-map", "-order_file", "-final_output", "-allowable_client", "-sdk_imports"] {
-            while let index = commandLine.firstIndex(of: arg) {
-                guard index > 0,
-                    index + 2 < commandLine.count,
-                    commandLine[index - 1] == argPrefix,
-                    commandLine[index + 1] == argPrefix
-                    else {
-                        break
-                }
-
-                commandLine.removeSubrange(index - 1 ... index + 2)
-            }
+        // swiftc link file list
+        while let index = commandLine.firstIndex(where: { $0.hasPrefix("@") && $0.hasSuffix(".LinkFileList") }) {
+            commandLine.remove(at: index)
         }
 
-        switch previewPayload.linkStyle {
-        case .dylib:
+        let linkerDriverIsSwiftc = commandLine.first?.hasSuffix("swiftc") == true
+
+        switch (previewPayload.linkStyle, linkerDriverIsSwiftc) {
+        case (.dylib, false):
             commandLine.append(contentsOf: [
                 "-dynamiclib",
                 payload.outputPath.str,
                 ])
 
-        case .bundleLoader:
+        case (.bundleLoader, false):
             commandLine.append(contentsOf: [
                 "-bundle",
                 "-bundle_loader",
                 payload.outputPath.str,
                 ])
-        case .staticLib:
+        case (.dylib, true):
+            commandLine.append(contentsOf: [
+                "-Xclang-linker",
+                "-dynamiclib",
+                "-Xclang-linker",
+                payload.outputPath.str,
+                ])
+
+        case (.bundleLoader, true):
+            commandLine.append(contentsOf: [
+                "-Xclang-linker",
+                "-bundle",
+                "-Xclang-linker",
+                "-bundle_loader",
+                "-Xclang-linker",
+                payload.outputPath.str,
+                ])
+        case (.staticLib, _):
             break
         }
 

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -804,8 +804,8 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS, .iOS))
-    func previewThunkBuilds() async throws {
+    @Test(.requireSDKs(.macOS, .iOS), arguments: [LinkerDriverChoice.clang, .swiftc])
+    func previewThunkBuilds(linkerDriver: LinkerDriverChoice) async throws {
         let archs = ["arm64", "arm64e"]
 
         for explicitModules in [false, true] {
@@ -846,6 +846,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
 
                             "SUPPORTS_TEXT_BASED_API": "YES",
                             "DYLIB_INSTALL_NAME_BASE": "@rpath",
+                            "LINKER_DRIVER": linkerDriver.rawValue,
                         ]),
                     ],
                     targets: [
@@ -1006,7 +1007,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
                             default: fatalError()
                             }
 
-                            try await _checkPreviewCommands(previewInfo, srcRoot: srcRoot, target: target, arch: arch, linkStyle: linkStyle, linkAgainst: linkAgainst, expectUnextendedModuleOverlay: expectUnextendedModuleOverlay, explicitModuleBuild: explicitModules)
+                            try await _checkPreviewCommands(previewInfo, srcRoot: srcRoot, target: target, arch: arch, linkStyle: linkStyle, linkAgainst: linkAgainst, expectUnextendedModuleOverlay: expectUnextendedModuleOverlay, explicitModuleBuild: explicitModules, linkerDriver: linkerDriver)
                             try await _execPreviewBuild(previewInfo)
                         }
                     }
@@ -1099,7 +1100,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
         case bundleLoader
     }
 
-    private func _checkPreviewCommands(_ previewInfo: PreviewInfoOutput, srcRoot: Path, target: ConfiguredTarget, arch: String, linkStyle: LinkStyle, linkAgainst: Path, expectUnextendedModuleOverlay: Bool, explicitModuleBuild: Bool) async throws {
+    private func _checkPreviewCommands(_ previewInfo: PreviewInfoOutput, srcRoot: Path, target: ConfiguredTarget, arch: String, linkStyle: LinkStyle, linkAgainst: Path, expectUnextendedModuleOverlay: Bool, explicitModuleBuild: Bool, linkerDriver: LinkerDriverChoice) async throws {
         let core = try await getCore()
         let sdkPath = core.sdkRegistry.lookup("iphoneos")!.path
         let targetName = target.target.name
@@ -1162,14 +1163,7 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
             "-Xfrontend", "-disable-modules-validate-system-headers",
         ]].reduce([], +))
 
-        let linkStyleArgs: [String]
-        switch linkStyle {
-        case .dylib:
-            linkStyleArgs = ["-dynamiclib", linkAgainst.str]
 
-        case .bundleLoader:
-            linkStyleArgs = ["-bundle", "-bundle_loader", linkAgainst.str]
-        }
 
         var linkerCommandLine = previewInfo.thunkInfo?.linkCommandLine ?? []
         for idx in linkerCommandLine.indices.reversed() {
@@ -1178,24 +1172,65 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
             }
         }
 
-        XCTAssertEqualSequences(linkerCommandLine, [[
-            "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang",
-            "-Xlinker", "-reproducible",
-            "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
-            "-isysroot", sdkPath.str,
-            "-Os",
-            "-Xlinker", "-no_warn_duplicate_libraries",
-            "-L\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
-            "-L\(srcRoot.str)/build/Debug-iphoneos",
-            "-F\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
-            "-F\(srcRoot.str)/build/Debug-iphoneos",
-            "-fobjc-link-runtime",
-            "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-            "-L/usr/lib/swift",
-        ], linkStyleArgs, [
-                "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.o",
-                "-o", "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.dylib",
-            ]].reduce([], +))
+        switch linkerDriver {
+        case .clang:
+            let linkStyleArgs: [String]
+            switch linkStyle {
+            case .dylib:
+                linkStyleArgs = ["-dynamiclib", linkAgainst.str]
+
+            case .bundleLoader:
+                linkStyleArgs = ["-bundle", "-bundle_loader", linkAgainst.str]
+            }
+
+            XCTAssertEqualSequences(linkerCommandLine, [[
+                "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang",
+                "-Xlinker", "-reproducible",
+                "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
+                "-isysroot", sdkPath.str,
+                "-Os",
+                "-Xlinker", "-no_warn_duplicate_libraries",
+                "-L\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
+                "-L\(srcRoot.str)/build/Debug-iphoneos",
+                "-F\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
+                "-F\(srcRoot.str)/build/Debug-iphoneos",
+                "-fobjc-link-runtime",
+                "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
+                "-L/usr/lib/swift",
+            ], linkStyleArgs, [
+                    "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.o",
+                    "-o", "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.dylib",
+                ]].reduce([], +))
+        case .swiftc:
+            let linkStyleArgs: [String]
+            switch linkStyle {
+            case .dylib:
+                linkStyleArgs = ["-Xclang-linker", "-dynamiclib", "-Xclang-linker", linkAgainst.str]
+
+            case .bundleLoader:
+                linkStyleArgs = ["-Xclang-linker", "-bundle", "-Xclang-linker", "-bundle_loader", "-Xclang-linker", linkAgainst.str]
+            }
+
+            XCTAssertEqualSequences(linkerCommandLine, [[
+                "\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
+                "-Xlinker", "-reproducible",
+                "-target", "\(arch)-apple-ios\(core.loadSDK(.iOS).defaultDeploymentTarget)",
+                "-sdk", sdkPath.str,
+                "-Xlinker", "-no_warn_duplicate_libraries",
+                "-L\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
+                "-L\(srcRoot.str)/build/Debug-iphoneos",
+                "-F\(srcRoot.str)/build/EagerLinkingTBDs/Debug-iphoneos",
+                "-F\(srcRoot.str)/build/Debug-iphoneos",
+                "-link-objc-runtime",
+                "-L\(core.developerPath.path.str)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
+                "-L/usr/lib/swift",
+            ], linkStyleArgs, [
+                    "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.o",
+                    "-o", "\(srcRoot.str)/build/ProjectName.build/Debug-iphoneos/\(targetName).build/Objects-normal/\(arch)/main.selection.preview-thunk.dylib",
+                ]].reduce([], +))
+        default:
+            Issue.record("unexpected linker driver")
+        }
     }
 
     /// Check that actually executing the command-lines we produced for previews will work for the scenarios we enumerated


### PR DESCRIPTION
* Explanation: Dynamic replacement based preview info relies on being able to filter various arguments from the linker command line. Some of these rules needed updates to support using swiftc as the linker driver for package targets containing swift sources.
* Scope: Dynamic replacement preview info in packages
* Risk:
Low, this is narrowly scoped to only affect dynamic replacement previews
* Testing: Updated existing tests