### PR TITLE
Clear failed PIF transfer so it doesn't block later transfers

### DIFF
--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -383,6 +383,8 @@ private struct TransferSessionPIFMsg: MessageHandler {
             throw StubError.error("unable to load transferred PIF: \(error)")
 
         case .auditFailed(let diff):
+            // Clear the operation so this failed transfer doesn't block subsequent ones.
+            operation.cancel()
             // this string is checked for on the IDE side.
             throw StubError.error("incremental PIF transfer did not produce the right contents. Diff: \(diff)")
 
@@ -496,8 +498,9 @@ private struct IncrementalPIFRetransmissionMsg: MessageHandler {
             throw MsgHandlingError("no PIF transfer has been initiated")
         }
 
-        // If we didn't load anything from cache, just return failure.
+        // If we didn't load anything from cache, clear the operation and just return failure.
         if !currentPIFOperation.loadingSession.didUseCache {
+            currentPIFOperation.cancel()
             throw MsgHandlingError("unable to load transferred PIF: \(message.diagnostic)")
         }
 

--- a/Tests/SwiftBuildTests/PIFTests.swift
+++ b/Tests/SwiftBuildTests/PIFTests.swift
@@ -117,6 +117,12 @@ fileprivate struct PIFTests {
                 await #expect(throws: (any Error).self) {
                     try await testSession.sendPIFIncrementally(workspace, auditWorkspace: auditWorkspace)
                 }
+
+                do {
+                    _ = try await testSession.sendPIFIncrementally(workspace, auditWorkspace: auditWorkspace)
+                } catch {
+                    #expect(!"\(error)".contains("operation in progress"))
+                }
             }
         }
     }
@@ -225,6 +231,60 @@ fileprivate struct PIFTests {
     }
 
     typealias LookupObject = (@Sendable (SwiftBuildServicePIFObjectType, String) async throws -> SWBPropertyListItem)
+
+    @Test
+    func incrementalPIFLookupFailureCancelsOperation() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            try await withAsyncDeferrable { deferrable in
+                let workspaceSignature = "abc"
+                let projectSignature = "proj"
+
+                let workspace = [
+                    "signature": .plString(workspaceSignature),
+                    "type": "workspace",
+                    "contents": [
+                        "guid": "W1",
+                        "name": "WS",
+                        "path": "/foo/bar",
+                        "projects": [
+                            .plString(projectSignature)
+                        ],
+                    ]
+                ] as SWBPropertyListItem
+
+                @Sendable func lookup(_ objectType: SwiftBuildServicePIFObjectType, _ signature: String) async throws -> SWBPropertyListItem {
+                    switch signature {
+                    case workspaceSignature:
+                        return workspace
+                    default:
+                        throw StubError.error("PIF object has been invalidated")
+                    }
+                }
+
+                let testSession = try await TestSWBSession(temporaryDirectory: temporaryDirectory)
+                await deferrable.addBlock {
+                    await #expect(throws: Never.self) {
+                        try await testSession.close()
+                    }
+                }
+
+                await #expect(performing: {
+                    try await testSession.session.sendPIF(workspaceSignature: workspaceSignature, lookupObject: lookup)
+                }, throws: { error in
+                    "\(error)".contains("unable to load transferred PIF: PIF object has been invalidated")
+                })
+
+                // Ensure a second attempt should show the same failure, not "operation in progress".
+                await #expect(performing: {
+                    try await testSession.session.sendPIF(workspaceSignature: workspaceSignature, lookupObject: lookup)
+                }, throws: { error in
+                    let description = "\(error)"
+                    return description.contains("unable to load transferred PIF: PIF object has been invalidated")
+                        && !description.contains("operation in progress")
+                })
+            }
+        }
+    }
 
     /// Check incremental PIF transfer.
     @Test(.skipHostOS(.windows), .userDefaults(["EnablePluginManagerLogging": "0"]))


### PR DESCRIPTION
A PIF transfer that failed on the no-cache retransmission or audit-mismatch paths left the session's operation set so every later transfer failed with "unable to initiate PIF transfer session (operation in progress?)"

rdar://185918980
