### PR TITLE
Introduce AI Model compiler specs.

### DIFF
--- a/Sources/SWBApplePlatform/AIModelCompilerSpec.swift
+++ b/Sources/SWBApplePlatform/AIModelCompilerSpec.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import SWBCore
+
+public final class AIModelCompilerSpec: GenericCompilerSpec, SpecIdentifierType, @unchecked Sendable {
+
+    /// Matches the identifier declared in `AIModel.xcspec`.
+    public static let identifier = "com.apple.compilers.aimodel"
+
+    // MARK: - CommandLineToolSpec
+
+    override public var enableSandboxing: Bool {
+        false
+    }
+}

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -154,6 +154,7 @@ struct ApplePlatformSpecsExtension: SpecificationsExtension {
             ResMergerLinkerSpec.self,
             SceneKitToolSpec.self,
             XCStringsCompilerSpec.self,
+            AIModelCompilerSpec.self,
         ]
     }
 

--- a/Sources/SWBApplePlatform/Specs/AIModel.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AIModel.xcspec
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+(
+    {
+        Type = FileType;
+        Identifier = "folder.aimodel";
+        BasedOn = wrapper;
+        Name = "Core AI Model";
+        Extensions = (
+            aimodel,
+        );
+        AppliesToBuildRules = YES;
+        IncludeInIndex = YES;
+        CanSetIncludeInIndex = YES;
+        UTI = "com.apple.coreai.aimodel";
+    },
+    {
+        Type = Compiler;
+        Identifier = "com.apple.compilers.aimodel";
+        Name = "AI Model Compiler";
+        Description = "aimodelc: compiler for aimodel files";
+        "IsArchitectureNeutral" = Yes;
+        CommandLine = "aimodelc package $(InputFile) --platform $(PLATFORM_FAMILY_NAME) --min-deployment-version $($(DEPLOYMENT_TARGET_SETTING_NAME)) --output $(ProductResourcesDir)/$(InputFileBase).aimodel [options]";
+        RuleName = "AIModelCompile $(ProductResourcesDir)/ $(InputFile)";
+        ExecDescription = "Compile AI Model file $(InputFileName)";
+        ProgressDescription = "Compiling $(CommandProgressByType) AI Model files";
+        InputFileTypes = (
+            "folder.aimodel",
+        );
+        "DeeplyStatInputDirectories" = Yes;
+        SynthesizeBuildRule = Yes;
+        Outputs = (
+            "$(ProductResourcesDir)/$(InputFileBase).aimodel",
+        );
+        Options = (
+            {
+                Name = "EFFECTIVE_TOOLCHAINS_DIRS";
+                Type = StringList;
+                CommandLineFlag = "--toolchain-dir";
+            },
+            {
+                Name = "build_file_compiler_flags";
+                Type = StringList;
+                DefaultValue = "";
+                "CommandLinePrefixFlag" = "";
+            },
+        );
+    },
+)

--- a/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.aimodelc.strings
+++ b/Sources/SWBApplePlatform/Specs/en.lproj/com.apple.compilers.aimodelc.strings
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+"Name" = "AI Model Compiler";
+"Description" = "aimodelc: AI Model Compiler";
+"Version" = "Default";
+"Vendor" = "Apple";

--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -1166,6 +1166,11 @@ public struct SwiftBuildFileType: Sendable {
         fileTypeIdentifier: "folder.mlpackage"
     )
 
