### PR TITLE
Add option so that the copy-aside step only copies binaries

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -261,6 +261,7 @@ public final class BuiltinMacros {
     public static let INSTALL_ROOT = BuiltinMacros.declarePathMacro("INSTALL_ROOT")
     public static let LLVM_LTO = BuiltinMacros.declareStringMacro("LLVM_LTO")
     public static let RETAIN_RAW_BINARIES = BuiltinMacros.declareBooleanMacro("RETAIN_RAW_BINARIES")
+    public static let RETAIN_RAW_BINARIES_ONLY = BuiltinMacros.declareBooleanMacro("RETAIN_RAW_BINARIES_ONLY")
     public static let SEPARATE_SYMBOL_EDIT = BuiltinMacros.declareBooleanMacro("SEPARATE_SYMBOL_EDIT")
     public static let SKIP_INSTALL = BuiltinMacros.declareBooleanMacro("SKIP_INSTALL")
     public static let SKIP_CLANG_STATIC_ANALYZER = BuiltinMacros.declareBooleanMacro("SKIP_CLANG_STATIC_ANALYZER")
@@ -975,6 +976,7 @@ public final class BuiltinMacros {
     public static let PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME = BuiltinMacros.declareBooleanMacro("PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME")
     public static let PATH = BuiltinMacros.declareStringMacro("PATH")
     public static let PBXCP_EXCLUDE_SUBPATHS = BuiltinMacros.declareStringListMacro("PBXCP_EXCLUDE_SUBPATHS")
+    public static let PBXCP_INCLUDE_ONLY_FILE_TYPES = BuiltinMacros.declareStringListMacro("PBXCP_INCLUDE_ONLY_FILE_TYPES")
     public static let PBXCP_INCLUDE_ONLY_SUBPATHS = BuiltinMacros.declareStringListMacro("PBXCP_INCLUDE_ONLY_SUBPATHS")
     public static let PBXCP_STRIP_BITCODE = BuiltinMacros.declareBooleanMacro("PBXCP_STRIP_BITCODE")
     public static let PBXCP_STRIP_SUBPATHS = BuiltinMacros.declareStringListMacro("PBXCP_STRIP_SUBPATHS")
@@ -2194,6 +2196,7 @@ public final class BuiltinMacros {
         PACKAGE_TYPE,
         PATH,
         PBXCP_EXCLUDE_SUBPATHS,
+        PBXCP_INCLUDE_ONLY_FILE_TYPES,
         PBXCP_INCLUDE_ONLY_SUBPATHS,
         PBXCP_STRIP_BITCODE,
         PBXCP_STRIP_SUBPATHS,
@@ -2283,6 +2286,7 @@ public final class BuiltinMacros {
         RESOURCES_TARGETED_DEVICE_FAMILY,
         RESOURCE_FLAG,
         RETAIN_RAW_BINARIES,
+        RETAIN_RAW_BINARIES_ONLY,
         REZ_COLLECTOR_DIR,
         REZ_NO_AUTOMATIC_SEARCH_PATHS,
         REZ_OBJECTS_DIR,

--- a/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CopyTool.swift
@@ -29,6 +29,7 @@ public final class CopyToolSpec : CompilerSpec, SpecIdentifierType, @unchecked S
         ruleName: String? = nil, executionDescription: String? = nil,
         removeHeaderDirectories: Bool = false, removeStaticExecutables: Bool = false,
         excludeSubpaths: [String] = [], includeOnlySubpaths: [String] = [],
+        includeOnlyFileTypes: [CopyFileType] = [],
         stripUnsignedBinaries: Bool? = nil, stripSubpaths: [String] = [],
         stripBitcode: Bool = false, skipCopyIfContentsEqual: Bool = false,
         additionalFilesToRemove: [String]? = nil,
@@ -89,6 +90,11 @@ public final class CopyToolSpec : CompilerSpec, SpecIdentifierType, @unchecked S
                     return nil
                 }
                 return cbc.scope.namespace.parseStringList(includeOnlySubpaths + ["$(inherited)"])
+            case BuiltinMacros.PBXCP_INCLUDE_ONLY_FILE_TYPES:
+                guard !includeOnlyFileTypes.isEmpty else {
+                    return nil
+                }
+                return cbc.scope.namespace.parseStringList(includeOnlyFileTypes.map(\.rawValue) + ["$(inherited)"])
             default:
                 return nil
             }

--- a/Sources/SWBCore/Specs/NativeBuildSystem.xcspec
+++ b/Sources/SWBCore/Specs/NativeBuildSystem.xcspec
@@ -370,6 +370,10 @@ When `GENERATE_INFOPLIST_FILE` is enabled, sets the value of the [CFBundleExecut
                 DefaultValue = "$(INSTALLED_PRODUCT_ASIDES)";
                 Description = "Specifies whether to keep copies of unstripped binaries available.";
             },
+            {   Name = RETAIN_RAW_BINARIES_ONLY;
+                Type = Boolean;
+                DefaultValue = NO;
+            },
             {   Name = SET_DIR_MODE_OWNER_GROUP;
                 Type = Boolean;
                 DefaultValue = YES;

--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -217,7 +217,9 @@ package final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskP
                 output = buildDir.join(fullProductName)
             }
             await appendGeneratedTasks(&tasks) { delegate in
-                await context.copySpec.constructCopyTasks(CommandBuildContext(producer: context, scope: scope, inputs: [input], output: output, commandOrderingInputs: additionalInputs), delegate, stripUnsignedBinaries: false, stripBitcode: false, repairViaOwnershipAnalysis: true)
+                // Unless we were asked to copy aside the whole product, only copy the binaries, since those are the only files this feature needs to retain.  (Enclosing directories and relevant symlinks in the product will also be copied.)
+                let includeOnlyFileTypes: [CopyFileType] = scope.evaluate(BuiltinMacros.RETAIN_RAW_BINARIES_ONLY) ? [.binary] : []
+                await context.copySpec.constructCopyTasks(CommandBuildContext(producer: context, scope: scope, inputs: [input], output: output, commandOrderingInputs: additionalInputs), delegate, includeOnlyFileTypes: includeOnlyFileTypes, stripUnsignedBinaries: false, stripBitcode: false, repairViaOwnershipAnalysis: true)
             }
         }
     }

