### PR TITLE
[ssaf] Integrate Per-TU Result Propagator with swift-build

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1033,6 +1033,7 @@ public final class BuiltinMacros {
     public static let RUN_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("RUN_CLANG_STATIC_ANALYZER")
     public static let INVOKE_SSAF = BuiltinMacros.declareBooleanMacro("INVOKE_SSAF")
     public static let EXTRACT_SUMMARIES = BuiltinMacros.declareStringMacro("EXTRACT_SUMMARIES")
+    public static let SOURCE_TRANSFORMATION = BuiltinMacros.declareStringMacro("SOURCE_TRANSFORMATION")
     public static let STOP_AT_LU_SUMMARY_GENERATION = BuiltinMacros.declareStringListMacro("STOP_AT_LU_SUMMARY_GENERATION")
     public static let SWIFT_API_DIGESTER_MODE = BuiltinMacros.declareEnumMacro("SWIFT_API_DIGESTER_MODE") as EnumMacroDeclaration<SwiftAPIDigesterMode>
     public static let RUN_SWIFT_ABI_CHECKER_TOOL = BuiltinMacros.declareBooleanMacro("RUN_SWIFT_ABI_CHECKER_TOOL")
@@ -2264,6 +2265,7 @@ public final class BuiltinMacros {
         RUN_CLANG_STATIC_ANALYZER,
         INVOKE_SSAF,
         EXTRACT_SUMMARIES,
+        SOURCE_TRANSFORMATION,
         STOP_AT_LU_SUMMARY_GENERATION,
         RUN_DOCUMENTATION_COMPILER,
         SKIP_BUILDING_DOCUMENTATION,

--- a/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
+++ b/Sources/SWBCore/SpecImplementations/RegisterSpecs.swift
@@ -83,6 +83,7 @@ public struct BuiltinSpecsExtension: SpecificationsExtension {
             AbstractCCompilerSpec.self,
             ClangCompilerSpec.self,
             ClangStaticAnalyzerSpec.self,
+            SSAFSourceTransformationSpec.self,
         ]
     }
 

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -509,6 +509,13 @@ public struct ClangTaskPayload: ClangModuleVerifierPayloadType, DependencyInfoEd
     }
 }
 
+extension ClangTaskPayload {
+    /// Creates a payload for an auxiliary clang invocation constructed outside of `ClangCompilerSpec`'s own task construction (e.g. an SSAF source transformation task that re-invokes the compiler driver).
+    public static func auxiliaryInvocation(serializedDiagnosticsPath: Path?, scope: MacroEvaluationScope) -> ClangTaskPayload {
+        ClangTaskPayload(serializedDiagnosticsPath: serializedDiagnosticsPath, indexingPayload: nil, diagnosticAttachmentInfo: LibclangDiagnosticAttachmentInfo.attachmentInfo(scope: scope))
+    }
+}
+
 /// Helper for fast argument matching.
 //
 // FIXME: We should eventually just redefine this to be based on regular

--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -509,13 +509,6 @@ public struct ClangTaskPayload: ClangModuleVerifierPayloadType, DependencyInfoEd
     }
 }
 
-extension ClangTaskPayload {
-    /// Creates a payload for an auxiliary clang invocation constructed outside of `ClangCompilerSpec`'s own task construction (e.g. an SSAF source transformation task that re-invokes the compiler driver).
-    public static func auxiliaryInvocation(serializedDiagnosticsPath: Path?, scope: MacroEvaluationScope) -> ClangTaskPayload {
-        ClangTaskPayload(serializedDiagnosticsPath: serializedDiagnosticsPath, indexingPayload: nil, diagnosticAttachmentInfo: LibclangDiagnosticAttachmentInfo.attachmentInfo(scope: scope))
-    }
-}
-
 /// Helper for fast argument matching.
 //
 // FIXME: We should eventually just redefine this to be based on regular
