### PR TITLE
Support injecting extra build variants, with opt-out setting

### DIFF
--- a/Sources/SWBCore/Settings/BuiltinMacros.swift
+++ b/Sources/SWBCore/Settings/BuiltinMacros.swift
@@ -518,6 +518,7 @@ public final class BuiltinMacros {
     public static let BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME = BuiltinMacros.declareStringMacro("BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME")
     public static let BUILD_SERVER_PROTOCOL_TARGET_TAGS = BuiltinMacros.declareStringListMacro("BUILD_SERVER_PROTOCOL_TARGET_TAGS")
     public static let BUILD_VARIANTS = BuiltinMacros.declareStringListMacro("BUILD_VARIANTS")
+    public static let EXTRA_BUILD_VARIANTS = BuiltinMacros.declareStringListMacro("EXTRA_BUILD_VARIANTS")
     public static let BuiltBinaryPath = BuiltinMacros.declareStringMacro("BuiltBinaryPath")
     public static let BUNDLE_FORMAT = BuiltinMacros.declareStringMacro("BUNDLE_FORMAT")
     public static let BUNDLE_LOADER = BuiltinMacros.declarePathMacro("BUNDLE_LOADER")
@@ -1583,6 +1584,7 @@ public final class BuiltinMacros {
         BUILD_SERVER_PROTOCOL_TARGET_TAGS,
         BUILD_STYLE,
         BUILD_VARIANTS,
+        EXTRA_BUILD_VARIANTS,
         BUILT_PRODUCTS_DIR,
         BuiltBinaryPath,
         BUNDLE_FORMAT,

--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -5047,8 +5047,17 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
     private func getBuildPhaseTargetTaskOverrides(_ target: BuildPhaseTarget, _ specLookupContext: any SpecLookupContext, _ sparseSDKs: [SDK], _ scope: MacroEvaluationScope, _ baseSDK: SDK?) -> MacroValueAssignmentTable {
         var table = MacroValueAssignmentTable(namespace: userNamespace)
 
-        // Ensure only a single variant is set if we're in an index build - either the first from `BUILD_VARIANTS` or `INDEX_BUILD_VARIANT` if it's set.
+        // Compute effective BUILD_VARIANTS: append EXTRA_BUILD_VARIANTS gated by SUPPORTS_VARIANT_<name>, then trim to a single variant for index builds.
         var variants: [String] = scope.evaluate(BuiltinMacros.BUILD_VARIANTS)
+        var didMutateVariants = false
+
+        for extra in scope.evaluate(BuiltinMacros.EXTRA_BUILD_VARIANTS) where !variants.contains(extra) {
+            if scope.evaluate(userNamespace.parseString("$(SUPPORTS_VARIANT_\(extra))")).boolValue {
+                variants.append(extra)
+                didMutateVariants = true
+            }
+        }
+
         if parameters.action == .indexBuild,
            let firstVariant = variants.first {
             let indexVariant = scope.evaluate(BuiltinMacros.INDEX_BUILD_VARIANT)
@@ -5057,6 +5066,10 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
             } else {
                 variants = [indexVariant]
             }
+            didMutateVariants = true
+        }
+
+        if didMutateVariants {
             table.push(BuiltinMacros.BUILD_VARIANTS, literal: variants)
         }
 

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -5816,6 +5816,92 @@ import SWBTestSupport
         #expect(try settings.globalScope.evaluate(BuiltinMacros.SDKROOT) == context.core.sdkRegistry.lookup("macosx", activeRunDestination: nil)?.path)
         #expect(settings.globalScope.evaluate(BuiltinMacros.ONLY_ACTIVE_ARCH))
     }
+
+    @Test(.requireSDKs(.macOS))
+    func extraBuildVariants() async throws {
+        let testWorkspace = TestWorkspace("Test", projects: [
+            TestProject("Project", groupTree: TestGroup("Sources", path: "Sources", children: [TestFile("main.swift")]), targets: [
+                TestStandardTarget("SupportedTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "SupportedTarget",
+                        "BUILD_VARIANTS": "normal",
+                        "EXTRA_BUILD_VARIANTS": "mtasan",
+                        "SUPPORTS_VARIANT_mtasan": "YES",
+                    ])
+                ]),
+                TestStandardTarget("DefaultBuildVariantsTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "DefaultBuildVariantsTarget",
+                        // BUILD_VARIANTS unset; defaults to "normal" via CoreBuildSystem.xcspec.
+                        "EXTRA_BUILD_VARIANTS": "mtasan",
+                        "SUPPORTS_VARIANT_mtasan": "YES",
+                    ])
+                ]),
+                TestStandardTarget("UnsupportedTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "UnsupportedTarget",
+                        "BUILD_VARIANTS": "normal",
+                        "EXTRA_BUILD_VARIANTS": "mtasan",
+                    ])
+                ]),
+                TestStandardTarget("ExplicitlyUnsupportedTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "ExplicitlyUnsupportedTarget",
+                        "BUILD_VARIANTS": "normal",
+                        "EXTRA_BUILD_VARIANTS": "mtasan",
+                        "SUPPORTS_VARIANT_mtasan": "NO",
+                    ])
+                ]),
+                TestStandardTarget("AlreadyPresentTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "AlreadyPresentTarget",
+                        "BUILD_VARIANTS": "normal mtasan",
+                        "EXTRA_BUILD_VARIANTS": "mtasan",
+                        "SUPPORTS_VARIANT_mtasan": "YES",
+                    ])
+                ]),
+                TestStandardTarget("MixedTarget",
+                                   type: .application,
+                                   buildConfigurations: [
+                    TestBuildConfiguration("Debug", buildSettings: [
+                        "PRODUCT_NAME": "MixedTarget",
+                        "BUILD_VARIANTS": "normal",
+                        "EXTRA_BUILD_VARIANTS": "mtasan tsan",
+                        "SUPPORTS_VARIANT_mtasan": "YES",
+                        "SUPPORTS_VARIANT_tsan": "NO",
+                    ])
+                ]),
+            ])
+        ])
+
+        let context = try await contextForTestData(testWorkspace)
+        let buildRequestContext = BuildRequestContext(workspaceContext: context)
+        let testProject = context.workspace.projects[0]
+        let parameters = BuildParameters(configuration: "Debug", activeRunDestination: .anyMac)
+
+        func variants(for targetName: String) -> [String] {
+            let target = testProject.targets.first(where: { $0.name == targetName })!
+            let settings = Settings(workspaceContext: context, buildRequestContext: buildRequestContext, parameters: parameters, project: testProject, target: target)
+            return settings.globalScope.evaluate(BuiltinMacros.BUILD_VARIANTS)
+        }
+
+        #expect(variants(for: "SupportedTarget") == ["normal", "mtasan"])
+        #expect(variants(for: "DefaultBuildVariantsTarget") == ["normal", "mtasan"])
+        #expect(variants(for: "UnsupportedTarget") == ["normal"])
+        #expect(variants(for: "ExplicitlyUnsupportedTarget") == ["normal"])
+        #expect(variants(for: "AlreadyPresentTarget") == ["normal", "mtasan"])
+        #expect(variants(for: "MixedTarget") == ["normal", "mtasan"])
+    }
 }
 
 @Suite fileprivate struct SettingsLookupTests: CoreBasedTests {


### PR DESCRIPTION
I want to be able to easily build all (or as many as possible) of any project's products with a sanitizer enabled. It would be nice if there was a single setting that could be used to inject additional variants into any existing build, and a way for projects to opt-out from this mechanism (i.e. because they know that specific targets are incompatible with a specific sanitizer).

This PR adds a generic mechanism for injecting extra BUILD_VARIANTS into a build, and an opt-out mechanism so that individual targets can declare that they do not support building specific variants.

- BUILD_VARIANTS is concatenated with a new setting EXTRA_BUILD_VARIANTS to produce the effective list of variants.
- Support for individual variants will be indicated by the SUPPORTS_VARIANT_<variant name> boolean setting.
  - XCBuild will not inject the variant unless the setting evaluates to boolean true.
  - This will be defaulted to true by SDKSettings for some SDKs and some sanitizers. This does not mean that the variant is automatically injected, but makes it eligible for injection with EXTRA_BUILD_VARIANTS.

rdar://187161036