--- a/Sources/SWBUniversalPlatform/Specs/PBXCp.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/PBXCp.xcspec
@@ -124,6 +124,12 @@
                 CommandLineFlag = "-include_only_subpath";
             },
 
+            {   Name = PBXCP_INCLUDE_ONLY_FILE_TYPES;
+                Type = StringList;
+                DefaultValue = "";
+                CommandLineFlag = "-include_only_file_type";
+            },
+
             {   Name = PBXCP_STRIP_UNSIGNED_BINARIES;
                 Type = Boolean;
                 DefaultValue = "$(COPY_PHASE_STRIP)";

--- a/Sources/SWBUtil/PbxCp.swift
+++ b/Sources/SWBUtil/PbxCp.swift
@@ -169,6 +169,91 @@ fileprivate func isMacho(_ path: Path) throws -> Bool {
     return ret
 }
 
+/// Returns `true` if the file at `path` is of one of the file types being copied.
+///
+/// The result is recorded in `pathsToCopyCache` so that a file which was examined while scanning one of its ancestor directories doesn't need to be examined again.
+fileprivate func fileMatchesIncludedFileTypes(_ path: Path, _ options: CopyOptions, _ pathsToCopyCache: inout [Path: Bool]) throws -> Bool {
+    if let cachedResult = pathsToCopyCache[path] {
+        return cachedResult
+    }
+    var result = false
+    for fileType in options.includeOnlyFileTypes {
+        switch fileType {
+        case .binary:
+            if try isMacho(path) {
+                result = true
+            }
+        }
+        if result {
+            break
+        }
+    }
+    pathsToCopyCache[path] = result
+    return result
+}
+
+/// Returns `true` if the directory at `path` recursively contains a file of one of the file types being copied.
+///
+/// Symlinks are not followed while scanning, both to avoid cycles and because a symlink to a file of one of these types elsewhere in the tree will be found on its own merits.
+///
+/// The result for `path` and for every directory and file traversed along the way is recorded in `pathsToCopyCache`, so that a directory which was traversed while checking one of its ancestors doesn't need to be traversed again.
+fileprivate func directoryContainsIncludedFileType(_ path: Path, _ options: CopyOptions, _ pathsToCopyCache: inout [Path: Bool]) throws -> Bool {
+    if let cachedResult = pathsToCopyCache[path] {
+        return cachedResult
+    }
+    var result = false
+    for dirEntry in (try? localFS.listdir(path)) ?? [] {
+        let entryPath = path.join(dirEntry)
+        let fileInfo = try localFS.getLinkFileInfo(entryPath)
+        if fileInfo.isSymlink {
+            continue
+        } else if fileInfo.isFile {
+            if try fileMatchesIncludedFileTypes(entryPath, options, &pathsToCopyCache) {
+                result = true
+                break
+            }
+        } else if fileInfo.isDirectory {
+            if try directoryContainsIncludedFileType(entryPath, options, &pathsToCopyCache) {
+                result = true
+                break
+            }
+        }
+    }
+    pathsToCopyCache[path] = result
+    return result
+}
+
+/// Returns `true` if the entry at `path` should be copied, given the file types (if any) which are being copied exclusively.
+///
+/// If no file types were requested then everything is copied.  Otherwise a file is copied if it is of one of these types, and a directory is copied if it recursively contains such a file.  A symlink is resolved and then evaluated by those same rules, so that structural symlinks in a versioned framework are preserved; a symlink which can't be resolved is not copied.
+///
+/// `pathsToCopyCache` maps the paths which have already been evaluated to whether they should be copied, so that a directory which was traversed while checking one of its ancestors doesn't need to be traversed again.  Since symlinks are resolved before consulting it, a symlink and its target share a single entry.
+fileprivate func entryShouldBeCopied(_ path: Path, _ options: CopyOptions, _ pathsToCopyCache: inout [Path: Bool]) throws -> Bool {
+    guard !options.includeOnlyFileTypes.isEmpty else {
+        // No file type filtering was requested, so copy everything.
+        return true
+    }
+
+    var path = path
+    var fileInfo = try localFS.getLinkFileInfo(path)
+    if fileInfo.isSymlink {
+        guard let resolvedPath = try? localFS.realpath(path) else {
+            // The symlink is dangling, so there's nothing to copy.
+            return false
+        }
+        path = resolvedPath
+        fileInfo = try localFS.getLinkFileInfo(path)
+    }
+
+    // Copy this path if either it is a file of one of the specified types, a directory which contains a file of one of the specified types, or a symbolic link which ultimately resolves to such a file or directory.
+    if fileInfo.isFile {
+        return try fileMatchesIncludedFileTypes(path, options, &pathsToCopyCache)
+    } else if fileInfo.isDirectory {
+        return try directoryContainsIncludedFileType(path, options, &pathsToCopyCache)
+    }
+    return false
+}
+
 fileprivate func textOutput(_ str: String, indentTo: Int, outStream: OutputByteStream) {
     outStream <<< "\(String(repeating: " ", count: indentTo * 3))\(str)\n"
 }
@@ -333,7 +418,7 @@ func _copyFile(_ srcPath: Path, _ dstPath: Path) throws {
     }
 }
 
