### PR TITLE
[6.4.x] Avoid computing product names in the wrong context when resolving implicit dependencies

### DIFF
--- a/Sources/SWBApplePlatform/InterfaceBuilderShared.swift
+++ b/Sources/SWBApplePlatform/InterfaceBuilderShared.swift
@@ -77,7 +77,7 @@ extension IbtoolCompilerSupport {
                             }
 
                             if let fileType = cbc.producer.lookupFileType(reference: fileRef), let stringFileType = cbc.producer.lookupFileType(identifier: "text.plist.strings"), fileType.conformsTo(stringFileType) {
-                                let absolutePath = cbc.producer.filePathResolver.resolveAbsolutePath(fileRef)
+                                let absolutePath = cbc.producer.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
                                 result.append((absolutePath, region))
                             }
                         }

--- a/Sources/SWBCore/BuildFileFilteringContext.swift
+++ b/Sources/SWBCore/BuildFileFilteringContext.swift
@@ -71,7 +71,7 @@ extension PathResolvingBuildFileFilteringContext {
 
     /// Returns the resolved absolute path of the header entry, or `nil` if the file is excluded by platform filters.
     public func path(header: TargetHeaderInfo.Entry) -> Path? {
-        let path = filePathResolver.resolveAbsolutePath(header.fileReference)
+        let path = filePathResolver.resolveAbsolutePath(header.fileReference, resolveParameterizedProductName: false)
         if isExcluded(path, filters: header.platformFilters) {
             return nil
         }

--- a/Sources/SWBCore/BuildFileResolution.swift
+++ b/Sources/SWBCore/BuildFileResolution.swift
@@ -103,10 +103,10 @@ extension BuildFileResolution {
             // Variant groups always resolve the path and file type of the first reference.
             // FIXME: This is historical, and should be cleaned up by making the input model more explicit. This also isn't exactly what Xcode would do, which is very risky. It is possible that we should extend Xcode to pass this information down with the top-level variant group itself. (This FIXME is from 2017 and was ported from TaskProducer.)
         case let asVariantGroup as VariantGroup where !asVariantGroup.children.isEmpty:
-            absolutePath = settingsForRef.filePathResolver.resolveAbsolutePath(asVariantGroup.children[0])
+            absolutePath = settingsForRef.filePathResolver.resolveAbsolutePath(asVariantGroup.children[0], resolveParameterizedProductName: true)
             fileType = specLookupContext.lookupFileType(reference: asVariantGroup.children[0])
         default:
-            absolutePath = settingsForRef.filePathResolver.resolveAbsolutePath(reference)
+            absolutePath = settingsForRef.filePathResolver.resolveAbsolutePath(reference, resolveParameterizedProductName: true)
             fileType = specLookupContext.lookupFileType(reference: reference)
         }
 

--- a/Sources/SWBCore/BuildRequestContext.swift
+++ b/Sources/SWBCore/BuildRequestContext.swift
@@ -215,7 +215,7 @@ extension BuildRequestContext {
                 return try workspace.resolveBuildableItemReference(buildFile.buildableItem)
             }) {
                 for ref in buildableReferences {
-                    let sourceCodeFile = settings.filePathResolver.resolveAbsolutePath(ref)
+                    let sourceCodeFile = settings.filePathResolver.resolveAbsolutePath(ref, resolveParameterizedProductName: false)
                     sourceCodeFileToBuildableReference[sourceCodeFile] = ref
                 }
             }

--- a/Sources/SWBCore/DependencyResolution.swift
+++ b/Sources/SWBCore/DependencyResolution.swift
@@ -610,7 +610,7 @@ extension SpecializationParameters {
     nonisolated func resolveBuildFilePath(_ buildFile: BuildFile, settings: Settings, dynamicallyBuildingTargets: Set<Target>) -> Path? {
         // FIXME: This is normalizing over file references and product references, but that doesn't make any sense in the context of resolving implicit dependencies. It would make much more sense for us to directly interpret the target relationship when dealing with a build file which directly references a target, rather than do so via path expansion.
         guard let reference = try? workspaceContext.workspace.resolveBuildableItemReference(buildFile.buildableItem, dynamicallyBuildingTargets: dynamicallyBuildingTargets) else { return nil }
-        return settings.filePathResolver.resolveAbsolutePath(reference)
+        return settings.filePathResolver.resolveAbsolutePath(reference, resolveParameterizedProductName: false)
     }
 
     /// Return the configured version(s) of a top-level target. For a normal build it will return only one version but for the index-build it may return multiple, one for each of the target's supported platforms.

--- a/Sources/SWBCore/ProjectModel/FilePathResolver.swift
+++ b/Sources/SWBCore/ProjectModel/FilePathResolver.swift
@@ -42,21 +42,24 @@ public final class FilePathResolver: Sendable
     }
 
     /// Resolve and return the absolute path for a Reference.
-    public func resolveAbsolutePath(_ reference: Reference) -> Path
+    public func resolveAbsolutePath(
+        _ reference: Reference,
+        resolveParameterizedProductName: Bool
+    ) -> Path
     {
         // If this is a FileGroup, look it up in the cache.
         if let fileGroup = reference as? FileGroup
         {
             return fileGroupCache.getOrInsert(fileGroup) {
-                return computeAbsolutePath(fileGroup)
+                return computeAbsolutePath(fileGroup, resolveParameterizedProductName: resolveParameterizedProductName)
             }
         }
 
-        return computeAbsolutePath(reference)
+        return computeAbsolutePath(reference, resolveParameterizedProductName: resolveParameterizedProductName)
     }
 
     /// Computes the absolute path for a Reference and returns it.  This method does no memoizing of the result, so resolveAbsolutePath() is the preferred client method.
-    private func computeAbsolutePath(_ reference: Reference) -> Path
+    private func computeAbsolutePath(_ reference: Reference, resolveParameterizedProductName: Bool) -> Path
     {
         // Evaluate the path for the reference.
         switch reference
@@ -83,7 +86,11 @@ public final class FilePathResolver: Sendable
                 sourceTreePath = resolveSourceTree(.buildSetting("TARGET_BUILD_DIR"), forReference: reference)
             }
 
-            return sourceTreePath.join(productReference.evaluatedName(scope: scope))
+            if resolveParameterizedProductName {
+                return sourceTreePath.join(productReference.evaluatedName(scope: scope))
+            } else {
+                return sourceTreePath.join(productReference.name)
+            }
 
         default:
             preconditionFailure("Cannot resolve the path for a \(type(of: reference))")
@@ -103,7 +110,9 @@ public final class FilePathResolver: Sendable
 
         case .groupRelative:
             // The reference is group-relative, so the source tree is the path of the Reference's parent.
-            let parentPath = (reference as? GroupTreeReference)?.parent.map(resolveAbsolutePath)
+            let parentPath = (reference as? GroupTreeReference)?.parent.map { parent in
+                resolveAbsolutePath(parent, resolveParameterizedProductName: false)
+            }
 
             // If we couldn't get a path for the parent (e.g., because there isn't a parent), then default to the value of $(PROJECT_DIR).
             return parentPath ?? projectDir

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3052,7 +3052,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             //
             // FIXME: It is unfortunate that we need to create a custom file path resolver just for this case (which will not use any cached values). This is also unfortunate from a user perspective, as it is not at all clear what settings could be used in an xcconfig file path. We should consider defining this more formally in a way that can also efficiently be evaluated.
             let resolver = FilePathResolver(scope: createScope(sdkToUse: sdk))
-            let path = resolver.resolveAbsolutePath(configFileRef)
+            let path = resolver.resolveAbsolutePath(configFileRef, resolveParameterizedProductName: false)
             inputPathsAffectingSettings.append(path)
 
             // Load and push a settings table from the file.
@@ -3288,7 +3288,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             //
             // FIXME: It is unfortunate that we need to create a custom file path resolver just for this case. See the similar comment for adding project settings.
             let resolver = FilePathResolver(scope: createScope(sdkToUse: sdk))
-            let path = resolver.resolveAbsolutePath(configFileRef)
+            let path = resolver.resolveAbsolutePath(configFileRef, resolveParameterizedProductName: false)
             inputPathsAffectingSettings.append(path)
 
             // Load and push a settings table from the file.
@@ -5590,7 +5590,7 @@ private class SettingsBuilder: ProjectMatchLookup {
             }
 
             // Note that we intentionally don't check this with a filtering context because we are already using these paths in the context of analyzing the validity of EXCLUDED/INCLUDED_SOURCE_FILE_NAMES.
-            return resolver.resolveAbsolutePath(fileRef)
+            return resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
         }
 
         _xcstringsPathsInTarget = paths

