### PR TITLE
[ssaf] Integrate SrcEditMerge tool with swift build for SSAF source transformation

### DIFF
--- a/Sources/SWBApplePlatform/CMakeLists.txt
+++ b/Sources/SWBApplePlatform/CMakeLists.txt
@@ -10,6 +10,7 @@ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SWBApplePlatform
   EntityLinkerTool.swift
+  SrcEditMergeTool.swift
   AIModelCompilerSpec.swift
   AppIntentsMetadataCompiler.swift
   AppIntentsMetadataTaskProducer.swift
@@ -116,6 +117,7 @@ SwiftBuild_Bundle(MODULE SWBApplePlatform FILES
   Specs/SceneKitFileTypes.xcspec
   Specs/SceneKitTools.xcspec
   Specs/SpriteKitFileTypes.xcspec
+  Specs/SrcEditMerge.xcspec
   Specs/SsafAnalyzer.xcspec
   Specs/StripSymbolsDarwin.xcspec
   Specs/TiffUtil.xcspec

--- a/Sources/SWBApplePlatform/Plugin.swift
+++ b/Sources/SWBApplePlatform/Plugin.swift
@@ -133,6 +133,7 @@ struct ApplePlatformSpecsExtension: SpecificationsExtension {
             AppIntentsMetadataCompilerSpec.self,
             EntityLinkerToolSpec.self,
             SsafAnalyzerToolSpec.self,
+            SrcEditMergeToolSpec.self,
             AppIntentsSSUTrainingCompilerSpec.self,
             ExtensionPointExtractorSpec.self,
             ActoolCompilerSpec.self,

--- a/Sources/SWBApplePlatform/Specs/SrcEditMerge.xcspec
+++ b/Sources/SWBApplePlatform/Specs/SrcEditMerge.xcspec
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+(
+    {
+        Type = Compiler;
+        Identifier = com.apple.build-tools.clang-ssaf-src-edit-merger;
+        ExecPath = "clang-ssaf-src-edit-merger";
+        Name = "Source Edit Merging Tool";
+        Description = "Merges source edit files emitted from compiler";
+        CommandLine = "clang-ssaf-src-edit-merger [inputs] -o $(OutputPath)";
+        RuleName = "MergeSourceEdits $(OutputPath)";
+        ExecDescription = "Merging Source Edit files";
+        ProgressDescription = "Merging $(OutputPath)";
+        InputFileTypes = ();
+        CommandOutputParser = XCGenericCommandOutputParser;
+        InputFileGroupings = ();
+        SynthesizeBuildRule = YES;
+        IsArchitectureNeutral = NO;
+    }
+)

--- a/Sources/SWBApplePlatform/SrcEditMergeTool.swift
+++ b/Sources/SWBApplePlatform/SrcEditMergeTool.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+public import SWBUtil
+public import SWBCore
+public import SWBMacro
+
+
+public final class SrcEditMergeToolSpec: GenericCommandLineToolSpec, SpecIdentifierType, @unchecked Sendable {
+    public static let identifier = "com.apple.build-tools.clang-ssaf-src-edit-merger"
+    required public init(_ parser: SpecParser, _ basedOnSpec: Spec?) {
+        super.init(parser, basedOnSpec)
+    }
+
+    public struct DiscoveredSrcEditMergeToolSpecInfo: DiscoveredCommandLineToolSpecInfo {
+        public let toolPath: Path
+        public var toolVersion: Version?
+    }
+
+    override public func discoveredCommandLineToolSpecInfo(_ producer: any CommandProducer, _ scope: MacroEvaluationScope, _ delegate: any CoreClientTargetDiagnosticProducingDelegate) async -> (any DiscoveredCommandLineToolSpecInfo)? {
+        let toolPath = self.resolveExecutablePath(producer, Path("clang-ssaf-src-edit-merger"))
+        return DiscoveredSrcEditMergeToolSpecInfo(toolPath: toolPath, toolVersion: nil)
+    }
+}

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1042,7 +1042,9 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             .filter { $0.path.str.hasSuffix(".ssaf-edit.yaml") }
                             .map { FileToBuild(context: context, absolutePath: $0.path) }
                         await appendGeneratedTasks(&perArchTasks) { delegate in
-                            let output = Path(binaryOutput.str + ".merged-src-edits.yaml")
+                            // Write this next to the product so it has a stable, discoverable
+                            // location that survives the build.
+                            let output = Path(scope.evaluate(scope.namespace.parseString("$(TARGET_BUILD_DIR)/$(PRODUCT_NAME)-merged-src-edits-$(CURRENT_VARIANT)-$(CURRENT_ARCH).yaml")))
                             await context.srcEditMergeToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: srcEditInputs, output: output), delegate)
                         }
                     }

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1035,6 +1035,17 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             .flatMap { ["-a", "\($0)AnalysisResult"] }
                         await context.ssafAnalyzerToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: linkedSummariesInput)], output: analyzerOutput), delegate, specialArgs: specialArgs)
                     }