-fileprivate func copyDirectory(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcParentPath: Path, _ dstPath: Path, options: CopyOptions, verbose: Bool, indentationLevel: Int, outStream: OutputByteStream) async throws -> Int {
+fileprivate func copyDirectory(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcParentPath: Path, _ dstPath: Path, options: CopyOptions, pathsToCopyCache: inout [Path: Bool], verbose: Bool, indentationLevel: Int, outStream: OutputByteStream) async throws -> Int {
     if verbose {
         textOutput("copying \(srcPath.basename)/...", indentTo: indentationLevel, outStream: outStream)
     }
@@ -387,10 +472,15 @@ fileprivate func copyDirectory(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcPa
             }
         }
 
+        // Skip any entry which is not of one of the file types in 'includeOnlyFileTypes' (which was populated by any -include_only_file_type options), and which is not a directory containing such a file.
+        if try !entryShouldBeCopied(srcEntryPath, options, &pathsToCopyCache) {
+            continue next_dir_entry
+        }
+
         let newDstPath = dstPath.join(dirEntry)
 
         // This entry is not to be skipped -- we copy it as appropriate.
-        let ret = try await copyEntry(srcEntryPath, srcTopLevelPath, srcParentPath, newDstPath, options: options, verbose: options.VerboseSource, indentationLevel: indentationLevel + 1, outStream: outStream)
+        let ret = try await copyEntry(srcEntryPath, srcTopLevelPath, srcParentPath, newDstPath, options: options, pathsToCopyCache: &pathsToCopyCache, verbose: options.VerboseSource, indentationLevel: indentationLevel + 1, outStream: outStream)
         num_files += ret
     }
 
