### PR TITLE
Track InstallAPI header dependencies via tapi's discovered deps

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPITools.swift
@@ -71,7 +71,7 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
     }
 
     /// Construct a new task to run the TAPI tool.
-    public func constructTAPITasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, generatedTBDFiles: [Path], builtBinaryPath: Path? = nil, fileListPath: Path? = nil, dsymPath: Path? = nil) async {
+    public func constructTAPITasks(_ cbc: CommandBuildContext, _ delegate: any TaskGenerationDelegate, generatedTBDFiles: [Path], builtBinaryPath: Path? = nil, fileListPath: Path? = nil, dsymPath: Path? = nil, dependencyInfoPath: Path? = nil) async {
         let scope = cbc.scope
         let useOnlyFilelist = scope.evaluate(BuiltinMacros.TAPI_ENABLE_PROJECT_HEADERS) || scope.evaluate(BuiltinMacros.TAPI_USE_SRCROOT)
 
@@ -149,8 +149,12 @@ public final class TAPIToolSpec : GenericCommandLineToolSpec, GCCCompatibleCompi
             commandLine.append(contentsOf: ["--product-name=" + scope.evaluate(BuiltinMacros.PRODUCT_NAME)])
         }
 
+        if let dependencyInfoPath {
+            commandLine += ["-Xparser", "-MMD", "-Xparser", "-MF", "-Xparser", dependencyInfoPath.str]
+        }
+
         let outputs: [any PlannedNode] = [delegate.createNode(cbc.output)] + cbc.commandOrderingOutputs
-        delegate.createTask(type: self, ruleInfo: ruleInfo, commandLine: commandLine, environment: environmentFromSpec(cbc, delegate, lookup: lookup), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs, outputs: outputs, action: nil, execDescription: resolveExecutionDescription(cbc, delegate, lookup: lookup), enableSandboxing: enableSandboxing)
+        delegate.createTask(type: self, dependencyData: dependencyInfoPath.map { .makefile($0) }, ruleInfo: ruleInfo, commandLine: commandLine, environment: environmentFromSpec(cbc, delegate, lookup: lookup), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs, outputs: outputs, action: nil, execDescription: resolveExecutionDescription(cbc, delegate, lookup: lookup), enableSandboxing: enableSandboxing)
     }
 
     override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -814,6 +814,10 @@ func addCommonInstallAPITasks(_ producer: PhasedTaskProducer, _ scope: MacroEval
     }
 
     let variant = scope.evaluate(BuiltinMacros.CURRENT_VARIANT)
+    let dependencyInfoPath: Path? = destination == .builtProduct && !headerDependencyInputs.isEmpty
+        ? scope.evaluate(BuiltinMacros.TARGET_TEMP_DIR).join("\(scope.evaluate(BuiltinMacros.PRODUCT_NAME))-\(variant).installapi.d")
+        : nil
+
     // Add support for passing the built binary path, when building.
     let builtBinaryPath: Path?
     let dsymPath: Path?
@@ -830,7 +834,7 @@ func addCommonInstallAPITasks(_ producer: PhasedTaskProducer, _ scope: MacroEval
     let delegate = PhasedProducerBasedTaskGenerationDelegate(producer: producer, context: producer.context, taskOptions: destination.correspondingTaskOrderingOptions, staleFileRemovalScope: destination.staleFileRemovalScope, phaseStartNodes: phaseStartNodes, phaseEndTask: phaseEndTask)
 
     let swiftTBDFiles = producer.context.generatedTBDFiles(forVariant: variant)
-    await producer.context.tapiSpec.constructTAPITasks(CommandBuildContext(producer: producer.context, scope: scope, inputs: inputs, output: tapiOutputNode.path, commandOrderingInputs: dependencyInputs, commandOrderingOutputs: [tapiOrderingNode]), delegate, generatedTBDFiles: swiftTBDFiles, builtBinaryPath: builtBinaryPath, fileListPath: jsonPath, dsymPath: dsymPath)
+    await producer.context.tapiSpec.constructTAPITasks(CommandBuildContext(producer: producer.context, scope: scope, inputs: inputs, output: tapiOutputNode.path, commandOrderingInputs: dependencyInputs, commandOrderingOutputs: [tapiOrderingNode]), delegate, generatedTBDFiles: swiftTBDFiles, builtBinaryPath: builtBinaryPath, fileListPath: jsonPath, dsymPath: dsymPath, dependencyInfoPath: dependencyInfoPath)
 
     return delegate.tasks
 }

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -312,6 +312,47 @@ fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS))
+    func frameworkInstallAPIEmitsHeaderDependencies() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            sourceRoot: Path("/TEST"),
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [
+                    TestFile("Pub.h"),
+                    TestFile("Fwk.c")]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "CODE_SIGN_IDENTITY": "-",
+                    "INFOPLIST_FILE": "Info.plist",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "SUPPORTS_TEXT_BASED_API": "YES",
+                    "TAPI_EXEC": tapiToolPath.str,
+                    "TAPI_VERIFY_MODE": "ErrorsOnly",
+                    "TAPI_USE_SRCROOT": "NO",
+                    "SKIP_INSTALL": "NO"])],
+            targets: [
+                TestStandardTarget(
+                    "Fwk",
+                    type: .framework,
+                    buildPhases: [
+                        TestSourcesBuildPhase(["Fwk.c"]),
+                        TestHeadersBuildPhase([
+                            TestBuildFile("Pub.h", headerVisibility: .public)])])])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        let fs = PseudoFS()
+        try await fs.writePlist(Path("/TEST/Info.plist"), .plDict([:]))
+
+        await tester.checkBuild(BuildParameters(action: .install, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
+            results.checkNoDiagnostics()
+            results.checkTask(.matchRuleType("GenerateTAPI")) { task in
+                task.checkCommandLineMatches([.anySequence, "-Xparser", "-MMD", "-Xparser", "-MF", "-Xparser", .suffix("Fwk-normal.installapi.d"), .anySequence])
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func frameworkBasicsWithExtraSettings() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
Complement the per-file header nodes: tapi emits the headers it parsed as a discovered-dependency file, so GenerateTAPI reruns when any consumed header changes.

rdar://182482020