### PR TITLE
Track Clang module directory-listing dependencies for correct incremental rebuilds

### DIFF
--- a/Sources/SWBCSupport/CLibclang.cpp
+++ b/Sources/SWBCSupport/CLibclang.cpp
@@ -1140,6 +1140,19 @@ extern "C" {
         CXCStringArray (*clang_experimental_DepGraphModule_getFileDeps)(CXDepGraphModule);
 
         /**
+         * \returns the list of directories whose contents (directory listing)
+         * this module depends on, e.g. the umbrella directory of an umbrella
+         * module or the headers directory of a framework module.
+         *
+         * If a file is added to or removed from any of these directories then
+         * the module needs to be rebuilt.
+         *
+         * The strings are only valid to use while the \c CXDepGraphModule object
+         * is valid.
+         */
+        CXCStringArray (*clang_experimental_DepGraphModule_getDirectoryDeps)(CXDepGraphModule);
+
+        /**
          * \returns the list of modules which this module direct depends on.
          *
          * This does include the context hash. The format is
@@ -1485,6 +1498,7 @@ struct LibclangWrapper {
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getContextHash);
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getModuleMapPath);
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getFileDeps);
+        LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getDirectoryDeps);
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getModuleDeps);
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getBuildArguments);
         LOOKUP_OPTIONAL(clang_experimental_DepGraphModule_getCacheKey);
@@ -1790,6 +1804,10 @@ extern "C" {
         return lib->wrapper->hasNegativeStatCacheDiagnostics;
     }
 
+    bool libclang_has_directory_dependencies(libclang_t lib) {
+        return lib->wrapper->fns.clang_experimental_DepGraphModule_getDirectoryDeps != nullptr;
+    }
+
     libclang_scanner_t libclang_scanner_create(libclang_t lib, libclang_casdatabases_t casdbs, libclang_casoptions_t casOpts) {
         return new libclang_scanner_t_{new LibclangScanner(
             lib->wrapper, LibclangFunctions::CXDependencyMode_Full,
@@ -1927,7 +1945,8 @@ extern "C" {
     static const char **copyStringSet(LibclangFunctions::CXCStringArray set) {
         const char **ret = new const char *[set.Count + 1];
         ret[set.Count] = nullptr;
-        memcpy(ret, set.Strings, set.Count * sizeof(const char *));
+        if (set.Count)
+            memcpy(ret, set.Strings, set.Count * sizeof(const char *));
         return ret;
     }
 
@@ -2153,6 +2172,9 @@ extern "C" {
                 LibclangFunctions::CXCStringArray fileDeps = lib->fns.clang_experimental_DepGraphModule_getFileDeps(depMod);
                 LibclangFunctions::CXCStringArray moduleDeps = lib->fns.clang_experimental_DepGraphModule_getModuleDeps(depMod);
                 LibclangFunctions::CXCStringArray buildArguments = lib->fns.clang_experimental_DepGraphModule_getBuildArguments(depMod);
+                LibclangFunctions::CXCStringArray directoryDeps = lib->fns.clang_experimental_DepGraphModule_getDirectoryDeps
+                    ? lib->fns.clang_experimental_DepGraphModule_getDirectoryDeps(depMod)
+                    : LibclangFunctions::CXCStringArray{nullptr, 0};
 
                 modules[i].name = name;
                 modules[i].context_hash = contextHash;
@@ -2163,6 +2185,7 @@ extern "C" {
                 modules[i].file_deps = copyStringSet(fileDeps);
                 modules[i].module_deps = copyStringSet(moduleDeps);
                 modules[i].build_arguments = copyStringSet(buildArguments);
+                modules[i].directory_deps = copyStringSet(directoryDeps);
 
                 modsToDispose.push_back(depMod);
             }
@@ -2172,6 +2195,7 @@ extern "C" {
                 delete[] modules[i].file_deps;
                 delete[] modules[i].module_deps;
                 delete[] modules[i].build_arguments;
+                delete[] modules[i].directory_deps;
             }
             delete[] modules;
             for (const auto &mod : modsToDispose)

--- a/Sources/SWBCSupport/CLibclang.h
+++ b/Sources/SWBCSupport/CLibclang.h
@@ -56,6 +56,7 @@ typedef struct {
     const char **module_deps;
     const char *cache_key;
     const char **build_arguments;
+    const char **directory_deps;
 } clang_module_dependency_t;
 
 typedef struct {
@@ -110,6 +111,9 @@ CSUPPORT_EXPORT bool libclang_has_structured_scanner_diagnostics(libclang_t lib)
 
 /// Whether libclang supports reporting negative stat caching diagnostics.
 CSUPPORT_EXPORT bool libclang_has_negative_stat_cache_diagnostics(libclang_t lib);
+
+/// Whether libclang supports reporting directory-listing dependencies for modules.
+CSUPPORT_EXPORT bool libclang_has_directory_dependencies(libclang_t lib);
 
 /// Create a new scanner instance with optional CAS databases.
 CSUPPORT_EXPORT libclang_scanner_t libclang_scanner_create(libclang_t lib, libclang_casdatabases_t, libclang_casoptions_t);

--- a/Sources/SWBCore/LibclangVendored/Libclang.swift
+++ b/Sources/SWBCore/LibclangVendored/Libclang.swift
@@ -95,6 +95,10 @@ public final class Libclang {
         libclang_has_negative_stat_cache_diagnostics(lib)
     }
 
+    public var supportsDirectoryDependencies: Bool {
+        libclang_has_directory_dependencies(lib)
+    }
+
     public var supportsCASPruning: Bool {
         libclang_has_cas_pruning_feature(lib)
     }
@@ -146,6 +150,7 @@ public final class DependencyScanner {
         public var context_hash: String { String(cString: clang_module_dependency.context_hash) }
         public var module_map_path: String { String(cString: clang_module_dependency.module_map_path) }
         public var file_deps: some Sequence<String> { clang_module_dependency.file_deps.toLazyStringSequence() }
+        public var directory_deps: some Sequence<String> { clang_module_dependency.directory_deps.toLazyStringSequence() }
         public var include_tree_id: String? { clang_module_dependency.include_tree_id.map { String(cString: $0) } }
         public var module_deps: some Sequence<String> { clang_module_dependency.module_deps.toLazyStringSequence() }
         public var cache_key: String? { clang_module_dependency.cache_key.map { String(cString: $0) } }

--- a/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
+++ b/Sources/SWBTaskExecution/DynamicTaskSpecs/ClangModuleDependencyGraph.swift
@@ -70,6 +70,13 @@ package final class ClangModuleDependencyGraph {
         /// The list of file (paths) dependencies that are required by the translation unit or module.
         package let files: [Path]
 
+        /// The list of directories whose contents (directory listing) are required by the translation unit or module.
+        ///
+        /// If a file is added to or removed from one of these directories, the translation unit or module must be
+        /// rebuilt. These are reported by the Clang dependency scanner for umbrella and framework modules, and are
+        /// empty when the loaded libclang does not support directory dependencies.
+        package let directories: [Path]
+
         /// The CASID of the include-tree required by this translation unit or module, if any.
         package let includeTreeID: String?
 
@@ -127,10 +134,12 @@ package final class ClangModuleDependencyGraph {
             scanningCommandLine: [String],
             transitiveIncludeTreeIDs: [String],
             transitiveCompileCommandCacheKeys: [String],
-            usesSerializedDiagnostics: Bool
+            usesSerializedDiagnostics: Bool,
+            directoryDependencies: [Path] = []
         ) {
             self.kind = .command
             self.files = fileDependencies
+            self.directories = directoryDependencies
             self.includeTreeID = includeTreeID
             self.modules = moduleDependencies
             self.workingDirectory = workingDirectory
@@ -151,10 +160,12 @@ package final class ClangModuleDependencyGraph {
             scanningCommandLine: [String],
             transitiveIncludeTreeIDs: [String],
             transitiveCompileCommandCacheKeys: [String],
-            usesSerializedDiagnostics: Bool
+            usesSerializedDiagnostics: Bool,
+            directoryDependencies: [Path] = []
         ) {
             self.kind = .module(pcmOutputPath: pcmOutputPath)
             self.files = fileDependencies
+            self.directories = directoryDependencies
             self.includeTreeID = includeTreeID
             self.modules = moduleDependencies
             self.workingDirectory = workingDirectory
@@ -166,9 +177,10 @@ package final class ClangModuleDependencyGraph {
         }
 
         package func serialize<T>(to serializer: T) where T : Serializer {
-            serializer.serializeAggregate(10) {
+            serializer.serializeAggregate(11) {
                 serializer.serialize(kind)
                 serializer.serialize(files)
+                serializer.serialize(directories)
                 serializer.serialize(includeTreeID)
                 serializer.serialize(modules)
                 serializer.serialize(workingDirectory)
@@ -181,9 +193,10 @@ package final class ClangModuleDependencyGraph {
         }
 
         package init(from deserializer: any Deserializer) throws {
-            try deserializer.beginAggregate(10)
+            try deserializer.beginAggregate(11)
             self.kind = try deserializer.deserialize()
             self.files = try deserializer.deserialize()
+            self.directories = try deserializer.deserialize()
             self.includeTreeID = try deserializer.deserialize()
             self.modules = try deserializer.deserialize()
             self.workingDirectory = try deserializer.deserialize()
@@ -293,6 +306,7 @@ package final class ClangModuleDependencyGraph {
 
     package struct ScanResult: Sendable {
         package let dependencyPaths: Set<Path>
+        package let directoryPaths: Set<Path>
         package let requiredTargetDependencies: Set<RequiredDependency>
 
         package struct RequiredDependency: Hashable, Sendable {
@@ -315,6 +329,7 @@ package final class ClangModuleDependencyGraph {
         verifyingModule: String?,
         outputPath: String,
         reportRequiredTargetDependencies: BooleanWarningLevel,
+        dependencyFilteringRootPath: Path?,
         fileSystem: any FSProxy
     ) throws -> ScanResult {
         let clangWithScanner = try libclangWithScanner(forPath: libclangPath, casOptions: casOptions, cacheFallbackIfNotAvailable: cacheFallbackIfNotAvailable, core: core)
@@ -345,6 +360,7 @@ package final class ClangModuleDependencyGraph {
         let scanningCommandLine = [compiler] + originalFileArgs
         let modulesCallbackErrors = SWBMutex<[any Error]>([])
         let dependencyPaths = SWBMutex<[Path]>([])
+        let directoryPaths = SWBMutex<[Path]>([])
         let includeTrees = SWBMutex<[String]>([])
         let cacheKeys = SWBMutex<[String]>([])
         let requiredTargetDependencies = SWBMutex<Set<ScanResult.RequiredDependency>>([])
@@ -382,6 +398,15 @@ package final class ClangModuleDependencyGraph {
                                 $0.append(contentsOf: fileDependencies)
                             }
 
+                            let directoryDependencies = module.directory_deps.map(Path.init).filter {
+                                // Filter here (not just in the scan task action) so the per-module `.scan` stores only trackable directories for the precompile task to register.
+                                guard let dependencyFilteringRootPath else { return true }
+                                return !$0.str.hasPrefix(dependencyFilteringRootPath.str)
+                            }
+                            directoryPaths.withLock {
+                                $0.append(contentsOf: directoryDependencies)
+                            }
+
                             if let includeTree = module.include_tree_id {
                                 includeTrees.withLock {
                                     $0.append(includeTree)
@@ -415,7 +440,8 @@ package final class ClangModuleDependencyGraph {
                                     transitiveIncludeTreeIDs: [],
                                     // Only the main compile task needs to know transitive cache keys.
                                     transitiveCompileCommandCacheKeys: [],
-                                    usesSerializedDiagnostics: usesSerializedDiagnostics)
+                                    usesSerializedDiagnostics: usesSerializedDiagnostics,
+                                    directoryDependencies: directoryDependencies)
                                 if reportRequiredTargetDependencies != .no, let targetDependencies = definingTargetsByModuleName[module.name] {
                                     requiredTargetDependencies.withLock {
                                         for targetDependency in targetDependencies {
@@ -499,7 +525,7 @@ package final class ClangModuleDependencyGraph {
             $0.append(contentsOf: dependencyInfo.files)
         }
 
-        return ScanResult(dependencyPaths: dependencyPaths.withLock { Set($0) }, requiredTargetDependencies: requiredTargetDependencies.withLock { $0 })
+        return ScanResult(dependencyPaths: dependencyPaths.withLock { Set($0) }, directoryPaths: directoryPaths.withLock { Set($0) }, requiredTargetDependencies: requiredTargetDependencies.withLock { $0 })
     }
 
     /// Query the dependencies for the specified key.

--- a/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/ClangScanTaskAction.swift
@@ -157,6 +157,7 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
                 verifyingModule: explicitModulesPayload.verifyingModule,
                 outputPath: explicitModulesPayload.outputPath.str,
                 reportRequiredTargetDependencies: explicitModulesPayload.reportRequiredTargetDependencies,
+                dependencyFilteringRootPath: explicitModulesPayload.dependencyFilteringRootPath,
                 fileSystem: executionDelegate.fs
             )
 
@@ -181,6 +182,7 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
         }
 
         var dependencyPaths = result.dependencyPaths
+        let directoryPaths = result.directoryPaths
         if let filteringPath = explicitModulesPayload.dependencyFilteringRootPath {
             dependencyPaths = dependencyPaths.filter {
                 // We intentionally do a prefix check instead of an ancestor check here, for performance reasons. The filtering path (SDK path) and paths returned by the compiler are guaranteed to be normalized, which makes this safe.
@@ -191,10 +193,19 @@ public final class ClangScanTaskAction: TaskAction, BuildValueValidatingTaskActi
 
         if executionDelegate.userPreferences.enableDebugActivityLogs {
             outputDelegate.emitOutput(ByteString(encodingAsUTF8: "Discovered dependency nodes:\n" + dependencyPaths.map(\.str).joined(separator: "\n") + "\n"))
+            if !directoryPaths.isEmpty {
+                outputDelegate.emitOutput(ByteString(encodingAsUTF8: "Discovered directory dependency nodes:\n" + directoryPaths.map(\.str).joined(separator: "\n") + "\n"))
+            }
         }
 
         for dep in dependencyPaths {
             dynamicExecutionDelegate.discoveredDependencyNode(ExecutionNode(identifier: dep.str))
+        }
+
+        // Register directory-listing dependencies (e.g. umbrella/framework module header directories) so that
+        // adding or removing a file in one of these directories correctly invalidates the affected module.
+        for dir in directoryPaths {
+            dynamicExecutionDelegate.discoveredDependencyDirectoryTree(dir)
         }
 
         if let target = task.forTarget {

--- a/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/PrecompileClangModuleTaskAction.swift
@@ -154,6 +154,15 @@ final public class PrecompileClangModuleTaskAction: TaskAction, BuildValueValida
             dynamicExecutionDelegate.discoveredDependencyNode(node)
         }
 
+        // Register directory-listing dependencies (e.g. umbrella/framework module header directories) so that adding
+        // or removing a header in one of these directories rebuilds this module's PCM. The scan task registers the
+        // same directories to force a rescan; the module precompile must track them too, because the scanner reports
+        // the directory (not each header) and so the module's file dependencies alone do not change when a header is
+        // added or removed.
+        for dir in dependencyInfo.directories {
+            dynamicExecutionDelegate.discoveredDependencyDirectoryTree(dir)
+        }
+
         guard let command = dependencyInfo.commands.only else {
             outputDelegate.emitError("Module dependency \(key.dependencyInfoPath) should have a single command-line")
             return .failed

--- a/Sources/SWBTestSupport/SkippedTestSupport.swift
+++ b/Sources/SWBTestSupport/SkippedTestSupport.swift
@@ -439,6 +439,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    package static var requireDependencyScannerDirectoryDependencies: Self {
+        enabled("clang is too old to report directory-listing (umbrella/framework) dependencies") {
+            let libclang = try #require(try await ConditionTraitContext.shared.libclang)
+            return libclang.supportsDirectoryDependencies
+        }
+    }
+
     package static var requireModuleCachePruning: Self {
         enabled {
             let libclang = try #require(try await ConditionTraitContext.shared.libclang)

--- a/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
+++ b/Tests/SWBBuildSystemTests/ClangExplicitModulesTests.swift
@@ -596,6 +596,120 @@ fileprivate struct ClangExplicitModulesTests: CoreBasedTests {
         }
     }
 
+    /// Verifies that adding (and removing) a header in a directory that a Clang module enumerates
+    /// correctly invalidates and rebuilds that module — the "negative dependency" / directory-listing
+    /// dependency behavior introduced by the Clang dependency scanner
+    /// (`clang_experimental_DepGraphModule_getDirectoryDeps`).
+    ///
+    /// The scenario uses an *umbrella directory* module so the set of headers in the directory is part
+    /// of the module, and a header can be added/removed purely on disk (no PIF/build-phase change)
+    /// between incremental builds. Before directory-listing dependencies were tracked, the second and
+    /// third builds here would incorrectly no-op (the module would not be rescanned/rebuilt).
+    ///
+    /// Gated on `.requireDependencyScannerDirectoryDependencies`: this only exercises the positive path
+    /// on a libclang that exports the directory-dependencies API (e.g. built from
+    /// swiftlang/llvm-project#13797); on older toolchains the test is skipped.
+    @Test(.requireSDKs(.host), .requireDependencyScannerDirectoryDependencies)
+    func explicitModulesUmbrellaDirectoryDependency() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources",
+                            children: [
+                                TestFile("file.m"),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "CLANG_ENABLE_MODULES": "YES",
+                                "_EXPERIMENTAL_CLANG_EXPLICIT_MODULES": "YES",
+                                // Make the umbrella-directory module map discoverable to the scanner.
+                                "OTHER_CFLAGS": "$(inherited) -I\(tmpDirPath.join("Test/aProject/UmbrellaHeaders").str)",
+                            ])],
+                        targets: [
+                            TestStandardTarget(
+                                "Library",
+                                type: .staticLibrary,
+                                buildPhases: [
+                                    TestSourcesBuildPhase(["file.m"]),
+                                ]),
+                        ])])
+
+            let tester = try await BuildOperationTester(getCore(), testWorkspace, simulated: false)
+
+            let umbrellaDir = testWorkspace.sourceRoot.join("aProject/UmbrellaHeaders")
+
+            // An umbrella-directory module: every header in `UmbrellaHeaders` is part of `UmbrellaMod`.
+            try await tester.fs.writeFileContents(umbrellaDir.join("module.modulemap")) { stream in
+                stream <<<
+                """
+                module UmbrellaMod {
+                    umbrella "."
+                    export *
+                }
+                """
+            }
+
+            try await tester.fs.writeFileContents(umbrellaDir.join("First.h")) { stream in
+                stream <<<
+                """
+                void first_fn(void);
+                """
+            }
+
+            try await tester.fs.writeFileContents(testWorkspace.sourceRoot.join("aProject/file.m")) { stream in
+                stream <<<
+                """
+                @import UmbrellaMod;
+
+                void use(void) {
+                    first_fn();
+                }
+                """
+            }
+
+            // Build 1 (clean): the module is scanned and precompiled.
+            try await tester.checkBuild(runDestination: .host, persistent: true) { results in
+                try results.checkTask(.matchRuleType("ScanDependencies")) { _ in }
+                try results.checkTask(.matchRuleType("CompileC")) { _ in }
+                results.checkTask(.matchRuleType("PrecompileModule")) { _ in }
+                results.checkNoDiagnostics()
+            }
+
+            // Add a new header into the enumerated directory *without* touching any existing file.
+            // The directory-listing dependency must invalidate the module.
+            try await tester.fs.writeFileContents(umbrellaDir.join("Second.h")) { stream in
+                stream <<<
+                """
+                void second_fn(void);
+                """
+            }
+
+            // Build 2: the directory-tree signature changed, so the module is rescanned and rebuilt.
+            try await tester.checkBuild(runDestination: .host, persistent: true) { results in
+                try results.checkTask(.matchRuleType("ScanDependencies")) { _ in }
+                // The module must be precompiled again because its directory contents changed.
+                results.checkTask(.matchRuleType("PrecompileModule")) { _ in }
+                results.checkNoDiagnostics()
+            }
+
+            // Removing a header from the directory must likewise invalidate and rebuild the module.
+            try tester.fs.remove(umbrellaDir.join("Second.h"))
+
+            try await tester.checkBuild(runDestination: .host, persistent: true) { results in
+                try results.checkTask(.matchRuleType("ScanDependencies")) { _ in }
+                results.checkTask(.matchRuleType("PrecompileModule")) { _ in }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
     @Test(.requireSDKs(.host))
     func explicitModulesDriverExpandsToMultipleCC1s() async throws {
         try await withTemporaryDirectory { tmpDirPath in


### PR DESCRIPTION
Umbrella and framework modules depend on the set of headers in a directory, not just specific files. Adding or removing a header must rebuild any module that enumerated it, but Swift Build only tracked concrete header files and so could reuse a stale PCM.

Clang's scanner (swiftlang/llvm-project#13797) now reports these via clang_experimental_DepGraphModule_getDirectoryDeps. Consume them and register each directory as an llbuild directory-tree dependency on both the scan task (to force a rescan) and the module precompile task (so the PCM itself rebuilds). SDK/system directories are filtered out, and the .scan aggregate count bumps 10 -> 11.

Runtime capability-gated: active only when the loaded libclang exports the symbol, and a no-op on older toolchains. Adds serialization unit tests and an umbrella-directory integration test.
