### PR TITLE
Update INFOPLIST_KEY_GCSupportsGameMode description (rdar://184515762)

### DIFF
--- a/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/CoreBuildSystem.xcspec
@@ -4747,7 +4747,7 @@ When this setting is enabled:
                 Type = Boolean;
                 Category = "Info.plist Values";
                 DisplayName = "Supports Game Mode";
-                Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the GCSupportsGameMode key in the `Info.plist` file to the value of this build setting.";
+                Description = "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [GCSupportsGameMode](https://developer.apple.com/documentation/bundleresources/information-property-list/gcsupportsgamemode) key in the `Info.plist` file to the value of this build setting. Use this build setting only if your app targets iOS 18 and earlier. For newer versions of iOS and macOS, set the [LSSupportsGameMode](https://developer.apple.com/documentation/bundleresources/information-property-list/lssupportsgamemode) key in your `Info.plist` file instead.";
             },
 
             // Info.plist Keys - Sticker Packs

--- a/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
+++ b/Sources/SWBCore/Specs/en.lproj/CoreBuildSystem.strings
@@ -689,7 +689,7 @@ Typically this path is not set per target, but is provided as an option on the c
 "[ENABLE_SECURITY_COMPILER_WARNINGS]-value-[NO]" = "No";
 
 "[ENABLE_C_BOUNDS_SAFETY]-name" = "Enable Language Extension for Bounds Safety in C";
-"[ENABLE_C_BOUNDS_SAFETY]-description" = "Enables the -fbounds-safety language extension, which guarantees bounds safety for C";
+"[ENABLE_C_BOUNDS_SAFETY]-description" = "Enables the -fbounds-safety language extension, which guarantees bounds safety for C.";
 "[ENABLE_C_BOUNDS_SAFETY]-value-[NO]" = "No";
 "[ENABLE_C_BOUNDS_SAFETY]-value-[YES]" = "Yes";
 

--- a/Tests/SWBCoreTests/SpecRegistryTests.swift
+++ b/Tests/SWBCoreTests/SpecRegistryTests.swift
@@ -410,7 +410,9 @@ import SWBUtil
                 #expect(option.localizedDescription == "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [\(keyName)](\(url)) key in the Info.plist file to an entry suitable for a multi-window application.")
             case "UILaunchScreen":
                 #expect(option.localizedDescription == "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [\(keyName)](\(url)) key in the Info.plist file to an empty dictionary.")
-            case _ where legacyKeyMappings.values.contains(keyName):
+            case "GCSupportsGameMode":
+                #expect(option.localizedDescription == "When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [\(keyName)](\(url)) key in the `Info.plist` file to the value of this build setting. Use this build setting only if your app targets iOS 18 and earlier. For newer versions of iOS and macOS, set the [LSSupportsGameMode](https://developer.apple.com/documentation/bundleresources/information-property-list/lssupportsgamemode) key in your `Info.plist` file instead.")
+           case _ where legacyKeyMappings.values.contains(keyName):
                 XCTAssertMatch(option.localizedDescription, .suffix("\n\n\(generateSentenceWithURL)"))
             default:
                 XCTAssertMatch(option.localizedDescription, .or(.equal(generateSentenceWithURL), .equal(generateSentenceWithoutURL)))


### PR DESCRIPTION
Updates the description of INFOPLIST_KEY_GCSupportsGameMode.

The info.plist key populated by this setting changed in iOS 18 and macOS from `GCSupportsGameMode` to `LSSupportsGameMode`. This PR updates the description to clarify this behavior. It also updates the unit test that checks the description.

This supports rdar://158769198 (The Info.plist documentation doesn't have LSSupportsGameMode)

Based on a patch provided by [cgreening2@apple.com](mailto:cgreening2@apple.com). 

Update: also added a missing period to `[ENABLE_C_BOUNDS_SAFETY]-description` in the `en.lproj` localization.