### PR TITLE
Limit concurrent nonblocking dependency graph construction

### DIFF
--- a/Sources/SWBBuildService/CMakeLists.txt
+++ b/Sources/SWBBuildService/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(SWBBuildService
   BuildServiceEntryPoint.swift
   ClientExchangeDelegate.swift
   DependencyGraphMessages.swift
+  DependencyGraphRequestCoordinator.swift
   DocumentationInfo.swift
   LocalizationInfo.swift
   Messages.swift

--- a/Sources/SWBBuildService/DependencyGraphMessages.swift
+++ b/Sources/SWBBuildService/DependencyGraphMessages.swift
@@ -121,16 +121,23 @@ struct NonBlockingComputeDependencyGraphMsg: MessageHandler {
             priority = .userInitiated
         }
 
-        _Concurrency.Task<Void, Never>(priority: priority) {
-            do {
-                let buildGraph = try await constructTargetBuildGraph(for: message.targetGUIDs, in: workspaceContext, buildParameters: message.buildParameters, includeImplicitDependencies: message.includeImplicitDependencies, dependencyScope: message.dependencyScope)
-                var adjacencyList: [TargetGUID: [TargetGUID]] = [:]
-                for configuredTarget in buildGraph.allTargets {
-                    adjacencyList[TargetGUID(rawValue: configuredTarget.target.guid), default: []].append(contentsOf: buildGraph.dependencies(of: configuredTarget).map { TargetGUID(rawValue: $0.target.guid) })
-                }
-                requestForReply.reply(DependencyGraphResponse(adjacencyList: adjacencyList))
-            } catch {
-                return requestForReply.reply(ErrorResponse("unable to compute dependency graph: \(error)"))
+        session.dependencyGraphRequestCoordinator.submit(lane: buildParameters.action == .indexBuild ? .index : .foreground, priority: priority) {
+            let buildGraph = try await constructTargetBuildGraph(for: message.targetGUIDs, in: workspaceContext, buildParameters: message.buildParameters, includeImplicitDependencies: message.includeImplicitDependencies, dependencyScope: message.dependencyScope)
+            try _Concurrency.Task.checkCancellation()
+            var adjacencyList: [TargetGUID: [TargetGUID]] = [:]
+            for configuredTarget in buildGraph.allTargets {
+                try _Concurrency.Task.checkCancellation()
+                adjacencyList[TargetGUID(rawValue: configuredTarget.target.guid), default: []].append(contentsOf: buildGraph.dependencies(of: configuredTarget).map { TargetGUID(rawValue: $0.target.guid) })
+            }
+            return DependencyGraphResponse(adjacencyList: adjacencyList)
+        } completion: { outcome in
+            switch outcome {
+            case .success(let response):
+                requestForReply.reply(response)
+            case .failure(let description):
+                requestForReply.reply(ErrorResponse("unable to compute dependency graph: \(description)"))
+            case .cancelled:
+                requestForReply.reply(VoidResponse())
             }
         }
 

--- a/Sources/SWBBuildService/DependencyGraphRequestCoordinator.swift
+++ b/Sources/SWBBuildService/DependencyGraphRequestCoordinator.swift
@@ -1,0 +1,155 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+package import SWBProtocol
+package import SWBUtil
+import Synchronization
+
+package final class DependencyGraphRequestCoordinator: Sendable {
+    package enum Lane: Sendable {
+        case index
+        case foreground
+    }
+
+    package enum Outcome: Equatable, Sendable {
+        case success(DependencyGraphResponse)
+        case failure(String)
+        case cancelled
+    }
+
+    package typealias Completion = @Sendable (Outcome) -> Void
+
+    private struct Operation: Sendable {
+        let task: _Concurrency.Task<Void, Never>
+        let completion: Completion
+    }
+
+    private struct State: ~Copyable {
+        var acceptsNewOperations = true
+        var operations: [UUID: Operation] = [:]
+    }
+
+    // Index graph requests are background work and can arrive from multiple sessions at once.
+    // Keep a process-wide admission limit while allowing foreground graphs to proceed independently.
+    private static let sharedIndexQueue = AsyncOperationQueue(concurrentTasks: 1)
+
+    private let state = SWBMutex(State())
+    private let indexQueue: AsyncOperationQueue
+    private let foregroundQueue: AsyncOperationQueue
+
+    package init(indexQueue: AsyncOperationQueue? = nil, foregroundQueue: AsyncOperationQueue? = nil) {
+        self.indexQueue = indexQueue ?? Self.sharedIndexQueue
+        self.foregroundQueue = foregroundQueue ?? AsyncOperationQueue(concurrentTasks: 1)
+    }
+
+    deinit {
+        // Request.service is unowned, so pending replies must not outlive session
+        // teardown. A task calling finish retains this coordinator through its reply;
+        // once deinit starts, the remaining tasks cannot promote their weak reference.
+        let operations = state.withLock { Array($0.operations.values) }
+        for operation in operations {
+            operation.task.cancel()
+        }
+        for operation in operations {
+            operation.completion(.cancelled)
+        }
+    }
+
+    package func submit(
+        lane: Lane,
+        priority: _Concurrency.TaskPriority,
+        operation: @escaping @Sendable () async throws -> DependencyGraphResponse,
+        completion: @escaping Completion
+    ) {
+        let id = UUID()
+        let queue =
+            switch lane {
+            case .index: indexQueue
+            case .foreground: foregroundQueue
+            }
+        let shouldCancelImmediately = state.withLock { state -> Bool in
+            guard state.acceptsNewOperations else {
+                return true
+            }
+
+            let task = _Concurrency.Task<Void, Never>(priority: priority) { [weak self] in
+                let outcome: Outcome
+                do {
+                    let response = try await queue.withOperation {
+                        try _Concurrency.Task.checkCancellation()
+                        let response = try await operation()
+                        try _Concurrency.Task.checkCancellation()
+                        return response
+                    }
+                    outcome = .success(response)
+                } catch is _Concurrency.CancellationError {
+                    outcome = .cancelled
+                } catch {
+                    outcome = .failure(String(describing: error))
+                }
+                self?.finish(id: id, outcome: outcome, completion: completion)
+            }
+            state.operations[id] = Operation(task: task, completion: completion)
+            return false
+        }
+
+        if shouldCancelImmediately {
+            completion(.cancelled)
+        }
+    }
+
+    package func close() async {
+        let tasks = state.withLock { state in
+            state.acceptsNewOperations = false
+            return state.operations.values.map(\.task)
+        }
+        for task in tasks {
+            task.cancel()
+        }
+        for task in tasks {
+            await task.value
+        }
+    }
+
+    package func waitForQuiescence() async {
+        // Operations remain tracked until both graph construction and the terminal reply
+        // callback have finished. The Task may still be returning from its final
+        // bookkeeping call after it is removed from this state.
+        // ServiceHostConnection processes requests serially, so production callers cannot
+        // submit more work while awaiting this method. It is not an admission barrier for
+        // arbitrary concurrent callers.
+        while true {
+            let tasks = state.withLock { state in
+                state.operations.values.map(\.task)
+            }
+            if tasks.isEmpty {
+                return
+            }
+            for task in tasks {
+                await task.value
+            }
+        }
+    }
+
+    private func finish(id: UUID, outcome: Outcome, completion: Completion) {
+        let committedOutcome = state.withLock { state in
+            state.acceptsNewOperations ? outcome : .cancelled
+        }
+        // Keep the task registered through the callback so close and quiescence
+        // cannot return while a terminal reply is still being sent.
+        completion(committedOutcome)
+        state.withLock { state in
+            state.operations[id] = nil
+        }
+    }
+}

--- a/Sources/SWBBuildService/Messages.swift
+++ b/Sources/SWBBuildService/Messages.swift
@@ -219,6 +219,7 @@ private struct ListSessionsHandler: MessageHandler {
 private struct WaitForQuiescenceHandler: MessageHandler {
     func handle(request: Request, message: WaitForQuiescenceRequest) async throws -> VoidResponse {
         let session = try request.session(for: message)
+        await session.dependencyGraphRequestCoordinator.waitForQuiescence()
         await session.buildDescriptionManager.waitForBuildDescriptionSerialization()
         return VoidResponse()
     }
@@ -227,6 +228,7 @@ private struct WaitForQuiescenceHandler: MessageHandler {
 private struct DeleteSessionHandler: MessageHandler {
     func handle(request: Request, message: DeleteSessionRequest) async throws -> VoidResponse {
         let session = try request.session(for: message)
+        await session.dependencyGraphRequestCoordinator.close()
         await session.buildDescriptionManager.waitForBuildDescriptionSerialization()
         request.buildService.sessionMap.removeValue(forKey: session.UID)
         return VoidResponse()

--- a/Sources/SWBBuildService/Session.swift
+++ b/Sources/SWBBuildService/Session.swift
@@ -149,6 +149,8 @@ public final class Session {
     /// The unique ID of the session.
     let UID: String
 
+    package let dependencyGraphRequestCoordinator = DependencyGraphRequestCoordinator()
+
     /// The active workspace session
     public internal(set) var workspaceContext: WorkspaceContext?
 

--- a/Tests/SWBBuildServiceTests/DependencyGraphRequestCoordinatorTests.swift
+++ b/Tests/SWBBuildServiceTests/DependencyGraphRequestCoordinatorTests.swift
@@ -1,0 +1,509 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import SWBBuildService
+import SWBProtocol
+import SWBUtil
+import Synchronization
+import Testing
+
+@Suite(.serialized) fileprivate struct DependencyGraphRequestCoordinatorTests {
+    @Test
+    func executesEverySubmittedRequestAndReportsItsOutcome() async {
+        let coordinator = makeCoordinator()
+        let activity = ActivityRecorder()
+        let firstRecorder = OutcomeRecorder()
+        let secondRecorder = OutcomeRecorder()
+        let firstStarted = WaitCondition()
+        let releaseFirst = WaitCondition()
+
+        coordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("index")
+            defer { activity.end("index") }
+            firstStarted.signal()
+            await releaseFirst.wait()
+            return makeResponse("first")
+        } completion: {
+            firstRecorder.record($0)
+        }
+
+        await firstStarted.wait()
+
+        coordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("index")
+            defer { activity.end("index") }
+            throw TestError.expected
+        } completion: {
+            secondRecorder.record($0)
+        }
+
+        releaseFirst.signal()
+        await coordinator.waitForQuiescence()
+
+        #expect(activity.startCount("index") == 2)
+        #expect(firstRecorder.outcomes == [.success(makeResponse("first"))])
+        #expect(secondRecorder.outcomes == [.failure("expected")])
+    }
+
+    @Test
+    func serializesIndexRequestsAcrossSessionsWithoutBlockingForeground() async {
+        let firstCoordinator = DependencyGraphRequestCoordinator()
+        let secondCoordinator = DependencyGraphRequestCoordinator()
+        let activity = ActivityRecorder()
+        let firstIndexStarted = WaitCondition()
+        let releaseFirstIndex = WaitCondition()
+        let secondIndexStarted = WaitCondition()
+        let releaseSecondIndex = WaitCondition()
+        let firstForegroundStarted = WaitCondition()
+        let secondForegroundStarted = WaitCondition()
+        let queuedForegroundStarted = WaitCondition()
+        let releaseForeground = WaitCondition()
+
+        firstCoordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("index-a")
+            defer { activity.end("index-a") }
+            firstIndexStarted.signal()
+            await releaseFirstIndex.wait()
+            return makeResponse("index-a")
+        } completion: { _ in
+        }
+
+        await firstIndexStarted.wait()
+
+        secondCoordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("index-b")
+            defer { activity.end("index-b") }
+            secondIndexStarted.signal()
+            await releaseSecondIndex.wait()
+            return makeResponse("index-b")
+        } completion: { _ in
+        }
+
+        firstCoordinator.submit(lane: .foreground, priority: .userInitiated) {
+            activity.begin("foreground-a")
+            defer { activity.end("foreground-a") }
+            firstForegroundStarted.signal()
+            await releaseForeground.wait()
+            return makeResponse("foreground-a")
+        } completion: { _ in
+        }
+
+        secondCoordinator.submit(lane: .foreground, priority: .userInitiated) {
+            activity.begin("foreground-b")
+            defer { activity.end("foreground-b") }
+            secondForegroundStarted.signal()
+            await releaseForeground.wait()
+            return makeResponse("foreground-b")
+        } completion: { _ in
+        }
+
+        await firstForegroundStarted.wait()
+        await secondForegroundStarted.wait()
+
+        firstCoordinator.submit(lane: .foreground, priority: .userInitiated) {
+            activity.begin("foreground-queued")
+            defer { activity.end("foreground-queued") }
+            queuedForegroundStarted.signal()
+            return makeResponse("foreground-queued")
+        } completion: { _ in
+        }
+
+        #expect(activity.startCount("index-b") == 0)
+        #expect(activity.startCount("foreground-queued") == 0)
+        #expect(activity.maximumConcurrentIndexOperations == 1)
+        #expect(activity.maximumConcurrentForegroundOperations == 2)
+        #expect(activity.maximumConcurrentOperations == 3)
+
+        releaseForeground.signal()
+        await queuedForegroundStarted.wait()
+        releaseFirstIndex.signal()
+        await secondIndexStarted.wait()
+        releaseSecondIndex.signal()
+        await firstCoordinator.waitForQuiescence()
+        await secondCoordinator.waitForQuiescence()
+
+        #expect(activity.maximumConcurrentIndexOperations == 1)
+        #expect(activity.maximumConcurrentForegroundOperations == 2)
+    }
+
+    @Test
+    func closeCancelsActiveAndQueuedRequestsAndWaitsForCompletion() async {
+        let coordinator = makeCoordinator()
+        let activeStarted = WaitCondition()
+        let releaseActive = WaitCondition()
+        let cancellationObserved = WaitCondition()
+        let activity = ActivityRecorder()
+        let sequence = SequenceRecorder()
+        let lifecycleDriver = LifecycleDriver()
+        let activeRecorder = OutcomeRecorder()
+        let queuedRecorder = OutcomeRecorder()
+        let lateRecorder = OutcomeRecorder()
+
+        coordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("active")
+            defer { activity.end("active") }
+            sequence.record("operation-started")
+            activeStarted.signal()
+            await withTaskCancellationHandler {
+                await releaseActive.wait()
+            } onCancel: {
+                cancellationObserved.signal()
+            }
+            sequence.record("operation-finished")
+            return makeResponse("late-success")
+        } completion: {
+            sequence.record("active-reply")
+            activeRecorder.record($0)
+        }
+
+        await activeStarted.wait()
+
+        coordinator.submit(lane: .index, priority: .utility) {
+            activity.begin("queued")
+            defer { activity.end("queued") }
+            return makeResponse("queued")
+        } completion: {
+            sequence.record("queued-reply")
+            queuedRecorder.record($0)
+        }
+
+        let closeTask = _Concurrency.Task {
+            await lifecycleDriver.close(coordinator, sequence: sequence)
+        }
+
+        await cancellationObserved.wait()
+        await queuedRecorder.received.wait()
+        #expect(activeRecorder.outcomes.isEmpty)
+
+        coordinator.submit(lane: .index, priority: .utility) {
+            Issue.record("A closed coordinator must not start new work")
+            return makeResponse("unexpected")
+        } completion: {
+            sequence.record("late-reply")
+            lateRecorder.record($0)
+        }
+        await lateRecorder.received.wait()
+
+        await lifecycleDriver.release(releaseActive, sequence: sequence, event: "release-active")
+        await closeTask.value
+        await coordinator.close()
+
+        #expect(activeRecorder.outcomes == [.cancelled])
+        #expect(queuedRecorder.outcomes == [.cancelled])
+        #expect(lateRecorder.outcomes == [.cancelled])
+        #expect(activity.startCount("active") == 1)
+        #expect(activity.startCount("queued") == 0)
+        #expect(sequence.index(of: "operation-finished") < sequence.index(of: "active-reply"))
+        #expect(sequence.index(of: "active-reply") < sequence.index(of: "close-returned"))
+    }
+
+    @Test
+    func closeWaitsForCommittedReplyAndPreservesItsOutcome() async {
+        await withTaskExecutorPreference(TestDriverExecutor()) {
+            let coordinator = makeCoordinator()
+            let releaseReply = DispatchSemaphore(value: 0)
+            let replyStarted = WaitCondition()
+            let closeStarted = WaitCondition()
+            let sequence = SequenceRecorder()
+            let recorder = OutcomeRecorder()
+            let lifecycleDriver = LifecycleDriver()
+
+            coordinator.submit(lane: .foreground, priority: .userInitiated) {
+                makeResponse("success")
+            } completion: {
+                sequence.record("reply-started")
+                replyStarted.signal()
+                releaseReply.wait()
+                sequence.record("reply-finished")
+                recorder.record($0)
+            }
+
+            await replyStarted.wait()
+
+            async let closeTask: Void = lifecycleDriver.close(
+                coordinator,
+                started: closeStarted,
+                sequence: sequence
+            )
+
+            await closeStarted.wait()
+            await lifecycleDriver.release(releaseReply)
+            await recorder.received.wait()
+            await closeTask
+
+            #expect(recorder.outcomes == [.success(makeResponse("success"))])
+            #expect(sequence.index(of: "reply-finished") < sequence.index(of: "close-returned"))
+        }
+    }
+
+    @Test
+    func quiescenceWaitsForOperationAndReplyCompletion() async {
+        await withTaskExecutorPreference(TestDriverExecutor()) {
+            let coordinator = makeCoordinator()
+            let releaseReply = DispatchSemaphore(value: 0)
+            let replyStarted = WaitCondition()
+            let quiescenceStarted = WaitCondition()
+            let sequence = SequenceRecorder()
+            let lifecycleDriver = LifecycleDriver()
+
+            coordinator.submit(lane: .index, priority: .utility) {
+                sequence.record("operation-finished")
+                return makeResponse("success")
+            } completion: { _ in
+                sequence.record("reply-started")
+                replyStarted.signal()
+                releaseReply.wait()
+                sequence.record("reply-finished")
+            }
+
+            await replyStarted.wait()
+
+            async let quiescenceTask: Void = lifecycleDriver.waitForQuiescence(
+                of: coordinator,
+                started: quiescenceStarted,
+                sequence: sequence
+            )
+
+            await quiescenceStarted.wait()
+            await lifecycleDriver.release(releaseReply)
+            await quiescenceTask
+
+            #expect(sequence.index(of: "reply-started") < sequence.index(of: "reply-finished"))
+            #expect(sequence.index(of: "reply-finished") < sequence.index(of: "quiescence-returned"))
+        }
+    }
+
+    @Test
+    func closeDoesNotWaitForAnotherSessionsIndexOperation() async throws {
+        let indexQueue = AsyncOperationQueue(concurrentTasks: 1)
+        let started = WaitCondition()
+        let release = WaitCondition()
+        let blocker = _Concurrency.Task {
+            try await indexQueue.withOperation {
+                started.signal()
+                await release.wait()
+            }
+        }
+        await started.wait()
+
+        let coordinator = makeCoordinator(indexQueue: indexQueue)
+        let recorder = OutcomeRecorder()
+        coordinator.submit(lane: .index, priority: .utility) {
+            Issue.record("A cancelled queued request must not enter graph construction")
+            return makeResponse("unexpected")
+        } completion: {
+            recorder.record($0)
+        }
+
+        await coordinator.close()
+        #expect(recorder.outcomes == [.cancelled])
+        release.signal()
+        try await blocker.value
+    }
+
+    @Test
+    func deinitRepliesBeforeActiveOperationFinishes() async throws {
+        var coordinator: DependencyGraphRequestCoordinator? = makeCoordinator()
+        let started = WaitCondition()
+        let release = WaitCondition()
+        let finished = WaitCondition()
+        let recorder = OutcomeRecorder()
+
+        try #require(coordinator).submit(lane: .foreground, priority: .userInitiated) {
+            started.signal()
+            await release.wait()
+            finished.signal()
+            return makeResponse("late-success")
+        } completion: {
+            recorder.record($0)
+        }
+
+        await started.wait()
+        coordinator = nil
+        #expect(recorder.outcomes == [.cancelled])
+        release.signal()
+        await finished.wait()
+    }
+
+    @Test
+    func concurrentSubmissionAndCloseReplyExactlyOnce() async {
+        let coordinator = makeCoordinator()
+        let replyCounts = SWBMutex<[Int: Int]>([:])
+
+        await withTaskGroup(of: Void.self) { group in
+            for id in 0..<128 {
+                group.addTask {
+                    coordinator.submit(lane: id.isMultiple(of: 2) ? .index : .foreground, priority: .medium) {
+                        await _Concurrency.Task.yield()
+                        return makeResponse(String(id))
+                    } completion: { _ in
+                        replyCounts.withLock { $0[id, default: 0] += 1 }
+                    }
+                }
+                if id.isMultiple(of: 16) {
+                    group.addTask {
+                        await coordinator.close()
+                    }
+                }
+            }
+        }
+        await coordinator.close()
+
+        #expect(replyCounts.withLock { $0.count } == 128)
+        #expect(replyCounts.withLock { $0.values.allSatisfy { $0 == 1 } })
+    }
+}
+
+// Reply callbacks deliberately block so these tests can observe pending replies.
+// Their drivers must progress independently of the cooperative pool they block.
+private final class TestDriverExecutor: TaskExecutor {
+    private let queue = DispatchQueue(label: "dependency-graph-test-driver")
+
+    func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        queue.async {
+            job.runSynchronously(on: self.asUnownedTaskExecutor())
+        }
+    }
+}
+
+private actor LifecycleDriver {
+    func close(
+        _ coordinator: DependencyGraphRequestCoordinator,
+        started: WaitCondition? = nil,
+        sequence: SequenceRecorder
+    ) async {
+        started?.signal()
+        await coordinator.close()
+        sequence.record("close-returned")
+    }
+
+    func waitForQuiescence(
+        of coordinator: DependencyGraphRequestCoordinator,
+        started: WaitCondition,
+        sequence: SequenceRecorder
+    ) async {
+        started.signal()
+        await coordinator.waitForQuiescence()
+        sequence.record("quiescence-returned")
+    }
+
+    func release(_ condition: WaitCondition, sequence: SequenceRecorder? = nil, event: String? = nil) {
+        if let sequence, let event {
+            sequence.record(event)
+        }
+        condition.signal()
+    }
+
+    func release(_ semaphore: DispatchSemaphore) {
+        semaphore.signal()
+    }
+}
+
+private enum TestError: Error, CustomStringConvertible {
+    case expected
+
+    var description: String {
+        "expected"
+    }
+}
+
+private final class OutcomeRecorder: Sendable {
+    let received = WaitCondition()
+    private let storage = SWBMutex<[DependencyGraphRequestCoordinator.Outcome]>([])
+
+    var outcomes: [DependencyGraphRequestCoordinator.Outcome] {
+        storage.withLock { $0 }
+    }
+
+    func record(_ outcome: DependencyGraphRequestCoordinator.Outcome) {
+        storage.withLock { $0.append(outcome) }
+        received.signal()
+    }
+}
+
+private final class SequenceRecorder: Sendable {
+    private let events = SWBMutex<[String]>([])
+
+    func record(_ event: String) {
+        events.withLock { $0.append(event) }
+    }
+
+    func index(of event: String) -> Int {
+        events.withLock { events in
+            events.firstIndex(of: event) ?? Int.max
+        }
+    }
+}
+
+private final class ActivityRecorder: Sendable {
+    private struct State {
+        var active: Set<String> = []
+        var starts: [String: Int] = [:]
+        var maximumConcurrentIndexOperations = 0
+        var maximumConcurrentForegroundOperations = 0
+        var maximumConcurrentOperations = 0
+    }
+
+    private let state = SWBMutex(State())
+
+    func begin(_ name: String) {
+        state.withLock { state in
+            state.active.insert(name)
+            state.starts[name, default: 0] += 1
+            state.maximumConcurrentIndexOperations = max(
+                state.maximumConcurrentIndexOperations,
+                state.active.filter { $0.hasPrefix("index") }.count
+            )
+            state.maximumConcurrentForegroundOperations = max(
+                state.maximumConcurrentForegroundOperations,
+                state.active.filter { $0.hasPrefix("foreground") }.count
+            )
+            state.maximumConcurrentOperations = max(state.maximumConcurrentOperations, state.active.count)
+        }
+    }
+
+    func end(_ name: String) {
+        state.withLock { state in
+            #expect(state.active.remove(name) != nil)
+        }
+    }
+
+    func startCount(_ name: String) -> Int {
+        state.withLock { $0.starts[name, default: 0] }
+    }
+
+    var maximumConcurrentIndexOperations: Int {
+        state.withLock { $0.maximumConcurrentIndexOperations }
+    }
+
+    var maximumConcurrentForegroundOperations: Int {
+        state.withLock { $0.maximumConcurrentForegroundOperations }
+    }
+
+    var maximumConcurrentOperations: Int {
+        state.withLock { $0.maximumConcurrentOperations }
+    }
+}
+
+private func makeCoordinator(
+    indexQueue: AsyncOperationQueue = AsyncOperationQueue(concurrentTasks: 1),
+    foregroundQueue: AsyncOperationQueue = AsyncOperationQueue(concurrentTasks: 1)
+) -> DependencyGraphRequestCoordinator {
+    DependencyGraphRequestCoordinator(indexQueue: indexQueue, foregroundQueue: foregroundQueue)
+}
+
+private func makeResponse(_ target: String) -> DependencyGraphResponse {
+    let target = TargetGUID(rawValue: target)
+    return DependencyGraphResponse(adjacencyList: [target: []])
+}

--- a/Tests/SwiftBuildTests/DependencyRequestTests.swift
+++ b/Tests/SwiftBuildTests/DependencyRequestTests.swift
@@ -20,8 +20,8 @@ import SWBUtil
 
 @Suite(.requireHostOS(.macOS))
 fileprivate struct DependencyClosureTests: CoreBasedTests {
-    @Test
-    func computeDependencyClosureBasic() async throws {
+    @Test(arguments: ["build", "indexbuild"])
+    func computeDependencyClosureBasic(action: String) async throws {
         try await withTemporaryDirectory { temporaryDirectory in
             try await withAsyncDeferrable { deferrable in
                 let tmpDirPath = temporaryDirectory.path
@@ -124,23 +124,24 @@ fileprivate struct DependencyClosureTests: CoreBasedTests {
                     )
                 ]).toObjects().propertyListItem))
 
-                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [appTarget.guid], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                let parameters = SWBBuildParameters(action: action, configuration: "Debug", activeRunDestination: .anyiOSDevice)
+                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [appTarget.guid], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [f1Target.guid, f2Target.guid, f3Target.guid, appTarget.guid])
-                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [f2Target.guid], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [f2Target.guid], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [f1Target.guid, f2Target.guid])
-                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [f3Target.guid], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                #expect(try await testSession.session.computeDependencyClosure(targetGUIDs: [f3Target.guid], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [f3Target.guid])
 
-                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: appTarget.guid)], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: appTarget.guid)], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [SWBTargetGUID(rawValue: appTarget.guid): [SWBTargetGUID(rawValue: f2Target.guid), SWBTargetGUID(rawValue: f3Target.guid)],
                          SWBTargetGUID(rawValue: f3Target.guid): [],
                          SWBTargetGUID(rawValue: f2Target.guid): [SWBTargetGUID(rawValue: f1Target.guid)],
                          SWBTargetGUID(rawValue: f1Target.guid): []
                         ])
