### PR TITLE
Fix `.when(platforms: [.wasi])` to match with `wasm32-unknown-wasip1-threads`

### DIFF
--- a/Sources/SWBProjectModel/PIFGenerationModel.swift
+++ b/Sources/SWBProjectModel/PIFGenerationModel.swift
@@ -1108,6 +1108,9 @@ public extension Array where Element == PIF.BuildSettings.Platform {
 
             case .wasi:
                 result.append(.init(platform: "wasi"))
+                result.append(.init(platform: "wasip1"))
+                result.append(.init(platform: "wasi", environment: "threads"))
+                result.append(.init(platform: "wasip1", environment: "threads"))
 
             case .openbsd:
                 result.append(.init(platform: "openbsd"))

--- a/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
+++ b/Sources/SwiftBuild/ProjectModel/BuildSettings.swift
@@ -303,6 +303,8 @@ public extension ProjectModel.BuildSettings.Platform {
         case .wasi:
             result.append(.init(platform: "wasi"))
             result.append(.init(platform: "wasip1"))
+            result.append(.init(platform: "wasi", environment: "threads"))
+            result.append(.init(platform: "wasip1", environment: "threads"))
 
         case .openbsd:
             result.append(.init(platform: "openbsd"))

--- a/Tests/SwiftBuildTests/ProjectModel/BuildSettingsTests.swift
+++ b/Tests/SwiftBuildTests/ProjectModel/BuildSettingsTests.swift
@@ -29,6 +29,20 @@ fileprivate struct BuildSettingsTests {
         try testCodable(obj) { $0[.SWIFT_MODULE_ALIASES, .macOS] = ["A=B", "C=D"] }
     }
 
+    @Test func wasiPlatformFilters() {
+        // For triples like `wasm32-unknown-wasip1-threads` the build-time filter carries the
+        // environment and matching is exact on (platform, environment), so `.wasi` must cover
+        // the environment-qualified variants alongside the environment-less ones.
+        let filters = Set(ProjectModel.BuildSettings.Platform.wasi.toPlatformFilter())
+        let expected: Set<ProjectModel.PlatformFilter> = [
+            .init(platform: "wasi"),
+            .init(platform: "wasip1"),
+            .init(platform: "wasi", environment: "threads"),
+            .init(platform: "wasip1", environment: "threads"),
+        ]
+        #expect(filters == expected)
+    }
+
     @Test func unknownBuildSettings() throws {
         var obj = ProjectModel.BuildSettings()
         obj[single: "CUSTOM1"] = "value"


### PR DESCRIPTION
The build-time platform filter for a wasm destination comes out as ("wasip1", "threads"): the synthesized Swift SDK sets SWIFT_PLATFORM_TARGET_PREFIX from LLVMTargetTripleSys ("wasip1") and LLVM_TARGET_TRIPLE_SUFFIX from LLVMTargetTripleEnvironment ("-threads"). The .wasi platform condition previously emitted only environment-less filters ("wasi", "")/("wasip1", ""), and PlatformFilter.matches() demands exact equality on (platform, environment), so no .wasi condition could ever match a `*-threads` triple.