### PR TITLE
Ensure disambiguated object library names can't collide either

### DIFF
--- a/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ObjectLibraryAssemblerTaskAction.swift
@@ -37,28 +37,28 @@ public final class ObjectLibraryAssemblerTaskAction: TaskAction {
             try? executionDelegate.fs.remove(options.output)
             try executionDelegate.fs.createDirectory(options.output, recursive: true)
 
-            // Track basename usage for duplicate detection and build destination mappings
-            var basenameCount: [String: Int] = [:]
+            // Track the names already claimed by earlier inputs, so that disambiguated names can't collide either.
+            var usedDestinationNames: Set<String> = []
             var inputsWithDestinations: [(source: Path, destination: String)] = []
 
             // Process each input to determine its destination name
             for input in options.inputs {
-                // Always use lowercase basenames to avoid collisions on case-insenitive filesystems
-                let basename = input.basename.lowercased()
-                let count = basenameCount[basename, default: 0]
-                basenameCount[basename] = count + 1
-
-                let destinationName: String
-                if count == 0 {
-                    // First occurrence, use original name
-                    destinationName = basename
-                } else {
-                    // Duplicate detected, add suffix before extension
-                    let nameWithoutSuffix = input.withoutSuffix
-                    let suffix = input.fileSuffix  // Includes the dot
-                    destinationName = "\(Path(nameWithoutSuffix).basename)-\(count)\(suffix)"
+                // Always use lowercase basenames to avoid collisions on case-insensitive filesystems
+                let basename = Path(input.basename.lowercased())
+                var destinationName = basename.str
+                if usedDestinationNames.contains(destinationName) {
+                    // Duplicate detected, add a suffix before the extension. Keep incrementing until we land on a name
+                    // no other input has claimed, since an input may already be named like a disambiguated one.
+                    let nameWithoutSuffix = basename.basenameWithoutSuffix
+                    let suffix = basename.fileSuffix  // Includes the dot
+                    var count = 1
+                    repeat {
+                        destinationName = "\(nameWithoutSuffix)-\(count)\(suffix)"
+                        count += 1
+                    } while usedDestinationNames.contains(destinationName)
                 }
 
+                usedDestinationNames.insert(destinationName)
                 inputsWithDestinations.append((source: input, destination: destinationName))
             }
 

--- a/Tests/SWBTaskExecutionTests/ObjectLibraryAssemblerTaskActionTests.swift
+++ b/Tests/SWBTaskExecutionTests/ObjectLibraryAssemblerTaskActionTests.swift
@@ -98,6 +98,112 @@ fileprivate struct ObjectLibraryAssemblerTaskActionTests {
     }
 
     @Test
+    func duplicatesCollidingWithDisambiguatedNames() async throws {
+        // An input may already be named like the disambiguated form of another input, so the names generated for
+        // duplicates must be checked against every name which has already been claimed.
+        let inputOne = Path.root.join("input1").join("file.o")
+        let inputTwo = Path.root.join("input2").join("file.o")
+        let inputThree = Path.root.join("input3").join("file-1.o")
+        let output = Path.root.join("output")
+
+        let executionDelegate = MockExecutionDelegate()
+        try executionDelegate.fs.createDirectory(inputOne.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputTwo.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputThree.dirname, recursive: true)
+        try executionDelegate.fs.write(inputOne, contents: ByteString(encodingAsUTF8: "one"))
+        try executionDelegate.fs.write(inputTwo, contents: ByteString(encodingAsUTF8: "two"))
+        try executionDelegate.fs.write(inputThree, contents: ByteString(encodingAsUTF8: "three"))
+
+        let outputDelegate = MockTaskOutputDelegate()
+
+        let commandLine = [
+            "builtin-ObjectLibraryAssembler",
+            "--linker-response-file-format",
+            "unixShellQuotedSpaceSeparated",
+            inputOne.str,
+            inputTwo.str,
+            inputThree.str,
+            "--output",
+            output.str
+        ].map { ByteString(encodingAsUTF8: $0) }
+
+        let inputs = [inputOne, inputTwo, inputThree].map { MakePlannedPathNode($0) }
+        var builder = PlannedTaskBuilder(type: mockTaskType, ruleInfo: [], commandLine: commandLine.map { .literal($0) }, inputs: inputs, outputs: [MakePlannedPathNode(output)])
+        let task = Task(&builder)
+
+        let result = await ObjectLibraryAssemblerTaskAction().performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        #expect(result == .succeeded, "Task should succeed")
+        #expect(outputDelegate.messages == [], "Should have no error messages")
+
+        // Each input must survive with its own contents, rather than one overwriting another.
+        #expect(try executionDelegate.fs.read(output.join("file.o")).asString == "one")
+        #expect(try executionDelegate.fs.read(output.join("file-1.o")).asString == "two")
+        #expect(try executionDelegate.fs.read(output.join("file-1-1.o")).asString == "three")
+    }
+
+    @Test
+    func duplicatesDifferingOnlyByCase() async throws {
+        // Basenames are lowercased so they can't collide on case-insensitive filesystems, which means inputs differing
+        // only by case are duplicates and every one of them but the first needs to be disambiguated.
+        let inputOne = Path.root.join("input1").join("File.o")
+        let inputTwo = Path.root.join("input2").join("FILE.o")
+        let inputThree = Path.root.join("input3").join("file.o")
+        let output = Path.root.join("output")
+
+        let executionDelegate = MockExecutionDelegate()
+        try executionDelegate.fs.createDirectory(inputOne.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputTwo.dirname, recursive: true)
+        try executionDelegate.fs.createDirectory(inputThree.dirname, recursive: true)
+        try executionDelegate.fs.write(inputOne, contents: ByteString(encodingAsUTF8: "one"))
+        try executionDelegate.fs.write(inputTwo, contents: ByteString(encodingAsUTF8: "two"))
+        try executionDelegate.fs.write(inputThree, contents: ByteString(encodingAsUTF8: "three"))
+
+        let outputDelegate = MockTaskOutputDelegate()
+
+        let commandLine = [
+            "builtin-ObjectLibraryAssembler",
+            "--linker-response-file-format",
+            "unixShellQuotedSpaceSeparated",
+            inputOne.str,
+            inputTwo.str,
+            inputThree.str,
+            "--output",
+            output.str
+        ].map { ByteString(encodingAsUTF8: $0) }
+
+        let inputs = [inputOne, inputTwo, inputThree].map { MakePlannedPathNode($0) }
+        var builder = PlannedTaskBuilder(type: mockTaskType, ruleInfo: [], commandLine: commandLine.map { .literal($0) }, inputs: inputs, outputs: [MakePlannedPathNode(output)])
+        let task = Task(&builder)
+
+        let result = await ObjectLibraryAssemblerTaskAction().performTaskAction(
+            task,
+            dynamicExecutionDelegate: MockDynamicTaskExecutionDelegate(),
+            executionDelegate: executionDelegate,
+            clientDelegate: MockTaskExecutionClientDelegate(),
+            outputDelegate: outputDelegate
+        )
+
+        #expect(result == .succeeded, "Task should succeed")
+        #expect(outputDelegate.messages == [], "Should have no error messages")
+
+        // All destination names are lowercased, including the disambiguated ones.
+        #expect(try executionDelegate.fs.read(output.join("file.o")).asString == "one")
+        #expect(try executionDelegate.fs.read(output.join("file-1.o")).asString == "two")
+        #expect(try executionDelegate.fs.read(output.join("file-2.o")).asString == "three")
+
+        let responseContent = try executionDelegate.fs.read(output.join("args.resp")).asString
+        #expect(!responseContent.contains("File"), "Response should not contain the original casing")
+        #expect(!responseContent.contains("FILE"), "Response should not contain the original casing")
+    }
+
+    @Test
     func noDuplicates() async throws {
         // Test that files with unique basenames are not renamed
         let inputOne = Path.root.join("a.o")


### PR DESCRIPTION
Follow-up to ab824233, which lowercased the basenames `ObjectLibraryAssembler` copies into the object library so they can't collide on case-insensitive filesystems. The names generated for duplicates were left out of that change: they are neither lowercased nor recorded as taken, so two inputs can still end up sharing a destination and one silently overwrites the other.

Two ways this happens today:

- An input literally named `file-1.o` claims the same name the second `file.o` was renamed to. The count is keyed on the original basename, so nothing notices. This one reproduces on case-sensitive filesystems too — inputs `file.o`, `file.o`, `file-1.o` produce `file.o`, `file-1.o`, `file-1.o`.
- The `-N` name is built from `input.withoutSuffix`, which keeps the original casing, so `FILE-1.o` and `file-1.o` collide on NTFS and on a default APFS volume — the case the original change set out to fix.

The fix tracks the destination names already claimed and keeps incrementing the suffix until it finds an unused one, deriving the name from the lowercased basename so the disambiguated form is lowercased as well.

Two tests are added to `ObjectLibraryAssemblerTaskActionTests`, one per scenario. Both fail against main (the first reads `"three"` where `"two"` is expected; the second doesn't produce `file-1.o` at all) and pass with the change. The existing `caseInsensitiveObjectLibraryCollision` build operation test and the object library task construction and wasm tests still pass.

This covers what's left of #1313 — the rest of that issue was already addressed by ab824233.