### PR TITLE
Update the default iOS deployment target for the watchapp2-container product type.

### DIFF
--- a/Sources/SWBApplePlatform/Specs/DarwinProductTypes.xcspec
+++ b/Sources/SWBApplePlatform/Specs/DarwinProductTypes.xcspec
@@ -406,7 +406,7 @@
             BUILD_ACTIVE_RESOURCES_ONLY = NO;
             EXCLUDED_ARCHS = arm64e;
             GENERATE_INFOPLIST_FILE = YES;
-            IPHONEOS_DEPLOYMENT_TARGET = "13.0";
+            IPHONEOS_DEPLOYMENT_TARGET = "15.0";
             PRODUCT_BINARY_SOURCE_PATH = "$(PLATFORM_DIR)/Library/Application Support/MessagesApplicationStub/MessagesApplicationStub";
             PRODUCT_TYPE_HAS_STUB_BINARY = YES;
             THIN_PRODUCT_STUB_BINARY = YES;

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -1112,7 +1112,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
             ])
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-        let IPHONEOS_DEPLOYMENT_TARGET = "13.0" // watch-only app stub containers are hardcoded to 13.0 by default
+        let IPHONEOS_DEPLOYMENT_TARGET = "15.0" // watch-only app stub containers are hardcoded to 15.0 by default (in the com.apple.product-type.application.watchapp2-container product type spec)
 
         // Create files in the filesystem so they're known to exist.
         let fs = PseudoFS()
@@ -1198,7 +1198,7 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         let core = try await getCore()
         let tester = try TaskConstructionTester(core, testProject)
         let SRCROOT = tester.workspace.projects[0].sourceRoot.str
-        let IPHONEOS_DEPLOYMENT_TARGET = "13.0" // watch-only app stub containers are hardcoded to 13.0 by default
+        let IPHONEOS_DEPLOYMENT_TARGET = "15.0" // watch-only app stub containers are hardcoded to 15.0 by default (in the com.apple.product-type.application.watchapp2-container product type spec)
 
         let actoolPath = try await self.actoolPath
 


### PR DESCRIPTION
rdar://175031679