@@ -624,6 +617,29 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
     /// The output file extension to use (an extension point for the static analyzer, as well as generating assembly and preprocessor output).
     func outputFileExtension(for input: FileToBuild) -> String {
         return ".o"
+    }
+
+    /// Computes the deterministic per-input prefix (before `outputFileExtension`) that the primary output path, and any sibling paths an override wants to derive from it, are based on.
+    func outputPrefix(for input: FileToBuild) -> String {
+        let (inputPrefix, _) = Path(input.absolutePath.basename).splitext()
+        return inputPrefix + input.uniquingSuffix
+    }
+
+    /// Whether to add a `-o <output>` argument to the command line (an extension point for invocations, like an SSAF source transformation, that must not specify an output path at all).
+    var emitsOutputFileArgument: Bool { true }
+
+    /// Per-translation-unit `--ssaf-*` command line arguments and additional inputs/outputs to add to this invocation (an extension point for the SSAF source transformation invocation, which needs a distinct set of arguments from ordinary summary extraction).
+    func ssafPerTranslationUnitArguments(_ cbc: CommandBuildContext, input: FileToBuild, outputNode: any PlannedNode, clangInfo: DiscoveredClangToolSpecInfo?, delegate: any TaskGenerationDelegate) -> (args: [String], extraInputs: [any PlannedNode], extraOutputs: [any PlannedNode]) {
+        guard cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true else {
+            return ([], [], [])
+        }
+        let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
+        let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".ssaf-tu.json")
+        return (
+            ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-compilation-unit-id=\(outputNode.path.str)", "--ssaf-tu-summary-file=\(jsonPath.str)"],
+            [],
+            [delegate.createNode(jsonPath)]
+        )
     }
 
     /// Whether to add serialize diagnostics options (an extension point for the static analyzer).
@@ -1079,8 +1095,6 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         //let input = cbc.input
         let input = cbc.inputs[0]
         let inputPath = input.absolutePath
-        let inputBasename = inputPath.basename
-        let (inputPrefix, _) = Path(inputBasename).splitext()
 
         // Our command build context should not contain any outputs, since we construct the output path ourselves.
         //
@@ -1091,7 +1105,7 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         }
 
         // Compute the primary output path (the compiled object file).
-        let outputPrefix = inputPrefix + input.uniquingSuffix
+        let outputPrefix = self.outputPrefix(for: input)
         let outputFileDir = self.outputFileDir(cbc)
         let outputNode = delegate.createNode(outputFileDir.join(outputPrefix + self.outputFileExtension(for: input)))
 
@@ -1264,7 +1278,9 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         inputDeps.append(inputPath)
 
         // Add the output file argument.
-        commandLine += ["-o", outputNode.path.str]
+        if emitsOutputFileArgument {
+            commandLine += ["-o", outputNode.path.str]
+        }
 
         var indexOutputPath: Path = outputNode.path
         if let clangInfo {
@@ -1295,9 +1311,10 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
 
         let environmentBindings = EnvironmentBindings(environmentFromSpec(cbc, delegate))
 
-        // Create indexing payload only for the preferred arch.
+        // Create indexing payload only for the preferred arch. Invocations that don't emit an output file
+        // argument (e.g. an SSAF source transformation) have no output path to index against.
         let indexingPayload: ClangIndexingPayload?
-        if let language, cbc.producer.preferredArch == nil || cbc.producer.preferredArch == arch {
+        if emitsOutputFileArgument, let language, cbc.producer.preferredArch == nil || cbc.producer.preferredArch == arch {
             // BUILT_PRODUCTS_DIR and PROJECT_DIR here are guaranteed to be absolute
             // by `getCommonTargetTaskOverrides`.
             indexingPayload = ClangIndexingPayload(
@@ -1380,12 +1397,10 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             commandLine += ["-mllvm", "-cas-friendly-debug-info"]
         }
 
-        if cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF), clangInfo?.toolFeatures.has(.invokeSsaf) == true {
-            let extractSummariesValue = cbc.scope.evaluate(BuiltinMacros.EXTRACT_SUMMARIES)
-            let jsonPath = outputNode.path.dirname.join(outputNode.path.basenameWithoutSuffix + ".ssaf-tu.json")
-            commandLine += ["--ssaf-extract-summaries=\(extractSummariesValue)", "--ssaf-compilation-unit-id=\(outputNode.path.str)", "--ssaf-tu-summary-file=\(jsonPath.str)"]
-            extraOutputs.append(delegate.createNode(jsonPath))
-        }
+        let ssafArguments = self.ssafPerTranslationUnitArguments(cbc, input: input, outputNode: outputNode, clangInfo: clangInfo, delegate: delegate)
+        commandLine += ssafArguments.args
+        inputNodes.append(contentsOf: ssafArguments.extraInputs)
+        extraOutputs.append(contentsOf: ssafArguments.extraOutputs)
 
         // If explicit modules are enabled we need to create the scan task first
         let extraInputs: [any PlannedNode]
@@ -1485,6 +1500,17 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
             if cbc.producer.generatePreprocessCommands {
                 await cbc.producer.clangPreprocessorSpec.constructTasks(cbc, delegate)
             }
+        }
+
+        // Re-invoke clang to apply an SSAF source transformation, once the global scope analysis result is
+        // available. Unlike the static analyzer/assembler/preprocessor above, this must run for every arch
+        // (not just the preferred one), since each arch's translation units need their own transformation.
+        if self.identifier == "com.apple.compilers.llvm.clang.1_0.compiler",
+           !hasEnabledIndexBuildArena,
+           cbc.scope.evaluate(BuiltinMacros.INVOKE_SSAF),
+           clangInfo?.toolFeatures.has(.invokeSsaf) == true,
+           !cbc.scope.evaluate(BuiltinMacros.SOURCE_TRANSFORMATION).isEmpty {
+            await cbc.producer.ssafSourceTransformationSpec.constructTasks(cbc, delegate)
         }
     }
 
