### PR TITLE
Fix build file ordering assignment

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -634,8 +634,8 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
             } else {
                 otherBuildFiles.append(resolvedBuildFile)
             }
-            resolvedBuildFiles = compileToSwiftFiles + otherBuildFiles
         }
+        resolvedBuildFiles = compileToSwiftFiles + otherBuildFiles
 
         // Allow subclasses to provide additional content
         // We have to process this _before_ the resolvedBuildFiles to workaround an issue where generated sources aren't added to main source code group.


### PR DESCRIPTION
This array concat and write was being done for every loop iteration. As the array is being overwritten every time, significant amounts of time can be saved by only writing after the loop.

This fixes the performance regression reported in #1479 and during a build of [SDWebImage/SDWebImageSVGNativeCoder](https://github.com/SDWebImage/SDWebImageSVGNativeCoder) reduces the time taken during "Create build description" from minutes to 1-2 seconds.

A trace from Instruments helped me track down the issue, which showed 99.7% of the entire build time was spent assigning and re-assigning this array:
<img width="844" height="344" alt="Screenshot 2026-08-12 at 11 46 29" src="https://github.com/user-attachments/assets/383bd7f4-3e3e-4b75-a821-b2a7b16470a7" />

Running the same trace after this change reduces the amount of time spent in that function to almost nothing.