### PR TITLE
[Previews] Fix XOJIT thunk builds when Swift caching prefix mapping is on

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3084,6 +3084,36 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         return Path(SwiftCompilerSpec.objectFileDirOutput(inputPath: sourceFile, moduleBaseNameSuffix: "", uniquingSuffix: ".\(thunkVariantSuffix).preview-thunk", objectFileDir: objectFileDir, fileExtension: ".o").withoutSuffix)
     }
 
+    /// The prefix mapping the driver applied to a frontend invocation for compilation caching, in the
+    /// direction the compiler consumes it: from the remapped pseudo-path (`/^src`) to the real path.
+    ///
+    /// The driver only emits these when it actually remapped paths, so an empty result means the
+    /// command line already refers to real locations.
+    public static func cacheReplayPrefixMapper(commandLine: [String]) -> PrefixMapper {
+        var mapper = PrefixMapper()
+        var index = commandLine.startIndex
+        while index < commandLine.endIndex {
+            guard commandLine[index] == "-cache-replay-prefix-map", index + 1 < commandLine.endIndex else {
+                index += 1
+                continue
+            }
+            let value = commandLine[index + 1]
+            if let separator = value.firstIndex(of: "=") {
+                // The joined `<remapped>=<real>` spelling, which the driver uses for frontends that
+                // predate the two argument form. Split on the first `=`, as `llvm::MappedPrefix` does,
+                // because only the real path can contain one.
+                mapper.add(from: Path(value[..<separator]), to: Path(value[value.index(after: separator)...]))
+                index += 2
+            } else if index + 2 < commandLine.endIndex {
+                mapper.add(from: Path(value), to: Path(commandLine[index + 2]))
+                index += 3
+            } else {
+                break
+            }
+        }
+        return mapper.sorted()
+    }
+
     public override func generatePreviewInfo(for task: any ExecutableTask, input: TaskGeneratePreviewInfoInput, fs: any FSProxy) -> [TaskGeneratePreviewInfoOutput] {
         guard let payload = task.payload as? SwiftTaskPayload else { return [] }
         guard let previewPayload = payload.previewPayload else { return [] }
@@ -3295,7 +3325,6 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
         }
 
         let selectedInputPath: Path
-        let newVFSOverlayPath: Path?
         if payload.previewStyle == .xojit {
             // Also pass the auxiliary Swift files.
             commandLine.append(contentsOf: originalInputs.map(\.str))
@@ -3326,25 +3355,14 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     try fs.createDirectory(newOutputFileMap.dirname, recursive: true)
                     try fs.write(newOutputFileMap, contents: ByteString(JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]).encode(map)))
                     commandLine.append(contentsOf: ["-output-file-map", newOutputFileMap.str])
-
-                    // rdar://127735418 ([JIT] Emit a vfsoverlay for JIT preview thunk compiler arguments so clients can specify the original file path when substituting contents)
-                    let vfs = VFS()
-                    vfs.addMapping(selectedInputPath, externalContents: inputPath)
-                    newVFSOverlayPath = driverPayload.tempDirPath.join("vfsoverlay-\(inputPath.basename).json")
-                    try fs.createDirectory(newOutputFileMap.dirname, recursive: true)
-                    let overlay = try vfs.toVFSOverlay().propertyListItem.asJSONFragment().asString
-                    try fs.write(newVFSOverlayPath!, contents: ByteString(encodingAsUTF8: overlay))
                 } catch {
-                    logErrorForPreviews("Failed to generate vfsoverlay for \(inputPath.basename), error: \(error)")
+                    logErrorForPreviews("Failed to generate output file map for \(inputPath.basename), error: \(error)")
                     return []
                 }
-            } else {
-                newVFSOverlayPath = nil
             }
         }
         else {
             selectedInputPath = inputPath
-            newVFSOverlayPath = nil
             commandLine.append(contentsOf: [inputPath.str])
         }
 
@@ -3412,8 +3430,52 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
                     }
                 }
                 // Add vfsoverlay after the driver invocation as it can affect the module dependencies, causing modules from regular builds not being reused here.
