### PR TITLE
Introduce __DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS build setting (StringListMacro)

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -638,6 +638,7 @@ public final class BuiltinMacros {
     public static let DEVELOPMENT_TEAM = BuiltinMacros.declareStringMacro("DEVELOPMENT_TEAM")
     public static let DIAGNOSE_LOCALIZATION_FILE_EXCLUSION = BuiltinMacros.declareEnumMacro("DIAGNOSE_LOCALIZATION_FILE_EXCLUSION") as EnumMacroDeclaration<BooleanWarningLevel>
     public static let __DIAGNOSE_DEPRECATED_ARCHS = BuiltinMacros.declareBooleanMacro("__DIAGNOSE_DEPRECATED_ARCHS")
+    public static let __DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS = BuiltinMacros.declareStringListMacro("__DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS")
     public static let DIFF = BuiltinMacros.declarePathMacro("DIFF")
     public static let _DISCOVER_COMMAND_LINE_LINKER_INPUTS = BuiltinMacros.declareBooleanMacro("_DISCOVER_COMMAND_LINE_LINKER_INPUTS")
     public static let _DISCOVER_COMMAND_LINE_LINKER_INPUTS_INCLUDE_WL = BuiltinMacros.declareBooleanMacro("_DISCOVER_COMMAND_LINE_LINKER_INPUTS_INCLUDE_WL")
@@ -1745,6 +1746,7 @@ public final class BuiltinMacros {
         __DIAGNOSE_INVALID_DEPLOYMENT_TARGET_AS_ERROR,
         DIAGNOSE_MISSING_TARGET_DEPENDENCIES,
         __DIAGNOSE_DEPRECATED_ARCHS,
+        __DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS,
         DIFF,
         DISABLE_FREEFORM_CODE_SIGN_OPTION_FLAGS,
         _DISCOVER_COMMAND_LINE_LINKER_INPUTS,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3326,7 +3326,15 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
         let platformErrorSuffix = " for platform '\(platform.displayName)'"
         let base = "deprecated product type '\(productType.identifier)'\(platformErrorSuffix)."
 
-        switch deprecationInfo.level {
+        var effectiveLevel = deprecationInfo.level
+        if effectiveLevel == .error {
+            let scope = createScope(sdkToUse: nil)
+            if scope.evaluate(BuiltinMacros.__DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS).contains(productType.identifier) {
+                effectiveLevel = .warning
+            }
+        }
+
+        switch effectiveLevel {
         case .warning: self.warnings.append("\(base) \(deprecationInfo.reason)")
         case .error: self.errors.append("\(base) \(deprecationInfo.reason)")
         }

--- a/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/WatchTaskConstructionTests.swift
@@ -1478,6 +1478,12 @@ fileprivate struct WatchTaskConstructionTests: CoreBasedTests {
         await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["WATCHOS_DEPLOYMENT_TARGET": "9.1"]), runDestination: .watchOS) { results in
             results.checkNoDiagnostics()
         }
+
+        // Expect a warning (not an error) when the downgrade setting is applied.
+        await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["WATCHOS_DEPLOYMENT_TARGET": "9.2", "__DOWNGRADE_DEPRECATED_PRODUCT_TYPE_ERRORS": "com.apple.product-type.watchkit2-extension"]), runDestination: .watchOS) { results in
+            results.checkWarning(.equal("deprecated product type 'com.apple.product-type.watchkit2-extension' for platform 'watchOS'. WatchKit extensions are no longer supported. Migrate your WatchKit extension to a single-target watchOS app. (in target 'WatchExtension' from project 'aProject')"))
+            results.checkNoDiagnostics()
+        }
     }
 
     @Test(.requireSDKs(.watchOS))


### PR DESCRIPTION
This allows specific projects to downgrade deprecated product type errors to warnings. The setting is evaluated in checkProductTypeDeprecationForDeploymentTarget and checked against the product type identifier. Projects opt in via addProjectSpecificOverrides using ProjectMatcher, initially targeting com.apple.product-type.watchkit2-extension.

rdar://176210378
