### PR TITLE
Only resolve xcframework paths for actual xcframeworks

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
@@ -61,9 +61,14 @@ final class XCFrameworkTaskProducer: StandardTaskProducer, TaskProducer {
             return (recursiveBuildFilesForPackageProducts(phase: phase))
                 .compactMap({ buildFile -> (reference: Reference, absolutePath: Path, fileType: FileTypeSpec)? in
                     guard currentPlatformFilter.matches(buildFile.platformFilters) else { return nil }
-                    return try? context.resolveBuildFileReference(buildFile)
+                    if let reference = try? context.workspaceContext.workspace.resolveBuildableItemReference(buildFile.buildableItem, dynamicallyBuildingTargets: context.globalTargetInfoProvider.dynamicallyBuildingTargets),
+                       reference is FileReference {
+                        guard let fileType = context.lookupFileType(reference: reference), fileType.identifier == "wrapper.xcframework" else { return nil }
+                        return (reference, context.settings.filePathResolver.resolveAbsolutePath(reference), fileType)
+                    }
+                    guard let resolved = try? context.resolveBuildFileReference(buildFile), resolved.fileType.identifier == "wrapper.xcframework" else { return nil }
+                    return resolved
                 })
-                .filter({ $0.fileType.identifier == "wrapper.xcframework" })
         }
 
         guard let configuredTarget = context.configuredTarget else {


### PR DESCRIPTION
XCFrameworkTaskProducer.prepare() resolved every build file reachable through package products to find the xcframeworks. Since a file reference's type is known without resolving its absolute path, resolve the path only for xcframeworks.

rdar://184265424
