### PR TITLE
Move SWIFT_EMIT_CONST_VALUE_PROTOCOLS list into the toolchain

### DIFF
--- a/Sources/SWBCore/ToolchainRegistry.swift
+++ b/Sources/SWBCore/ToolchainRegistry.swift
@@ -85,7 +85,11 @@ public final class Toolchain: Hashable, Sendable {
 
         self.path = path
         self.displayName = displayName
-        self.defaultSettings = defaultSettings
+        if let swiftConstantValuesBuildSettings = Self.swiftConstantValuesBuildSettings(toolchainPath: path, fs: fs) {
+            self.defaultSettings = defaultSettings.addingContents(of: swiftConstantValuesBuildSettings)
+        } else {
+            self.defaultSettings = defaultSettings
+        }
         self.overrideSettings = overrideSettings
         self.defaultSettingsWhenPrimary = defaultSettingsWhenPrimary
         self.executableSearchPaths = StackedSearchPath(paths: executableSearchPaths, fs: fs)
@@ -398,6 +402,39 @@ public final class Toolchain: Hashable, Sendable {
         } else {
             nil
         }
+    }
+
+    private static func swiftConstantValuesBuildSettings(toolchainPath: Path, fs: any FSProxy) -> [String: PropertyListItem]? {
+        var constValueProtocols = Set<String>()
+        // TODO: Start of section to remove
+        // FIXME: rdar://165705575 (Remove hard-coded strings for SWIFT_EMIT_CONST_VALUE_PROTOCOLS)
+        // Preserve the previous approach of hard-coded strings until the JSON files are reliably present
+        let appIntentsProtocols = "AppIntent EntityQuery AppEntity TransientEntity AppEnum AppShortcutProviding AppShortcutsProvider AnyResolverProviding AppIntentsPackage DynamicOptionsProvider _IntentValueRepresentable _AssistantIntentsProvider _GenerativeFunctionExtractable IntentValueQuery Resolver"
+        let extensionKitProtocols = "AppExtension ExtensionPointDefining"
+        constValueProtocols.formUnion(appIntentsProtocols.split(separator: " ").map(String.init))
+        constValueProtocols.formUnion(extensionKitProtocols.split(separator: " ").map(String.init))
+        // TODO: End of section to remove
+        let swiftConstantValuesPath = toolchainPath.join("usr/share/swift/SwiftConstantValues")
+        if fs.isDirectory(swiftConstantValuesPath), let fileNames = try? fs.listdir(swiftConstantValuesPath) {
+            for fileName in fileNames where fileName.hasSuffix(".json") {
+                let filePath = swiftConstantValuesPath.join(fileName)
+                if let swiftConstantValues = try? JSONDecoder().decode(SwiftConstantValues.self, from: Data(fs.read(filePath))) {
+                    constValueProtocols.formUnion(swiftConstantValues.constValueProtocols)
+                }
+            }
+        }
+        if !constValueProtocols.isEmpty {
+            return [
+                "SWIFT_EMIT_CONST_VALUE_PROTOCOLS": .plString(constValueProtocols.sorted().joined(separator: " ")),
+            ]
+        } else {
+            return nil
+        }
+    }
+
+    private struct SwiftConstantValues: Decodable {
+        let version: Int
+        let constValueProtocols: [String]
     }
 }
 

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -2573,10 +2573,13 @@ import SWBTestSupport
                 #expect(toolchain.identifier == "org.swift.testoss")
                 #expect(toolchain.displayName == "TestOSS")
                 #expect(toolchain.version == Version(1, 2, 3))
-                #expect(toolchain.defaultSettings == [
+                let buildSettingsToIgnore: Set<String> = [
+                    "SWIFT_EMIT_CONST_VALUE_PROTOCOLS",
+                ]
+                #expect(toolchain.defaultSettings.filter { !buildSettingsToIgnore.contains($0.key) } == [
                     "TOOLCHAIN_DEFAULT": .plString("IncorrectValue"),
                 ])
-                #expect(toolchain.overrideSettings == [
+                #expect(toolchain.overrideSettings.filter { !buildSettingsToIgnore.contains($0.key) } == [
                     "TOOLCHAIN_OVERRIDE": .plString("CorrectValue"),
                     "SWIFT_DEVELOPMENT_TOOLCHAIN": "YES",
                     "SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME": "YES"


### PR DESCRIPTION
- Load list of protocols from JSON files in a set location within the toolchain.
- Abstract private function to return a dictionary of settings to add, simplifying future expansion.
- Continue to start with the old hard-coded list for now; eventually we'll switch to JSON-only.
- Account for additional build setting in `SettingsTests.toolchainBuildSettings()`.

rdar://145691846