### PR TITLE
Limit XCFramework invalidation to the selected slice

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift
@@ -140,7 +140,9 @@ final class XCFrameworkTaskProducer: StandardTaskProducer, TaskProducer {
                     expectedSignatures = nil
                 }
 
-                access(path: config.path)
+                // Only metadata and the selected library can affect this build description.
+                access(path: config.path.join("Info.plist"))
+                access(path: config.path.join(config.libraryIdentifier))
                 await context.processXCFrameworkLibrarySpec.constructTasks(CommandBuildContext(producer: context, scope: scope, inputs: [FileToBuild(context: context, absolutePath: config.path)], outputs: config.outputs, commandOrderingInputs: outputDirectoryIsBuildDirectory ? [delegate.createBuildDirectoryNode(absolutePath: config.outputDirectory)] : []), delegate, platform: config.platform, environment: config.environment, libraryIdentifier: config.libraryIdentifier, outputDirectory: config.outputDirectory, libraryPath: config.libraryPath, expectedSignatures: expectedSignatures)
 
                 if scope.evaluate(BuiltinMacros.ENABLE_SIGNATURE_AGGREGATION) {

--- a/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/XCFrameworkTaskConstructionTests.swift
@@ -76,7 +76,10 @@ fileprivate struct XCFrameworkTaskConstructionTests: CoreBasedTests {
         try await XCFrameworkTestSupport.writeXCFramework(supportXCFramework, fs: fs, path: supportXCFrameworkPath, infoLookup: infoLookup)
 
         try await tester.checkBuild(BuildParameters(action: .build, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
-            #expect(results.buildPlan.invalidationPaths.contains(supportXCFrameworkPath))
+            let selectedLibraryPath = supportXCFrameworkPath.join("arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)")
+            #expect(results.buildPlan.invalidationPaths.contains(supportXCFrameworkPath.join("Info.plist")))
+            #expect(results.buildPlan.invalidationPaths.contains(selectedLibraryPath))
+            #expect(!results.buildPlan.invalidationPaths.contains(supportXCFrameworkPath))
 
             var processSupportXCFrameworkTask: (any PlannedTask)?
             results.checkTask(.matchRuleType("ProcessXCFramework")) { task in

--- a/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
+++ b/Tests/SWBTaskExecutionTests/BuildDescriptionTests.swift
@@ -399,6 +399,79 @@ fileprivate struct BuildDescriptionTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.macOS, .iOS))
+    func xcframeworkInvalidationTracksSelectedSlice() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            try await withAsyncDeferrable { deferrable in
+                let core = try await getCore()
+                let macOSLibraryIdentifier = "arm64-apple-macos\(core.loadSDK(.macOS).defaultDeploymentTarget)"
+                let iOSLibraryIdentifier = "arm64-apple-iphoneos\(core.loadSDK(.iOS).defaultDeploymentTarget)"
+                let testProject = TestProject(
+                    "aProject",
+                    groupTree: TestGroup(
+                        "Sources",
+                        children: [
+                            TestFile("file.c"),
+                            TestFile("Support.xcframework"),
+                            TestFile("Info.plist"),
+                        ]),
+                    buildConfigurations: [
+                        TestBuildConfiguration("Debug", buildSettings: [
+                            "ARCHS": "arm64",
+                            "CODE_SIGN_IDENTITY": "-",
+                            "INFOPLIST_FILE": "Info.plist",
+                            "PRODUCT_NAME": "$(TARGET_NAME)",
+                        ]),
+                    ],
+                    targets: [
+                        TestStandardTarget(
+                            "App",
+                            type: .application,
+                            buildPhases: [
+                                TestSourcesBuildPhase(["file.c"]),
+                                TestFrameworksBuildPhase(["Support.xcframework"]),
+                            ]),
+                    ])
+                let workspace = try TestWorkspace("Test", sourceRoot: tmpDirPath, projects: [testProject]).load(core)
+                let sourceRoot = workspace.projects[0].sourceRoot
+                let fs = PseudoFS()
+                try fs.createDirectory(sourceRoot, recursive: true)
+                try fs.write(sourceRoot.join("file.c"), contents: "int f() { return 0; }")
+
+                let xcframework = try XCFramework(version: Version(1, 0), libraries: [
+                    XCFramework.Library(libraryIdentifier: macOSLibraryIdentifier, supportedPlatform: "macos", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Versions/A/Support"), headersPath: nil),
+                    XCFramework.Library(libraryIdentifier: iOSLibraryIdentifier, supportedPlatform: "ios", supportedArchitectures: ["arm64"], platformVariant: nil, libraryPath: Path("Support.framework"), binaryPath: Path("Support.framework/Support"), headersPath: nil),
+                ])
+                let xcframeworkPath = sourceRoot.join("Support.xcframework")
+                try fs.createDirectory(xcframeworkPath, recursive: true)
+                try await XCFrameworkTestSupport.writeXCFramework(xcframework, fs: fs, path: xcframeworkPath, infoLookup: core)
+
+                let manager = BuildDescriptionManager(fs: fs, buildDescriptionMemoryCacheEvictionPolicy: .never)
+                await deferrable.addBlock { await manager.waitForBuildDescriptionSerialization() }
+                func buildDescriptionSource() async throws -> BuildDescriptionRetrievalSource {
+                    let planRequest = try await self.planRequest(for: workspace, activeRunDestination: .macOS, fs: fs, includingTargets: { _ in true })
+                    let clientDelegate = MockTestTaskPlanningClientDelegate(hostOS: planRequest.workspaceContext.core.hostOperatingSystem)
+                    return try #require(try await manager.getNewOrCachedBuildDescription(planRequest, clientDelegate: clientDelegate)).source
+                }
+
+                #expect(try await buildDescriptionSource() == .new)
+                #expect(try await buildDescriptionSource() == .inMemoryCache)
+
+                let unselectedBinaryPath = xcframeworkPath.join(iOSLibraryIdentifier).join("Support.framework/Support")
+                try fs.setFileTimestamp(unselectedBinaryPath, timestamp: 10)
+                #expect(try await buildDescriptionSource() == .inMemoryCache)
+
+                let selectedBinaryPath = xcframeworkPath.join(macOSLibraryIdentifier).join("Support.framework/Support")
+                try fs.setFileTimestamp(selectedBinaryPath, timestamp: 11)
+                #expect(try await buildDescriptionSource() == .new)
+                #expect(try await buildDescriptionSource() == .inMemoryCache)
+
+                try fs.setFileTimestamp(xcframeworkPath.join("Info.plist"), timestamp: 12)
+                #expect(try await buildDescriptionSource() == .new)
+            }
+        }
+    }
+
     /// A cached build description, looked up by its `buildDescriptionID` via the `.cachedOnly` path, may be reused
     /// across a workspace reload as long as the reloaded workspace still contains the description's targets — index
     /// clients rely on reusing a description after a PIF change. It must be rejected only when a referenced target was


### PR DESCRIPTION
This is a follow-up to #1690, which limited the XCFramework parser cache signature to `Info.plist` while retaining complete-root BuildDescription invalidation.

`XCFrameworkTaskProducer` currently registers the complete XCFramework root as a build-description invalidation path. Validating a cached build description therefore recursively stats every platform slice, even though task construction only reads the root `Info.plist` and enumerates the slice selected for the current build destination.

This change tracks the root `Info.plist` and the selected `libraryIdentifier` directory instead. `ProcessXCFramework` continues to use the complete XCFramework as a directory-tree task input, so execution-time copying and signature validation are unchanged. A different destination produces a different build description and selects its corresponding slice.

In five alternating A/B pairs on a large workspace with 863 XCFramework roots and fresh DerivedData for every run, median CreateBuildDescription time decreased from 14.675 seconds to 12.514 seconds (-2.161 seconds, -14.73%). The trimmed mean decreased from 14.818 seconds to 12.907 seconds (-1.911 seconds, -12.90%). Recursive stat inputs decreased from 33,844 entries to 16,248 (-51.99%).

The normalized manifests contained the same 36,569 command keys and 1,551 node keys in both arms, with no node value differences.

Testing:
- Added task-construction coverage for the narrowed invalidation paths.
- Added cache-behavior coverage proving that an unselected slice change reuses the in-memory BuildDescription, while changes to the selected slice or root `Info.plist` invalidate it.
- `swift test -c release --filter 'XCFramework|xcframeworkInvalidationTracksSelectedSlice'`: 105 tests in 15 suites passed.
- Final committed HEAD: 12 affected tests in 2 suites passed.