### PR TITLE
Fix ExtensionKit embedded binary validation warning on install

### DIFF
--- a/Sources/SWBCore/ProjectModel/BuildPhase.swift
+++ b/Sources/SWBCore/ProjectModel/BuildPhase.swift
@@ -182,6 +182,14 @@ public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sen
 {
     public override var name: String { return "Copy Files" }
 
+    /// Special `destinationSubfolder` values that select a base directory other than `$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)`.
+    public enum SpecialDestinationSubfolder {
+        /// Copy to an absolute path (`$(INSTALL_ROOT)` when deploying, otherwise `/`).
+        public static let absolute = "<absolute>"
+        /// Copy relative to `$(BUILT_PRODUCTS_DIR)`.
+        public static let builtProductsDir = "<builtProductsDir>"
+    }
+
     /// The destination subfolder to copy to.  This will commonly be a location relative to `$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)`, but can also be a special indicator such as `<absolute>` or `<builtProductsDir>`.
     public let destinationSubfolder: MacroStringExpression
     /// The subpath relative to the destination subfolder to copy to.  Will often be empty.
@@ -195,7 +203,7 @@ public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sen
         var destinationSubpath = model.destinationSubpath
 
         // Special case: If this condition is true, then we are dealing with the unfortunate definition for the XPCServices folder, and we want to convert it to a better definition here.  In particular we want to go through $(TARGET_BUILD_DIR) rather than $(BUILT_PRODUCTS_DIR).
-        if case .string(let dsf) = destinationSubfolder, dsf == "<builtProductsDir>", case .string(let dsp) = destinationSubpath, dsp == "$(CONTENTS_FOLDER_PATH)/XPCServices" {
+        if case .string(let dsf) = destinationSubfolder, dsf == SpecialDestinationSubfolder.builtProductsDir, case .string(let dsp) = destinationSubpath, dsp == "$(CONTENTS_FOLDER_PATH)/XPCServices" {
             destinationSubfolder = .string("$(XPCSERVICES_FOLDER_PATH)")
             destinationSubpath = .string("")
         }
@@ -212,7 +220,7 @@ public final class CopyFilesBuildPhase: BuildPhaseWithBuildFiles, @unchecked Sen
         var destinationSubpath = try Self.parseValueForKeyAsString(PIFKey_BuildPhase_destinationSubpath, pifDict: pifDict)
 
         // Special case: If this condition is true, then we are dealing with the unfortunate definition for the XPCServices folder, and we want to convert it to a better definition here.  In particular we want to go through $(TARGET_BUILD_DIR) rather than $(BUILT_PRODUCTS_DIR).
-        if destinationSubfolder == "<builtProductsDir>", destinationSubpath == "$(CONTENTS_FOLDER_PATH)/XPCServices" {
+        if destinationSubfolder == SpecialDestinationSubfolder.builtProductsDir, destinationSubpath == "$(CONTENTS_FOLDER_PATH)/XPCServices" {
             destinationSubfolder = "$(XPCSERVICES_FOLDER_PATH)"
             destinationSubpath = ""
         }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -513,6 +513,11 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                 let signingIdentity = scope.evaluate(BuiltinMacros.EXPANDED_CODE_SIGN_IDENTITY)
                 let infoPlistPath = scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH))
 
+                // Use the same base directory as the embedded binary to build the tool's Info.plist path.
+                let infoPlistToolPath = self.managedBuildPhase.destinationSubfolder.stringRep == "<builtProductsDir>"
+                    ? scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH))
+                    : infoPlistPath
+
                 // Ensure that ValidateEmbeddedBinary runs *after* CodeSign (of this product, not the product being copied).
                 // This is important because the validation of the embedded product might depend on the parent product's signature.
                 let codeSignOrderingNodes = ProductPostprocessingTaskProducer.pathsToSign(scope, context.settings).map { context.createVirtualNode("CodeSign \($0.path.str)") }
