### PR TITLE
Prefer a known framework install path over SKIP_INSTALL when inferrin…

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -2268,16 +2268,19 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
             }
             let installPath = scope.evaluate(BuiltinMacros.INSTALL_PATH)
 
-            if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL)
-                && scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
-                // Build-time / IPI module.
-                table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "ipi")
-            } else if privateInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
+            // A known framework install path takes precedence over the IPI inference,
+            // e.g. the module having install path a private location must not be reclassified
+            // as project-internal (IPI) merely because SKIP_INSTALL happens to be YES.
+            if privateInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
                 // SPI module.
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "spi")
             } else if publicInstallPaths.contains(where: { $0.isAncestorOrEqual(of: installPath) }) {
                 // Public module.
                 table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "api")
+            } else if scope.evaluate(BuiltinMacros.SWIFT_ENABLE_IPI_LIBRARY_LEVEL)
+                && scope.evaluate(BuiltinMacros.SKIP_INSTALL) {
+                // Build-time / IPI module: not installed to any known framework location.
+                table.push(BuiltinMacros.SWIFT_LIBRARY_LEVEL, literal: "ipi")
             }
             // Else, leave it to the compiler's default.
         }

--- a/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/SwiftTaskConstructionTests.swift
@@ -4140,6 +4140,17 @@ fileprivate struct SwiftTaskConstructionTests: CoreBasedTests {
             task.checkCommandLineContains(["-library-level", "ipi"])
         }
 
+        // A known private-framework install path takes precedence over IPI inference,
+        // even with SKIP_INSTALL=YES, it stays "spi" rather than being reclassified as project-internal.
+        try await checkLibraryLevelForConfig(targetType: .framework,
+                                             buildSettings: ["INSTALL_PATH" : "/System/Library/PrivateFrameworks/MyFramework",
+                                                             "SKIP_INSTALL"  : "YES",
+                                                             "SWIFT_ENABLE_IPI_LIBRARY_LEVEL" : "YES",
+                                                             "__KNOWN_SPI_INSTALL_PATHS" : "/System/Library/PrivateFrameworks"]) { task in
+            task.checkCommandLineContains(["-library-level", "spi"])
+            task.checkCommandLineDoesNotContain("ipi")
+        }
+
         // Don't infer "ipi" from SKIP_INSTALL when SWIFT_ENABLE_IPI_LIBRARY_LEVEL is explicitly NO.
         try await checkLibraryLevelForConfig(targetType: .framework,
                                              buildSettings: ["SKIP_INSTALL" : "YES",


### PR DESCRIPTION
…g SWIFT_LIBRARY_LEVEL

SKIP_INSTALL is automatically set to YES when INSTALL_PATH is empty. It doesn't work in reverse. Meaning, we should first check whether the module installed in known public/private location, only if not we perform IPI derivation

rdar://186946943

_[Put a one line description of your change into the PR title, please be specific]_

_[Explain the context, and why you're making that change. What is the problem you're trying to solve.]_

_[Tests can be run by commenting `@swift-ci test` on the pull request, for more information see [this](https://github.com/swiftlang/swift-build/blob/main/README.md)]_
