### PR TITLE
Deprecate the old WatchKit extension product type

### DIFF
--- a/Sources/SWBApplePlatform/Specs/watchOSShared.xcspec
+++ b/Sources/SWBApplePlatform/Specs/watchOSShared.xcspec
@@ -62,6 +62,12 @@
         Name = "WatchKit Extension";
         Description = "WatchKit Extension";
         DefaultTargetName = "WatchKit Extension";
+        DeprecationReason = "WatchKit extensions are no longer supported. Migrate your WatchKit extension to a single-target watchOS app.";
+        DeprecationLevel = "error";
+        DeprecationDeploymentTarget = {
+            watchos = "9.2";
+            watchsimulator = "9.2";
+        };
         "DefaultBuildProperties" = {
             "CODE_SIGNING_ALLOWED" = YES;
             "APPLICATION_EXTENSION_API_ONLY" = YES;

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1511,6 +1511,7 @@ private class SettingsBuilder: ProjectMatchLookup {
         // If we're constructing a Settings object for use by the editor, then we stop here; we don't add any overrides.
         guard settingsContext.purpose.includeOverrides else {
             let boundDeploymentTarget = bindDeploymentTarget(boundProperties.platform, boundProperties.sdk, boundProperties.sdkVariant)
+            checkProductTypeDeprecationForDeploymentTarget(boundDeploymentTarget, specLookupContext)
             return (boundProperties, boundDeploymentTarget)
         }
 
@@ -1560,6 +1561,9 @@ private class SettingsBuilder: ProjectMatchLookup {
 
         // Bind the deployment target, and push it if necessary.  This means that no further settings should affect the deployment target.
         let boundDeploymentTarget = bindDeploymentTarget(boundProperties.platform, boundProperties.sdk, boundProperties.sdkVariant)
+
+        // Check for product type deprecation that is conditional on the deployment target.
+        checkProductTypeDeprecationForDeploymentTarget(boundDeploymentTarget, specLookupContext)
 
         // Settings pushed after this point should generally be derived and not primary data passed in to the builder.  These methods have not been audited to ensure that this is so, and the ramifications that not being so are not known.
 
@@ -3213,7 +3217,8 @@ private class SettingsBuilder: ProjectMatchLookup {
 
         if let productType = specLookupContext.getSpec(target.productTypeIdentifier) as? ProductTypeSpec {
             // Check for a deprecated product type.
-            if let deprecationInfo = productType.deprecationInfo {
+            // If there are deployment target thresholds, the check is deferred to after deployment targets are bound.
+            if let deprecationInfo = productType.deprecationInfo, deprecationInfo.deploymentTargetThresholds == nil {
                 let base = "deprecated product type '\(target.productTypeIdentifier)'\(platformErrorSuffix)."
 
                 switch deprecationInfo.level {
@@ -3241,6 +3246,34 @@ private class SettingsBuilder: ProjectMatchLookup {
             self.productType = productType
         } else {
             self.errors.append("unable to resolve product type '\(target.productTypeIdentifier)'\(platformErrorSuffix)")
+        }
+    }
+
+    /// Check for product type deprecation that is conditional on the deployment target.
+    /// This is called after the deployment target is bound, so we have access to the resolved version.
+    private func checkProductTypeDeprecationForDeploymentTarget(_ boundDeploymentTarget: BoundDeploymentTarget, _ specLookupContext: any SpecLookupContext) {
+        guard let productType = self.productType,
+              let deprecationInfo = productType.deprecationInfo,
+              let thresholds = deprecationInfo.deploymentTargetThresholds,
+              let platform = specLookupContext.platform,
+              let deploymentTarget = boundDeploymentTarget.platformDeploymentTarget else {
+            return
+        }
+
+        guard let threshold = thresholds[platform.name] else {
+            return
+        }
+
+        guard deploymentTarget >= threshold else {
+            return
+        }
+
+        let platformErrorSuffix = " for platform '\(platform.displayName)'"
+        let base = "deprecated product type '\(productType.identifier)'\(platformErrorSuffix)."
+
+        switch deprecationInfo.level {
+        case .warning: self.warnings.append("\(base) \(deprecationInfo.reason)")
+        case .error: self.errors.append("\(base) \(deprecationInfo.reason)")
         }
     }
 

--- a/Sources/SWBCore/SpecImplementations/ProductTypes.swift
+++ b/Sources/SWBCore/SpecImplementations/ProductTypes.swift
@@ -36,6 +36,10 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
 
         /// The level in which the deprecation should be reported.
         @_spi(Testing) public let level: DeprecationLevel
+
+        /// If non-nil, the deprecation is only active when the deployment target for the current platform
+        /// is at or above the version specified for that platform name.
+        @_spi(Testing) public let deploymentTargetThresholds: [String: Version]?
     }
 
     class public override var typeName: String {
@@ -206,7 +210,27 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
                 // Having no `DeprecationLevel` is fine and in that case, the default should be 'warning'. However, an invalid value is not allowed.
                 let parsedLevel = parser.parseString("DeprecationLevel") ?? "warning"
                 if let level = DeprecationLevel(level: parsedLevel) {
-                    return DeprecationInfo(reason: reason, level: level)
+                    let deploymentTargetThresholds: [String: Version]? = {
+                        guard let item = parser.parseObject("DeprecationDeploymentTarget") else { return nil }
+                        guard case .plDict(let dict) = item else {
+                            parser.error("'DeprecationDeploymentTarget' must be a dictionary")
+                            return nil
+                        }
+                        var result = [String: Version]()
+                        for (key, value) in dict {
+                            guard case .plString(let versionString) = value else {
+                                parser.error("value for platform '\(key)' in 'DeprecationDeploymentTarget' must be a string")
+                                return nil
+                            }
+                            guard let version = try? Version(versionString) else {
+                                parser.error("invalid version '\(versionString)' for platform '\(key)' in 'DeprecationDeploymentTarget'")
+                                return nil
+                            }
+                            result[key] = version
+                        }
+                        return result.isEmpty ? nil : result
+                    }()
+                    return DeprecationInfo(reason: reason, level: level, deploymentTargetThresholds: deploymentTargetThresholds)
                 }
                 else {
                     parser.error("invalid 'DeprecationLevel' value of '\(parsedLevel)'")
@@ -216,6 +240,9 @@ public class ProductTypeSpec : Spec, SpecType, @unchecked Sendable {
             else if parser.parseString("DeprecationLevel") != nil {
                 parser.error("expected 'DeprecationReason' if key 'DeprecationLevel' is used.")
             }
+
+            // Consume the key even when there's no DeprecationReason, to avoid unknown key warnings.
+            _ = parser.parseObject("DeprecationDeploymentTarget")
 
             return nil
         }()

--- a/Tests/SWBBuildSystemTests/WatchBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/WatchBuildOperationTests.swift
@@ -114,7 +114,8 @@ fileprivate struct WatchBuildOperationTests: CoreBasedTests {
                                                     "SKIP_INSTALL": "YES",
                                                     "SWIFT_VERSION": swiftVersion,
                                                     "TARGETED_DEVICE_FAMILY": "4",
-                                                    "WATCHOS_DEPLOYMENT_TARGET": core.loadSDK(.watchOS).defaultDeploymentTarget,
+                                                    // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                                                    "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                                                    ]),
                         ],
                         buildPhases: [

--- a/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/XCFrameworkBuildOperationTests.swift
@@ -165,6 +165,8 @@ fileprivate struct XCFrameworkBuildOperationTests: CoreBasedTests {
                                 "F7", type: .watchKitExtension,
                                 buildConfigurations: [TestBuildConfiguration("Debug", buildSettings: [
                                     "SDKROOT": "watchsimulator", // explicitly using the simulator here to avoid code signing and entitlement requirements
+                                    // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                                    "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                                 ])],
                                 buildPhases: [
                                     TestFrameworksBuildPhase([TestBuildFile(.target("P1Product"))]),

--- a/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallLocTaskConstructionTests.swift
@@ -447,6 +447,8 @@ fileprivate struct InstallLocTaskConstructionTests: CoreBasedTests {
                                                 "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
                                                 "SDKROOT": "watchos",
                                                 "SKIP_INSTALL": "YES",
+                                                // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                                                "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                                                ]),
                     ],
                     buildPhases: [

--- a/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/MultiPlatformTaskConstructionTests.swift
@@ -184,6 +184,8 @@ fileprivate struct MultiPlatformTaskConstructionTests: CoreBasedTests {
                             "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
                             "SDKROOT": "watchos",
                             "TARGETED_DEVICE_FAMILY": "4",
+                            // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                            "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                         ]),
                     ],
                     buildPhases: [

--- a/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/UnitTestTaskConstructionTests.swift
@@ -1331,7 +1331,11 @@ fileprivate struct UnitTestTaskConstructionTests: CoreBasedTests {
                     "WatchExtension",
                     type: .watchKitExtension,
                     buildConfigurations: [
-                        TestBuildConfiguration("Debug", buildSettings: ["INFOPLIST_FILE": "WatchExtension-Info.plist"]),
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "INFOPLIST_FILE": "WatchExtension-Info.plist",
+                            // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                            "WATCHOS_DEPLOYMENT_TARGET": "9.0",
+                        ]),
                     ],
                     buildPhases: [
                         TestSourcesBuildPhase([

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -28,6 +28,8 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let archs = ["arm64", "arm64e"]
         let swiftCompilerPath = try await self.swiftCompilerPath
+        // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+        let WATCHOS_DEPLOYMENT_TARGET_extension = "9.0"
         let testProject = try await TestProject(
             "aProject",
             groupTree: TestGroup(
@@ -143,7 +145,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                                                 "SKIP_INSTALL": "YES",
                                                 "SWIFT_VERSION": swiftVersion,
                                                 "TARGETED_DEVICE_FAMILY": "4",
-                                                "WATCHOS_DEPLOYMENT_TARGET": core.loadSDK(.watchOS).defaultDeploymentTarget,
+                                                "WATCHOS_DEPLOYMENT_TARGET": WATCHOS_DEPLOYMENT_TARGET_extension,
                                                ]),
                     ],
                     buildPhases: [
@@ -229,7 +231,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                     task.checkRuleInfo([.equal("CompileC"), .suffix("Controller.o"), .suffix("Controller.m"), .equal(variant), .equal(arch), .equal("objective-c"), .any])
                     let expectedCommandLine: [String] = [
                         ["clang"],
-                        ["-target", "arm64_32-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)"],
+                        ["-target", "arm64_32-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)"],
                         ["-isysroot", core.loadSDK(.watchOS).path.str],
                         ["-o", "\(SRCROOT)/build/aProject.build/Debug-watchos/\(target.target.name).build/Objects-\(variant)/\(arch)/Controller.o"]
                     ].reduce([], +)
@@ -239,7 +241,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
                     task.checkRuleInfo(["SwiftDriver Compilation", "Watchable WatchKit Extension", .equal(variant), .equal(arch), .equal("com.apple.xcode.tools.swift.compiler")])
                     let responseFilePath = "@\(SRCROOT)/build/aProject.build/Debug-watchos/\(target.target.name).build/Objects-\(variant)/\(arch)/\(target.target.name).SwiftFileList"
-                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOS).path.str, "-target", "\(arch)-apple-watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)"])
+                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOS).path.str, "-target", "\(arch)-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)"])
                 }
 
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements"))
@@ -248,7 +250,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 try results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                     let expectedCommandLine: [String] = [
                         ["clang"],
-                        ["-target", "\(arch)-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)"],
+                        ["-target", "\(arch)-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)"],
                         ["-isysroot", core.loadSDK(.watchOS).path.str, "-Xlinker", "-rpath", "-Xlinker", "@executable_path/Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../../Frameworks"],
                         ["-fapplication-extension", "\(SRCROOT)/build/Debug-watchos/\(target.target.name).appex/\(target.target.name)"]
                     ].reduce([], +)
@@ -269,11 +271,11 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 // There should be two actool tasks
                 for variant in ["thinned", "unthinned"] {
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileAssetCatalogVariant"), .matchRuleItem(variant)) { task in
-                        task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/aProject.build/Debug-watchos/\(target.target.name).build/assetcatalog_output/\(variant)", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET, "--platform", "watchos"])
+                        task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/aProject.build/Debug-watchos/\(target.target.name).build/assetcatalog_output/\(variant)", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET_extension, "--platform", "watchos"])
                     }
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("GenerateAssetSymbols")) { task in
-                    task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/Debug-watchos/\(target.target.name).appex", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET, "--platform", "watchos", "--bundle-identifier", "com.test.aProject", "--generate-swift-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchos/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.swift", "--generate-objc-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchos/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.h"])
+                    task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/Debug-watchos/\(target.target.name).appex", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET_extension, "--platform", "watchos", "--bundle-identifier", "com.test.aProject", "--generate-swift-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchos/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.swift", "--generate-objc-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchos/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.h"])
                 }
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("LinkAssetCatalog"))
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("LinkAssetCatalogSignature"))
@@ -537,7 +539,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                     task.checkRuleInfo([.equal("CompileC"), .suffix("Controller.o"), .suffix("Controller.m"), .equal(variant), .equal(arch), .equal("objective-c"), .any])
                     let expectedCommandLine: [String] = [
                         ["clang"],
-                        ["-target", "\(arch)-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)-simulator"],
+                        ["-target", "\(arch)-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)-simulator"],
                         ["-isysroot", core.loadSDK(.watchOSSimulator).path.str],
                         ["-o", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/Objects-\(variant)/\(arch)/Controller.o"]
                     ].reduce([], +)
@@ -546,7 +548,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 results.checkTask(.matchTarget(target), .matchRuleType("SwiftDriver Compilation")) { task in
                     task.checkRuleInfo(["SwiftDriver Compilation", "Watchable WatchKit Extension", .equal(variant), .equal(arch), .equal("com.apple.xcode.tools.swift.compiler")])
                     let responseFilePath = "@\(SRCROOT)/build/aProject.build/Debug-watchsimulator/\(target.target.name).build/Objects-\(variant)/\(arch)/\(target.target.name).SwiftFileList"
-                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOSSimulator).path.str, "-target", "x86_64-apple-watchos\(core.loadSDK(.watchOS).defaultDeploymentTarget)-simulator"])
+                    task.checkCommandLineContains([swiftCompilerPath.str, responseFilePath, "-sdk", core.loadSDK(.watchOSSimulator).path.str, "-target", "x86_64-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)-simulator"])
                 }
 
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("SwiftDriver Compilation Requirements"))
@@ -555,7 +557,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 results.checkTask(.matchTarget(target), .matchRuleType("Ld")) { task in
                     let expectedCommandLine: [String] = [
                         ["clang"],
-                        ["-target", "x86_64-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET)-simulator"],
+                        ["-target", "x86_64-apple-watchos\(WATCHOS_DEPLOYMENT_TARGET_extension)-simulator"],
                         ["-isysroot", core.loadSDK(.watchOSSimulator).path.str, "-Xlinker", "-rpath", "-Xlinker", "@executable_path/Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../../Frameworks"],
                         ["-fapplication-extension", "\(SRCROOT)/build/Debug-watchsimulator/Watchable WatchKit Extension.appex/Watchable WatchKit Extension"]
                     ].reduce([], +)
@@ -572,11 +574,11 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                 // There should be two actool tasks
                 for variant in ["thinned", "unthinned"] {
                     results.checkTask(.matchTarget(target), .matchRuleType("CompileAssetCatalogVariant"), .matchRuleItem(variant)) { task in
-                        task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/assetcatalog_output/\(variant)", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET, "--platform", "watchsimulator"])
+                        task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/assetcatalog_output/\(variant)", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET_extension, "--platform", "watchsimulator"])
                     }
                 }
                 results.checkTask(.matchTarget(target), .matchRuleType("GenerateAssetSymbols")) { task in
-                    task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/Debug-watchsimulator/Watchable WatchKit Extension.appex", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET, "--platform", "watchsimulator", "--bundle-identifier", "com.test.aProject", "--generate-swift-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.swift", "--generate-objc-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.h"])
+                    task.checkCommandLineContains([actoolPath.str, "\(SRCROOT)/Sources/watchosExtension/Assets.xcassets", "--compile", "\(SRCROOT)/build/Debug-watchsimulator/Watchable WatchKit Extension.appex", "--target-device", "watch", "--complication", "Complication", "--minimum-deployment-target", WATCHOS_DEPLOYMENT_TARGET_extension, "--platform", "watchsimulator", "--bundle-identifier", "com.test.aProject", "--generate-swift-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.swift", "--generate-objc-asset-symbols", "\(SRCROOT)/build/aProject.build/Debug-watchsimulator/Watchable WatchKit Extension.build/DerivedSources/GeneratedAssetSymbols.h"])
                 }
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("LinkAssetCatalog"))
                 results.checkTaskExists(.matchTarget(target), .matchRuleType("LinkAssetCatalogSignature"))
@@ -1087,7 +1089,8 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                                                 "SKIP_INSTALL": "YES",
                                                 "SWIFT_VERSION": swiftVersion,
                                                 "TARGETED_DEVICE_FAMILY": "4",
-                                                "WATCHOS_DEPLOYMENT_TARGET": core.loadSDK(.watchOS).defaultDeploymentTarget,
+                                                // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                                                "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                                                ]),
                     ],
                     buildPhases: [
@@ -1337,6 +1340,8 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
                                 "INFOPLIST_FILE": "Sources/watchosExtension/Info.plist",
                                 "SDKROOT": "watchos",
                                 "SKIP_INSTALL": "YES",
+                                // Extension-based watchOS apps are no longer supported in watchOS 9.2 and later and will emit an error.
+                                "WATCHOS_DEPLOYMENT_TARGET": "9.0",
                             ]),
                     ],
                     buildPhases: [
@@ -1414,6 +1419,54 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
 
         // Expect no warning for earlier deployment targets.
         await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["IPHONEOS_DEPLOYMENT_TARGET": "12.0"]), runDestination: .iOS) { results in
+            results.checkNoDiagnostics()
+        }
+    }
+
+    @Test(.requireSDKs(.watchOS))
+    func watchKit2ExtensionDeprecation() async throws {
+        let swiftCompilerPath = try await self.swiftCompilerPath
+        let testProject = try await TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "Sources", path: "Sources",
+                children: [
+                    TestFile("ExtensionDelegate.swift"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration(
+                    "Debug",
+                    buildSettings: [
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "watchos",
+                        "SWIFT_EXEC": swiftCompilerPath.str,
+                        "SWIFT_VERSION": swiftVersion,
+                    ]),
+            ],
+            targets: [
+                TestStandardTarget(
+                    "WatchExtension",
+                    type: .watchKitExtension,
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [:]),
+                    ],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["ExtensionDelegate.swift"]),
+                    ]
+                ),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        // Expect an error when deploying to watchOS 9.2 or later.
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["WATCHOS_DEPLOYMENT_TARGET": "9.2"]), runDestination: .watchOS) { results in
+            results.checkError(.equal("deprecated product type 'com.apple.product-type.watchkit2-extension' for platform 'watchOS'. WatchKit extensions are no longer supported. Migrate your WatchKit extension to a single-target watchOS app. (in target 'WatchExtension' from project 'aProject')"))
+            results.checkNoDiagnostics()
+        }
+
+        // Expect no deprecation error for earlier deployment targets.
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["WATCHOS_DEPLOYMENT_TARGET": "9.1"]), runDestination: .watchOS) { results in
             results.checkNoDiagnostics()
         }
     }


### PR DESCRIPTION
Deprecate the com.apple.product-type.watchkit2-extension product type with a new deployment-target-conditional deprecation mechanism. A new DeprecationDeploymentTarget dictionary in product type specs maps platform names to version thresholds, so the deprecation diagnostic is only emitted when the deployment target meets or exceeds the specified version.

For watchKit2-extension, the deprecation error fires at watchOS 9.2+, guiding developers to migrate to single-target watchOS apps.

rdar://165878788