+
+                    if !scope.evaluate(BuiltinMacros.SOURCE_TRANSFORMATION).isEmpty {
+                        // Collect only the .ssaf-edit.yaml sidecars that clang actually planned as task outputs.
+                        let srcEditInputs = perArchTasks.flatMap { $0.outputs }
+                            .filter { $0.path.str.hasSuffix(".ssaf-edit.yaml") }
+                            .map { FileToBuild(context: context, absolutePath: $0.path) }
+                        await appendGeneratedTasks(&perArchTasks) { delegate in
+                            let output = Path(binaryOutput.str + ".merged-src-edits.yaml")
+                            await context.srcEditMergeToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: srcEditInputs, output: output), delegate)
+                        }
+                    }
                 }
 
                 // Handle linking prelinked objects.  Presently we always do this if GENERATE_PRELINK_OBJECT_FILE even if there are no other tasks, since PRELINK_LIBS or PRELINK_FLAGS might be set to values which will cause a prelinked object file to be generated.

--- a/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/BuildPhaseTaskProducers/SourcesTaskProducer.swift
@@ -1042,8 +1042,8 @@ package final class SourcesTaskProducer: FilesBasedBuildPhaseTaskProducerBase, F
                             .filter { $0.path.str.hasSuffix(".ssaf-edit.yaml") }
                             .map { FileToBuild(context: context, absolutePath: $0.path) }
                         await appendGeneratedTasks(&perArchTasks) { delegate in
-                            // Write this next to the product so it has a stable, discoverable
-                            // location that survives the build.
+                            // Write this next to the product so it's easy to find alongside
+                            // the build output.
                             let output = Path(scope.evaluate(scope.namespace.parseString("$(TARGET_BUILD_DIR)/$(PRODUCT_NAME)-merged-src-edits-$(CURRENT_VARIANT)-$(CURRENT_ARCH).yaml")))
                             await context.srcEditMergeToolSpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: srcEditInputs, output: output), delegate)
                         }

--- a/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/TaskProducer.swift
@@ -235,6 +235,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
     public let clangStaticAnalyzerSpec: ClangCompilerSpec
     public let entityLinkerToolSpec: CommandLineToolSpec
     public let ssafAnalyzerToolSpec: CommandLineToolSpec
+    public let srcEditMergeToolSpec: CommandLineToolSpec
     public let ssafSourceTransformationSpec: ClangCompilerSpec
     public let clangModuleVerifierSpec: ClangCompilerSpec
     private let _clangStatCacheSpec: Result<ClangStatCacheSpec, any Error>
@@ -361,6 +362,7 @@ public class TaskProducerContext: StaleFileRemovalContext, BuildFileResolution
         self.clangStaticAnalyzerSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-linker", domain: domain, ofType: CommandLineToolSpec.self)
         self.ssafAnalyzerToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-analyzer", domain: domain, ofType: CommandLineToolSpec.self)
+        self.srcEditMergeToolSpec = try! workspaceContext.core.specRegistry.getSpec("com.apple.build-tools.clang-ssaf-src-edit-merger", domain: domain, ofType: CommandLineToolSpec.self)
         self.ssafSourceTransformationSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: SSAFSourceTransformationSpec.self)
         self.clangModuleVerifierSpec = try! workspaceContext.core.specRegistry.getSpec(domain: domain, ofType: ClangModuleVerifierSpec.self)
         self._clangStatCacheSpec = Result { try workspaceContext.core.specRegistry.getSpec("com.apple.compilers.clang-stat-cache", ofType: ClangStatCacheSpec.self) }

