### PR TITLE
Add a SWIFT_STATS_OUTPUT_DIR build setting

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -1151,6 +1151,7 @@ public final class BuiltinMacros {
     public static let SWIFT_IR_OUTPUT_DIR = BuiltinMacros.declarePathMacro("SWIFT_IR_OUTPUT_DIR")
     public static let SWIFT_OPT_RECORD_OUTPUT_DIR = BuiltinMacros.declarePathMacro("SWIFT_OPT_RECORD_OUTPUT_DIR")
     public static let SWIFT_SIL_OUTPUT_DIR = BuiltinMacros.declarePathMacro("SWIFT_SIL_OUTPUT_DIR")
+    public static let SWIFT_STATS_OUTPUT_DIR = BuiltinMacros.declarePathMacro("SWIFT_STATS_OUTPUT_DIR")
     public static let SWIFT_STDLIB = BuiltinMacros.declareStringMacro("SWIFT_STDLIB")
     public static let SWIFT_STDLIB_TOOL = BuiltinMacros.declareStringMacro("SWIFT_STDLIB_TOOL")
     public static let SWIFT_STDLIB_TOOL_FOLDERS_TO_SCAN = BuiltinMacros.declarePathListMacro("SWIFT_STDLIB_TOOL_FOLDERS_TO_SCAN")
@@ -2440,6 +2441,7 @@ public final class BuiltinMacros {
         SWIFT_OPT_RECORD_OUTPUT_DIR,
         SWIFT_RESPONSE_FILE_PATH,
         SWIFT_SIL_OUTPUT_DIR,
+        SWIFT_STATS_OUTPUT_DIR,
         SWIFT_STDLIB,
         SWIFT_STDLIB_TOOL,
         SWIFT_STDLIB_TOOL_FOLDERS_TO_SCAN,

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -2016,6 +2016,9 @@ public final class SwiftCompilerSpec : CompilerSpec, SpecIdentifierType, SwiftDi
             if await cbc.producer.shouldUseSDKStatCache() && toolSpecInfo.toolFeatures.has(.vfsstatcache) {
                 allInputsNodes.append(delegate.createVirtualNode("ClangStatCache \(cbc.scope.evaluate(BuiltinMacros.SDK_STAT_CACHE_PATH))"))
             }
+            if let statsOutputDir = cbc.scope.evaluate(BuiltinMacros.SWIFT_STATS_OUTPUT_DIR, lookup: lookup).nilIfEmpty {
+                allInputsNodes.append(delegate.createVirtualNode("CreateBuildDirectory-\(statsOutputDir.str)"))
+            }
             let execDescription: String
             switch compilationMode {
             case .generateModule:

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CreateBuildDirectoryTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/CreateBuildDirectoryTaskProducer.swift
@@ -61,7 +61,9 @@ final class CreateBuildDirectoryTaskProducer: StandardTaskProducer, TaskProducer
                 return path
             }
 
-            return buildDirectories + cacheDirectories
+            let statsDirectories = [targetContext.settings.globalScope.evaluate(BuiltinMacros.SWIFT_STATS_OUTPUT_DIR).nilIfEmpty].compactMap { $0 }
+
+            return buildDirectories + cacheDirectories + statsDirectories
         })
         buildDirectoryContext.freeze()
     }

--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1268,6 +1268,12 @@
                 Type = Path;
             },
 
+            {
+                Name = "SWIFT_STATS_OUTPUT_DIR";
+                Type = Path;
+                CommandLineFlag = "-stats-output-dir";
+            },
+
             // Reflection metadata options
             {
                 Name = "SWIFT_REFLECTION_METADATA_LEVEL";

--- a/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/SwiftBuildOperationTests.swift
@@ -68,6 +68,59 @@ fileprivate struct SwiftBuildOperationTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host))
+    func swiftStatsOutputDir() async throws {
+        try await withTemporaryDirectory { (tmpDir: Path) in
+            let statsDir = tmpDir.join("stats")
+            let testProject = try await TestProject(
+                "TestProject",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("main.swift"),
+                    ]),
+                buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "ARCHS": "$(ARCHS_STANDARD)",
+                        "CODE_SIGNING_ALLOWED": "NO",
+                        "PRODUCT_NAME": "$(TARGET_NAME)",
+                        "SDKROOT": "$(HOST_PLATFORM)",
+                        "SUPPORTED_PLATFORMS": "$(HOST_PLATFORM)",
+                        "SWIFT_STATS_OUTPUT_DIR": statsDir.str,
+                        "SWIFT_VERSION": swiftVersion,
+                    ])
+                ],
+                targets: [
+                    TestStandardTarget(
+                        "tool",
+                        type: .commandLineTool,
+                        buildConfigurations: [
+                            TestBuildConfiguration("Debug"),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["main.swift"]),
+                        ]
+                    ),
+                ])
+            let tester = try await BuildOperationTester(getCore(), testProject, simulated: false)
+
+            let projectDir = tester.workspace.projects[0].sourceRoot
+
+            try await tester.fs.writeFileContents(projectDir.join("main.swift")) { stream in
+                stream <<< "let x = 1\n"
+            }
+
+            try await tester.checkBuild(runDestination: .host) { results in
+                results.checkNoDiagnostics()
+            }
+
+            let statsDirContents = try tester.fs.listdir(statsDir)
+            let statsFiles = statsDirContents.filter { $0.hasPrefix("stats-") && $0.hasSuffix(".json") }
+            #expect(!statsFiles.isEmpty, "expected statistics files in \(statsDir.str), found: \(statsDirContents)")
+        }
+    }
+
     /// Test that building a project with module-only architectures and generated Objective-C headers still generates the headers for the module-only architectures.
     @Test(.requireSDKs(.watchOS))
     func swiftModuleOnlyArchsWithGeneratedObjectiveCHeaders() async throws {

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -5875,6 +5875,55 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.host))
+    func statsOutputDir() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let statsDir = tmpDir.join("stats")
+            let testProject = try await TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.swift")
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "Test",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "SWIFT_EXEC": swiftCompilerPath.str,
+                                    "SWIFT_VERSION": swiftVersion,
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["File1.swift"]),
+                        ]
+                    )
+                ])
+
+            let core = try await getCore()
+            let tester = try TaskConstructionTester(core, testProject)
+
+            await tester.checkBuild(BuildParameters(configuration: "Debug", overrides: ["SWIFT_STATS_OUTPUT_DIR": statsDir.str]), runDestination: .host) { results in
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { compileTask in
+                    compileTask.checkCommandLineContains(["-stats-output-dir", statsDir.str])
+                }
+                results.checkTask(.matchRule(["CreateBuildDirectory", statsDir.str])) { _ in }
+            }
+
+            await tester.checkBuild(BuildParameters(configuration: "Debug"), runDestination: .host) { results in
+                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { compileTask in
+                    compileTask.checkCommandLineDoesNotContain("-stats-output-dir")
+                }
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.host))
     func indexOptionsNotAddedIfIndexingIsDisabled() async throws {
         try await withTemporaryDirectory { tmpDir in
             let testProject = try await TestProject(


### PR DESCRIPTION
This maps to -stats-output-dir and aggregates stats for each swift frontend job in the specified directory