@@ -2053,6 +2079,67 @@ public final class ClangStaticAnalyzerSpec : ClangCompilerSpec, @unchecked Senda
 
     public override func interestingPath(for task: any ExecutableTask) -> Path? {
         return Path(task.ruleInfo[1])
+    }
+}
+
+/// Re-invokes clang per translation unit to apply an SSAF source transformation, once the global scope
+/// analysis result is available. This can't be folded into the main `CompileC` invocation: that task's
+/// output is an input to the analysis result this invocation consumes, so doing so would create a
+/// dependency cycle. Reusing `ClangCompilerSpec.constructTasks` (rather than hand-patching the main
+/// invocation's command line) guarantees every per-file flag stays in sync with the main compile by
+/// construction, since both invocations share the same `CommandBuildContext`.
+public final class SSAFSourceTransformationSpec : ClangCompilerSpec, @unchecked Sendable {
+    public class override var identifier: String {
+        "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source"
+    }
+
+    /// This invocation doesn't rewrite the object file; give it a distinct primary output instead.
+    override func outputFileExtension(for input: FileToBuild) -> String {
+        return ".ssaf-edit.yaml"
+    }
+
+    /// The `--ssaf-source-transformation` driver mode doesn't accept an output path at all.
+    override var emitsOutputFileArgument: Bool { false }
+
+    /// Customize the rule info.
+    override func ruleInfo(_ cbc: CommandBuildContext, input: Path, output: Path, variant: String, arch: String, language: String?) -> [String] {
+        return ["TransformSource", output.str, input.str]
+    }
+
+    override func ssafPerTranslationUnitArguments(_ cbc: CommandBuildContext, input: FileToBuild, outputNode: any PlannedNode, clangInfo: DiscoveredClangToolSpecInfo?, delegate: any TaskGenerationDelegate) -> (args: [String], extraInputs: [any PlannedNode], extraOutputs: [any PlannedNode]) {
+        let sourceTransformationValue = cbc.scope.evaluate(BuiltinMacros.SOURCE_TRANSFORMATION)
+        guard !sourceTransformationValue.isEmpty else {
+            return ([], [], [])
+        }
+
+        // The compilation unit ID must match the one the main CompileC invocation for this file used
+        // when it extracted its summary, i.e. the real (un-transformed) object path.
+        let objectPath = self.outputFileDir(cbc).join(self.outputPrefix(for: input) + ".o")
+
+        let binaryOutput = cbc.scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(cbc.scope.evaluate(BuiltinMacros.EXECUTABLE_PATH))
+        let analyzerOutput = Path(binaryOutput.str + ".ssaf-analysis.json")
+
+        let transformationReportFile = self.outputFileDir(cbc).join(self.outputPrefix(for: input) + ".ssaf-report.sarif.json")
+
+        return (
+            [
+                "--ssaf-source-transformation=\(sourceTransformationValue)",
+                "--ssaf-global-scope-analysis-result=\(analyzerOutput.str)",
+                "--ssaf-src-edit-file=\(outputNode.path.str)",
+                "--ssaf-transformation-report-file=\(transformationReportFile.str)",
+                "--ssaf-compilation-unit-id=\(objectPath.str)",
+            ],
+            [delegate.createNode(analyzerOutput)],
+            [delegate.createNode(transformationReportFile)]
+        )
+    }
+
+    public override func customOutputParserType(for task: any ExecutableTask) -> (any TaskOutputParser.Type)? {
+        return nil
+    }
+
+    public override func interestingPath(for task: any ExecutableTask) -> Path? {
+        return Path(task.ruleInfo[2])
     }
 }
 

