### PR TITLE
Re-sign stubs injected into codeless frameworks

### DIFF
--- a/Sources/SWBCore/PlannedTaskAction.swift
+++ b/Sources/SWBCore/PlannedTaskAction.swift
@@ -173,6 +173,8 @@ public struct FileCopyTaskActionContext {
     public let stubPartialCompilerCommandLine: [String]
     public let stubPartialLinkerCommandLine: [String]
     public let stubPartialLipoCommandLine: [String]
+    public let stubPartialCodesignCommandLine: [String]
+    public let codesignEnvironment: [String: String]
     public let partialTargetValues: [String]
     public let llvmTargetTripleOSVersion: String
     public let llvmTargetTripleSuffix: String
@@ -180,11 +182,13 @@ public struct FileCopyTaskActionContext {
     public let swiftPlatformTargetPrefix: String
     public let isMacCatalyst: Bool
 
-    public init(skipAppStoreDeployment: Bool, stubPartialCompilerCommandLine: [String], stubPartialLinkerCommandLine: [String], stubPartialLipoCommandLine: [String], partialTargetValues: [String], llvmTargetTripleOSVersion: String, llvmTargetTripleSuffix: String, platformName: String, swiftPlatformTargetPrefix: String, isMacCatalyst: Bool) {
+    public init(skipAppStoreDeployment: Bool, stubPartialCompilerCommandLine: [String], stubPartialLinkerCommandLine: [String], stubPartialLipoCommandLine: [String], stubPartialCodesignCommandLine: [String], codesignEnvironment: [String: String], partialTargetValues: [String], llvmTargetTripleOSVersion: String, llvmTargetTripleSuffix: String, platformName: String, swiftPlatformTargetPrefix: String, isMacCatalyst: Bool) {
         self.skipAppStoreDeployment = skipAppStoreDeployment
         self.stubPartialCompilerCommandLine = stubPartialCompilerCommandLine
         self.stubPartialLinkerCommandLine = stubPartialLinkerCommandLine
         self.stubPartialLipoCommandLine = stubPartialLipoCommandLine
+        self.stubPartialCodesignCommandLine = stubPartialCodesignCommandLine
+        self.codesignEnvironment = codesignEnvironment
         self.partialTargetValues = partialTargetValues
         self.llvmTargetTripleOSVersion = llvmTargetTripleOSVersion
         self.llvmTargetTripleSuffix = llvmTargetTripleSuffix
@@ -215,7 +219,7 @@ public struct FileCopyTaskActionContext {
         }
     }
 
-    public func stubCommandLine(frameworkPath: Path, isDeepBundle: Bool, platformRegistry: PlatformRegistry, sdkRegistry: SDKRegistry, tempDir: Path) throws -> (compileAndLink: [(compile: [String], link: [String])], lipo: [String]) {
+    public func stubCommandLine(frameworkPath: Path, versionedSubdirectory: String?, platformRegistry: PlatformRegistry, sdkRegistry: SDKRegistry, tempDir: Path) throws -> (compileAndLink: [(compile: [String], link: [String])], lipo: [String], codesign: [String]?) {
         let platform = platformRegistry.lookup(name: platformName)
         let bundleSupportedPlatform: String?
         switch platform?.additionalInfoPlistEntries["CFBundleSupportedPlatforms"] as? PropertyListItem {
@@ -260,7 +264,9 @@ public struct FileCopyTaskActionContext {
                         link: stubPartialLinkerCommandLine + ["-target", "\(partialTargetValue)-\(targetTripleOSVersion)\(llvmTargetTripleSuffix)", "-install_name", stubInstallName, "-o", tempDir.join("\(partialTargetValue)").str, tempDir.join("\(partialTargetValue).o").str]
                     )
                 },
-            lipo: stubPartialLipoCommandLine + ["-output", frameworkPath.join(isDeepBundle ? "Versions/A" : nil).join(frameworkPath.basenameWithoutSuffix).str] + partialTargetValues.map { partialTargetValue in tempDir.join("\(partialTargetValue)").str }
+            lipo: stubPartialLipoCommandLine + ["-output", frameworkPath.join(versionedSubdirectory).join(frameworkPath.basenameWithoutSuffix).str] + partialTargetValues.map { partialTargetValue in tempDir.join("\(partialTargetValue)").str },
+            // The linker ad-hoc signs the stub using its temporary file name as the signature identifier. Downstream re-signing flows can capture that stale identifier into an explicit designated requirement while codesign itself re-derives the identifier from the bundle, producing signatures which fail App Store validation. Re-sign the bundle so that the stub's signature identifier is derived from the framework from the start.
+            codesign: stubPartialCodesignCommandLine.isEmpty ? nil : stubPartialCodesignCommandLine + [frameworkPath.join(versionedSubdirectory).str]
         )
     }
 }
@@ -280,9 +286,11 @@ extension FileCopyTaskActionContext {
 
         // If we couldn't find clang, skip the special stub binary handling. We may be using an Open Source toolchain which only has Swift. Also skip it for installLoc builds.
         if compilerPath.isEmpty || !compilerPath.isAbsolute || cbc.scope.evaluate(BuiltinMacros.BUILD_COMPONENTS).contains("installLoc") {
-            self.init(skipAppStoreDeployment: true, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false)
+            self.init(skipAppStoreDeployment: true, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], stubPartialCodesignCommandLine: [], codesignEnvironment: [:], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false)
             return
         }
+
+        let codesignPath = cbc.producer.codesignSpec.resolveExecutablePath(cbc.producer, Path(cbc.producer.codesignSpec.computeExecutablePath(cbc)))
 
         let scope = cbc.scope
 
@@ -306,6 +314,9 @@ extension FileCopyTaskActionContext {
             stubPartialCompilerCommandLine: [compilerPath.str] + stubPartialCommonCommandLine + ["-x", "c", "-c", Path.null.str],
             stubPartialLinkerCommandLine: [linkerPath.str] + stubPartialCommonCommandLine + ["-dynamiclib", "-Xlinker", "-adhoc_codesign"],
             stubPartialLipoCommandLine: [lipoPath.str, "-create"],
+            // The linker ad-hoc signs the injected stub regardless of code signing policy, so normalizing its signature identifier is deliberately not gated on CODE_SIGNING_ALLOWED: archives built without signing are still re-signed by distribution flows which derive designated requirements from the existing identifier.
+            stubPartialCodesignCommandLine: [codesignPath.str, "--force", "--sign", "-"],
+            codesignEnvironment: CodesignToolSpec.computeCodeSigningEnvironment(cbc),
             partialTargetValues: partialTargetValues,
             llvmTargetTripleOSVersion: llvmTargetTripleOSVersion,
             llvmTargetTripleSuffix: llvmTargetTripleSuffix,

--- a/Sources/SWBTaskExecution/TaskActions/FileCopyTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/FileCopyTaskAction.swift
@@ -32,11 +32,13 @@ public final class FileCopyTaskAction: TaskAction
 
     // Temporary workaround for the App Store
     public override func serialize<T: Serializer>(to serializer: T) {
-        serializer.beginAggregate(11)
+        serializer.beginAggregate(13)
         serializer.serialize(context.skipAppStoreDeployment)
         serializer.serialize(context.stubPartialCompilerCommandLine)
         serializer.serialize(context.stubPartialLinkerCommandLine)
         serializer.serialize(context.stubPartialLipoCommandLine)
+        serializer.serialize(context.stubPartialCodesignCommandLine)
+        serializer.serialize(context.codesignEnvironment)
         serializer.serialize(context.partialTargetValues)
         serializer.serialize(context.llvmTargetTripleOSVersion)
         serializer.serialize(context.llvmTargetTripleSuffix)
@@ -49,12 +51,14 @@ public final class FileCopyTaskAction: TaskAction
 
     // Temporary workaround for the App Store
     public required init(from deserializer: any Deserializer) throws {
-        try deserializer.beginAggregate(11)
+        try deserializer.beginAggregate(13)
         self.context = try .init(
             skipAppStoreDeployment: deserializer.deserialize(),
             stubPartialCompilerCommandLine: deserializer.deserialize(),
             stubPartialLinkerCommandLine: deserializer.deserialize(),
             stubPartialLipoCommandLine: deserializer.deserialize(),
+            stubPartialCodesignCommandLine: deserializer.deserialize(),
+            codesignEnvironment: deserializer.deserialize(),
             partialTargetValues: deserializer.deserialize(),
             llvmTargetTripleOSVersion: deserializer.deserialize(),
             llvmTargetTripleSuffix: deserializer.deserialize(),
@@ -110,7 +114,6 @@ public final class FileCopyTaskAction: TaskAction
             return .failed
         }
 
-        let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
         do {
             let commandLine = Array(task.commandLineAsStrings)
             let frameworkBasePath = commandLine.dropLast().last.map(Path.init)?.frameworkPath?.basename
@@ -120,10 +123,13 @@ public final class FileCopyTaskAction: TaskAction
             // Note: piggybacking on ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT since that really should just become a general purpose "skip App Store deployment things" setting.
             if !context.skipAppStoreDeployment, let frameworkBasePath, let frameworkPath = destinationPath?.join(frameworkBasePath), let bundle = Bundle(path: frameworkPath.str), bundle.executableIsMissingOrStatic(fs: executionDelegate.fs) == .codeless {
                 let isDeepBundle = executionDelegate.fs.isDirectory(frameworkPath.join("Versions"))
-                try await withTemporaryDirectory { tempDir in
-                    let commandLine = try context.stubCommandLine(frameworkPath: frameworkPath, isDeepBundle: isDeepBundle, platformRegistry: executionDelegate.platformRegistry, sdkRegistry: executionDelegate.sdkRegistry, tempDir: tempDir)
+                // Deep bundles are not required to use "A" as their framework version, so resolve the actual version directory from the "Current" symlink where possible. Only the basename is used so that absolute or multi-component symlink targets cannot produce a path outside the bundle.
+                let versionedSubdirectory: String? = isDeepBundle ? "Versions/\((try? executionDelegate.fs.readlink(frameworkPath.join("Versions/Current")))?.basename ?? "A")" : nil
+                let stubResult = try await withTemporaryDirectory { tempDir -> CommandResult in
+                    let stubCommands = try context.stubCommandLine(frameworkPath: frameworkPath, versionedSubdirectory: versionedSubdirectory, platformRegistry: executionDelegate.platformRegistry, sdkRegistry: executionDelegate.sdkRegistry, tempDir: tempDir)
+                    let stubCommandLines = stubCommands.compileAndLink.flatMap { [$0.compile, $0.link] } + [stubCommands.lipo] + (stubCommands.codesign.map { [$0] } ?? [])
 
-                    outputDelegate.emit(Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("Injecting stub binary into codeless framework"), childDiagnostics: (commandLine.compileAndLink.flatMap { [$0.compile, $0.link] } + [commandLine.lipo]).map { commandLine in
+                    outputDelegate.emit(Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData("Injecting stub binary into codeless framework"), childDiagnostics: stubCommandLines.map { commandLine in
                         Diagnostic(behavior: .note, location: .unknown, data: DiagnosticData(defaultCommandSequenceEncoder(hostOS: executionDelegate.hostOperatingSystem, unixEncodingStrategy: .singleQuotes).encode(commandLine)))
                     }))
 
@@ -132,17 +138,35 @@ public final class FileCopyTaskAction: TaskAction
                         try executionDelegate.fs.symlink(frameworkPath.join(frameworkPath.basenameWithoutSuffix), target: Path("Versions/Current/\(frameworkPath.basenameWithoutSuffix)"))
                     }
 
-                    for commandLine in commandLine.compileAndLink.flatMap({ [$0.compile, $0.link] }) + [commandLine.lipo] {
-                        try await spawn(commandLine: commandLine, environment: task.environment.bindingsDictionary, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+                    let environment = task.environment.bindingsDictionary
+                    // The signing environment only concerns codesign itself. The CODESIGN_ALLOCATE resolution computed at task construction takes precedence, matching the codesign tool spec, where the computed environment wins.
+                    let codesignEnvironment = environment.merging(context.codesignEnvironment) { _, computedValue in computedValue }
+                    for stubCommandLine in stubCommandLines {
+                        // Use a fresh delegate per command: a declined (cancelled) spawn invokes no delegate callbacks, so reusing one would surface the previous command's state.
+                        let processDelegate = TaskProcessDelegate(outputDelegate: outputDelegate)
+                        try await spawn(commandLine: stubCommandLine, environment: stubCommandLine == stubCommands.codesign ? codesignEnvironment : environment, workingDirectory: task.workingDirectory, dynamicExecutionDelegate: dynamicExecutionDelegate, clientDelegate: clientDelegate, processDelegate: processDelegate)
+                        if let error = processDelegate.executionError {
+                            outputDelegate.error(error)
+                            return .failed
+                        }
+                        let commandResult = processDelegate.commandResult ?? .failed
+                        if commandResult != .succeeded {
+                            if commandResult != .cancelled {
+                                outputDelegate.emitError("Failed to inject stub binary into codeless framework \(frameworkPath.basename)")
+                                // An earlier stub command may have already pinned a successful exit status on the output delegate; override it so the task is reported as failed.
+                                outputDelegate.updateResult(.exit(exitStatus: .exit(1), metrics: nil))
+                            }
+                            return commandResult
+                        }
                     }
+                    return .succeeded
+                }
+                if stubResult != .succeeded {
+                    return stubResult
                 }
             }
         } catch {
             outputDelegate.error(error.localizedDescription)
-            return .failed
-        }
-        if let error = processDelegate.executionError {
-            outputDelegate.error(error)
             return .failed
         }
 

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -3686,6 +3686,11 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
                                 #expect(minos == (runDestination.buildVersionPlatform(core) == .macCatalyst ? "minos 14.2" : "minos 11.0"))
                                 #expect(try Set(MachO(reader: BinaryReader(data: tester.fs.read(Path(frameworkPath)))).slices().map { $0.arch }) == ["arm64"])
                             }
+
+                            // Check that the injected stub was re-signed with the bundle-derived identifier rather than the linker's ad-hoc signature, whose temporary file name identifier breaks designated requirements computed by re-signing flows.
+                            let codesignOutput = try await runHostProcess(["/usr/bin/codesign", "--display", "--verbose", "\(frameworkDestinationDir)/AStaticFwk.framework"], interruptible: false)
+                            #expect(codesignOutput.contains("Identifier=com.apple.AStaticFwk"))
+                            #expect(!codesignOutput.contains("linker-signed"))
                         }
 
                         try results.checkTask(.matchRule(["Copy", "\(frameworkDestinationDir)/ADynamicFwk.framework", "\(tmpDirPath.str)/ADynamicFwk.framework"])) { task in
@@ -3785,6 +3790,89 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
 
             // Turn off the temporary App Store stub binary workaround
             try await checkBuild(overrides: ["ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT": "YES"])
+        }
+    }
+
+    /// Tests that the stub binary injected into codeless frameworks carries a bundle-derived signature identifier even when code signing is disallowed. Archives built without signing are still re-signed by distribution flows, which derive designated requirements from the existing identifier, so a stub left with the linker's temporary-file-name identifier is rejected by App Store validation.
+    @Test(.requireSDKs(.macOS, .iOS), .requireXcode27(), arguments: [.anyMac, .anyiOSDevice] as [RunDestinationInfo])
+    func codelessFrameworkStubSignatureNormalizationWithCodeSigningDisallowed(runDestination: RunDestinationInfo) async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let testWorkspace = TestWorkspace(
+                "Test",
+                sourceRoot: tmpDirPath.join("Test"),
+                projects: [
+                    TestProject(
+                        "aProject",
+                        groupTree: TestGroup(
+                            "Sources", path: "Sources", children: [
+                                TestFile("App.c"),
+                                TestFile("AStaticFwk.framework", path: tmpDirPath.join("AStaticFwk.framework").str, sourceTree: .absolute),
+                            ]),
+                        buildConfigurations: [TestBuildConfiguration(
+                            "Debug",
+                            buildSettings: [
+                                "CODE_SIGNING_ALLOWED": "NO",
+                                "PRODUCT_NAME": "$(TARGET_NAME)",
+                                "ALWAYS_SEARCH_USER_PATHS": "NO",
+                                "GENERATE_INFOPLIST_FILE": "YES",
+                                "FRAMEWORK_SEARCH_PATHS": "$(inherited) \(tmpDirPath.str)",
+                                "COPY_PHASE_STRIP": "NO",
+                                "SDKROOT": runDestination.sdk,
+                            ]
+                        )],
+                        targets: [
+                            TestStandardTarget(
+                                "App", type: .application,
+                                buildPhases: [
+                                    TestSourcesBuildPhase([
+                                        TestBuildFile("App.c")
+                                    ]),
+                                    TestFrameworksBuildPhase([
+                                        TestBuildFile("AStaticFwk.framework"),
+                                    ]),
+                                    TestCopyFilesBuildPhase([
+                                        TestBuildFile("AStaticFwk.framework", codeSignOnCopy: false, removeHeadersOnCopy: true),
+                                    ], destinationSubfolder: .frameworks, onlyForDeployment: false),
+                                ]),
+                        ])
+                ])
+            let core = try await self.getCore()
+            let tester = try await BuildOperationTester(core, testWorkspace, simulated: false)
+            let SRCROOT = testWorkspace.sourceRoot.join("aProject")
+
+            let platform = core.platformRegistry.lookup(name: runDestination.platform)
+            let bundleSupportedPlatforms = try #require(platform?.additionalInfoPlistEntries["CFBundleSupportedPlatforms"])
+
+            try await tester.fs.writeFramework(tmpDirPath.join("AStaticFwk.framework"), archs: ["arm64"], platform: #require(runDestination.buildVersionPlatform(core)), infoLookup: core, static: true) { _, _, _, resourcesDir in
+                try await tester.fs.writePlist(resourcesDir.join("Info.plist"), .plDict([
+                    "LSMinimumSystemVersion": "11.0",
+                    "MinimumOSVersion": "11.0",
+                    "CFBundleSupportedPlatforms": bundleSupportedPlatforms,
+                    "CFBundleIdentifier": "com.apple.AStaticFwk",
+                ]))
+            }
+
+            try await tester.fs.writeFileContents(SRCROOT.join("Sources/App.c")) { contents in
+                contents <<< "int main(void) {\n"
+                contents <<< "  return 0;\n"
+                contents <<< "}\n"
+            }
+
+            try await tester.checkBuild(runDestination: runDestination) { results in
+                results.checkNote(.prefix("Injecting stub binary into codeless framework"))
+                results.checkNoDiagnostics()
+            }
+
+            let frameworkDestinationDir: String
+            if runDestination.platform == "macosx" {
+                frameworkDestinationDir = "\(SRCROOT.str)/build/Debug\(runDestination.builtProductsDirSuffix(core: core))/App.app/Contents/Frameworks"
+            } else {
+                frameworkDestinationDir = "\(SRCROOT.str)/build/Debug\(runDestination.builtProductsDirSuffix(core: core))/App.app/Frameworks"
+            }
+
+            let codesignOutput = try await runHostProcess(["/usr/bin/codesign", "--display", "--verbose", "\(frameworkDestinationDir)/AStaticFwk.framework"], interruptible: false)
+            #expect(codesignOutput.contains("Identifier=com.apple.AStaticFwk"))
+            #expect(!codesignOutput.contains("linker-signed"))
         }
     }
 

--- a/Tests/SWBTaskExecutionTests/FileCopyTaskTests.swift
+++ b/Tests/SWBTaskExecutionTests/FileCopyTaskTests.swift
@@ -35,7 +35,7 @@ fileprivate struct FileCopyTaskTests {
             }
 
             // Set up the copy task and run it.
-            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
+            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], stubPartialCodesignCommandLine: [], codesignEnvironment: [:], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-copy", testDataDirPath.join("LoneFile.txt").str, tmpDir.str], workingDirectory: testDataDirPath, outputs: [], action: action, execDescription: "Copy File")
 
             let outputDelegate = MockTaskOutputDelegate()
@@ -74,7 +74,7 @@ fileprivate struct FileCopyTaskTests {
             }
 
             // Set up the copy task and run it.
-            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
+            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], stubPartialCodesignCommandLine: [], codesignEnvironment: [:], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-copy", testDataDirPath.join("SimpleDir").str, tmpDir.str], workingDirectory: testDataDirPath, outputs: [], action: action, execDescription: "Copy Directory")
 
             let outputDelegate = MockTaskOutputDelegate()
@@ -106,7 +106,7 @@ fileprivate struct FileCopyTaskTests {
             let testDataDirPath = try Path(#require(Bundle.module.resourceURL).appendingPathComponent("TestData").appendingPathComponent("FileCopyTask").path)
 
             // Set up the copy task and run it.
-            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
+            let action = FileCopyTaskAction(.init(skipAppStoreDeployment: false, stubPartialCompilerCommandLine: [], stubPartialLinkerCommandLine: [], stubPartialLipoCommandLine: [], stubPartialCodesignCommandLine: [], codesignEnvironment: [:], partialTargetValues: [], llvmTargetTripleOSVersion: "", llvmTargetTripleSuffix: "", platformName: "", swiftPlatformTargetPrefix: "", isMacCatalyst: false))
             let task = Task(forTarget: nil, ruleInfo: [], commandLine: ["builtin-copy", testDataDirPath.join("MissingFile.bogus").str, tmpDir.str], workingDirectory: testDataDirPath, outputs: [], action: action, execDescription: "Copy File")
 
             let outputDelegate = MockTaskOutputDelegate()


### PR DESCRIPTION
> [!IMPORTANT]  
> The below is produced by Claude and Codex, I have read it and it sounds reasonable to me but my knowledge of Swift Build and code signing is rather limited. I've confirmed using this change with Xcode 26 and 27 fixes the problem.
>
> If this is close to what you foresee the fix to be, I would be happy to make minor modifications. Otherwise, I've left 'Allow edits and access to secrets by maintainers' enabled.

# Description

When `FileCopyTaskAction` injects a stub into a codeless framework, the linker ad-hoc signs it using the temporary output filename as the signature identifier, for example `arm64-apple`.

Distribution signing flows can derive a designated requirement from that identifier before re-signing the framework. Since `codesign` then derives the real identifier from the framework bundle, the resulting requirement can become inconsistent and fail App Store validation with error 90035.

This change:

- Ad-hoc re-signs the framework after the stub has been compiled, linked, and combined, causing the identifier to be derived from the framework's `Info.plist`.
- Performs the normalization regardless of `CODE_SIGNING_ALLOWED`, because the linker creates its ad-hoc signature regardless of that setting and unsigned archives may be signed later.
- Uses the computed code-signing environment for the `codesign` invocation.
- Resolves deep-framework versions through `Versions/Current` instead of assuming `Versions/A`, while restricting the symlink result to its basename.
- Propagates failures from each stub-generation subprocess.

This does not change application signing or select a distribution identity. It only replaces the linker's signature on the generated stub with a regular ad-hoc framework signature.

## Tests

- Added `codelessFrameworkStubSignatureNormalizationWithCodeSigningDisallowed`, covering macOS and iOS device destinations.
- Extended `copiedFrameworkContentPruning` to verify the bundle-derived identifier and absence of the `linker-signed` flag.
- Updated `FileCopyTaskTests` for the additional task-action context.

The focused tests passed locally with Xcode 27 beta 5:

- New signature-normalization regression: 2/2
- `copiedFrameworkContentPruning`: 3/3
- `FileCopyTaskTests`: 3/3

Fixes #1663