@@ -522,7 +527,7 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                 func lookup(_ macro: MacroDeclaration) -> MacroExpression? {
                     switch macro {
                     case BuiltinMacros.InfoPlistPath:
-                        return cbc.scope.namespace.parseLiteralString(infoPlistPath.str)
+                        return cbc.scope.namespace.parseLiteralString(infoPlistToolPath.str)
                     case BuiltinMacros.SigningCert:
                         return cbc.scope.namespace.parseLiteralString(signingIdentity)
                     default:

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/CopyFilesTaskProducer.swift
@@ -106,13 +106,13 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
     private func computeOutputDirectory(_ scope: MacroEvaluationScope) -> Path {
         // FIXME: Clean up the typing of these properties. <rdar://problem/23702533> Copy files phase properties should be stronger typed
         let subfolder: Path
-        if self.managedBuildPhase.destinationSubfolder.stringRep == "<absolute>" || self.managedBuildPhase.destinationSubfolder.stringRep == "" {
+        if self.managedBuildPhase.destinationSubfolder.stringRep == CopyFilesBuildPhase.SpecialDestinationSubfolder.absolute || self.managedBuildPhase.destinationSubfolder.stringRep == "" {
             if scope.evaluate(BuiltinMacros.DEPLOYMENT_LOCATION) {
                 subfolder = scope.evaluate(BuiltinMacros.INSTALL_ROOT)
             } else {
                 subfolder = Path("/")
             }
-        } else if self.managedBuildPhase.destinationSubfolder.stringRep == "<builtProductsDir>" {
+        } else if self.managedBuildPhase.destinationSubfolder.stringRep == CopyFilesBuildPhase.SpecialDestinationSubfolder.builtProductsDir {
             subfolder = scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR)
         } else {
             let destinationSubfolder = scope.evaluate(self.managedBuildPhase.destinationSubfolder)
@@ -514,7 +514,7 @@ class CopyFilesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, FilesBasedBui
                 let infoPlistPath = scope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH))
 
                 // Use the same base directory as the embedded binary to build the tool's Info.plist path.
-                let infoPlistToolPath = self.managedBuildPhase.destinationSubfolder.stringRep == "<builtProductsDir>"
+                let infoPlistToolPath = self.managedBuildPhase.destinationSubfolder.stringRep == CopyFilesBuildPhase.SpecialDestinationSubfolder.builtProductsDir
                     ? scope.evaluate(BuiltinMacros.BUILT_PRODUCTS_DIR).join(scope.evaluate(BuiltinMacros.INFOPLIST_PATH))
                     : infoPlistPath
 

--- a/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/AppExtensionTaskConstructionTests.swift
@@ -110,6 +110,63 @@ fileprivate struct AppExtensionTaskConstructionTests: CoreBasedTests {
     }
 
     @Test(.requireSDKs(.macOS, .iOS))
+    func extensionKitEmbeddingInfoPlistBaseConsistency() async throws {
+        let testProject = TestProject(
+            "aProject",
+            groupTree: TestGroup(
+                "Sources", children: [
+                    TestFile("Source.c"),
+                ]),
+            buildConfigurations: [
+                TestBuildConfiguration("Release", buildSettings: [
+                    "CODE_SIGNING_ALLOWED": "NO",
+                    "GENERATE_INFOPLIST_FILE": "YES",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "SKIP_INSTALL": "NO",
+                    "SUPPORTED_PLATFORMS": "macosx iphoneos",
+                ])
+            ],
+            targets: [
+                TestStandardTarget(
+                    "Foo",
+                    type: .application,
+                    buildConfigurations: [TestBuildConfiguration("Release")],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["Source.c"]),
+                        TestCopyFilesBuildPhase([
+                            TestBuildFile(.target("Modern"))], destinationSubfolder: .builtProductsDir, destinationSubpath: "$(EXTENSIONS_FOLDER_PATH)", onlyForDeployment: false),
+                    ],
+                    dependencies: ["Modern"]),
+                TestStandardTarget(
+                    "Modern",
+                    type: .extensionKitExtension,
+                    buildConfigurations: [TestBuildConfiguration("Release")],
+                    buildPhases: [
+                        TestSourcesBuildPhase(["Source.c"]),
+                    ]),
+            ])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        for runDestination in [RunDestinationInfo.macOS, RunDestinationInfo.iOS] {
+            await tester.checkBuild(BuildParameters(action: .install, configuration: "Release"), runDestination: runDestination) { results in
+                results.checkTask(.matchTargetName("Foo"), .matchRuleType("ValidateEmbeddedBinary"), .matchRuleItemBasename("Modern.appex")) { task in
+                    let args = task.commandLine.map(\.asString)
+                    let embeddedBinary = Path(args[1])
+                    guard let flagIndex = args.firstIndex(of: "-info-plist-path"), flagIndex + 1 < args.count else {
+                        Issue.record("ValidateEmbeddedBinary command line is missing -info-plist-path: \(args)")
+                        return
+                    }
+                    // Both paths must resolve within the same app bundle otherwise the tool uses a bogus relative path.
+                    let infoPlistPath = Path(args[flagIndex + 1])
+                    #expect(infoPlistPath.dirname.isAncestor(of: embeddedBinary),
+                            "-info-plist-path base (\(infoPlistPath.str)) is inconsistent with the embedded binary path (\(embeddedBinary.str))")
+                }
+                results.checkNoDiagnostics()
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS, .iOS))
     func appExtensionSwiftEmbedding() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
Use the same base directory as the embedded binary to build ValidateEmbeddedBinary's -info-plist-path so the tool's relative-path check stays within the bundle across the BUILT_PRODUCTS_DIR/TARGET_BUILD_DIR install symlink.

rdar://183728945