--- a/Sources/SWBTestSupport/DummyCommandProducer.swift
+++ b/Sources/SWBTestSupport/DummyCommandProducer.swift
@@ -129,6 +129,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
         self.clangStaticAnalyzerSpec = try getSpec(ofType: ClangStaticAnalyzerSpec.self)
         self.entityLinkerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-linker", ofType: CommandLineToolSpec.self)
         self.ssafAnalyzerToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-analyzer", ofType: CommandLineToolSpec.self)
+        self.srcEditMergeToolSpec = try getSpec("com.apple.build-tools.clang-ssaf-src-edit-merger", ofType: CommandLineToolSpec.self)
         self.ssafSourceTransformationSpec = try getSpec(ofType: SSAFSourceTransformationSpec.self)
         self.clangModuleVerifierSpec = try getSpec(ofType: ClangModuleVerifierSpec.self)
         self.diffSpec = try getSpec("com.apple.build-tools.diff", ofType: CommandLineToolSpec.self)
@@ -172,6 +173,7 @@ package struct MockCommandProducer: CommandProducer, Sendable {
     package let clangStaticAnalyzerSpec: ClangCompilerSpec
     package let entityLinkerToolSpec: CommandLineToolSpec
     package let ssafAnalyzerToolSpec: CommandLineToolSpec
+    package let srcEditMergeToolSpec: CommandLineToolSpec
     package let ssafSourceTransformationSpec: ClangCompilerSpec
     package let clangModuleVerifierSpec: ClangCompilerSpec
     package let diffSpec: CommandLineToolSpec

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -556,6 +556,17 @@ fileprivate struct ClangTests: CoreBasedTests {
                     #expect(outputPaths.contains(srcEditFile))
                     #expect(outputPaths.contains(transformationReportFile))
                 }
+
+                // The MergeSourceEdits task should receive the .ssaf-edit.yaml produced by TransformSource
+                // as input and merge it into a single output alongside the binary.
+                results.checkTask(.matchRuleType("MergeSourceEdits")) { task in
+                    #expect(task.inputs.map(\.path).contains(srcEditFile))
+                    let mergeOutput = task.outputs.map(\.path).first(where: { $0.str.hasSuffix(".merged-src-edits.yaml") })
+                    #expect(mergeOutput != nil)
+                    if let mergeOutput {
+                        task.checkCommandLineContains([srcEditFile.str, "-o", mergeOutput.str])
+                    }
+                }
                 results.checkNoDiagnostics()
             }
         }
@@ -570,6 +581,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                 }
                 results.checkNoTask(.matchRuleType("LinkEntity"))
                 results.checkNoTask(.matchRuleType("AnalyzeSSAF"))
+                results.checkNoTask(.matchRuleType("MergeSourceEdits"))
                 results.checkNoDiagnostics()
             }
         }
@@ -584,6 +596,7 @@ fileprivate struct ClangTests: CoreBasedTests {
                     task.checkCommandLineContains(["--ssaf-extract-summaries=CallGraph,UnsafeBufferUsage"])
                 }
                 results.checkNoTask(.matchRuleType("TransformSource"))
+                results.checkNoTask(.matchRuleType("MergeSourceEdits"))
                 results.checkNoDiagnostics()
             }
         }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -558,10 +558,10 @@ fileprivate struct ClangTests: CoreBasedTests {
                 }
 
                 // The MergeSourceEdits task should receive the .ssaf-edit.yaml produced by TransformSource
-                // as input and merge it into a single output alongside the binary.
+                // as input and merge it into a single output next to the product.
                 results.checkTask(.matchRuleType("MergeSourceEdits")) { task in
                     #expect(task.inputs.map(\.path).contains(srcEditFile))
-                    let mergeOutput = task.outputs.map(\.path).first(where: { $0.str.hasSuffix(".merged-src-edits.yaml") })
+                    let mergeOutput = task.outputs.map(\.path).first(where: { $0.str.hasSuffix(".yaml") && $0.basename.hasPrefix("Test-merged-src-edits-") })
                     #expect(mergeOutput != nil)
                     if let mergeOutput {
                         task.checkCommandLineContains([srcEditFile.str, "-o", mergeOutput.str])


### PR DESCRIPTION
Add SrcEditMergeToolSpec, wired to merge the per-translation-unit .ssaf-edit.yaml files emitted by the SSAF source-transformation re-invocation of clang (TransformSource) into a single merged-src-edits.yaml alongside the binary.

rdar://176928043