### PR TITLE
Use Path.pathEnvironmentSeparator rather than explicit separator string.

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -1014,7 +1014,7 @@ extension Core {
 
             // Add the entries from PATH.
             if let value = userInfo?.buildSystemEnvironment["PATH"] {
-                for item in value.split(separator: ":") {
+                for item in value.split(separator: Path.pathEnvironmentSeparator) {
                     // Only honor absolute paths.
                     let path = Path(item)
                     if path.isAbsolute {


### PR DESCRIPTION
(cherry picked from commit 7f319aded254c9d4fd6178d8e7a7533989f3edfc)