### PR TITLE
[6.4] Fix build file ordering assignment

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/FilesBasedBuildPhaseTaskProducer.swift
@@ -632,8 +632,8 @@ package class FilesBasedBuildPhaseTaskProducerBase: PhasedTaskProducer {
             } else {
                 otherBuildFiles.append(resolvedBuildFile)
             }
-            resolvedBuildFiles = compileToSwiftFiles + otherBuildFiles
         }
+        resolvedBuildFiles = compileToSwiftFiles + otherBuildFiles
 
         // Allow subclasses to provide additional content
         // We have to process this _before_ the resolvedBuildFiles to workaround an issue where generated sources aren't added to main source code group.


### PR DESCRIPTION
* Explanation: From original PR by @stjernegard:
This array concat and write was being done for every loop iteration. As the array is being overwritten every time, significant amounts of time can be saved by only writing after the loop.

This fixes the performance regression reported in #1479 and during a build of SDWebImage/SDWebImageSVGNativeCoder reduces the time taken during "Create build description" from minutes to 1-2 seconds.
* Scope: Addresses performance issue in task construction
* Risk:
Low, this is a targeted change covered by existing tests
* Testing: Covered by existing unit tests


