### PR TITLE
Stop passing --validate-assistant-intents / --assistant-intents-app-name-override to appintentsmetadataprocessor

### DIFF
--- a/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppIntentsMetadata.xcspec
@@ -169,24 +169,6 @@
                 };
             },
             {
-                Name = ENABLE_ASSISTANT_INTENTS_PROVIDER_VALIDATION;
-                Type = Boolean;
-                DefaultValue = YES;
-                CommandLineArgs = {
-                    YES = ( "--validate-assistant-intents" );
-                    NO = ();
-                };
-            },
-            {
-                Name = LM_ENABLE_ASSISTANT_INTENT_APP_NAME_OVERRIDE;
-                Type = Boolean;
-                DefaultValue = NO;
-                CommandLineArgs = {
-                    YES = ( "--assistant-intents-app-name-override" );
-                    NO = ();
-                };
-            },
-            {
                 Name = LM_NO_APP_SHORTCUT_LOCALIZATION;
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Sources/SWBApplePlatform/Specs/AppShortcutStringsMetadata.xcspec
+++ b/Sources/SWBApplePlatform/Specs/AppShortcutStringsMetadata.xcspec
@@ -67,24 +67,6 @@
                 CommandLineFlag = "--deployment-target";
             },
             {
-                Name = ENABLE_ASSISTANT_INTENTS_PROVIDER_VALIDATION;
-                Type = Boolean;
-                DefaultValue = YES;
-                CommandLineArgs = {
-                    YES = ( "--validate-assistant-intents" );
-                    NO = ();
-                };
-            },
-            {
-                Name = LM_ENABLE_ASSISTANT_INTENT_APP_NAME_OVERRIDE;
-                Type = Boolean;
-                DefaultValue = NO;
-                CommandLineArgs = {
-                    YES = ( "--assistant-intents-app-name-override" );
-                    NO = ();
-                };
-            },
-            {
                 Name = LM_AUX_INTENTS_METADATA_FILES_LIST_PATH;
                 Type = Path;
                 DefaultValue = "$(TEMP_DIR)/$(PRODUCT_NAME).DependencyMetadataFileList";

--- a/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
+++ b/Tests/SWBBuildSystemTests/AppShortcutsStringsValidationTests.swift
@@ -208,7 +208,6 @@ fileprivate struct AppShortcutsStringsValidationTests: CoreBasedTests {
                                                "--input-data-path", metadataFolderPath,
                                                "--platform-family",  "macOS",
                                                "--deployment-target", core.loadSDK(.macOS).defaultDeploymentTarget,
-                                               "--validate-assistant-intents",
                                                "--metadata-file-list", "\(tmpDir.str)/build/AppShortcutsProject.build/Debug/testTarget.build/testTarget.DependencyMetadataFileList"
                                               ])
                     }
@@ -229,7 +228,8 @@ fileprivate struct AppShortcutsStringsValidationTests: CoreBasedTests {
             }
 
             try await tester.checkBuild(parameters: parameters, runDestination: .macOS) { results in
-                results.checkWarning(.contains("This phrase is not used in any App Shortcut or as a Negative Phrase."))
+                results.checkWarning(.contains("This phrase is not used in any App Shortcut or as a Negative Phrase"))
+                results.checkNoWarnings()
                 results.checkNoErrors()
             }
         }

--- a/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppIntentsMetadataTaskConstructionTests.swift
@@ -104,7 +104,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                       "--static-metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyStaticMetadataFileList"]
 
                         let commandLineAfterConst = (swiftFeatures.has(.constExtractCompleteMetadata) ? ["--compile-time-extraction"] : []) +
-                        ["--deployment-aware-processing", "--validate-assistant-intents"]
+                        ["--deployment-aware-processing"]
                         let commandLine: [String]
                         if swiftFeatures.has(.emitContValuesSidecar) {
                             commandLine = commandLineBeforeConst +
@@ -169,7 +169,6 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                "--input-data-path", "\(SRCROOT)/build/Debug-iphoneos/LinkTest.app/Metadata.appintents",
                                                "--platform-family",  "iOS",
                                                "--deployment-target", core.loadSDK(.iOS).defaultDeploymentTarget,
-                                               "--validate-assistant-intents",
                                                "--metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyMetadataFileList"
                                               ])
                     }
@@ -272,7 +271,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                       "--metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyMetadataFileList",
                                                       "--static-metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyStaticMetadataFileList"]
                         let commandLineAfterConst = (swiftFeatures.has(.constExtractCompleteMetadata) ? ["--compile-time-extraction"] : []) +
