### PR TITLE
Fix explicit access of Foundation imports in resource bundle accessor

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -2064,7 +2064,7 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
         let filePath = scope.evaluate(BuiltinMacros.DERIVED_SOURCES_DIR).join("resource_bundle_accessor.swift")
 
         let contents = bundleName.isEmpty ? """
-            import class Foundation.Bundle
+            internal import class Foundation.Bundle
 
             extension Foundation.Bundle {
                 static let module = {
@@ -2073,9 +2073,9 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                 }()
             }
             """ : """
-            import class Foundation.Bundle
-            import class Foundation.ProcessInfo
-            import struct Foundation.URL
+            internal import class Foundation.Bundle
+            internal import class Foundation.ProcessInfo
+            internal import struct Foundation.URL
 
             private class BundleFinder {}
 

--- a/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/PackageProductConstructionTests.swift
@@ -1100,6 +1100,9 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             results.checkNoDiagnostics()
             results.checkTarget("tool") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in
+                    XCTAssertMatch(contents.unsafeStringValue, .contains("internal import class Foundation.Bundle"))
+                    XCTAssertMatch(contents.unsafeStringValue, .contains("internal import class Foundation.ProcessInfo"))
+                    XCTAssertMatch(contents.unsafeStringValue, .contains("internal import struct Foundation.URL"))
                     XCTAssertMatch(contents.unsafeStringValue, .contains("static nonisolated let module: Bundle"))
                     XCTAssertMatch(contents.unsafeStringValue, .contains("let bundleName = \"tool_resources\""))
                 }
@@ -1147,6 +1150,7 @@ fileprivate struct PackageProductConstructionTests: CoreBasedTests {
             // Playground apps won't have a resource bundle but they will have asset catalogs, so they should get a resource bundle accessor.
             results.checkTarget("tool_without_resource_bundle_with_catalog") { target in
                 results.checkWriteAuxiliaryFileTask(.matchTarget(target), .matchRuleType("WriteAuxiliaryFile"), .matchRuleItemBasename("resource_bundle_accessor.swift")) { task, contents in
+                    XCTAssertMatch(contents.unsafeStringValue, .contains("internal import class Foundation.Bundle"))
                     XCTAssertMatch(contents.unsafeStringValue, .contains("static let module = {"))
                     XCTAssertMatch(contents.unsafeStringValue, .not(.contains("let bundleName = \"tool_resources\"")))
                     XCTAssertMatch(contents.unsafeStringValue, .not(.contains("let bundleName = \"tools_resources\"")))


### PR DESCRIPTION
## Summary

- generate resource bundle accessor imports with explicit `internal` access
- cover both named and empty resource bundles

This is the SwiftBuild side of swiftlang/swift-package-manager#10163.

## Testing

- `swift test --filter PackageProductConstructionTests`
- reproduced the reported failure before the change
- verified the generated accessor builds with `-warnings-as-errors` after the change