--- a/Sources/SWBCore/TaskGeneration.swift
+++ b/Sources/SWBCore/TaskGeneration.swift
@@ -152,6 +152,9 @@ public protocol CommandProducer: PlatformBuildContext, SpecLookupContext, Refere
     var entityLinkerToolSpec: CommandLineToolSpec { get }
     var ssafAnalyzerToolSpec: CommandLineToolSpec { get }
 
+    /// The SSAF source transformation spec to use.
+    var ssafSourceTransformationSpec: ClangCompilerSpec { get }
+
     /// The Clang modules verifier tool spec to use.
     var clangModuleVerifierSpec: ClangCompilerSpec { get }
 

--- a/Sources/SWBGenericUnixPlatform/Specs/UnixCompile.xcspec
+++ b/Sources/SWBGenericUnixPlatform/Specs/UnixCompile.xcspec
@@ -128,4 +128,23 @@
             },
         );
     },
+    {
+        Domain = generic-unix;
+        Identifier = "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Type = Compiler;
+        BasedOn = "default:com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Options = (
+            {
+                Name = SDKROOT;
+                Type = Path;
+                CommandLineArgs = ();
+            },
+            {
+                Name = SYSROOT;
+                DefaultValue = "$(SDKROOT)";
+                Type = Path;
+                CommandLineFlag = "--sysroot";
+            },
+        );
+    },
 )

--- a/Sources/SWBQNXPlatform/Specs/QNXCompile.xcspec
+++ b/Sources/SWBQNXPlatform/Specs/QNXCompile.xcspec
@@ -137,4 +137,17 @@
             },
         );
     },
+    {
+        Domain = qnx;
+        Identifier = "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Type = Compiler;
+        BasedOn = "default:com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Options = (
+            {
+                Name = SDKROOT;
+                Type = Path;
+                CommandLineArgs = ();
+            },
+        );
+    },
 )

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1035,6 +1035,64 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             .flatMap { ["-a", "\($0)AnalysisResult"] }
                         await context.ssafAnalyzerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: linkedSummariesInput)], output: analyzerOutput), delegate, specialArgs: specialArgs)
                     }
