### PR TITLE
Add SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL to explain IPI classification dec…

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1089,6 +1089,7 @@ public final class BuiltinMacros {
     public static let SWIFT_ENABLE_INCREMENTAL_COMPILATION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_COMPILATION")
     public static let SWIFT_ENABLE_INCREMENTAL_SCAN = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_INCREMENTAL_SCAN")
     public static let SWIFT_ENABLE_IPI_LIBRARY_LEVEL = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_IPI_LIBRARY_LEVEL")
+    public static let SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL = BuiltinMacros.declareBooleanMacro("SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL")
     public static let SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES")
     public static let SWIFT_ENABLE_LIBRARY_EVOLUTION = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_LIBRARY_EVOLUTION")
     public static let SWIFT_ENABLE_BARE_SLASH_REGEX = BuiltinMacros.declareBooleanMacro("SWIFT_ENABLE_BARE_SLASH_REGEX")
@@ -2369,6 +2370,7 @@ public final class BuiltinMacros {
         SWIFT_ENABLE_INCREMENTAL_COMPILATION,
         SWIFT_ENABLE_INCREMENTAL_SCAN,
         SWIFT_ENABLE_IPI_LIBRARY_LEVEL,
+        SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL,
         SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES,
         SWIFT_ENABLE_LIBRARY_EVOLUTION,
         SWIFT_USE_INTEGRATED_DRIVER,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -1633,6 +1633,23 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             if toolSpecInfo.toolFeatures.has(.libraryLevel),
                let libraryLevel = cbc.scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).nilIfEmpty {
                 args += ["-library-level", libraryLevel]
+                if libraryLevel == "ipi", cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL) {
+                    // Explained here rather than where SWIFT_LIBRARY_LEVEL is derived, so it is
+                    // reported only for targets that actually compile Swift (this task only runs
+                    // for those).
+                    // Re-checks the same condition Settings.swift uses to infer the level (search
+                    // "infer the default SWIFT_LIBRARY_LEVEL") to distinguish derived from explicit.
+                    if cbc.scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL) && cbc.scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
+                        delegate.note("passing -library-level ipi (derived because SKIP_INSTALL=YES)")
+                    } else {
+                        delegate.note("passing -library-level ipi (SWIFT_LIBRARY_LEVEL set explicitly)")
+                    }
+                }
+            } else if cbc.scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL) == "ipi",
+                      cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL) {
+                // Just for the explanation purposes -- to cover the rare case when frontend
+                // does not support ipi library level feature
+                delegate.note("not passing -library-level ipi: the toolchain does not support it")
             }
 
             let ipiNames = cbc.producer.ipiClangModuleNames
@@ -1648,6 +1665,10 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     for name in ipiNames {
                         args += ["-Xfrontend", "-ipi-clang-module", "-Xfrontend", name]
                     }
+                } else if cbc.scope.evaluate(BuiltinMacros.SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL) {
+                    // Just for the explanation purposes -- to cover the rare case when ipi modules are not passed
+                    // when neither driver not frontend supports ipi library level feature
+                    delegate.note("not passing -ipi-clang-module for \(ipiNames.joined(separator: ", ")): neither the driver nor the frontend supports it")
                 }
             }
 

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -325,7 +325,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
         // Perform post-processing analysis of the build graph
         self.clientsOfBundlesByTarget = Self.computeBundleClients(buildGraph: planRequest.buildGraph, buildRequestContext: planRequest.buildRequestContext)
         self.artifactBundlesByTarget = await Self.computeArtifactBundleInfo(buildGraph: planRequest.buildGraph, provisioningInputs: planRequest.provisioningInputs, buildRequest: planRequest.buildRequest, buildRequestContext: planRequest.buildRequestContext, workspaceContext: planRequest.workspaceContext, getLinkageGraph: getLinkageGraph, metadataCache: self.artifactBundleMetadataCache, delegate: delegate)
-        self.ipiClangModuleNamesByTarget = Self.computeIPIClangInfo(buildGraph: planRequest.buildGraph, buildRequestContext: planRequest.buildRequestContext, workspaceContext: planRequest.workspaceContext)
+        self.ipiClangModuleNamesByTarget = Self.computeIPIClangInfo(buildGraph: planRequest.buildGraph, buildRequestContext: planRequest.buildRequestContext, workspaceContext: planRequest.workspaceContext, delegate: delegate)
         let directlyLinkedDependenciesByTarget: [ConfiguredTarget: OrderedSet<LinkedDependency>]
         (self.impartedBuildPropertiesByTarget, directlyLinkedDependenciesByTarget) = await Self.computeImpartedBuildProperties(planRequest: planRequest, getLinkageGraph: getLinkageGraph, delegate: delegate)
         self.mergeableTargetsToMergingTargets = Self.computeMergeableLibraries(buildGraph: planRequest.buildGraph, provisioningInputs: planRequest.provisioningInputs, buildRequestContext: planRequest.buildRequestContext)