-                if let vfsOverlay = newVFSOverlayPath {
-                    commandLine.append(contentsOf: ["-vfsoverlay", vfsOverlay.str])
+                do {
+                    // When compilation caching prefix mapping is enabled, the frontend invocation the
+                    // driver planned refers to remapped locations (`/^src/main.swift`) rather than real
+                    // ones. Those only resolve against the CAS file system, which this uncached preview
+                    // build deliberately doesn't set up, so overlay the remapped prefixes back onto the
+                    // real directories they stand for. This is also needed for paths recorded *inside*
+                    // the module artifacts the preview loads from the CAS, such as the headers a PCM
+                    // refers to, which no amount of command line rewriting could reach.
+                    //
+                    // The driver hands us the inverse mapping in `-cache-replay-prefix-map`. Use the
+                    // inverse mapping to figure out the directory remap vfsoverlay.
+                    let replayPrefixMapper = SwiftCompilerSpec.cacheReplayPrefixMapper(commandLine: commandLine)
+                    if !replayPrefixMapper.isEmpty {
+                        let overlay = DirectoryRemapVFSOverlay(version: 0, caseSensitive: false, redirectingWith: .fallthrough, remapping: replayPrefixMapper.mappings.map {
+                            DirectoryRemapVFSOverlay.Remap(name: $0.from.str, externalContents: $0.to.str)
+                        })
+                        // Deliberately not named after the thunk. Previews asks for thunk info once using
+                        // a placeholder variant suffix, then substitutes the real suffix into the command
+                        // line for each variant it builds, regenerating only the thunk overlay below. A
+                        // name derived from `inputPath` would be rewritten to a file nobody ever writes.
+                        // This content only depends on the target's prefix map anyway, so one file per
+                        // temp directory is right. Written atomically because preview info for several
+                        // source files in a target can land here concurrently.
+                        let path = driverPayload.tempDirPath.join("prefix-map-vfsoverlay.json")
+                        try fs.createDirectory(path.dirname, recursive: true)
+                        try fs.write(path, contents: overlay.propertyListItem.asJSONFragment(), atomically: true)
+                        commandLine.append(contentsOf: ["-vfsoverlay", path.str])
+                    }
+
+                    // rdar://127735418 ([JIT] Emit a vfsoverlay for JIT preview thunk compiler arguments so clients can specify the original file path when substituting contents)
+                    //
+                    // Key the substitution on the path as the frontend sees it, which is the prefix
+                    // mapped spelling when caching remapped it. Getting this wrong doesn't fail the
+                    // build, it silently compiles the original source instead of the thunk.
+                    //
+                    // This overlay has to come last so that it wins over the prefix map overlay above:
+                    // `-vfsoverlay` files are consulted in reverse order.
+                    let vfs = VFS()
+                    vfs.addMapping(replayPrefixMapper.inverted().map(selectedInputPath), externalContents: inputPath)
+                    let vfsOverlayPath = driverPayload.tempDirPath.join("vfsoverlay-\(inputPath.basename).json")
+                    try fs.createDirectory(vfsOverlayPath.dirname, recursive: true)
+                    try fs.write(vfsOverlayPath, contents: vfs.toVFSOverlay().propertyListItem.asJSONFragment())
+                    commandLine.append(contentsOf: ["-vfsoverlay", vfsOverlayPath.str])
+                } catch {
+                    logErrorForPreviews("Failed to generate vfsoverlay for \(inputPath.basename), error: \(error)")
+                    return []
                 }
             } else {
                 commandLine = []

--- a/Sources/SWBUtil/CMakeLists.txt
+++ b/Sources/SWBUtil/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(SWBUtil
   PluginManager.swift
   PluginManagerCommon.swift
   POSIX.swift
+  PrefixMapper.swift
   Process+Async.swift
   Process.swift
   ProcessInfo.swift

--- a/Sources/SWBUtil/PrefixMapper.swift
+++ b/Sources/SWBUtil/PrefixMapper.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Rewrites path prefixes, mirroring `llvm::PrefixMapper`.
+///
+/// This reproduces, in Swift Build, the path canonicalization the compiler and `swift-driver`
+/// perform for compilation caching, where real paths are replaced by stable pseudo-paths such as
+/// `/^src` so that cache keys don't depend on where the sources live.
+///
+/// Ordering matters: mappings are applied in order and the first match wins, so `sort()` must be
+/// called before mapping to produce the same result the compiler would.
+public struct PrefixMapper: Sendable {
+    /// A single prefix replacement, rewriting the prefix `from` to `to`.
+    public struct Mapping: Sendable, Equatable {
+        public let from: Path
+        public let to: Path
+
+        public init(from: Path, to: Path) {
+            self.from = from
+            self.to = to
+        }
+    }
+
+    /// The mappings, in the order they will be applied.
+    public private(set) var mappings: [Mapping]
+
+    public init(mappings: [Mapping] = []) {
+        self.mappings = mappings
+    }
+
+    public var isEmpty: Bool {
+        mappings.isEmpty
+    }
+
+    public mutating func add(from: Path, to: Path) {
+        mappings.append(Mapping(from: from, to: to))
+    }
+
+    /// Order the mappings the way `llvm::PrefixMapper::sort` does, by descending `from`, so a more
+    /// specific prefix is preferred over a prefix of itself (`/tmp/tmp` before `/tmp`).
+    public mutating func sort() {
+        // Sorting descending is sufficient to order any prefix ahead of its own prefixes, because a
+        // string always sorts after the strings that are prefixes of it.
+        mappings.sort { $0.from.str > $1.from.str }
+    }
+
+    /// The receiver, sorted. See `sort()`.
+    public func sorted() -> PrefixMapper {
+        var copy = self
+        copy.sort()
+        return copy
+    }
+
+    /// Apply the first matching mapping to `path`, or return `path` unchanged if none matches.
+    ///
+    /// Matching is on whole path components, so `/^src` does not match `/^src-other/file.swift`.
+    public func map(_ path: Path) -> Path {
+        for mapping in mappings {
+            // `relativeSubpath(from:)` matches whole components and returns the empty string for an
+            // exact match, covering both of the cases `llvm::PrefixMapper` handles.
+            guard let suffix = path.relativeSubpath(from: mapping.from) else { continue }
+            return suffix.isEmpty ? mapping.to : mapping.to.join(suffix)
+        }
+        return path
+    }
+
+    /// The inverse mapper, exchanging `from` and `to` in every mapping.
+    ///
+    /// The result is sorted, because the order that was correct for the forward direction says
+    /// nothing about the order the inverse direction needs.
+    public func inverted() -> PrefixMapper {
+        PrefixMapper(mappings: mappings.map { Mapping(from: $0.to, to: $0.from) }).sorted()
+    }
+}

--- a/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/PreviewsBuildOperationTests.swift
@@ -1211,6 +1211,156 @@ fileprivate struct PreviewsBuildOperationTests: CoreBasedTests {
         }
     }
 
+    /// Compilation caching with prefix mapping rewrites the paths in the frontend invocation the driver
+    /// plans, so the preview thunk is asked to compile `/^src/main.swift`. Those pseudo-paths only
+    /// resolve against the CAS file system, which the uncached preview compile deliberately doesn't set
+    /// up, so we hand the frontend an overlay that maps every prefix back onto the real directory.
+    ///
+    /// The thunk substitution then has to be keyed on the prefix mapped spelling too, because that is
+    /// what the frontend looks up. Getting that wrong doesn't fail the compile, it silently builds the
+    /// original source instead of the thunk, which is why this asserts on the symbols in the object
+    /// file rather than just the exit status.
+    ///
+    /// The target deliberately has a second source file, and the thunk deliberately uses Foundation:
+    /// the former is a prefix mapped input the thunk overlay does not cover, and the latter forces the
+    /// compiler to resolve the header paths recorded inside the PCMs it loads from the CAS, which are
+    /// prefix mapped as well. Without the overlay each of those fails to open.
+    @Test(.requireSDKs(.iOS), .requireSwiftFeatures(.compilationCaching), .requireXcode26(), .skipDeveloperDirectoryWithEqualSign)
+    func previewXOJITThunkInfoWithCompilationCachingPrefixMapping() async throws {
+        try await withTemporaryDirectory { (tmpDirPath: Path) in
+            let srcRoot = tmpDirPath.join("srcroot")
+
+            let testProject = TestProject(
+                "ProjectName",
+                sourceRoot: srcRoot,
+                groupTree: TestGroup(
+                    "Sources", path: "Sources",
+                    children: [TestFile("main.swift"), TestFile("Extra.swift")]
+                ),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "GENERATE_INFOPLIST_FILE": "YES",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "iphoneos",
+                        "SWIFT_VERSION": try await swiftVersion,
+                        "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                        "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+                        "SWIFT_ENABLE_COMPILE_CACHE": "YES",
+                        "SWIFT_ENABLE_PREFIX_MAPPING": "YES",
+                        "SWIFT_ENABLE_PROJECT_PREFIX_MAPPING": "YES",
+                        "COMPILATION_CACHE_CAS_PATH": tmpDirPath.join("CompilationCache").str,
+                        // No dSYM: dsymutil warns about the explicit modules it can't find on disk
+                        // because caching keeps them in the CAS, and which warnings it emits varies by
+                        // toolchain. None of that is what this test is about. Matches `swiftCachingSimple`.
+                        "DEBUG_INFORMATION_FORMAT": "dwarf",
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "AppTarget",
+                        type: .application,
+                        buildPhases: [
+                            TestSourcesBuildPhase([TestBuildFile("main.swift"), TestBuildFile("Extra.swift")])
+                        ]
+                    )
+                ]
+            )
+
+            let core = try await getCore()
+            let tester = try await BuildOperationTester(core, testProject, simulated: false)
+
+            let buildSourceFile = srcRoot.join("Sources/main.swift")
+            try tester.fs.createDirectory(buildSourceFile.dirname, recursive: true)
+            try tester.fs.write(buildSourceFile, contents: "")
+            // The thunk can only import what the original build already depends on, so pull Foundation
+            // into the module graph here.
+            try await tester.fs.writeFileContents(srcRoot.join("Sources/Extra.swift")) { stream in
+                stream <<< """
+                    import Foundation
+                    struct Extra { static let value = Date() }
+                    """
+            }
+
+            let buildParameters = BuildParameters(
+                configuration: "Debug",
+                overrides: ["ENABLE_XOJIT_PREVIEWS": "YES"]
+            )
+
+            try await tester.checkBuild(
+                parameters: buildParameters,
+                runDestination: .iOSSimulator,
+                buildCommand: .build(style: .buildOnly, skipDependencies: false)
+            ) { results in
+                results.checkNoErrors()
+
+                let buildDescription = results.buildDescription
+                let appTarget = try #require(buildDescription.allConfiguredTargets.first { $0.target.name == "AppTarget" })
+
+                let previewInfos = buildDescription.generatePreviewInfoForTesting(
+                    for: [appTarget],
+                    workspaceContext: tester.workspaceContext,
+                    buildRequestContext: results.buildRequestContext,
+                    input: .thunkInfo(sourceFile: buildSourceFile, thunkVariantSuffix: "selection")
+                )
+                let thunkInfo = try #require(previewInfos.only?.thunkInfo)
+                let compileCommandLine = thunkInfo.compileCommandLine
+
+                // Establish that this build really is prefix mapped, so the rest of the test is
+                // exercising the interesting configuration rather than passing by default.
+                let prefixMapper = SwiftCompilerSpec.cacheReplayPrefixMapper(commandLine: compileCommandLine)
+                try #require(!prefixMapper.isEmpty, "expected the driver to prefix map the frontend invocation")
+
+                let primaryFileIndex = try #require(compileCommandLine.firstIndex(of: "-primary-file"))
+                let primaryFile = Path(compileCommandLine[primaryFileIndex + 1])
+                #expect(primaryFile != buildSourceFile, "expected the primary input to be prefix mapped")
+
+                // Two overlays, and the thunk substitution has to be the last one so it takes
+                // precedence: `-vfsoverlay` files are consulted in reverse order.
+                let overlayPaths = compileCommandLine.enumerated().compactMap { index, arg in
+                    arg == "-vfsoverlay" && index + 1 < compileCommandLine.count ? Path(compileCommandLine[index + 1]) : nil
+                }
+                try #require(overlayPaths.count == 2)
+
+                // The first overlay maps each prefix back onto the directory it stands for.
+                //
+                // Its name must not mention the thunk variant. Previews requests thunk info once with a
+                // placeholder suffix and then substitutes the real suffix into the command line for each
+                // variant, regenerating only the thunk overlay, so a name derived from the thunk would
+                // point at a file that is never written.
+                #expect(!overlayPaths[0].str.contains("selection"), "the prefix map overlay name must not embed the thunk variant suffix")
+                let prefixMapOverlay = try PropertyList.fromJSONFileAtPath(overlayPaths[0], fs: tester.fs)
+                #expect(prefixMapOverlay.dictValue?["redirecting-with"]?.stringValue == "fallthrough")
+                let remaps = try #require(prefixMapOverlay.dictValue?["roots"]?.arrayValue)
+                #expect(remaps.count == prefixMapper.mappings.count)
+                for mapping in prefixMapper.mappings {
+                    let remap = try #require(remaps.first { $0.dictValue?["name"]?.stringValue == mapping.from.str }, "no remap for \(mapping.from.str) in \(overlayPaths[0].str)")
+                    #expect(remap.dictValue?["type"]?.stringValue == "directory-remap")
+                    #expect(remap.dictValue?["external-contents"]?.stringValue == mapping.to.str)
+                }
+
+                // The second overlay substitutes the thunk for exactly the path the frontend will read.
+                let thunkOverlay = try PropertyList.fromJSONFileAtPath(overlayPaths[1], fs: tester.fs)
+                let root = try #require(thunkOverlay.dictValue?["roots"]?.arrayValue?.only?.dictValue)
+                let entry = try #require(root["contents"]?.arrayValue?.only?.dictValue)
+                #expect(Path(try #require(root["name"]?.stringValue)).join(try #require(entry["name"]?.stringValue)) == primaryFile)
+                #expect(entry["external-contents"]?.stringValue == thunkInfo.thunkSourceFile.str)
+
+                // Finally, run it. A thunk that can't find its inputs fails outright, but a thunk whose
+                // substitution didn't apply compiles the original source and succeeds, so check that the
+                // object we got actually contains the thunk.
+                try await tester.fs.writeFileContents(thunkInfo.thunkSourceFile) { stream in
+                    stream <<< """
+                        import Foundation
+                        func __previewThunkMarker() -> String { "\\(Date())\\(Extra.value)" }
+                        """
+                }
+                try await runProcess(compileCommandLine)
+                let symbols = try await runProcess(["/usr/bin/nm", thunkInfo.thunkObjectFile.str])
+                #expect(symbols.contains("__previewThunkMarker"), "thunk object does not contain the thunk, the substitution did not apply")
+            }
+        }
+    }
+
     private enum LinkStyle {
         case dylib
         case bundleLoader

--- a/Tests/SWBUtilTests/PrefixMapperTests.swift
+++ b/Tests/SWBUtilTests/PrefixMapperTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import SWBTestSupport
+import SWBUtil
+
+@Suite(.skipHostOS(.windows, "testing unix path style"))
+fileprivate struct PrefixMapperTests {
+    private func mapper(_ mappings: (String, String)...) -> PrefixMapper {
+        PrefixMapper(mappings: mappings.map { .init(from: Path($0.0), to: Path($0.1)) }).sorted()
+    }
+
+    @Test
+    func empty() {
+        let mapper = PrefixMapper()
+        #expect(mapper.isEmpty)
+        #expect(mapper.map(Path("/src/main.swift")) == Path("/src/main.swift"))
+    }
+
+    @Test
+    func mapsPrefixAndSuffix() {
+        let mapper = mapper(("/Users/me/proj", "/^src"))
+        #expect(mapper.map(Path("/Users/me/proj/Sources/main.swift")) == Path("/^src/Sources/main.swift"))
+    }
+
+    @Test
+    func mapsExactMatch() {
+        let mapper = mapper(("/Users/me/proj", "/^src"))
+        #expect(mapper.map(Path("/Users/me/proj")) == Path("/^src"))
+    }
+
+    @Test
+    func leavesUnrelatedPathsAlone() {
+        let mapper = mapper(("/Users/me/proj", "/^src"))
+        #expect(mapper.map(Path("/Users/me/other/main.swift")) == Path("/Users/me/other/main.swift"))
+    }
+
+    /// `llvm::PrefixMapper` only matches on whole path components, so a mapping for `/tmp` must not
+    /// rewrite `/tmp-other`.
+    @Test
+    func matchesWholeComponentsOnly() {
+        let mapper = mapper(("/tmp", "/^tmp"))
+        #expect(mapper.map(Path("/tmp-other/main.swift")) == Path("/tmp-other/main.swift"))
+        #expect(mapper.map(Path("/tmp/main.swift")) == Path("/^tmp/main.swift"))
+    }
+
+    /// Sorting has to prefer the more specific prefix, matching `llvm::PrefixMapper::sort`, regardless
+    /// of the order the mappings were added in.
+    @Test
+    func prefersMoreSpecificPrefix() {
+        for mappings in [[("/tmp", "/^tmp"), ("/tmp/inner", "/^inner")], [("/tmp/inner", "/^inner"), ("/tmp", "/^tmp")]] {
+            let mapper = PrefixMapper(mappings: mappings.map { .init(from: Path($0.0), to: Path($0.1)) }).sorted()
+            #expect(mapper.map(Path("/tmp/inner/main.swift")) == Path("/^inner/main.swift"))
+            #expect(mapper.map(Path("/tmp/outer/main.swift")) == Path("/^tmp/outer/main.swift"))
+        }
+    }
+
+    @Test
+    func inverted() {
+        let mapper = mapper(("/Users/me/proj", "/^src"), ("/Users/me/build", "/^derived")).inverted()
+        #expect(mapper.map(Path("/^src/main.swift")) == Path("/Users/me/proj/main.swift"))
+        #expect(mapper.map(Path("/^derived/Objects/main.o")) == Path("/Users/me/build/Objects/main.o"))
+        #expect(mapper.map(Path("/^unmapped/x")) == Path("/^unmapped/x"))
+    }
+
+    /// Inverting has to re-sort, because the ordering that was right for the forward direction says
+    /// nothing about the ordering the inverse needs.
+    @Test
+    func invertedPrefersMoreSpecificPrefix() {
+        let mapper = mapper(("/a", "/^x"), ("/b", "/^x/inner")).inverted()
+        #expect(mapper.map(Path("/^x/inner/main.swift")) == Path("/b/main.swift"))
+        #expect(mapper.map(Path("/^x/other/main.swift")) == Path("/a/other/main.swift"))
+    }
+}


### PR DESCRIPTION
With compilation caching prefix mapping enabled, swift-driver rewrites the paths in the frontend invocation it plans, so the preview thunk is asked to compile `/^src/main.swift`. Those pseudo-paths only resolve against the CAS file system, which the uncached preview build deliberately does not set up because `-module-import-from-cas` is meant to read sources from the real file system, so the thunk build failed with "error opening input file '/^src/...'". Remapped paths recorded inside the module artifacts loaded from the CAS, such as the headers a PCM refers to, fail the same way and cannot be reached by rewriting the command line at all.

Pass a `directory-remap` VFS overlay that maps every prefix back onto the directory it stands for, built by inverting the mapping the driver reports in `-cache-replay-prefix-map`. Those arguments are left in place because the compiler needs them to locate macro plugins, which are dlopen'd outside of any VFS. `PrefixMapper` mirrors `llvm::PrefixMapper` so the ordering and matching agree with what the compiler and driver do.

The thunk substitution overlay is now keyed on the prefix mapped spelling too, since that is the path the frontend looks up, and is passed last so it wins over the prefix map overlay. Getting that wrong does not fail the build, it silently compiles the original source instead of the thunk, so the new test asserts on the symbols in the resulting object file. For the same reason the prefix map overlay is deliberately not named after the thunk: Previews requests thunk info once using a placeholder variant suffix and then substitutes the real suffix into the command line for each variant it builds, regenerating only the thunk overlay, so a name derived from the thunk would point at a file nobody writes.

rdar://184756825