+
+                    // Re-invoke clang per translation unit to apply SSAF source transformations, now that
+                    // the global analysis result is available.
+                    let sourceTransformationValue = scope.evaluate(BuiltinMacros.SOURCE_TRANSFORMATION)
+                    if !sourceTransformationValue.isEmpty {
+                        let analyzerOutput = Path(binaryOutput.str + ".ssaf-analysis.json")
+                        let ssafCompileTasks = perArchTasks.filter { task in task.outputs.contains { $0.path.str.hasSuffix(".ssaf-tu.json") } }
+                        await appendGeneratedTasks(&perArchTasks) { delegate in
+                            for task in ssafCompileTasks {
+                                guard task.ruleInfo.count > 2 else { continue }
+                                let objectPath = Path(task.ruleInfo[1])
+                                let sourcePath = Path(task.ruleInfo[2])
+                                let compilationUnitId = objectPath.str
+                                let srcEditFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-edit.yaml")
+                                let transformationReportFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-report.sarif.json")
+                                let transformationDiagnosticsFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-transform.dia")
+
+                                var reusedCommandLine: [String] = []
+                                var argsIterator = task.execTask.commandLine.map(\.asString).makeIterator()
+                                while let arg = argsIterator.next() {
+                                    if arg == "-o" {
+                                        // Drop the output path; this invocation doesn't rewrite the object file.
+                                        _ = argsIterator.next()
+                                    } else if arg == "--serialize-diagnostics" {
+                                        // Redirect to a dedicated diagnostics file so this doesn't race with the original CompileC task's .dia file.
+                                        _ = argsIterator.next()
+                                        reusedCommandLine.append(contentsOf: ["--serialize-diagnostics", transformationDiagnosticsFile.str])
+                                    } else if arg.hasPrefix("--ssaf-extract-summaries=")
+                                        || arg.hasPrefix("--ssaf-tu-summary-file=")
+                                        || arg.hasPrefix("--ssaf-compilation-unit-id=") {
+                                        continue
+                                    } else {
+                                        reusedCommandLine.append(arg)
+                                    }
+                                }
+                                let commandLine = reusedCommandLine + [
+                                    "--ssaf-source-transformation=\(sourceTransformationValue)",
+                                    "--ssaf-global-scope-analysis-result=\(analyzerOutput.str)",
+                                    "--ssaf-src-edit-file=\(srcEditFile.str)",
+                                    "--ssaf-transformation-report-file=\(transformationReportFile.str)",
+                                    "--ssaf-compilation-unit-id=\(compilationUnitId)",
+                                ]
+
+                                delegate.createTask(
+                                    type: context.clangSpec,
+                                    payload: ClangTaskPayload.auxiliaryInvocation(serializedDiagnosticsPath: transformationDiagnosticsFile, scope: scope),
+                                    ruleInfo: ["TransformSource", srcEditFile.str, sourcePath.str],
+                                    commandLine: commandLine,
+                                    environment: task.execTask.environment,
+                                    workingDirectory: task.execTask.workingDirectory,
+                                    inputs: [sourcePath, analyzerOutput],
+                                    outputs: [srcEditFile, transformationReportFile, transformationDiagnosticsFile],
+                                    execDescription: "Transform \(sourcePath.basename)",
+                                    enableSandboxing: context.clangSpec.enableSandboxing
+                                )
+                            }
+                        }
+                    }
                 }
 
                 // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1035,64 +1035,6 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             .flatMap { ["-a", "\($0)AnalysisResult"] }
                         await context.ssafAnalyzerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: linkedSummariesInput)], output: analyzerOutput), delegate, specialArgs: specialArgs)
                     }
-
-                    // Re-invoke clang per translation unit to apply SSAF source transformations, now that
-                    // the global analysis result is available.
-                    let sourceTransformationValue = scope.evaluate(BuiltinMacros.SOURCE_TRANSFORMATION)
-                    if !sourceTransformationValue.isEmpty {
-                        let analyzerOutput = Path(binaryOutput.str + ".ssaf-analysis.json")
-                        let ssafCompileTasks = perArchTasks.filter { task in task.outputs.contains { $0.path.str.hasSuffix(".ssaf-tu.json") } }
-                        await appendGeneratedTasks(&perArchTasks) { delegate in
-                            for task in ssafCompileTasks {
-                                guard task.ruleInfo.count > 2 else { continue }
-                                let objectPath = Path(task.ruleInfo[1])
-                                let sourcePath = Path(task.ruleInfo[2])
-                                let compilationUnitId = objectPath.str
-                                let srcEditFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-edit.yaml")
-                                let transformationReportFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-report.sarif.json")
-                                let transformationDiagnosticsFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-transform.dia")
-
-                                var reusedCommandLine: [String] = []
-                                var argsIterator = task.execTask.commandLine.map(\.asString).makeIterator()
-                                while let arg = argsIterator.next() {
-                                    if arg == "-o" {
-                                        // Drop the output path; this invocation doesn't rewrite the object file.
-                                        _ = argsIterator.next()
-                                    } else if arg == "--serialize-diagnostics" {
-                                        // Redirect to a dedicated diagnostics file so this doesn't race with the original CompileC task's .dia file.
-                                        _ = argsIterator.next()
-                                        reusedCommandLine.append(contentsOf: ["--serialize-diagnostics", transformationDiagnosticsFile.str])
-                                    } else if arg.hasPrefix("--ssaf-extract-summaries=")
-                                        || arg.hasPrefix("--ssaf-tu-summary-file=")
-                                        || arg.hasPrefix("--ssaf-compilation-unit-id=") {
-                                        continue
-                                    } else {
-                                        reusedCommandLine.append(arg)
-                                    }
-                                }
-                                let commandLine = reusedCommandLine + [
-                                    "--ssaf-source-transformation=\(sourceTransformationValue)",
-                                    "--ssaf-global-scope-analysis-result=\(analyzerOutput.str)",
-                                    "--ssaf-src-edit-file=\(srcEditFile.str)",
-                                    "--ssaf-transformation-report-file=\(transformationReportFile.str)",
-                                    "--ssaf-compilation-unit-id=\(compilationUnitId)",
-                                ]
-
-                                delegate.createTask(
-                                    type: context.clangSpec,
-                                    payload: ClangTaskPayload.auxiliaryInvocation(serializedDiagnosticsPath: transformationDiagnosticsFile, scope: scope),
-                                    ruleInfo: ["TransformSource", srcEditFile.str, sourcePath.str],
-                                    commandLine: commandLine,
-                                    environment: task.execTask.environment,
-                                    workingDirectory: task.execTask.workingDirectory,
-                                    inputs: [sourcePath, analyzerOutput],
-                                    outputs: [srcEditFile, transformationReportFile, transformationDiagnosticsFile],
-                                    execDescription: "Transform \(sourcePath.basename)",
-                                    enableSandboxing: context.clangSpec.enableSandboxing
-                                )
-                            }
-                        }
-                    }
                 }
 
                 // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -235,6 +235,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     public let clangStaticAnalyzerSpec: ClangCompilerSpec
     public let entityLinkerToolSpec: CommandLineToolSpec
     public let ssafAnalyzerToolSpec: CommandLineToolSpec
