### PR TITLE
Don't infer SWIFT_LIBRARY_LEVEL from SKIP_INSTALL over an explicit -l…

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2241,9 +2241,13 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
         // FIXME: Arguably we should emit a warning if the optimization settings are out of sync, as the user may be getting weird results.  It's not clear if there are lots of old projects which might spuriously get such a warning, and this isn't a new state of affairs.
         table.push(BuiltinMacros.IS_UNOPTIMIZED_BUILD, literal: (scope.evaluate(BuiltinMacros.GCC_OPTIMIZATION_LEVEL) == "0" || scope.evaluate(BuiltinMacros.SWIFT_OPTIMIZATION_LEVEL) == "-Onone"))
 
-        // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.
+        // If unset, infer the default SWIFT_LIBRARY_LEVEL from the INSTALL_PATH.  An explicit
+        // -library-level in OTHER_SWIFT_FLAGS counts as set; it is emitted first, and last wins.
         if scope.evaluateAsString(BuiltinMacros.SWIFT_LIBRARY_LEVEL).isEmpty &&
-           scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib" {
+           scope.evaluate(BuiltinMacros.MACH_O_TYPE) == "mh_dylib" &&
+           !scope.evaluate(BuiltinMacros.OTHER_SWIFT_FLAGS).contains(where: {
+               $0 == "-library-level"
+           }) {
             let privateInstallPaths = scope.evaluate(BuiltinMacros.__KNOWN_SPI_INSTALL_PATHS).map { Path($0) }
             // Public frameworks and libraries can be installed directly at these base
             // locations, or relocated under one of the known prefixes.

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4164,6 +4164,22 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
                                                              "SWIFT_LIBRARY_LEVEL" : "spi"]) { task in
             task.checkCommandLineContains(["-library-level", "spi"])
         }
+
+        // An explicit -library-level in OTHER_SWIFT_FLAGS also takes precedence over SKIP_INSTALL.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["SKIP_INSTALL" : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "YES",
+                                                             "OTHER_SWIFT_FLAGS" : "-library-level spi"]) { task in
+            task.checkCommandLineContainsUninterrupted(["-library-level", "spi"])
+            task.checkCommandLineDoesNotContain("ipi")
+        }
+
+        // An explicit SWIFT_LIBRARY_LEVEL has precedence over library-level.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["SWIFT_LIBRARY_LEVEL" : "api",
+                                                             "OTHER_SWIFT_FLAGS" : "-library-level spi"]) { task in
+            task.checkCommandLineContainsUninterrupted(["-library-level", "api"])
+        }
     }
 
     // Test -ipi-clang-module emission for a Clang IPI (SKIP_INSTALL=YES + MODULEMAP_FILE under SRCROOT).


### PR DESCRIPTION
…ibrary-level

A target that passed -library-level spi itself compiled as ipi whenever SKIP_INSTALL was YES. That affects multiple projects in B&I.

Skip the inference when OTHER_SWIFT_FLAGS already sets the level. An assigned SWIFT_LIBRARY_LEVEL still takes precedence over the raw flag.

rdar://187128757

_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
