### PR TITLE
[6.4.x] Deduplicate Swift -add_ast_path arguments when linking

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/LinkerTools.swift
@@ -780,6 +780,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         // If we are linking Swift and build for debugging, pass the right .swiftmodule file for the current architecture to the
         // linker. This is needed so that debugging these modules works correctly. Note that `swiftModulePaths` will be empty for
         // anything but static archives and object files, because dynamic libraries and frameworks do not require this.
+        var linkContainsSwiftASTPathResponseFiles = false
         if isLinkUsingSwift && cbc.scope.evaluate(BuiltinMacros.GCC_GENERATE_DEBUGGING_SYMBOLS) && !cbc.scope.evaluate(BuiltinMacros.PLATFORM_REQUIRES_SWIFT_MODULEWRAP) {
             for library in libraries {
                 if let swiftModulePath = library.swiftModulePaths[cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)] {
@@ -787,6 +788,7 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
                 }
                 if let additionalArgsPath = library.swiftModuleAdditionalLinkerArgResponseFilePaths[cbc.scope.evaluate(BuiltinMacros.CURRENT_ARCH)] {
                     commandLine += ["@\(additionalArgsPath.str)"]
+                    linkContainsSwiftASTPathResponseFiles = true
                 }
             }
         }
@@ -862,8 +864,12 @@ public final class LdLinkerSpec : GenericLinkerSpec, SpecIdentifierType, @unchec
         let ldSearchPaths = Set(cbc.scope.evaluate(BuiltinMacros.FRAMEWORK_SEARCH_PATHS) + cbc.scope.evaluate(BuiltinMacros.LIBRARY_SEARCH_PATHS))
         let otherInputs = delegate.buildDirectories.sorted().compactMap { path in ldSearchPaths.contains(path.str) ? delegate.createBuildDirectoryNode(absolutePath: path) : nil } + cbc.commandOrderingInputs
 
-        // Create the task.
-        delegate.createTask(type: self, dependencyData: dependencyInfo, payload: payload, ruleInfo: defaultRuleInfo(cbc, delegate), commandLine: commandLine, environment: EnvironmentBindings(environment), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs + otherInputs, outputs: outputs, action: delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences), execDescription: resolveExecutionDescription(cbc, delegate), enableSandboxing: enableSandboxing)
+        // Create the task. Links that carry Swift AST-path response files run through LinkerTaskAction
+        // so those paths can be deduplicated; other links may defer execution as usual.
+        let action = linkContainsSwiftASTPathResponseFiles
+            ? createTaskAction(cbc, delegate)
+            : delegate.taskActionCreationDelegate.createDeferredExecutionTaskActionIfRequested(userPreferences: cbc.producer.userPreferences)
+        delegate.createTask(type: self, dependencyData: dependencyInfo, payload: payload, ruleInfo: defaultRuleInfo(cbc, delegate), commandLine: commandLine, environment: EnvironmentBindings(environment), workingDirectory: cbc.producer.defaultWorkingDirectory, inputs: inputs + otherInputs, outputs: outputs, action: action, execDescription: resolveExecutionDescription(cbc, delegate), enableSandboxing: enableSandboxing)
     }
 
     public static func addAdditionalDependenciesFromCommandLine(_ cbc: CommandBuildContext, _ commandLine: [String], _ environment: EnvironmentBindings, _ inputs: inout [any PlannedNode], _ outputs: inout [any PlannedNode], _ delegate: any TaskGenerationDelegate) {

--- a/Sources/SWBTaskExecution/TaskActions/LinkerTaskAction.swift
+++ b/Sources/SWBTaskExecution/TaskActions/LinkerTaskAction.swift
@@ -77,6 +77,8 @@ public final class LinkerTaskAction: TaskAction {
             }
         }
 