@@ -403,7 +493,7 @@ fileprivate func copyDirectory(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcPa
 }
 
 // Funnel function which recursively copies the given path.
-fileprivate func copyEntry(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcParentPath: Path, _ dstPath: Path, options: CopyOptions, verbose: Bool, indentationLevel: Int, outStream: OutputByteStream) async throws -> Int {
+fileprivate func copyEntry(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcParentPath: Path, _ dstPath: Path, options: CopyOptions, pathsToCopyCache: inout [Path: Bool], verbose: Bool, indentationLevel: Int, outStream: OutputByteStream) async throws -> Int {
     let fileInfo = try localFS.getLinkFileInfo(srcPath)
     if fileInfo.isSymlink {
         try copySymlink(srcPath, dstPath, dryRun: options.dryRun, verbose: verbose, indentationLevel: indentationLevel, outStream: outStream)
@@ -416,7 +506,7 @@ fileprivate func copyEntry(_ srcPath: Path, _ srcTopLevelPath: Path, _ srcParent
         }
         return 1
     } else if fileInfo.isDirectory {
-        return try await copyDirectory(srcPath, srcTopLevelPath, srcParentPath, dstPath, options: options, verbose: verbose, indentationLevel: indentationLevel, outStream: outStream)
+        return try await copyDirectory(srcPath, srcTopLevelPath, srcParentPath, dstPath, options: options, pathsToCopyCache: &pathsToCopyCache, verbose: verbose, indentationLevel: indentationLevel, outStream: outStream)
     } else {
         throw StubError.error("\(srcPath): unsupported or unknown file type: \(fileInfo.fileAttrs[.type] as! String)")
     }
@@ -483,13 +573,24 @@ fileprivate func copyTree(_ srcPath: Path, _ dstPath: Path, options: CopyOptions
         outStream <<< "error: Unable to compute parent path for -> '\(srcPath.str)'\n"
         return false
     }
+
+    // Maps the paths which have been evaluated to whether they should be copied, so that a directory which was traversed while checking one of its ancestors (because options.includeOnlyFileTypes is not empty) doesn't need to be traversed again.
+    var pathsToCopyCache = [Path: Bool]()
     do {
-        try await _ = copyEntry(srcPath, srcPath, parentPath, dstPath, options: options, verbose: options.verboseEntry || options.VerboseSource, indentationLevel: 0, outStream: outStream)
+        try await _ = copyEntry(srcPath, srcPath, parentPath, dstPath, options: options, pathsToCopyCache: &pathsToCopyCache, verbose: options.verboseEntry || options.VerboseSource, indentationLevel: 0, outStream: outStream)
     } catch {
         outStream <<< "error: \(error.localizedDescription)\n"
         return false
     }
     return true
+}
+
+/// A type of file which `builtin-copy` can be asked to copy exclusively, via the `-include_only_file_type` option.
+///
+/// Enclosing directories and symlinks which resolve to such files or directories containing such files will also be copied.
+public enum CopyFileType: String, CaseIterable, Sendable, ExpressibleByArgument {
+    /// Any Mach-O file (executable, dynamic library, bundle, or object file) or `ar` static archive.
+    case binary
 }
 
 struct CopyOptions: AsyncParsableCommand {
@@ -548,6 +649,9 @@ struct CopyOptions: AsyncParsableCommand {
 
     @Option(name: .customLong("include_only_subpath", withSingleDash: true), help: "only copy the entry relative to <src>")
     var includeOnlySubpaths: [Path] = []
+
+    @Option(name: .customLong("include_only_file_type", withSingleDash: true), help: "only copy files of <type>, and directories which contain them; however, files passed as arguments are always copied")
+    var includeOnlyFileTypes: [CopyFileType] = []
 
     @Option(name: .customLong("strip_subpath", withSingleDash: true), help: "strips debug symbols from the entry relative to <src>")
     var stripSubpaths: [Path] = []

--- a/Tests/SWBUtilTests/PBXCpTests.swift
+++ b/Tests/SWBUtilTests/PBXCpTests.swift
@@ -296,6 +296,95 @@ fileprivate struct PBXCpTests {
         }
     }
 
+    /// Test the `-include_only_file_type` option, which copies only files of the given types, and the directories which contain them.
+    @Test
+    func includeOnlyFileType() async throws {
+        try await withTemporaryDirectory { tmp in
+            let src = tmp.join("src")
+            let fs = localFS
+
+            // These are fake Mach-O and static archive files, just enough to trick PBXCp.
+            let machOContents: [UInt8] = [0xFE, 0xED, 0xFA, 0xCE, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
+            let archiveContents: [UInt8] = [0x21, 0x3C, 0x61, 0x72, 0x63, 0x68, 0x3E, 0x0A, 0x0, 0x0, 0x0, 0x0]
+
+            // Create a macOS-style framework bundle so we can test copying symlinks.
+            try fs.createDirectory(src)
+            try fs.createDirectory(src.join("MacOS.framework"))
+            try fs.createDirectory(src.join("MacOS.framework").join("Versions"))
+            try fs.createDirectory(src.join("MacOS.framework").join("Versions").join("A"))
+            try fs.symlink(src.join("MacOS.framework").join("Versions").join("Current"), target: Path("A"))
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("Any"), contents: ByteString(machOContents))
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("libStatic.a"), contents: ByteString(archiveContents))
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("Info.plist"), contents: "Info")
+            try fs.symlink(src.join("MacOS.framework").join("Any"), target: Path("Versions").join("Current").join("Any"))
+            try fs.createDirectory(src.join("MacOS.framework").join("Versions").join("A").join("_CodeSignature"))
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("_CodeSignature").join("CodeResources"), contents: "Signing Resources")
+            try fs.createDirectory(src.join("MacOS.framework").join("Versions").join("A").join("Resources"))
+            try fs.symlink(src.join("MacOS.framework").join("Resources"), target: Path("Versions").join("Current"))
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("Resources").join("A"), contents: "A")
+            try fs.write(src.join("MacOS.framework").join("Versions").join("A").join("Resources").join("B"), contents: "B")
+
+            // Copying only binaries should copy the Mach-O file and the static archive, and the directories and symlinks which lead to them, but nothing else.
+            do {
+                let dst = tmp.join("dst1")
+                // The destination has to exist, I guess?
+                try fs.createDirectory(dst)
+                let result = await pbxcp(["builtin-copy", "-include_only_file_type", "binary", "-v", src.join("MacOS.framework").str, dst.str], cwd: Path("/"))
+                #expect(result.success == true)
+                #expect(result.output == (
+                    "copying MacOS.framework/...\n"))
+                #expect(try fs.listdir(dst).sorted() == ["MacOS.framework"])
+                #expect(try fs.listdir(dst.join("MacOS.framework")).sorted() == ["Any", "Resources", "Versions"])
+                #expect(try fs.listdir(dst.join("MacOS.framework").join("Versions")).sorted() == ["A", "Current"])
+                #expect(try fs.listdir(dst.join("MacOS.framework").join("Versions").join("A")).sorted() == ["Any", "libStatic.a"])
+            }
+
+            // Create an iOS-style framework bundle so we can test not copying things at the same level as the binary.
+            try fs.createDirectory(src.join("iOS.framework"))
+            try fs.write(src.join("iOS.framework").join("Again"), contents: ByteString(machOContents))
+            try fs.write(src.join("iOS.framework").join("Again.car"), contents: "Assets")           // Should not be copied
+            try fs.createDirectory(src.join("iOS.framework").join("_CodeSignature"))
+            try fs.write(src.join("iOS.framework").join("_CodeSignature").join("CodeResources"), contents: "Signing Resources")
+            try fs.createDirectory(src.join("iOS.framework").join("Resources"))
+            try fs.write(src.join("iOS.framework").join("Resources").join("A"), contents: "A")
+            try fs.write(src.join("iOS.framework").join("Resources").join("B"), contents: "B")
+
+            // Check that this copies the binary but not the resources.
+            do {
+                let dst = tmp.join("dst2")
+                // The destination has to exist, I guess?
+                try fs.createDirectory(dst)
+                let result = await pbxcp(["builtin-copy", "-include_only_file_type", "binary", "-v", src.join("iOS.framework").str, dst.str], cwd: Path("/"))
+                #expect(result.success == true)
+                #expect(result.output == (
+                    "copying iOS.framework/...\n"))
+                #expect(try fs.listdir(dst).sorted() == ["iOS.framework"])
+                #expect(try fs.listdir(dst.join("iOS.framework")).sorted() == ["Again"])
+            }
+
+            // Files passed as arguments are always copied, even if they aren't of one of the given file types.
+            do {
+                let dst = tmp.join("dst3")
+                // The destination has to exist, I guess?
+                try fs.createDirectory(dst)
+                let result = await pbxcp(["builtin-copy", "-include_only_file_type", "binary", "-v", src.join("iOS.framework").join("Again.car").str, dst.str], cwd: Path("/"))
+                #expect(result.success == true)
+                #expect(result.output == (
+                    "copying Again.car...\n" +
+                    " 6 bytes\n"))
+                #expect(try fs.listdir(dst).sorted() == ["Again.car"])
+            }
+
+            // An unrecognized file type is an error.
+            do {
+                let dst = tmp.join("dst4")
+                let result = await pbxcp(["builtin-copy", "-include_only_file_type", "bogus", "-v", src.join("iOS.framework").str, dst.str], cwd: Path("/"))
+                #expect(result.success == false)
+                XCTAssertMatch(result.output, .contains("The value 'bogus' is invalid for '-include_only_file_type <include_only_file_type>'"))
+            }
+        }
+    }
+
     /// Check that we can invoke `strip`.
     @Test
     func stripUnstrippedBinaries() async throws {


### PR DESCRIPTION
Add a new setting `RETAIN_RAW_BINARIES_ONLY` which when enabled will cause the copy-aside step of an install build to only copy binaries, their enclosing directories, and symlinks which resolve to such binaries or directories. No other content will be copied.

rdar://78187414