### PR TITLE
Skip the Metal tests on arm64 hosts

### DIFF
--- a/Tests/SWBBuildSystemTests/BuildCommandTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildCommandTests.swift
@@ -408,7 +408,7 @@ fileprivate struct BuildCommandTests: CoreBasedTests {
         }
     }
 
-    @Test(.requireSDKs(.macOS), .requireXcode16(), .skipInGitHubActions("Metal toolchain is not installed on GitHub runners"))
+    @Test(.requireSDKs(.macOS), .requireXcode16(), .bug("rdar://185931146"), .skipInGitHubActions("Metal toolchain is not installed on GitHub runners"), .disabled(if: Architecture.hostStringValue == "arm64", "Metal toolchain is not installed on arm64 CI hosts"))
     func singleFileCompileMetal() async throws {
         let core = try await Self.makeCore(configurationDelegate: TestingCoreConfigurationDelegate(loadMetalToolchain: true))
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in

--- a/Tests/SWBBuildSystemTests/BuildOperationTests.swift
+++ b/Tests/SWBBuildSystemTests/BuildOperationTests.swift
@@ -6246,7 +6246,7 @@ That command depends on command in Target 'agg2' (project \'aProject\'): script 
         }
     }
 
-    @Test(.requireSDKs(.macOS), .skipInGitHubActions("Metal toolchain is not installed on GitHub runners"))
+    @Test(.requireSDKs(.macOS), .bug("rdar://185931146"), .skipInGitHubActions("Metal toolchain is not installed on GitHub runners"), .disabled(if: Architecture.hostStringValue == "arm64", "Metal toolchain is not installed on arm64 CI hosts"))
     func incrementalMetalLinkWithCodeSign() async throws {
         let core = try await Self.makeCore(configurationDelegate: TestingCoreConfigurationDelegate(loadMetalToolchain: true))
         try await withTemporaryDirectory { tmpDirPath async throws -> Void in


### PR DESCRIPTION
The arm64 CI hosts do not currently have Metal toolchain installed. Skip `singleFileCompileMetal` and `incrementalMetalLinkWithCodeSign` on arm64 hosts to unblock CI, alongside the existing skip for GitHub runners,
tracked by rdar://185931146.