### PR TITLE
Add .noindex to shared SDKExplicitPrecompiledModules dir

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -546,7 +546,7 @@ final class WorkspaceSettings: Sendable {
         table.push(BuiltinMacros.SWIFT_EXPLICIT_MODULES_OUTPUT_PATH, Static { BuiltinMacros.namespace.parseString("$(OBJROOT)/SwiftExplicitPrecompiledModules") })
 
         // Shared output path for SDK explicit modules. Lives adjacent to ModuleCache.noindex under DerivedData so it is shared across projects (SDK PCMs are invariant across projects that share an SDK and toolchain).
-        table.push(BuiltinMacros.SDK_EXPLICIT_MODULES_OUTPUT_PATH, Static { BuiltinMacros.namespace.parseString("$(DERIVED_DATA_DIR)/SDKExplicitPrecompiledModules") })
+        table.push(BuiltinMacros.SDK_EXPLICIT_MODULES_OUTPUT_PATH, Static { BuiltinMacros.namespace.parseString("$(DERIVED_DATA_DIR)/SDKExplicitPrecompiledModules.noindex") })
 
         // Add default values for the compilation caching plugin (off-by-default).
         if case .xcode(_) = core.developerPath {

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -8633,7 +8633,7 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
                     #expect(task.inputs.isEmpty)
                 }
 
-                results.checkTask(.matchRuleType("CreateBuildDirectory"), .matchRuleItem("\(derivedDataRoot.str)/SDKExplicitPrecompiledModules")) { task in
+                results.checkTask(.matchRuleType("CreateBuildDirectory"), .matchRuleItem("\(derivedDataRoot.str)/SDKExplicitPrecompiledModules.noindex")) { task in
                     #expect(task.inputs.isEmpty)
                 }
 


### PR DESCRIPTION
c2eb24be9 added a shared directory to hold SDK modules that can be shared across schemes. Opt this dir out of indexable functionalities to match ModuleCache.noindex