### PR TITLE
Fix Android platform filter matching

### DIFF
--- a/Sources/SWBCore/PlatformFiltering.swift
+++ b/Sources/SWBCore/PlatformFiltering.swift
@@ -19,7 +19,10 @@ extension PlatformFilter {
         let os = (!scope.evaluate(BuiltinMacros.__USE_PLATFORM_NAME_FOR_FILTERS) ? scope.evaluate(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX).nilIfEmpty : nil) ?? platformName
 
         // FIXME: We should consider moving to directly using the triple for the whole computation here once we have more tests in place.
-        let triple = try? LLVMTriple(scope.evaluate(BuiltinMacros.CURRENT_TARGET_TRIPLE))
+        // This uses SWIFT_TARGET_TRIPLE instead of CURRENT_TARGET_TRIPLE because the arch of SWIFT_TARGET_TRIPLE
+        // will be bound to undefined_arch outside the architecture loop, allowing matching on platform/environment
+        // components.
+        let swiftTriple = try? LLVMTriple(scope.evaluate(BuiltinMacros.SWIFT_TARGET_TRIPLE))
         let targetTripleSuffix = scope.evaluate(BuiltinMacros.LLVM_TARGET_TRIPLE_SUFFIX)
         let env: String
 
@@ -28,7 +31,7 @@ extension PlatformFilter {
             // To implicitly enforce this behavior (and avoid the need for Swift Build clients to replicate it individually) for any target platform
             // whose *environment* is "simulator" we simply omit it, effectively treating the target the same as the corresponding device platform.
             env = ""
-        } else if let triple, let tripleEnv = triple.environment, tripleEnv != triple.environmentComponent {
+        } else if let swiftTriple, let tripleEnv = swiftTriple.environment, tripleEnv != swiftTriple.environmentComponent {
             // Remove the version number from the environment component where applicable (for example, with Android triples.
             env = "-\(tripleEnv)"
         } else {

--- a/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
+++ b/Tests/SWBAndroidPlatformTests/SWBAndroidPlatformTests.swift
@@ -143,6 +143,82 @@ fileprivate struct AndroidTaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    @Test(.requireSDKs(.android), arguments: ["aarch64", "x86_64"])
+    func androidPlatformFilterIsActive(arch: String) async throws {
+        let androidFilters: Set<SWBTestSupport.PlatformFilter> = [
+            SWBTestSupport.PlatformFilter(platform: "linux", environment: "android"),
+            SWBTestSupport.PlatformFilter(platform: "linux", environment: "androideabi"),
+        ]
+
+        try await withTemporaryDirectory { (tmpDir: Path) -> () in
+            let testProject = TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("main.c"),
+                        TestFile("androidOnly.c"),
+                        TestFile("static.c"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ARCHS": arch,
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "android",
+                        "SUPPORTED_PLATFORMS": "android",
+                        "ANDROID_DEPLOYMENT_TARGET": "28",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "tool",
+                        type: .commandLineTool,
+                        buildPhases: [
+                            TestSourcesBuildPhase([
+                                TestBuildFile("main.c"),
+                                TestBuildFile("androidOnly.c", platformFilters: androidFilters),
+                            ]),
+                            TestFrameworksBuildPhase([
+                                TestBuildFile(.target("staticlib"), platformFilters: androidFilters),
+                            ]),
+                        ],
+                        dependencies: [
+                            TestTargetDependency("staticlib", platformFilters: androidFilters),
+                        ]
+                    ),
+                    TestStandardTarget(
+                        "staticlib",
+                        type: .staticLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                // FIXME: Find a way to make these default
+                                "EXECUTABLE_PREFIX": "lib",
+                            ])
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["static.c"]),
+                        ]
+                    ),
+                ])
+
+            let tester = try TaskConstructionTester(try await getCore(), testProject)
+            await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .android) { results in
+                results.checkTask(.matchTargetName("tool"), .matchRuleType("CompileC"), .matchRuleItemBasename("androidOnly.c")) { task in
+                    task.checkCommandLineContains(["-target", "\(arch)-unknown-linux-android28"])
+                }
+
+                results.checkTask(.matchTargetName("staticlib"), .matchRuleType("CompileC"), .matchRuleItemBasename("static.c")) { _ in }
+                results.checkTask(.matchTargetName("tool"), .matchRuleType("Ld")) { task in
+                    task.checkCommandLineContains(["-lstaticlib"])
+                }
+
+                results.checkNoDiagnostics()
+            }
+        }
+    }
 }
 
 fileprivate extension Core {

--- a/Tests/SWBCoreTests/PlatformFilteringTests.swift
+++ b/Tests/SWBCoreTests/PlatformFilteringTests.swift
@@ -350,7 +350,7 @@ import Testing
 
     private func createPlatformFilter(triple: String, swiftPlatformTargetPrefix: String, targetTripleSuffix: String = "") -> PlatformFilter? {
         var table = MacroValueAssignmentTable(namespace: BuiltinMacros.namespace)
-        table.push(BuiltinMacros.CURRENT_TARGET_TRIPLE, literal: triple)
+        table.push(BuiltinMacros.SWIFT_TARGET_TRIPLE, literal: triple)
         table.push(BuiltinMacros.SWIFT_PLATFORM_TARGET_PREFIX, literal: swiftPlatformTargetPrefix)
         table.push(BuiltinMacros.LLVM_TARGET_TRIPLE_SUFFIX, literal: targetTripleSuffix)
         let scope = MacroEvaluationScope(table: table)


### PR DESCRIPTION
It's important to use SWIFT_TARGET_TRIPLE instead of CURRENT_TARGET_TRIPLE when stripping the version number from the environment of an Android triple during platform filter matching, because it permits an unbound architecture.