+    public let ssafSourceTransformationSpec: ClangCompilerSpec
     public let clangModuleVerifierSpec: ClangCompilerSpec
     private let _clangStatCacheSpec: Result<ClangStatCacheSpec, any Error>
     var clangStatCacheSpec: ClangStatCacheSpec? { return specForResult(_clangStatCacheSpec) }
@@ -360,6 +361,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-linker", domain: domain, ofType: CommandLineToolSpec.self)
         self.ssafAnalyzerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-analyzer", domain: domain, ofType: CommandLineToolSpec.self)
+        self.ssafSourceTransformationSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: SSAFSourceTransformationSpec.self)
         self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
         self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }
         self.codesignSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.codesign", domain: domain, ofType: CodesignToolSpec.self)

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -129,6 +129,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-linker", ofType: CommandLineToolSpec.self)
         self.ssafAnalyzerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-analyzer", ofType: CommandLineToolSpec.self)
+        self.ssafSourceTransformationSpec = try getSpec(ofType: SSAFSourceTransformationSpec.self)
         self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
         self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
         self.stripSpec = try getSpec("com.apple.build-tools.strip", ofType: StripToolSpec.self)
@@ -171,6 +172,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package let clangStaticAnalyzerSpec: ClangCompilerSpec
     package let entityLinkerToolSpec: CommandLineToolSpec
     package let ssafAnalyzerToolSpec: CommandLineToolSpec
+    package let ssafSourceTransformationSpec: ClangCompilerSpec
     package let clangModuleVerifierSpec: ClangCompilerSpec
     package let diffSpec: CommandLineToolSpec
     package let stripSpec: StripToolSpec

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -4244,4 +4244,14 @@
         ShowInCompilerSelectionPopup = NO;
         PrunePrecompiledHeaderCache = NO;
     },
+    {
+        Identifier = "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Type = Compiler;
+        BasedOn = "com.apple.compilers.llvm.clang.1_0";
+        Name = "SSAF Source Transformation";
+        Description = "Apple Clang SSAF Source Transformation";
+        IsAbstract = YES;
+        ShowInCompilerSelectionPopup = NO;
+        ShowOnlySelfDefinedProperties = YES;
+    },
 )

--- a/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Clang.xcspec
@@ -3503,6 +3503,11 @@
                     DefaultValue = "";
                     Category = "SAPolicy";
             },
