### PR TITLE
Revert "Pass `-Xcc -std=c++2b` to Swift when `CLANG_CXX_LANGUAGE_STANDARD` is set to `c++2b`"

### DIFF
--- a/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
+++ b/Sources/SWBUniversalPlatform/Specs/Swift.xcspec
@@ -1589,8 +1589,6 @@
                     "objcxx-gnu++20" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "objcxx-c++23" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "objcxx-gnu++23" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
-                    "objcxx-c++2b" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
-                    "objcxx-gnu++2b" = ("-Xcc", "-std=$(CLANG_CXX_LANGUAGE_STANDARD)");
                     "<<otherwise>>" = ();
                 };
             },

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4584,15 +4584,6 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             }
         }
 
-        try await withTemporaryDirectory { tmpDir in
-            let tester = try await setupInteropTest(tmpDir, enableInterop: true, cxxLangStandard: "c++2b")
-            await tester.checkBuild(runDestination: .macOS) { results in
-                results.checkTask(.matchRuleType("SwiftDriver Compilation")) { task in
-                    task.checkCommandLineContainsUninterrupted(["-Xcc", "-std=c++2b"])
-                }
-            }
-        }
-
         // Verify that we don't pass C++ settings to Swift compilations when C++
         // interoperability is disabled.
         try await withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
This reverts commit 92872567b5dff0d4507809c190a6bb664fec8ea0.