### PR TITLE
Drop armv7k as a Swift module-only arch on watchOS

### DIFF
--- a/Sources/SWBApplePlatform/Specs/watchOSDevice.xcspec
+++ b/Sources/SWBApplePlatform/Specs/watchOSDevice.xcspec
@@ -49,6 +49,7 @@
         Name = "armv7k";
         DeploymentTargetRange = ( "0", "9" );
         DeprecatedError = YES;
+        IncludeAsSwiftModuleOnlyArch = NO;
     },
     {
         _Domain = watchos;


### PR DESCRIPTION
`armv7k` is retired on watchOS, so opt armv7k out via IncludeAsSwiftModuleOnlyArch, matching armv7/armv7s-ios.

Resolves: rdar://182837743