--- a/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
+++ b/Sources/SWBCore/SpecImplementations/CommandLineToolSpec.swift
@@ -1105,7 +1105,7 @@ open class CommandLineToolSpec : PropertyDomainSpec, SpecType, TaskTypeDescripti
             if case .reference(let guid)? = first.buildFile?.buildableItem {
                 var ref = cbc.producer.lookupReference(for: guid)
                 func matchesPath(_ ref: Reference) -> Bool {
-                    return cbc.producer.filePathResolver.resolveAbsolutePath(ref) == first.absolutePath
+                    return cbc.producer.filePathResolver.resolveAbsolutePath(ref, resolveParameterizedProductName: true) == first.absolutePath
                 }
                 // Deconstruct variant groups.
                 //

--- a/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift
@@ -3557,7 +3557,7 @@ public extension BuildPhaseWithBuildFiles {
                   let reference = referenceLookupContext.lookupReference(for: guid),
                   let fileRef = reference as? FileReference else { return false }
 
-            let path = filePathResolver.resolveAbsolutePath(fileRef)
+            let path = filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
             guard !filteringContext.isExcluded(path, filters: buildFile.platformFilters) else { return false }
 
             // FIXME: We should bind file type identifiers at project load time, and reject unknown ones.

--- a/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/TAPISymbolExtractor.swift
@@ -231,12 +231,12 @@ final public class TAPISymbolExtractor: GenericCompilerSpec, GCCCompatibleCompil
                       fileType.conformsTo(cFamilySourceFileType)
                 else { continue }
 
-                let path = cbc.producer.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = cbc.producer.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
                 sourceFileDirnames.insert(path.dirname.str)
             }
 
             let headersMatchingSourceFilesInThisProject = projectInfo.knownHeaders.filter {
-                let headerPath = cbc.producer.filePathResolver.resolveAbsolutePath($0)
+                let headerPath = cbc.producer.filePathResolver.resolveAbsolutePath($0, resolveParameterizedProductName: false)
 
                 return sourceFileDirnames.contains(headerPath.dirname.str)
             }

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift
@@ -488,7 +488,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                     guard currentPlatformFilter.matches(buildFile.platformFilters) else { continue }
                     guard case .reference(let referenceGUID) = buildFile.buildableItem else { continue }
                     guard let reference = workspaceContext.workspace.lookupReference(for: referenceGUID) else { continue }
-                    let resolvedPath = settings.filePathResolver.resolveAbsolutePath(reference)
+                    let resolvedPath = settings.filePathResolver.resolveAbsolutePath(reference, resolveParameterizedProductName: false)
                     // TODO: Remove the fileExtension check once SwiftPM has been updated to consistently set the file type on artifact bundle references in PIF
                     if resolvedPath.fileExtension == "artifactbundle" || specLookupContext.lookupFileType(reference: reference)?.conformsTo(artifactBundleFileType) == true {
                         do {
@@ -1259,7 +1259,7 @@ package final class GlobalProductPlan: GlobalTargetInfoProvider
                         // private headers, it will work fine, it will just be weird.
                         if let reference = workspace.lookupReference(for: guid) {
                             if specLookupContext.lookupFileType(reference: reference)?.conformsToAny(headerFileTypes) ?? false {
-                                let path = settings.filePathResolver.resolveAbsolutePath(reference)
+                                let path = settings.filePathResolver.resolveAbsolutePath(reference, resolveParameterizedProductName: false)
                                 let basename = path.basenameWithoutSuffix
                                 let exactMatch = basename == moduleName
                                 if exactMatch || (basename.caseInsensitiveCompare(moduleName) == .orderedSame) {

--- a/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
+++ b/Sources/SWBTaskConstruction/ProductPlanning/ProductPlanner.swift
@@ -125,7 +125,7 @@ private struct ProductPlanBuilder
         var path = Path("placeholder")
         if let standardTarget = self.configuredTarget.target as? StandardTarget
         {
-            path = taskProducerContext.settings.filePathResolver.resolveAbsolutePath(standardTarget.productReference)
+            path = taskProducerContext.settings.filePathResolver.resolveAbsolutePath(standardTarget.productReference, resolveParameterizedProductName: true)
         }
 
         // Have the target create its task producers.

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/HeadermapTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/HeadermapTaskProducer.swift
@@ -139,7 +139,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
 
             func addEntry(_ fileRef: FileReference) {
                 // FIXME: This is not the right context to evaluate the path in, but what is?
-                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
 
                 // In order to match Xcode exactly, we guarantee that we always use the name from the first target.
                 if !installedHeaderProductNames.contains(path) {
@@ -156,7 +156,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
         // Add all of the project header entries.
         for fileRef in projectInfo.knownHeaders {
             // FIXME: This is not the right context to evaluate the path in, but what is?
-            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
             let basename = path.basename
 
             // If this is an installed header, then map it recursively. This will resolve to a later entry in the "all targets" headermap, or it will be resolved via the VFS (we hope).
@@ -205,7 +205,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
         func addProductRelativeEntry(_ fileRef: FileReference) {
             // Add an entry for a public/private header:
             //   Header.h -> <PRODUCT_NAME>/Header.h
-            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
             let basename = path.basename
             guard !alreadyAddedBasenames.contains(basename) else { return }
             hmap.insert(Path(basename), value: Path(targetProductName).join(basename))
@@ -215,7 +215,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
             // Add two entries for a project header:
             //   Header.h -> source path
             //   <PRODUCT_NAME>/Header.h -> source path
-            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+            let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
             let basename = path.basename
             guard !alreadyAddedBasenames.contains(basename) else { return }
             hmap.insert(Path(basename), value: path)
@@ -295,7 +295,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
                 // Add an entry: <PRODUCT_NAME>/Header.h -> source path
                 //
                 // FIXME: This isn't the correct file resolver to use.
-                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
                 let basename = path.basename
                 let key = Path(targetProductName).join(basename)
 
@@ -370,7 +370,7 @@ final class HeadermapTaskProducer: PhasedTaskProducer, TaskProducer {
                 // Add an entry: <PRODUCT_NAME>/Header.h -> source path
                 //
                 // FIXME: This isn't the correct file resolver to use.
-                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
                 hmap.insert(Path(targetProductName).join(path.basename), value: path)
             }
             targetInfo.publicHeaders.map(\.fileReference).forEach(addEntry)

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/TAPISymbolExtractorTaskProducer.swift
@@ -201,7 +201,7 @@ final class TAPISymbolExtractorTaskProducer: PhasedTaskProducer, TaskProducer {
             func computeProductHeader(for fileRef: SWBCore.FileReference, isFramework: Bool, visibility: TAPIFileList.HeaderVisibility, inputNodes: inout [any PlannedNode]) -> TAPIFileList.HeaderInfo? {
                 // The JSON file should have the product headers, not the source headers, so we need to compute the output path.
                 // FIXME: We should be able to get this info from - or at least share it with - the HeadersTaskProducer.
-                let path = producer.context.settings.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = producer.context.settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
 
                 let language: String?
                 if let languageDialect = producer.context.lookupFileType(reference: fileRef)?.languageDialect, GCCCompatibleLanguageDialect.allCLanguages.contains(languageDialect) {

--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/HeadermapVFSTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/HeadermapVFSTaskProducer.swift
@@ -154,7 +154,7 @@ extension TaskProducerContext {
                 // Compute the header path.
                 //
                 // FIXME: This isn't the correct file resolver to use.
-                let path = settings.filePathResolver.resolveAbsolutePath(fileRef)
+                let path = settings.filePathResolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: false)
 
                 // Compute the installed header path.
                 let installPath = installDir.join(path.basename)

--- a/Tests/SWBCorePerfTests/FilePathResolverPerfTests.swift
+++ b/Tests/SWBCorePerfTests/FilePathResolverPerfTests.swift
@@ -61,7 +61,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
                 let resolver = FilePathResolver(scope: self.scope)
 
                 // Resolve the path.
-                let resolvedPath = resolver.resolveAbsolutePath(rootGroup)
+                let resolvedPath = resolver.resolveAbsolutePath(rootGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/SomeProject"))
             }
         }
@@ -77,7 +77,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
             for _ in 1...100000
             {
                 // Resolve the path using the resolver property so that all but the first resolution uses its file group cache.
-                let resolvedPath = self.resolver.resolveAbsolutePath(rootGroup)
+                let resolvedPath = self.resolver.resolveAbsolutePath(rootGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/SomeProject"))
             }
         }
@@ -96,7 +96,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
                 let resolver = FilePathResolver(scope: self.scope)
 
                 // Resolve the path.
-                let resolvedPath = resolver.resolveAbsolutePath(rootGroup)
+                let resolvedPath = resolver.resolveAbsolutePath(rootGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/AbsolutePath"))
             }
         }
@@ -117,7 +117,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
                 let resolver = FilePathResolver(scope: self.scope)
 
                 // Resolve the path.
-                let resolvedPath = resolver.resolveAbsolutePath(childGroup)
+                let resolvedPath = resolver.resolveAbsolutePath(childGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/SomeProject/AllFiles"))
             }
         }
@@ -140,7 +140,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
                 let resolver = FilePathResolver(scope: self.scope)
 
                 // Resolve the path.
-                let resolvedPath = resolver.resolveAbsolutePath(grandchildGroup)
+                let resolvedPath = resolver.resolveAbsolutePath(grandchildGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/SomeProject/AllFiles/SomeFiles"))
             }
         }
@@ -160,7 +160,7 @@ fileprivate struct FilePathResolverPerfTests: PerfTests {
             for _ in 1...100000
             {
                 // Resolve the path using the resolver property so that all but the first resolution uses its file group cache.
-                let resolvedPath = self.resolver.resolveAbsolutePath(grandchildGroup)
+                let resolvedPath = self.resolver.resolveAbsolutePath(grandchildGroup, resolveParameterizedProductName: true)
                 #expect(resolvedPath == Path("/tmp/SomeProject/AllFiles/SomeFiles"))
             }
         }

--- a/Tests/SWBCoreTests/FilePathResolverTests.swift
+++ b/Tests/SWBCoreTests/FilePathResolverTests.swift
@@ -69,7 +69,7 @@ import SWBMacro
         let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/SomeProject/ClassOne.m"))
     }
 
@@ -95,16 +95,16 @@ import SWBMacro
             let grandchildGroup = try #require(childGroup.children[0] as? FileGroup)
             let variantGroupRef = try #require(childGroup.children[3] as? VariantGroup)
             let resolvedPaths = [
-                resolver.resolveAbsolutePath(rootGroup),
-                resolver.resolveAbsolutePath(childGroup),
-                resolver.resolveAbsolutePath(grandchildGroup),
-                resolver.resolveAbsolutePath(try #require(grandchildGroup.children[0] as? FileReference)),
-                resolver.resolveAbsolutePath(try #require(grandchildGroup.children[1] as? FileReference)),
-                resolver.resolveAbsolutePath(try #require(childGroup.children[1] as? FileReference)),
-                resolver.resolveAbsolutePath(try #require(childGroup.children[2] as? FileReference)),
-                resolver.resolveAbsolutePath(variantGroupRef),
-                resolver.resolveAbsolutePath(try #require(variantGroupRef.children[0] as? FileReference)),
-                resolver.resolveAbsolutePath(try #require(variantGroupRef.children[1] as? FileReference)),
+                resolver.resolveAbsolutePath(rootGroup, resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(childGroup, resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(grandchildGroup, resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(grandchildGroup.children[0] as? FileReference), resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(grandchildGroup.children[1] as? FileReference), resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(childGroup.children[1] as? FileReference), resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(childGroup.children[2] as? FileReference), resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(variantGroupRef, resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(variantGroupRef.children[0] as? FileReference), resolveParameterizedProductName: true),
+                resolver.resolveAbsolutePath(try #require(variantGroupRef.children[1] as? FileReference), resolveParameterizedProductName: true),
             ];
             let expectedPaths = [
                 Path.root.join("tmp/SomeProject"),
@@ -128,7 +128,7 @@ import SWBMacro
         let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/RelativeDir/ClassTwo.m"))
     }
 
@@ -139,7 +139,7 @@ import SWBMacro
 
         // Get the absolute path for the reference and test it.
         // An empty source tree is
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/ClassThree.m"))
     }
 
@@ -149,7 +149,7 @@ import SWBMacro
         let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/ClassFour.m"))
     }
 
@@ -160,7 +160,7 @@ import SWBMacro
 
         // Get the absolute path for the reference and test it.
         // An empty source tree is
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/ClassThree.m"))
     }
 
@@ -170,7 +170,7 @@ import SWBMacro
         let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/Sources/Arch_x86_64/ClassFive.m"))
     }
 
@@ -180,7 +180,7 @@ import SWBMacro
         let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
         // Get the absolute path for the reference and test it.
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/Sources/ClassSix.m"))
     }
 
@@ -199,7 +199,7 @@ import SWBMacro
         let childGroup = try #require(rootGroup.children[0] as? FileGroup)
         let grandchildGroup = try #require(childGroup.children[0] as? FileGroup)
         let fileRef = try #require(grandchildGroup.children[0] as? FileReference)
-        let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+        let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/OtherFiles/Resource.txt"))
     }
 
@@ -210,7 +210,7 @@ import SWBMacro
 
         // Get the absolute path for the productreference and test it.
         let productReference = target.productReference
-        let resolvedPath = resolver.resolveAbsolutePath(productReference)
+        let resolvedPath = resolver.resolveAbsolutePath(productReference, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/build/Debug/anApp.app"))
     }
 
@@ -227,7 +227,7 @@ import SWBMacro
         let target = try #require(Target.create(model, pifLoader, signature: "Mock") as? StandardTarget)
 
         // The product reference name "$(PRODUCT_NAME).app" should resolve to "MyApp.app".
-        let resolvedPath = resolver.resolveAbsolutePath(target.productReference)
+        let resolvedPath = resolver.resolveAbsolutePath(target.productReference, resolveParameterizedProductName: true)
         #expect(resolvedPath == Path.root.join("tmp/SomeProject/build/Debug/MyApp.app"))
     }
 
@@ -244,7 +244,7 @@ import SWBMacro
             let fileRef = try #require(Reference.create(model, pifLoader, isRoot: true) as? FileReference)
 
             // Get the absolute path for the reference and test it.
-            let resolvedPath = resolver.resolveAbsolutePath(fileRef)
+            let resolvedPath = resolver.resolveAbsolutePath(fileRef, resolveParameterizedProductName: true)
             #expect(resolvedPath.normalize().str == expectedPathString)
         }
     }

--- a/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
+++ b/Tests/SWBCoreTests/TargetDependencyResolverTests.swift
@@ -2994,6 +2994,83 @@ fileprivate enum TargetPlatformSpecializationMode {
         delegate.checkNoDiagnostics()
     }
 
+    @Test(.requireSDKs(.macOS))
+    func implicitDependencyDoesNotEvaluateProductReferenceNameInLinkingTargetContext() async throws {
+        let core = try await getCore()
+        let workspace = try TestWorkspace(
+            "Workspace",
+            projects: [
+                TestProject(
+                    "P1",
+                    groupTree: TestGroup("G1", children: []),
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [:]),
+                    ],
+                    targets: [
+                        TestStandardTarget(
+                            "Tool1",
+                            type: .commandLineTool,
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "tool"]),
+                            ],
+                            buildPhases: [
+                                TestFrameworksBuildPhase([TestBuildFile(.target("Lib"))]),
+                            ],
+                            dependencies: ["Lib"]
+                        ),
+                        TestStandardTarget(
+                            "Tool2",
+                            type: .commandLineTool,
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "tool"]),
+                            ],
+                            buildPhases: [
+                                TestFrameworksBuildPhase([TestBuildFile(.target("Lib"))]),
+                            ],
+                            dependencies: ["Lib"]
+                        ),
+                    ]
+                ),
+                TestProject(
+                    "P2",
+                    groupTree: TestGroup("G2", children: []),
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [:]),
+                    ],
+                    targets: [
+                        TestStandardTarget(
+                            "Lib",
+                            type: .framework,
+                            buildConfigurations: [
+                                TestBuildConfiguration("Debug", buildSettings: ["PRODUCT_NAME": "Lib.framework"]),
+                            ],
+                            productReferenceName: "$(PRODUCT_NAME)"
+                        ),
+                    ]
+                ),
+            ]
+        ).load(core)
+        let workspaceContext = WorkspaceContext(core: core, workspace: workspace, processExecutionCache: .sharedForTesting)
+
+        let toolProject = workspace.projects[0]
+        let libProject = workspace.projects[1]
+
+        let buildParameters = BuildParameters(configuration: "Debug")
+        let tool1Target = BuildRequest.BuildTargetInfo(parameters: buildParameters, target: toolProject.targets[0])
+        let tool2Target = BuildRequest.BuildTargetInfo(parameters: buildParameters, target: toolProject.targets[1])
+        let libTarget = BuildRequest.BuildTargetInfo(parameters: buildParameters, target: libProject.targets[0])
+        let buildRequest = BuildRequest(parameters: buildParameters, buildTargets: [tool1Target, tool2Target], continueBuildingAfterErrors: true, useParallelTargets: false, useImplicitDependencies: true, useDryRun: false)
+        let buildRequestContext = BuildRequestContext(workspaceContext: workspaceContext)
+
+        let delegate = EmptyTargetDependencyResolverDelegate(workspace: workspaceContext.workspace)
+
+        let buildGraph = await TargetGraphFactory(workspaceContext: workspaceContext, buildRequest: buildRequest, buildRequestContext: buildRequestContext, delegate: delegate).graph(type: .dependency)
+        #expect(try buildGraph.dependencies(tool1Target) == [try buildGraph.target(for: libTarget)])
+        #expect(try buildGraph.dependencies(tool2Target) == [try buildGraph.target(for: libTarget)])
+        #expect(try buildGraph.dependencies(libTarget) == [])
+        delegate.checkNoDiagnostics()
+    }
+
     /// Test that a target which implicitly depends on itself does not result in an infinite recursion.
     @Test
     func selfDependency() async throws {


### PR DESCRIPTION
6.4.x cherrypick of https://github.com/swiftlang/swift-build/pull/1661

* Explanation: When computing implicit dependencies, product reference names were being resolved in the context of the dependent rather than the dependency. This caused them to be computed incorrectly, effectively causing a target to depend on itself. This false dependency would usually be dropped, except where multiple targets in a workspace shared a product name, in which case we would incorrectly infer a dependency between them.

Add a resolveParameterizedProductName parameter to control product name resolution behavior. Currently, parameterized product names can only appear in packages, and packages are never allowed as an implicit dependency, so we can just skip resolving the product name altogether to avoid the incorrect dependency.
* Scope: Implicit dependency resolution
* Issues: rdar://185193762
* Testing: Added unit test