@@ -697,7 +697,8 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
     /// either `SKIP_INSTALL=YES`, or an empty `INSTALL_PATH` — and, in the latter case, has a
     /// `MODULEMAP_FILE` whose resolved path lies under some `SRCROOT` in the consumer's
     /// transitive dependency closure (including the consumer's own `SRCROOT`).
-    private static func computeIPIClangInfo(buildGraph: TargetBuildGraph, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext) -> [ConfiguredTarget: [String]] {
+    /// When `SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL` is enabled, emit note with details on ipi classification
+    private static func computeIPIClangInfo(buildGraph: TargetBuildGraph, buildRequestContext: BuildRequestContext, workspaceContext: WorkspaceContext, delegate: any GlobalProductPlanDelegate) -> [ConfiguredTarget: [String]] {
         // Target-local info, computed once per target. None of these depend on which
         // consumer pulls the target into its closure, no need to be recomputed per consumer
         struct TargetIPIInfo {
@@ -707,6 +708,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
             let installs: Bool               // has a non-empty INSTALL_PATH, i.e. is a delivered product
             let resolvedModulemapDir: Path?  // realpath-resolved dir of MODULEMAP_FILE, nil if none
             let moduleNames: [String]        // populated only for targets that could qualify
+            let explain: Bool                // SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL, for this consumer
         }
         // Precomputing the expensive per-target info (computeModuleInfo, realpath, macro evaluations)
         var ipiInfoByTarget: [ConfiguredTarget: TargetIPIInfo] = [:]
@@ -722,6 +724,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
             let producesClangModule = definesModule || !modulemapFile.isEmpty || !modulemapContents.isEmpty
             let skipInstall = scope.evaluate(BuiltinMacros.SKIP_INSTALL)
             let installs = !scope.evaluate(BuiltinMacros.INSTALL_PATH).isEmpty
+            let explain = scope.evaluate(BuiltinMacros.SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL)
             let resolvedModulemapDir: Path? = {
                 guard !modulemapFile.isEmpty else { return nil }
                 let modulemapPath = Path(modulemapFile).isAbsolute
@@ -759,7 +762,8 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                 skipInstall: skipInstall,
                 installs: installs,
                 resolvedModulemapDir: resolvedModulemapDir,
-                moduleNames: moduleNames)
+                moduleNames: moduleNames,
+                explain: explain)
         }
         // Aggregate each target's closure by folding over `buildGraph.allTargets`, which the
         // resolver provides in dependency-first topological order: by the time we reach a target,
@@ -779,6 +783,30 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
             if info.producesClangModule {
                 if info.skipInstall {
                     skipNames.formUnion(info.moduleNames)
+                    if info.explain {
+                        // Explain the classification here, at the producing target, because the
+                        // reason is a property of this target — not of whoever imports it. (The
+                        // classification itself stays per consumer below; the reason is the same
+                        // for every consumer.) Prefer the modulemap-under-SRCROOT reason when it
+                        // applies: it names the actual file. A non-installing target has
+                        // SKIP_INSTALL forced to YES, so that rule would otherwise always co-occur
+                        // with — and be masked by — a bare SKIP_INSTALL note. The check mirrors
+                        // rule 2: not installing, modulemap under this target's own SRCROOT (always
+                        // in any consumer's closure). Otherwise fall back to SKIP_INSTALL.
+                        let modulemapSrcroot: Path?
+                        if !info.installs, let dir = info.resolvedModulemapDir, let root = info.resolvedSrcroot, root.isAncestorOrEqual(of: dir) {
+                            modulemapSrcroot = root
+                        } else {
+                            modulemapSrcroot = nil
+                        }
+                        for name in info.moduleNames.sorted() {
+                            if let root = modulemapSrcroot, let dir = info.resolvedModulemapDir {
+                                delegate.note(.overrideTarget(target), "Clang module '\(name)' is IPI: its module map in '\(dir.str)' is under SRCROOT '\(root.str)' and the target does not install")
+                            } else {
+                                delegate.note(.overrideTarget(target), "Clang module '\(name)' is IPI: SKIP_INSTALL=YES")
+                            }
+                        }
+                    }
                 }
                 // Only offer the module as a SRCROOT-qualified candidate if the target does not
                 // install. An installed product publishes its module for external consumers, so

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -124,6 +124,11 @@
                 DefaultValue = YES;
             },
             {
+                Name = "SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL";
+                Type = Boolean;
+                DefaultValue = NO;
+            },
+            {
                 Name = "SWIFT_ENABLE_LAYOUT_STRING_VALUE_WITNESSES";
                 Type = Boolean;
                 DefaultValue = NO;

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4465,6 +4465,176 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
         }
     }
 
