### PR TITLE
Tolerate symlinks in alternate linker selection test

### DIFF
--- a/Tests/SWBBuildSystemTests/LinkerTests.swift
+++ b/Tests/SWBBuildSystemTests/LinkerTests.swift
@@ -182,7 +182,7 @@ fileprivate struct LinkerTests: CoreBasedTests {
     /// * The clang output on Windows has paths that have double slashes, not
     ///   quite valid command quoted. i.e. "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC"
     ///   This needs to be taken into account.
-    @Test(.requireSDKs(.host))
+    @Test(.requireSDKs(.host), .skipInGitHubActions("GitHub actions runners symlink Xcode installs and break this test"))
     func alternateLinkerSelection() async throws {
         let runDestination: RunDestinationInfo = .host
         let swiftVersion = try await self.swiftVersion


### PR DESCRIPTION
New CI workflows symlink Xcode and break this test