### PR TITLE
Fix activeRunDestination_MultiPlatform_Target on Xcode 27

### DIFF
--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -5428,13 +5428,20 @@ import SWBTestSupport
                 "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator watchos watchsimulator",
             ],
             runDestination: .watchOS) { context, settings, scope in
+                let watchOSSDK = context.sdkRegistry.lookup("watchos")
                 #expect(settings.errors == [])
                 #expect(settings.warnings == [])
                 #expect(scope.evaluate(BuiltinMacros.PLATFORM_NAME) == "watchos")
                 #expect(scope.evaluate(BuiltinMacros.PLATFORM_FAMILY_NAME) == "watchOS")
-                #expect(scope.evaluate(BuiltinMacros.SDKROOT) == context.sdkRegistry.lookup("watchos")?.path)
+                #expect(scope.evaluate(BuiltinMacros.SDKROOT) == watchOSSDK?.path)
                 #expect(scope.evaluate(BuiltinMacros.ONLY_ACTIVE_ARCH))
-                #expect(Set(scope.evaluate(BuiltinMacros.ARCHS)) == Set(["arm64_32"]))
+
+                // arm64_32 is only supported for watchOS deployment targets below 27, so from
+                // Xcode 27 onwards the run destination's arm64_32 architecture is constrained out
+                // of ARCHS_STANDARD and resolves to its compatibility architecture, arm64.
+                let deploymentTarget = watchOSSDK?.defaultDeploymentTarget ?? Version(0)
+                let expectedArch = deploymentTarget < Version(27) ? "arm64_32" : "arm64"
+                #expect(Set(scope.evaluate(BuiltinMacros.ARCHS)) == Set([expectedArch]))
             }
     }
 


### PR DESCRIPTION
The test asserted that a watchOS device run destination resolves ARCHS to `arm64_32`. Since the arm64_32 architecture spec in watchOSDevice.xcspec gained `DeploymentTargetRange = ( "0", "27" )`,
`Settings.addStandardArchitecturesOverride` constrains arm64_32 out of ARCHS_STANDARD at watchOS deployment targets of 27 or later, leaving its compatibility architecture `arm64`.

Derive the expected architecture from the watchOS SDK's default deployment target so the test asserts the exact value on either side of that cutoff.