### PR TITLE
Sign the .tbd only when installapi produces it

### DIFF
--- a/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
+++ b/Sources/SWBTaskConstruction/TaskProducers/OtherTaskProducers/ProductPostprocessingTaskProducer.swift
@@ -429,13 +429,10 @@ package final class ProductPostprocessingTaskProducer: PhasedTaskProducer, TaskP
                 paths.append((subscope.evaluate(BuiltinMacros.TARGET_BUILD_DIR).join(Path(previewBlankInjectionDylibPath)).normalize(), subscope, false, false, true))
             }
 
-            // If we are creating a TBD for this product, then also sign the .tbd file.
-            //
-            // FIXME: This is not strictly correct, because there are situations where these methods return true but we don't actually enable InstallAPI. We should resolve this eventually.
-            //
-            // TAPI will only be run when the output is a dylib.
-            // Swift static library may schedule installAPI phase to generate a swiftmodule.
-            if let productType = settings.productType, productType.supportsInstallAPI && (shouldUseInstallAPI(subscope, settings) || stubAPIDestination(subscope, settings) == .builtProduct) {
+            // Only sign the .tbd when installapi will actually produce it
+            let buildComponents = subscope.evaluate(BuiltinMacros.BUILD_COMPONENTS)
+            let willGenerateInstallAPI = buildComponents.contains("api") || (buildComponents.contains("build") && subscope.evaluate(BuiltinMacros.TAPI_ENABLE_VERIFICATION_MODE))
+            if let productType = settings.productType, productType.supportsInstallAPI && ((shouldUseInstallAPI(subscope, settings) && willGenerateInstallAPI) || stubAPIDestination(subscope, settings) == .builtProduct) {
                 let tapiOutputPath = Path(subscope.evaluate(BuiltinMacros.TAPI_OUTPUT_PATH))
                 paths.append((tapiOutputPath, subscope, false, false, false))
             }

--- a/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
+++ b/Tests/SWBTaskConstructionTests/InstallAPITaskConstructionTests.swift
@@ -24,6 +24,43 @@ import SWBTaskConstruction
 @Suite
 fileprivate struct InstallAPITaskConstructionTests: CoreBasedTests {
     @Test(.requireSDKs(.macOS))
+    func tbdNotSignedWhenNotProduced() async throws {
+        let testProject = try await TestProject(
+            "aProject",
+            sourceRoot: Path("/TEST"),
+            groupTree: TestGroup(
+                "SomeFiles", path: "Sources",
+                children: [TestFile("Mock.c")]),
+            buildConfigurations: [
+                TestBuildConfiguration("Debug", buildSettings: [
+                    "CODE_SIGN_IDENTITY": "-",
+                    "INFOPLIST_FILE": "Info.plist",
+                    "PRODUCT_NAME": "$(TARGET_NAME)",
+                    "SUPPORTS_TEXT_BASED_API": "YES",
+                    "TAPI_ENABLE_VERIFICATION_MODE": "NO",
+                    "SKIP_INSTALL": "NO",
+                    "TAPI_EXEC": tapiToolPath.str])],
+            targets: [
+                TestStandardTarget(
+                    "Fwk",
+                    type: .framework,
+                    buildPhases: [TestSourcesBuildPhase(["Mock.c"])])])
+        let tester = try await TaskConstructionTester(getCore(), testProject)
+
+        let fs = PseudoFS()
+        try fs.createDirectory(tester.workspace.projects[0].sourceRoot, recursive: true)
+        try await fs.writePlist(Path("/TEST/Info.plist"), .plDict([:]))
+
+        // checkBuild's integrity check flags "missing creator" if codesign signs the unproduced .tbd.
+        for action in [BuildAction.build, .install] {
+            await tester.checkBuild(BuildParameters(action: action, configuration: "Debug"), runDestination: .macOS, fs: fs) { results in
+                results.checkNoTask(.matchRuleType("GenerateTAPI"), .matchRuleItemBasename("Fwk.tbd"))
+                results.checkNoTask(.matchRuleType("CodeSign"), .matchRuleItemBasename("Fwk.tbd"))
+            }
+        }
+    }
+
+    @Test(.requireSDKs(.macOS))
     func TBDSigning() async throws {
         let testProject = try await TestProject(
             "aProject",


### PR DESCRIPTION
installapi emits the .tbd only when building the api component or verifying. However, codesign was signing it unconditionally for installapi targets leaving a mutated node with no creator.

rdar://187077726