### PR TITLE
Gate -final_output on deployment location, not postprocessing

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Ld.xcspec
@@ -785,7 +785,8 @@
                 Name = "LD_FINAL_OUTPUT_FILE";
                 Type = Path;
                 DefaultValue = "$(INSTALL_PATH)/$(EXECUTABLE_PATH)";
-                Condition = "$(DEPLOYMENT_POSTPROCESSING)  &&  !$(SKIP_INSTALL)  &&  $(INSTALL_PATH) != \"\"";
+                // -final_output is the product's install path, so gate it on deployment location, not postprocessing.
+                Condition = "$(DEPLOYMENT_LOCATION)  &&  !$(SKIP_INSTALL)  &&  $(INSTALL_PATH) != \"\"";
                 CommandLineArgs = {
                     "" = ();
                     "<<otherwise>>" = (

--- a/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/TaskConstructionTests.swift
@@ -10030,4 +10030,39 @@ fileprivate struct TaskConstructionTests: CoreBasedTests {
             }
         }
     }
+
+    /// `-final_output` is gated on deployment location, not postprocessing. rdar://182546393
+    @Test(.requireSDKs(.macOS))
+    func linkerFinalOutputGatedOnDeploymentLocation() async throws {
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup("Sources", children: [TestFile("main.c")]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "CODE_SIGNING_ALLOWED": "NO",
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "INSTALL_PATH": "/Library/Frameworks",
+                    "SKIP_INSTALL": "NO",
+                ]),
+            ],
+            targets: [
+                TestStandardTarget("Fwk", type: .framework, buildPhases: [TestSourcesBuildPhase(["main.c"])]),
+            ])
+        let core = try await getCore()
+        let tester = try TaskConstructionTester(core, testProject)
+        let finalOutput = ["-Xlinker", "-final_output", "-Xlinker", "/Library/Frameworks/Fwk.framework/Versions/A/Fwk"]
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["DEPLOYMENT_LOCATION": "YES", "DEPLOYMENT_POSTPROCESSING": "NO"]), runDestination: .macOS) { results in
+            results.checkTask(.matchRuleType("Ld")) { task in
+                task.checkCommandLineContainsUninterrupted(finalOutput)
+            }
+        }
+
+        await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug", overrides: ["DEPLOYMENT_LOCATION": "NO"]), runDestination: .macOS) { results in
+            results.checkTask(.matchRuleType("Ld")) { task in
+                task.checkCommandLineDoesNotContain("-final_output")
+            }
+        }
+    }
 }


### PR DESCRIPTION
-final_output records the product's install path, so it applies whenever the product is deployed not only when postprocessing runs. Under a deployed layout a build and a build-for-install are the same link task, and using DEPLOYMENT_POSTPROCESSING results in churn.

rdar://182546393