+            {   Name = SOURCE_TRANSFORMATION;
+                    Type = String;
+                    DefaultValue = "";
+                    Category = "SAPolicy";
+            },
             {   Name = STOP_AT_LU_SUMMARY_GENERATION;
                     Type = StringList;
                     DefaultValue = "";

--- a/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
+++ b/Sources/SWBUniversalPlatform/Specs/en.lproj/Apple Clang.strings
@@ -971,6 +971,9 @@ The restrictions on `offsetof` may be relaxed in a future version of the C++ sta
 "[EXTRACT_SUMMARIES]-name" = "Extract Summaries";
 "[EXTRACT_SUMMARIES]-description" = "Specifies the type of per-translation-unit summary for `Clang` to extract when `INVOKE_SSAF` is enabled. The value is passed verbatim to the `--ssaf-extract-summaries` flag (for example, `CallGraph`). Has no effect when `INVOKE_SSAF` is disabled.";
 
+"[SOURCE_TRANSFORMATION]-name" = "Source Transformation";
+"[SOURCE_TRANSFORMATION]-description" = "Specifies the type of source transformation for `Clang` to perform when `INVOKE_SSAF` is enabled. The value is passed verbatim to the `--ssaf-source-transformation` flag. Has no effect when `INVOKE_SSAF` is disabled.";
+
 "[CLANG_STATIC_ANALYZER_MODE]-name" = "Mode of Analysis for 'Build'";
 "[CLANG_STATIC_ANALYZER_MODE]-description" = "The depth the static analyzer uses during the Build action. Use `Deep` to exercise the full power of the analyzer. Use `Shallow` for faster analysis.";
 "[CLANG_STATIC_ANALYZER_MODE]-value-[shallow]" = "Shallow (faster)";

--- a/Sources/SWBWebAssemblyPlatform/Specs/WasmCompile.xcspec
+++ b/Sources/SWBWebAssemblyPlatform/Specs/WasmCompile.xcspec
@@ -37,6 +37,12 @@
     },
     {
         Domain = webassembly;
+        Identifier = "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Type = Compiler;
+        BasedOn = "generic-unix:com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+    },
+    {
+        Domain = webassembly;
         Identifier = "com.apple.xcode.tools.swift.compiler";
         Type = Compiler;
         BasedOn = "generic-unix:com.apple.xcode.tools.swift.compiler";

--- a/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
+++ b/Sources/SWBWindowsPlatform/Specs/WindowsCompile.xcspec
@@ -145,6 +145,19 @@
     },
     {
         Domain = windows;
+        Identifier = "com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Type = Compiler;
+        BasedOn = "default:com.apple.compilers.llvm.clang.1_0.ssaf-transform-source";
+        Options = (
+            {
+                Name = SDKROOT;
+                Type = Path;
+                CommandLineFlag = "--sysroot";
+            },
+        );
+    },
+    {
+        Domain = windows;
         Identifier = "com.apple.xcode.tools.swift.compiler";
         Type = Compiler;
         BasedOn = "default:com.apple.xcode.tools.swift.compiler";

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -450,7 +450,7 @@ fileprivate struct ClangTests: CoreBasedTests {
 
     @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
     func invokeSsafOptions() async throws {
-        func getTestProject(invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "") -> TestProject {
+        func getTestProject(invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "", sourceTransformation: String = "") -> TestProject {
             TestProject(
                 "aProject",
                 groupTree: TestGroup(
@@ -466,6 +466,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                             "INVOKE_SSAF": invokeSSAF,
                             "EXTRACT_SUMMARIES": extractSummaries,
                             "STOP_AT_LU_SUMMARY_GENERATION": stopAtLUSummaryGeneration,
+                            "SOURCE_TRANSFORMATION": sourceTransformation,
                             // Uncomment to test with a local build of clang
                             // "CC": "<LOCAL_CLANG_PATH>/bin/clang",
                         ]),
@@ -485,12 +486,16 @@ fileprivate struct ClangTests: CoreBasedTests {
 
         // When INVOKE_SSAF is YES, the extract-summaries value and a .ssaf-tu.json summary file path are added.
         // The summary file is co-located with the object file: same directory, same basename, .ssaf-tu.json extension.
+        // With SOURCE_TRANSFORMATION also set, a TransformSource task should be created to apply it once the
+        // global analysis result is available.
         do {
-            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph,UnsafeBufferUsage", stopAtLUSummaryGeneration: "CallGraph"))
+            let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph,UnsafeBufferUsage", stopAtLUSummaryGeneration: "CallGraph", sourceTransformation: "UnsafeBufferUsage"))
             await tester.checkBuild(runDestination: .host) { results in
+                var objectPath: Path? = nil
                 results.checkTask(.matchRuleType("CompileC")) { task in
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph,UnsafeBufferUsage"])
-                    if let objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") }) {
+                    objectPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".o") })
+                    if let objectPath {
                         let expectedJsonPath = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-tu.json").str
                         task.checkCommandLineContains(["--ssaf-tu-summary-file=\(expectedJsonPath)"])
                     } else {
@@ -509,6 +514,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                     #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".linked-summaries.json") }))
                 }
                 //
+                var analyzerOutputPath: Path? = nil
                 results.checkTask(.matchRuleType("AnalyzeSSAF")) { task in
                     task.checkCommandLineDoesNotContain("CallGraphAnalysisResult")
                     task.checkCommandLineContains(["-a", "UnsafeBufferUsageAnalysisResult"])
@@ -518,7 +524,37 @@ fileprivate struct ClangTests: CoreBasedTests {
                     } else {
                         Issue.record("Expected Test.dylib.linked-summaries.json as input to the AnalyzeSSAF task")
                     }
-                    #expect(task.outputs.map({ $0.path }).contains(where: { $0.str.hasSuffix(".ssaf-analysis.json") }))
+                    analyzerOutputPath = task.outputs.map({ $0.path }).first(where: { $0.str.hasSuffix(".ssaf-analysis.json") })
+                    #expect(analyzerOutputPath != nil)
+                }
+
+                // The TransformSource task re-invokes clang to apply SOURCE_TRANSFORMATION once the analysis
+                // result is available.
+                guard let objectPath, let analyzerOutputPath else {
+                    Issue.record("Expected to find both a CompileC .o output and an AnalyzeSSAF .ssaf-analysis.json output")
+                    return
+                }
+                let srcEditFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-edit.yaml")
+                let transformationReportFile = objectPath.dirname.join(objectPath.basenameWithoutSuffix + ".ssaf-report.sarif.json")
+                results.checkTask(.matchRuleType("TransformSource")) { task in
+                    task.checkCommandLineContains([
+                        "--ssaf-source-transformation=UnsafeBufferUsage",
+                        "--ssaf-global-scope-analysis-result=\(analyzerOutputPath.str)",
+                        "--ssaf-src-edit-file=\(srcEditFile.str)",
+                        "--ssaf-transformation-report-file=\(transformationReportFile.str)",
+                        "--ssaf-compilation-unit-id=\(objectPath.str)",
+                    ])
+
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-extract-summaries=")])
+                    task.checkCommandLineNoMatch([.prefix("--ssaf-tu-summary-file=")])
+                    #expect(task.commandLine.filter({ $0.asString.hasPrefix("--ssaf-compilation-unit-id=") }).count == 1)
+
+                    task.checkCommandLineDoesNotContain("-o")
+                    task.checkCommandLineDoesNotContain(objectPath.str)
+
+                    let outputPaths = task.outputs.map(\.path)
+                    #expect(outputPaths.contains(srcEditFile))
+                    #expect(outputPaths.contains(transformationReportFile))
                 }
                 results.checkNoDiagnostics()
             }
@@ -539,12 +575,15 @@ fileprivate struct ClangTests: CoreBasedTests {
         }
 
         // The value of EXTRACT_SUMMARIES is passed through verbatim to --ssaf-extract-summaries.
+        // With SOURCE_TRANSFORMATION left empty, no TransformSource task should be created even though
+        // INVOKE_SSAF is enabled.
         do {
             let tester = try TaskConstructionTester(core, getTestProject(invokeSSAF: "YES", extractSummaries: "CallGraph,UnsafeBufferUsage"))
             await tester.checkBuild(runDestination: .host) { results in
                 results.checkTask(.matchRuleType("CompileC")) { task in
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph,UnsafeBufferUsage"])
                 }
+                results.checkNoTask(.matchRuleType("TransformSource"))
                 results.checkNoDiagnostics()
             }
         }


### PR DESCRIPTION
Add a SOURCE_TRANSFORMATION build setting that, when set alongside INVOKE_SSAF, re-invokes clang once per translation unit after the global scope analysis result is available, applying the requested --ssaf-source-transformation.

rdar://176928017