### PR TITLE
Enable index-while-building with clang from a Swift.org toolchain

### DIFF
--- a/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
+++ b/Sources/SWBCore/SpecImplementations/Tools/CCompiler.swift
@@ -681,7 +681,9 @@ public class ClangCompilerSpec : CompilerSpec, SpecIdentifierType, GCCCompatible
         commandLine += self.commandLineFromOptions(producer, scope: scope, inputFileType: inputFileType, optionContext: optionContext, buildOptionsFilter: .specOnly, lookup: { declaration in
             if declaration.name == "CLANG_INDEX_STORE_ENABLE" && optionContext is DiscoveredClangToolSpecInfo {
                 let clangToolInfo = optionContext as! DiscoveredClangToolSpecInfo
-                if !clangToolInfo.isAppleClang {
+                // Only the Swift fork of Clang supports index while building. Disable it if this isn't an
+                // Apple Clang and it doesn't have the --index-unit-output-path feature.
+                if !clangToolInfo.isAppleClang && !clangToolInfo.toolFeatures.has(.indexUnitOutputPath) {
                     return BuiltinMacros.namespace.parseString("NO")
                 }
             }

--- a/Tests/SWBTaskConstructionTests/ClangTests.swift
+++ b/Tests/SWBTaskConstructionTests/ClangTests.swift
@@ -448,6 +448,54 @@ fileprivate struct ClangTests: CoreBasedTests {
         }
     }
 
+    @Test(.requireSDKs(.host))
+    func indexOptionsRequireClangSupport() async throws {
+        let clangInfo = try await self.clangInfo
+        let supportsIndexWhileBuilding = clangInfo.isAppleClang || clangInfo.toolFeatures.has(.indexUnitOutputPath)
+
+        try await withTemporaryDirectory { tmpDir in
+            let testProject = TestProject(
+                "ProjectName",
+                sourceRoot: tmpDir,
+                groupTree: TestGroup(
+                    "SomeFiles",
+                    children: [
+                        TestFile("File1.c")
+                    ]),
+                targets: [
+                    TestStandardTarget(
+                        "Test",
+                        type: .dynamicLibrary,
+                        buildConfigurations: [
+                            TestBuildConfiguration(
+                                "Debug",
+                                buildSettings: [
+                                    "COMPILER_INDEX_STORE_ENABLE": "YES",
+                                    "INDEX_DATA_STORE_DIR": tmpDir.join("index").str,
+                                    "CC": clangInfo.toolPath.str,
+                                ]
+                            ),
+                        ],
+                        buildPhases: [
+                            TestSourcesBuildPhase(["File1.c"]),
+                        ]
+                    )
+                ])
+
+            let core = try await getCore()
+            let tester = try TaskConstructionTester(core, testProject)
+            await tester.checkBuild(BuildParameters(configuration: "Debug", commandLineOverrides: ["INDEX_ENABLE_DATA_STORE": "YES"]), runDestination: .host) { results in
+                results.checkTask(.matchRuleType("CompileC")) { compileTask in
+                    if supportsIndexWhileBuilding {
+                        compileTask.checkCommandLineContainsUninterrupted(["-index-store-path", tmpDir.join("index").str])
+                    } else {
+                        compileTask.checkCommandLineDoesNotContain("-index-store-path")
+                    }
+                }
+            }
+        }
+    }
+
     @Test(.requireSDKs(.host), .requireClangFeatures(.invokeSsaf))
     func invokeSsafOptions() async throws {
         func getTestProject(invokeSSAF: String, extractSummaries: String = "", stopAtLUSummaryGeneration: String = "", sourceTransformation: String = "") -> TestProject {


### PR DESCRIPTION
Previously when enabling index-while-building for Clang we checked for an Apple Clang to determine compatibility. Also check for the indexUnitOutputPath feature in features.json, which will be present in an open source clang with the functionality.