+    // Test SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL emits a note explaining each Clang IPI classification rule.
+    @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
+    func ipiClangModuleExplain() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("MainLib.swift"),
+                        TestFile("Skipped.h"),
+                        TestFile("ModulemapLoc.h"),
+                        TestFile("ModulemapLoc.modulemap"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                        "SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL": "YES",
+                    ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "MainLib",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("MainLib.swift")]),
+                        ],
+                        dependencies: ["Skipped", "ModulemapLoc"]),
+                    // SKIP_INSTALL is set, thus module is project-internal.
+                    TestStandardTarget(
+                        "Skipped",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SKIP_INSTALL": "YES",
+                                "DEFINES_MODULE": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("Skipped.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                    // Empty INSTALL_PATH and in-tree modulemap.
+                    TestStandardTarget(
+                        "ModulemapLoc",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "INSTALL_PATH": "",
+                                "DEFINES_MODULE": "YES",
+                                "MODULEMAP_FILE": "ModulemapLoc.modulemap",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestHeadersBuildPhase([
+                                TestBuildFile("ModulemapLoc.h", headerVisibility: .public),
+                            ]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                results.checkNote(.contains("Clang module 'Skipped' is IPI: SKIP_INSTALL=YES"))
+                results.checkNote(.and(.contains("Clang module 'ModulemapLoc' is IPI: its module map in"),
+                                       .contains("is under SRCROOT")))
+                // A modulemap-derived module also has SKIP_INSTALL forced to YES (empty
+                // INSTALL_PATH), but the modulemap note is more specific, so the SKIP_INSTALL
+                // note is suppressed for it.
+                #expect(results.checkNote(.contains("Clang module 'ModulemapLoc' is IPI: SKIP_INSTALL=YES"), failIfNotFound: false) == false)
+            }
+        }
+    }
+
+    // Test SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL emits a note when a Swift target is compiled with
+    // -library-level ipi, whether the level was derived (SKIP_INSTALL) or set explicitly.
+    @Test(.requireSDKs(.macOS))
+    func ipiSwiftLibraryLevelExplain() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let srcRoot = tmpDir.join("srcroot")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "SomeFiles", path: "Sources",
+                    children: [
+                        TestFile("Root.swift"),
+                        TestFile("DerivedIPI.swift"),
+                        TestFile("ExplicitIPI.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "SWIFT_ENABLE_IPI_LIBRARY_LEVEL": "YES",
+                        "SWIFT_EXPLAIN_IPI_LIBRARY_LEVEL": "YES",
+                    ]),
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "Root",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("Root.swift")]),
+                        ],
+                        dependencies: ["DerivedIPI", "ExplicitIPI"]),
+                    // Derived from SKIP_INSTALL=YES setting
+                    TestStandardTarget(
+                        "DerivedIPI",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SKIP_INSTALL": "YES",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("DerivedIPI.swift")]),
+                        ]),
+                    // SWIFT_LIBRARY_LEVEL=ipi set directly (e.g. through the -library-level flag)
+                    TestStandardTarget(
+                        "ExplicitIPI",
+                        type: .framework,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug", buildSettings: [
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "SWIFT_EXEC": swiftCompilerPath.str,
+                                "SWIFT_VERSION": "5.0",
+                                "SWIFT_LIBRARY_LEVEL": "ipi",
+                            ]),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("ExplicitIPI.swift")]),
+                        ]),
+                ])
+
+            let tester = try await TaskConstructionTester(getCore(), testProject)
+            await tester.checkBuild(runDestination: .macOS) { results in
+                // Emitted from the Swift compile (Swift-only), distinguishing derived from explicit
+                // by re-checking SKIP_INSTALL at the emission site.
+                results.checkNote(.and(.contains("passing -library-level ipi (derived because SKIP_INSTALL=YES)"), .contains("in target 'DerivedIPI'")))
+                results.checkNote(.and(.contains("passing -library-level ipi (SWIFT_LIBRARY_LEVEL set explicitly)"), .contains("in target 'ExplicitIPI'")))
+            }
+        }
+    }
+
     // Test -ipi-clang-module emission works across projects: consumer in project A, IPI dep in project B.
     @Test(.requireSDKs(.macOS), .requireSwiftFeatures(.ipiClangModule))
     func ipiClangModuleCrossProject() async throws {


### PR DESCRIPTION
…isions

Adds a debug-only build setting that emits notes explaining why a Swift or Clang module was classified project-internal.

rdar://184747937

_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
