### PR TITLE
Move PBXCpTests.swift and PlannedNodeTests.swift to the correct test bundles, and other test cleanup.

### DIFF
--- a/Tests/SWBCoreTests/FileToBuildTests.swift
+++ b/Tests/SWBCoreTests/FileToBuildTests.swift
@@ -41,3 +41,17 @@ import SWBCore
         #expect(fg.assignedBuildRuleAction == nil)  // initial build rule action should be nil
     }
 }
+
+@Suite(.skipHostOS(.windows, "path tests need a big overhaul for Windows"))
+fileprivate struct RegionVariantTests {
+    @Test
+    func regionVariantPathComponent() {
+        #expect(Path("").regionVariantPathComponent == "")
+        #expect(Path("/").regionVariantPathComponent == "")
+        #expect(Path("/tmp/foo.c").regionVariantPathComponent == "")
+        #expect(Path("/tmp/en.lproj").regionVariantPathComponent == "")
+        #expect(Path("/tmp/en.lproj/foo.c").regionVariantPathComponent == "en.lproj/")
+        #expect(Path("/tmp/en.lproj/subdir/foo.c").regionVariantPathComponent == "")
+        #expect(Path("/tmp/.lproj/foo.c").regionVariantPathComponent == ".lproj/")
+    }
+}

--- a/Tests/SWBCoreTests/PlannedNodeTests.swift
+++ b/Tests/SWBCoreTests/PlannedNodeTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SWBTaskConstruction
 import SWBCore
 import SWBTestSupport
 import SWBUtil

--- a/Tests/SWBUtilTests/PBXCpTests.swift
+++ b/Tests/SWBUtilTests/PBXCpTests.swift
@@ -14,7 +14,6 @@ import Foundation
 import Testing
 import SWBUtil
 import SWBTestSupport
-import SWBCore
 
 #if canImport(System)
 import System
@@ -23,7 +22,7 @@ import SystemPackage
 #endif
 
 @Suite
-fileprivate struct PBXCpTests: CoreBasedTests {
+fileprivate struct PBXCpTests {
     @Test
     func usage() async {
         let result = await pbxcp(["builtin-copy", "--help"], cwd: Path("/"))
@@ -506,9 +505,8 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             // This is a fake Mach-O file, just enough to trick PBXCp.
             try fs.write(src.join("fake-bin"), contents: [0xFE, 0xED, 0xFA, 0xCE, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0])
 
-            // Check that we run the bitcode_strip tool and capture its output.  Note that bitcode_strip is in the default toolchain, so we need to pass the path to it there.
-            let defaultToolchain = try #require(try await getCore().toolchainRegistry.defaultToolchain)
-            let bitcodeStripPath = defaultToolchain.path.join("usr/bin/bitcode_strip")
+            // Check that we run the bitcode_strip tool.  Note that the tool is never actually executed here because we pass -dry-run, so the path need not exist.
+            let bitcodeStripPath = Path("/fake-toolchain/usr/bin/bitcode_strip")
             // Note that we always strip all bitcode (-r), even if 'replace-with-marker' is passed.
             let result = await pbxcp(["builtin-copy", "-dry-run", "-bitcode-strip", "replace-with-marker", "-bitcode-strip-tool", bitcodeStripPath.str, src.str + Path.pathSeparatorString, dst.str], cwd: Path("/"))
             #expect(result.success == true)
@@ -531,9 +529,8 @@ fileprivate struct PBXCpTests: CoreBasedTests {
             // This is a fake Mach-O file, just enough to trick PBXCp.
             try fs.write(src.join("fake-bin"), contents: [0xFE, 0xED, 0xFA, 0xCE, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0])
 
-            // Check that we run the bitcode_strip tool and capture its output.  Note that bitcode_strip is in the default toolchain, so we need to pass the path to it there.
-            let defaultToolchain = try #require(try await getCore().toolchainRegistry.defaultToolchain)
-            let bitcodeStripPath = defaultToolchain.path.join("usr/bin/bitcode_strip")
+            // Check that we run the bitcode_strip tool.  Note that the tool is never actually executed here because we pass -dry-run, so the path need not exist.
+            let bitcodeStripPath = Path("/fake-toolchain/usr/bin/bitcode_strip")
             // Note that we always strip all bitcode (-r), even if 'replace-with-marker' is passed.
             let result = await pbxcp(["builtin-copy", "-dry-run", "-strip-unsigned-binaries", "-bitcode-strip", "replace-with-marker", "-bitcode-strip-tool", bitcodeStripPath.str, src.str + Path.pathSeparatorString, dst.str], cwd: Path("/"))
             #expect(result.success == true)

--- a/Tests/SWBUtilTests/PathTests.swift
+++ b/Tests/SWBUtilTests/PathTests.swift
@@ -14,7 +14,6 @@ import Foundation
 import Testing
 import SWBTestSupport
 import SWBUtil
-import SWBCore
 
 @Suite(.skipHostOS(.windows, "path tests need a big overhaul for Windows"))
 fileprivate struct PathTests {
@@ -147,17 +146,6 @@ fileprivate struct PathTests {
         #expect(Path("/tmp/en.lproj/foo.c").regionVariantName == "en")
         #expect(Path("/tmp/en.lproj/subdir/foo.c").regionVariantName == nil)
         #expect(Path("/tmp/.lproj/foo.c").regionVariantName == "")
-    }
-
-    @Test
-    func regionVariantPathComponent() {
-        #expect(Path("").regionVariantPathComponent == "")
-        #expect(Path("/").regionVariantPathComponent == "")
-        #expect(Path("/tmp/foo.c").regionVariantPathComponent == "")
-        #expect(Path("/tmp/en.lproj").regionVariantPathComponent == "")
-        #expect(Path("/tmp/en.lproj/foo.c").regionVariantPathComponent == "en.lproj/")
-        #expect(Path("/tmp/en.lproj/subdir/foo.c").regionVariantPathComponent == "")
-        #expect(Path("/tmp/.lproj/foo.c").regionVariantPathComponent == ".lproj/")
     }
 
     @Test

--- a/Tests/SWBUtilTests/ProcessTests.swift
+++ b/Tests/SWBUtilTests/ProcessTests.swift
@@ -14,6 +14,7 @@ import Foundation
 import Testing
 import SWBTestSupport
 import SWBUtil
+// Strange for SWBUtilTests to be importing SWBCore, but it's needed for the use of StackedSearchPath in the enablement condition for uncaughtSignal().
 import SWBCore
 
 @Suite(.requireProcessSpawning)
@@ -105,6 +106,7 @@ fileprivate struct ProcessTests {
         #expect(result.exitStatus == .exit(42))
     }
 
+    // Note that `StackedSearchPath` comes from SWBCore, not SWBUtil.
     @Test(.enabled(if: StackedSearchPath(environment: .current, fs: localFS).lookup(Path("clang")) != nil, "requires clang in PATH"))
     func uncaughtSignal() async throws {
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
These two files were part of higher-level test bundles and can be moved to the same-level test bundles fairly easily. PBXCpTests requires a small change which doesn't impact the validity of the test.

Also remove the import of SWBCore from PathTests.swift, as it is part of SWBUtilTests. This requires moving `regionVariantPathComponent()` to SWBCoreTests, which is reasonable since it's testing functionality defined at that level (in an extension on a protocol) anyway.

Finally, `ProcessTests` is in SWBUtilTests but imports SWBCore in order to use `StackedSearchPath` in a test condition. This is not technically a layering violation, but is "feels" like one, so add comments to this effect. Perhaps we can completely remove the dependency in the future.