+        commandLine = deduplicatingSwiftASTPaths(commandLine, fileSystem: executionDelegate.fs, workingDirectory: task.workingDirectory)
+
         if extractArchiveInputs {
             do {
                 return try await withTemporaryDirectory(fs: executionDelegate.fs) { tempDir in
@@ -111,6 +113,44 @@ public final class LinkerTaskAction: TaskAction {
                 outputDelegate: outputDelegate
             )
         }
+    }
+
+    /// Coalesce duplicate `-Xlinker -add_ast_path -Xlinker <path>` paths.
+    /// Swift emits `-add_ast_path` per module for its entire transitive closure, so shared
+    /// modules repeat once per dependent and exceed `ARG_MAX`.
+    package func deduplicatingSwiftASTPaths(_ commandLine: [String], fileSystem: any FSProxy, workingDirectory: Path) -> [String] {
+        guard commandLine.contains(where: { $0 == "-add_ast_path" || ($0.hasPrefix("@") && $0.hasSuffix("-linker-args.resp")) }) else {
+            return commandLine
+        }
+
+        var tokens: [String] = []
+        tokens.reserveCapacity(commandLine.count)
+        for arg in commandLine {
+            if arg.hasPrefix("@"), arg.hasSuffix("-linker-args.resp"),
+               let expanded = try? ResponseFiles.expandResponseFiles([arg], fileSystem: fileSystem, relativeTo: workingDirectory, format: responseFileFormat) {
+                tokens.append(contentsOf: expanded)
+            } else {
+                tokens.append(arg)
+            }
+        }
+
+        var result: [String] = []
+        result.reserveCapacity(tokens.count)
+        var seenASTPaths = Set<String>()
+        var index = 0
+        while index < tokens.count {
+            if index + 3 < tokens.count, tokens[index] == "-Xlinker", tokens[index + 1] == "-add_ast_path", tokens[index + 2] == "-Xlinker" {
+                let path = tokens[index + 3]
+                if seenASTPaths.insert(path).inserted {
+                    result.append(contentsOf: tokens[index ... index + 3])
+                }
+                index += 4
+                continue
+            }
+            result.append(tokens[index])
+            index += 1
+        }
+        return result
     }
 
     private func extractStaticArchiveInputs(

--- a/Tests/SWBTaskExecutionTests/LinkerTaskActionTests.swift
+++ b/Tests/SWBTaskExecutionTests/LinkerTaskActionTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import SWBCore
+import SWBTaskExecution
+import SWBTestSupport
+import SWBUtil
+
+@Suite
+fileprivate struct LinkerTaskActionTests {
+    private let format: ResponseFileFormat = .unixShellQuotedSpaceSeparated
+
+    private func action() -> LinkerTaskAction {
+        LinkerTaskAction(expandResponseFiles: false, responseFileFormat: format, extractArchiveInputs: false)
+    }
+
+    private func writeLinkerArgsResp(_ fs: any FSProxy, _ path: Path, astPaths: [String]) throws {
+        let args = astPaths.flatMap { ["-Xlinker", "-add_ast_path", "-Xlinker", $0] }
+        try fs.createDirectory(path.dirname, recursive: true)
+        try fs.write(path, contents: ByteString(encodingAsUTF8: ResponseFiles.responseFileContents(args: args, format: format)))
+    }
+
+    private func astPaths(in commandLine: [String]) -> [String] {
+        var result: [String] = []
+        var i = 0
+        while i < commandLine.count {
+            if i + 3 < commandLine.count, commandLine[i] == "-Xlinker", commandLine[i + 1] == "-add_ast_path", commandLine[i + 2] == "-Xlinker" {
+                result.append(commandLine[i + 3])
+                i += 4
+            } else {
+                i += 1
+            }
+        }
+        return result
+    }
+
+    @Test
+    func deduplicatesAddASTPathsAcrossResponseFiles() throws {
+        let fs = MockExecutionDelegate().fs
+        let respA = Path.root.join("mods").join("A-linker-args.resp")
+        let respB = Path.root.join("mods").join("B-linker-args.resp")
+        try writeLinkerArgsResp(fs, respA, astPaths: ["/mods/A.swiftmodule", "/a b/Shared.swiftmodule"])
+        try writeLinkerArgsResp(fs, respB, astPaths: ["/mods/B.swiftmodule", "/a b/Shared.swiftmodule"])
+
+        let commandLine = [
+            "clang",
+            "-filelist", "/objs.txt",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/mods/A.swiftmodule",
+            "@\(respA.str)",
+            "@\(respB.str)",
+            "-Xlinker", "-rpath", "-Xlinker", "@loader_path/Frameworks",
+            "@/nonexistent/common-args.resp",
+            "-o", "/out",
+        ]
+
+        let result = action().deduplicatingSwiftASTPaths(commandLine, fileSystem: fs, workingDirectory: Path.root)
+
+        // Each distinct AST path appears exactly once.
+        #expect(astPaths(in: result) == ["/mods/A.swiftmodule", "/a b/Shared.swiftmodule", "/mods/B.swiftmodule"])
+        #expect(!result.contains("@\(respA.str)"))
+        #expect(!result.contains("@\(respB.str)"))
+        // Non-AST arguments are preserved.
+        #expect(result.contains("@loader_path/Frameworks"))
+        #expect(result.contains("@/nonexistent/common-args.resp"))
+        #expect(result.firstIndex(of: "-filelist").map { result[$0 + 1] } == "/objs.txt")
+        #expect(result.last == "/out")
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-build/pull/1666

rdar://185323523