### PR TITLE
[6.4.x] Skip sandbox violation scan for tasks that fail during setup

### DIFF
--- a/Sources/SWBBuildSystem/BuildOperation.swift
+++ b/Sources/SWBBuildSystem/BuildOperation.swift
@@ -2088,7 +2088,8 @@ internal final class OperationSystemAdaptor: SWBLLBuild.BuildSystemDelegate, Act
         }
 
         // We can call this here because we're on an llbuild worker thread. This shouldn't be used while on `self.queue` because we have Swift async work elsewhere which blocks on that queue.
-        let sandboxViolations = task.isSandboxed && result == .failed ? task.extractSandboxViolationMessages_ASYNC_UNSAFE(startTime: outputDelegate.startTime) : []
+        // A task that failed at setup never launched its sandboxed subprocess so skip the log scan.
+        let sandboxViolations = task.isSandboxed && result == .failed && !failedTaskSetup ? task.extractSandboxViolationMessages_ASYNC_UNSAFE(startTime: outputDelegate.startTime) : []
 
         queue.async {
             for message in sandboxViolations {


### PR DESCRIPTION
6.4.x cherry-pick of https://github.com/swiftlang/swift-build/pull/1682

rdar://177373700