-                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: f2Target.guid)], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: f2Target.guid)], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [SWBTargetGUID(rawValue: f2Target.guid): [SWBTargetGUID(rawValue: f1Target.guid)],
                          SWBTargetGUID(rawValue: f1Target.guid): []])
-                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: f3Target.guid)], buildParameters: SWBBuildParameters(), includeImplicitDependencies: true) ==
+                #expect(try await testSession.session.computeDependencyGraph(targetGUIDs: [SWBTargetGUID(rawValue: f3Target.guid)], buildParameters: parameters, includeImplicitDependencies: true) ==
                         [SWBTargetGUID(rawValue: f3Target.guid): []])
             }
         }


### PR DESCRIPTION
## Summary

`NonBlockingComputeDependencyGraphMsg` currently starts an independent task for every request, allowing overlapping computations to retain multiple request contexts and graph states. This PR limits concurrent graph construction while keeping foreground requests independent of indexing work.

## Changes

- Limit index graph construction to one operation across the service process.
- Limit foreground graph construction to one operation per session, using queues independent of indexing and other sessions.
- Track each request through its terminal response. Session deletion requests cancellation and awaits owned tasks; quiescence also waits for their responses.
- Send synchronous cancellation responses for outstanding requests during teardown.

Only the nonblocking request path is limited; other graph-construction paths and normal build-task scheduling are unchanged. Queue depth and total memory usage are not capped.

