### PR TITLE
Add a build setting which allows overriding the display name reported by the build server for a target

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -509,6 +509,7 @@ public final class BuiltinMacros {
     public static let BUILD_DIR = BuiltinMacros.declarePathMacro("BUILD_DIR")
     public static let BUILD_LIBRARY_FOR_DISTRIBUTION = BuiltinMacros.declareBooleanMacro("BUILD_LIBRARY_FOR_DISTRIBUTION")
     public static let BUILD_PACKAGE_FOR_DISTRIBUTION = BuiltinMacros.declareBooleanMacro("BUILD_PACKAGE_FOR_DISTRIBUTION")
+    public static let BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME = BuiltinMacros.declareStringMacro("BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME")
     public static let BUILD_SERVER_PROTOCOL_TARGET_TAGS = BuiltinMacros.declareStringListMacro("BUILD_SERVER_PROTOCOL_TARGET_TAGS")
     public static let BUILD_VARIANTS = BuiltinMacros.declareStringListMacro("BUILD_VARIANTS")
     public static let BuiltBinaryPath = BuiltinMacros.declareStringMacro("BuiltBinaryPath")
@@ -1558,6 +1559,7 @@ public final class BuiltinMacros {
         BUILD_DIR,
         BUILD_LIBRARY_FOR_DISTRIBUTION,
         BUILD_PACKAGE_FOR_DISTRIBUTION,
+        BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME,
         BUILD_SERVER_PROTOCOL_TARGET_TAGS,
         BUILD_STYLE,
         BUILD_VARIANTS,

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -18,6 +18,7 @@ extension ProjectModel {
     public struct BuildSettings: Sendable, Hashable {
         public enum SingleValueSetting: String, CaseIterable, Sendable, Equatable, Codable {
             case APPLICATION_EXTENSION_API_ONLY
+            case BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME
             case BUILT_PRODUCTS_DIR
             case CLANG_CXX_LANGUAGE_STANDARD
             case CLANG_ENABLE_MODULES

--- a/Sources/SwiftBuild/SWBBuildServer.swift
+++ b/Sources/SwiftBuild/SWBBuildServer.swift
@@ -291,9 +291,16 @@ public actor SWBBuildServer: QueueBasedMessageHandler {
                     nil
                 }
 
+                let displayName = try await session.evaluateMacroAsString(
+                    "BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME",
+                    level: .target(targetInfo.identifier.targetGUID.rawValue),
+                    buildParameters: buildRequest.parameters,
+                    overrides: nil
+                )
+
                 return BuildTarget(
                     id: try BuildTargetIdentifier(configuredTargetIdentifier: targetInfo.identifier),
-                    displayName: targetInfo.name,
+                    displayName: displayName.nilIfEmpty ?? targetInfo.name,
                     baseDirectory: nil,
                     tags: tags,
                     capabilities: BuildTargetCapabilities(),

--- a/Tests/SwiftBuildTests/BuildServerTests.swift
+++ b/Tests/SwiftBuildTests/BuildServerTests.swift
@@ -206,6 +206,59 @@ fileprivate struct BuildServerTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host))
+    func workspaceTargetDisplayNameOverride() async throws {
+        try await withBuildServerConnection(setup: { tmpDir in
+            let testWorkspace = TestWorkspace(
+                "aWorkspace",
+                sourceRoot: tmpDir.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        defaultConfigurationName: "Debug",
+                        groupTree: TestGroup(
+                            "Foo",
+                            children: [
+                                TestFile("a.swift"),
+                            ]
+                        ),
+                        targets: [
+                            TestStandardTarget(
+                                "Target",
+                                type: .dynamicLibrary,
+                                buildConfigurations: [
+                                    TestBuildConfiguration("Debug", buildSettings: [
+                                        "BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME": "DisplayNameOverride",
+                                        "SDKROOT": "auto",
+                                        "SUPPORTED_PLATFORMS": "$(AVAILABLE_PLATFORMS)",
+                                    ])
+                                ],
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        "a.swift"
+                                    ])
+                                ]
+                            ),
+                        ]
+                    )
+                ])
+
+            var request = SWBBuildRequest()
+            request.parameters = SWBBuildParameters()
+            request.parameters.action = "build"
+            request.parameters.configurationName = "Debug"
+            for target in testWorkspace.projects.flatMap({ $0.targets }) {
+                request.add(target: SWBConfiguredTarget(guid: target.guid))
+            }
+            request.parameters.activeRunDestination = .host
+
+            return (testWorkspace, request)
+        }) { connection, _, _ in
+            let targetsResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            #expect(targetsResponse.targets.map(\.displayName) == ["DisplayNameOverride"])
+        }
+    }
+
     @Test(.requireSDKs(.host), .skipHostOS(.freebsd, "test occasionally hangs on FreeBSD"))
     func targetSources() async throws {
         try await withBuildServerConnection(setup: { tmpDir in


### PR DESCRIPTION
SourceKit-LSP surfaces these display names to the user, so we don't want to use the PIF target name which may include disambiguating suffixes. Follow the model used by tags to provide a build setting PIF clients can use to override what's reported