-                        ["--deployment-aware-processing", "--validate-assistant-intents"]
+                        ["--deployment-aware-processing"]
                         let commandLine: [String]
                         if swiftFeatures.has(.emitContValuesSidecar) {
                             commandLine = commandLineBeforeConst +
@@ -336,7 +335,6 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                "--input-data-path", "\(SRCROOT)/build/Debug-iphoneos/LinkTest.app/Metadata.appintents",
                                                "--platform-family",  "iOS",
                                                "--deployment-target", results.runDestinationSDK.defaultDeploymentTarget,
-                                               "--validate-assistant-intents",
                                                "--metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyMetadataFileList"
                                               ])
                     }
@@ -547,7 +545,6 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                "--app-name-override",
                                                "--platform-family",  "iOS",
                                                "--deployment-target", core.loadSDK(.iOS).defaultDeploymentTarget,
-                                               "--validate-assistant-intents",
                                                "--metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyMetadataFileList"
                                               ])
                     }
@@ -1198,67 +1195,6 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.iOS))
-    func disableAssistantIntentsProviderValidation() async throws {
-        try await withTemporaryDirectory { tmpDir in
-            let testProject = try await TestProject(
-                "aProject",
-                sourceRoot: tmpDir,
-                groupTree: TestGroup(
-                    "SomeFiles",
-                    children: [
-                        TestFile("source.swift")
-                    ]),
-                buildConfigurations: [
-                    TestBuildConfiguration(
-                        "Debug",
-                        buildSettings: [
-                            "AD_HOC_CODE_SIGNING_ALLOWED": "YES",
-                            "ARCHS": "arm64",
-                            "CODE_SIGN_IDENTITY": "-",
-                            "GENERATE_INFOPLIST_FILE": "YES",
-                            "PRODUCT_BUNDLE_IDENTIFIER": "com.foo.bar",
-                            "PRODUCT_NAME": "$(TARGET_NAME)",
-                            "SDKROOT": "iphoneos",
-                            "SWIFT_EXEC": swiftCompilerPath.str,
-                            "SWIFT_VERSION": swiftVersion,
-                            "VERSIONING_SYSTEM": "apple-generic",
-                            "SWIFT_EMIT_CONST_VALUE_PROTOCOLS": "Foo Bar",
-                        ]),
-                ],
-                targets: [
-                    TestStandardTarget(
-                        "LinkTest",
-                        type: .application,
-                        buildConfigurations: [
-                            TestBuildConfiguration(
-                                "Debug",
-                                buildSettings: [
-                                    "LM_ENABLE_LINK_GENERATION": "YES",
-                                    "ENABLE_ASSISTANT_INTENTS_PROVIDER_VALIDATION": "NO"
-                                ]),
-                        ],
-                        buildPhases: [
-                            TestSourcesBuildPhase(["source.swift"]),
-                        ]
-                    )
-                ])
-
-            let core = try await getCore()
-            let tester = try TaskConstructionTester(core, testProject)
-            await tester.checkBuild(runDestination: .iOS) { results in
-                results.checkTask(.matchRuleType("ExtractAppIntentsMetadata")) { task in
-                    let executableName = task.commandLine.first
-                    if let executableName,
-                       executableName == "appintentsmetadataprocessor" {
-                        task.checkCommandLineDoesNotContain("---validate-assistant-intents")
-                    }
-                    results.checkNoDiagnostics()
-                }
-            }
-        }
-    }
-
-    @Test(.requireSDKs(.iOS))
     func multipleBuildVariants() async throws {
         let swiftCompilerPath = try await self.swiftCompilerPath
         let swiftVersion = try await self.swiftVersion
@@ -1337,7 +1273,7 @@ fileprivate struct AppIntentsMetadataTaskConstructionTests: CoreBasedTests {
                                                       "--static-metadata-file-list", "\(tmpDir.str)/build/aProject.build/Debug-iphoneos/LinkTest.build/LinkTest.DependencyStaticMetadataFileList"]
 
                         let commandLineAfterConst = (swiftFeatures.has(.constExtractCompleteMetadata) ? ["--compile-time-extraction"] : []) +
-                        ["--deployment-aware-processing", "--validate-assistant-intents"]
+                        ["--deployment-aware-processing"]
                         let commandLine: [String]
                         if swiftFeatures.has(.emitContValuesSidecar) {
                             commandLine = commandLineBeforeConst +


### PR DESCRIPTION
- Remove the options flags, and the Xcode build settings that govern them, from .xcspec files.
- Update unit tests to exclude `--validate-assistant-intents` from expected arguments.
- Delete `AppIntentsMetadataTaskConstructionTests.disableAssistantIntentsProviderValidation()`.

rdar://177561318