+    public static let aimodel = SwiftBuildFileType(
+        fileType: "aimodel",
+        fileTypeIdentifier: "folder.aimodel"
+    )
+
     public static let metal: SwiftBuildFileType = SwiftBuildFileType(
         fileType: "metal",
         fileTypeIdentifier: "sourcecode.metal"
@@ -1182,6 +1187,7 @@ public struct SwiftBuildFileType: Sendable {
         .xcdatamodeld,
         .xcdatamodel,
         .xcmappingmodel,
+        .aimodel,
         .mlmodel,
         .mlpackage,
         .metal,

--- a/Sources/SWBTestSupport/TestWorkspaces.swift
+++ b/Sources/SWBTestSupport/TestWorkspaces.swift
@@ -322,6 +322,8 @@ package final class TestFile: TestInternalStructureItem, CustomStringConvertible
             return "com.apple.package"
         case "":
             return "public.directory"
+        case ".aimodel":
+            return "folder.aimodel"
         case let ext where ext.hasPrefix(".fake-"):
             // If this is a fake extension, just return "file".
             return "file"

--- a/Tests/SWBTaskConstructionTests/AIModelTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AIModelTaskConstructionTests.swift
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import Testing
+
+@_spi(Testing) import SWBCore
+import SWBProtocol
+import SWBTestSupport
+import SWBUtil
+
+import SWBTaskConstruction
+
+import class SWBMacro.StringMacroDeclaration
+
+@Suite
+fileprivate struct AIModelTaskConstructionTests: CoreBasedTests {
+    @available(macOS 27.0, *)
+    @Test(.requireSDKs(.macOS))
+    func aimodelCompilerPackageWithDefaultInferenceMode() async throws {
+        try await checkModelCompileCommandLineStrings(
+            options: .init(
+                modelName: "MyModel",
+                runDestination: .macOS,
+                deploymentTarget: "27.0"
+            ),
+            expectedCommandLineArguments: [
+                "aimodelc",
+                "package",
+                .suffix("MyModel.aimodel"),
+                "--platform",
+                "macOS",
+                "--min-deployment-version",
+                "27.0",
+                "--output",
+                .suffix("AI Model App.app/Contents/Resources/MyModel.aimodel"),
+                "--toolchain-dir",
+                .suffix("XcodeDefault.xctoolchain"),
+            ]
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Helper method that uses a test project and build configuration, and yields only the
+    /// sequence of command line arguments generated for the `AIModelCompile` task.
+    /// - Parameters:
+    ///   - compilerOptions: Collection of parameters affecting the relevant task.
+    ///   - expectedCommandLineArguments: Matched against the generated command.
+    func checkModelCompileCommandLineStrings(
+        options compilerOptions: ModelCompilerTestOptions,
+        expectedCommandLineArguments: [StringPattern]
+    ) async throws {
+        try await withTemporaryDirectory { tmpDir in
+
+            let core = try await getCore()
+
+            let deploymentTargetKey = try #require(
+                compilerOptions.runDestination.buildVersionPlatform(core)?.deploymentTargetSettingName(infoLookup: core)
+            )
+
+            let buildSettings = try await [
+
+                // Options specific to the AI Model compiler.
+                deploymentTargetKey: compilerOptions.deploymentTarget,
+
+                // Options required by the swift compiler.
+                "SWIFT_EXEC": swiftCompilerPath.str,
+                "SWIFT_VERSION": swiftVersion,
+
+                // Miscellaneous options.
+                "PRODUCT_NAME": "$(TARGET_NAME)",
+                "PRODUCT_BUNDLE_IDENTIFIER": "com.apple.ai-model-project",
+                "GENERATE_INFOPLIST_FILE": "YES",
+            ]
+
+            let testProject = TestProject(
+                "AI Model Project",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "Sources",
+                    children: [
+                        TestFile("Main.swift"),
+                        TestFile("MyModel.aimodel"),
+                    ]
+                ),
+                buildConfigurations: [
+                    TestBuildConfiguration(
+                        "Debug",
+                        buildSettings: buildSettings
+                    )
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "AI Model App",
+                        type: .application,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug")
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                "Main.swift",
+                                "MyModel.aimodel"
+                            ])
+                        ]
+                    )
+                ]
+            )
+
+            let tester = try TaskConstructionTester(core, testProject)
+
+            await tester.checkBuild(
+                BuildParameters(configuration: "Debug"),
+                runDestination: compilerOptions.runDestination
+            ) { results in
+
+                results.checkTask(.matchRuleType("AIModelCompile")) { task in
+                    task.checkCommandLineMatches(expectedCommandLineArguments)
+                }
+            }
+        }
+    }
+
+    /// These options allow asset testing configuration parameters to be passed through a few
+    /// functional layers without exploding the parameter count.
+    struct ModelCompilerTestOptions {
+
+        /// Name of the model to be compiled.
+        var modelName: String
+
+        /// Where we want this asset to run.
+        var runDestination: SWBCore.RunDestinationInfo
+
+        /// Something like "27.0".
+        var deploymentTarget: String
+    }
+}
+


### PR DESCRIPTION
Supports processing of `aimodel` files in build pipelines.

Task construction tests are included with this change.