### PR TITLE
Move Mig filetype to AppleFileTypes.xcspec

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AppleFileTypes.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppleFileTypes.xcspec
@@ -201,4 +201,13 @@
         AppliesToBuildRules = yes;
         UTI = "com.apple.xcode.model.class";
     },
+    {
+        Type = FileType;
+        Identifier = sourcecode.mig;
+        BasedOn = sourcecode;
+        Name = "MiG source files";
+        Extensions = (defs, mig);
+        AppliesToBuildRules = yes;
+        UTI = "public.mig-source";
+    },
 )

--- a/Sources/SWBApplePlatform/Specs/MiG.xcspec
+++ b/Sources/SWBApplePlatform/Specs/MiG.xcspec
@@ -12,15 +12,6 @@
 
 (
     {
-        Type = FileType;
-        Identifier = sourcecode.mig;
-        BasedOn = sourcecode;
-        Name = "MiG source files";
-        Extensions = (defs, mig);
-        AppliesToBuildRules = yes;
-        UTI = "public.mig-source";
-    },
-    {
         _Domain = darwin;
         Type = Compiler;
         Identifier = com.apple.compilers.mig;


### PR DESCRIPTION
Otherwise MiG.xcspec mixes specs from the Darwin and empty domains, and fails validation when loaded in Xcode.