## Measured impact — Release builds

In one 900-second run per variant with six concurrent Preview requests, observed peak physical footprint fell from **43.49 GiB to 7.14 GiB (83.6% lower)**. Both variants completed all six requests successfully.

```mermaid
xychart-beta
    title "Observed peak physical footprint — 900-second window"
    x-axis ["Unpatched", "Patched"]
    y-axis "GiB" 0 --> 50
    bar [43.49, 7.14]
```

| Metric | Unpatched | Patched | Observed change |
|---|---:|---:|---:|
| Peak physical footprint over 900 s | 43.49 GiB | 7.14 GiB | 83.6% lower |
| Physical footprint at 900 s | 42.85 GiB | 1.06 GiB | 97.5% lower |
| Time until all six Preview responses completed | 111.91 s | 98.19 s | 12.3% shorter |
| Service CPU time over 900 s | 2,594.25 CPU-s | 985.28 CPU-s | 62.0% lower |
| Average service CPU usage during the Preview request interval | 250.10% | 179.49% | 28.2% lower |

Compared Release builds (`-O`, whole-module optimization) of upstream `b2e24c9a875bc38370c9da36ea25bc2877522540` and this PR's production sources on Xcode 27.0 (27A5252f), Swift 6.4, macOS 26.6.2 (25G83), and 64 GiB RAM. Each run used fresh Xcode/service processes, the same workload, and restored DerivedData and UI state. Requests were submitted at 60 s; `proc_pid_rusage` was sampled every 100 ms for 900 s.

The patched run came first, and the observation window includes startup and background work. OS page cache and Simulator state were not reset; another Xcode instance remained open. CPU figures are service-only (100% = one core). Preview duration covers request submission through the final response, not graph construction alone.

## Testing

Validated locally on macOS with Swift 6.4:

- `swift test --disable-sandbox --force-resolved-versions`: passed with pinned dependencies, including existing known issues and SDK-conditional skips.
- All eight coordinator tests passed 100 repetitions each with Thread Sanitizer and `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`, with no sanitizer reports.
- Added coverage for cross-session admission, independent foreground progress, cancellation, exactly-once responses, and response completion during shutdown. The dependency-request integration test covers both `build` and `indexbuild` actions.
- `bash .github/scripts/format-check.sh` and diff-whitespace checks passed.
