### PR TITLE
Use XCFramework Info.plist for cache signatures

### DIFF
--- a/Sources/SWBCore/BuildRequestContext.swift
+++ b/Sources/SWBCore/BuildRequestContext.swift
@@ -134,7 +134,9 @@ public final class BuildRequestContext: Sendable {
     }
 
     public func getCachedXCFramework(at path: Path) throws -> XCFramework {
-        try workspaceContext.xcframeworkCache.get(at: path, filesSignature: filesSignature(for: [path]))
+        // XCFramework parsing only reads Info.plist; task construction separately tracks
+        // the root for build-description invalidation.
+        try workspaceContext.xcframeworkCache.get(at: path, filesSignature: filesSignature(for: [path.join("Info.plist")]))
     }
 
     public func getKnownTestingLibraryPathSuffixes() async -> [Path] {

--- a/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
@@ -76,6 +76,8 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
+            #expect(results.buildPlan.invalidationPaths.contains(supportXCFrameworkPath))
+
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in
                 task.checkCommandLine(["builtin-process-xcframework", "--xcframework", "\(SRCROOT)/Support.xcframework", "--platform", "macos", "--library-identifier", "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)", "--target-path", "\(SRCROOT)/build/Debug"])


### PR DESCRIPTION
`getCachedXCFramework(at:)` currently computes a `FilesSignature` for the complete XCFramework directory. Because directory signatures recursively traverse every slice and collect metadata for every file, cache lookup does substantially more work than XCFramework parsing itself, which only reads the root `Info.plist`.

This changes the metadata cache signature to use the XCFramework's `Info.plist`. The complete XCFramework root remains a build-description invalidation path and a `ProcessXCFramework` input, so changes to binaries and other bundle contents continue to invalidate the build description. The task-construction test now explicitly verifies that the root remains in `BuildPlan.invalidationPaths`.

In alternating A/B/A/B/A/B trials on a large workspace with fresh DerivedData for each run, the average time to produce the build-description signature decreased from 15.19 seconds to 12.87 seconds (-2.32 seconds, -15.25%).

Testing:
- Built `SWBBuildService` in release configuration.
- Passed 76 XCFramework-related tests across 6 suites.
- Passed all 11 `XCFrameworkTaskConstructionTests` after adding the invalidation-path assertion.