### PR TITLE
Track xcconfig override files as settings inputs

### DIFF
--- a/Sources/SWBCore/Settings/Settings.swift
+++ b/Sources/SWBCore/Settings/Settings.swift
@@ -3437,6 +3437,20 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
         push(table)
     }
 
+    /// Applies an xcconfig override and tracks paths in `inputPathsAffectingSettings`
+    private func addXCConfigOverride(path: Path?, overrides: [String: String], context: MacroConfigLoadContext) {
+        guard let path else {
+            push(createTableFromUserSettings(overrides), .exported)
+            return
+        }
+        let info = buildRequestContext.getCachedMacroConfigFile(path, project: project, context: context)
+        push(info.table, .exported)
+        diagnostics.append(contentsOf: info.diagnostics)
+        for path in info.dependencyPaths {
+            inputPathsAffectingSettings.append(path)
+        }
+    }
+
     /// Add the various overriding settings.
     func addOverrides(sdk: SDK?) {
         push(getWorkspacePathOverrides(), .none)
@@ -3469,23 +3483,9 @@ private class SettingsBuilder: ProjectMatchLookup, TripleLookup {
             push(buildRequestContext.loadSettingsFromConfig(data: settingsExtension.xcconfigOverrideData(fromParameters: self.parameters), path: nil, namespace: workspaceContext.workspace.userNamespace, searchPaths: project.map { [$0.sourceRoot] } ?? []).table, .exported)
         }
 
-        // Add the command line xcconfig-based build settings.
-        if let path = parameters.commandLineConfigOverridesPath {
-            let info = buildRequestContext.getCachedMacroConfigFile(path, project: project, context: .commandLineConfiguration)
-            push(info.table, .exported)
-            self.diagnostics.append(contentsOf: info.diagnostics)
-        } else {
-            push(createTableFromUserSettings(parameters.commandLineConfigOverrides), .exported)
-        }
-
-        // Add the environment xcconfig-based build settings.
-        if let path = parameters.environmentConfigOverridesPath {
-            let info = buildRequestContext.getCachedMacroConfigFile(path, project: project, context: .environmentConfiguration)
-            push(info.table, .exported)
-            self.diagnostics.append(contentsOf: info.diagnostics)
-        } else {
-            push(createTableFromUserSettings(parameters.environmentConfigOverrides), .exported)
-        }
+        // Command-line and environment xcconfig overrides.
+        addXCConfigOverride(path: parameters.commandLineConfigOverridesPath, overrides: parameters.commandLineConfigOverrides, context: .commandLineConfiguration)
+        addXCConfigOverride(path: parameters.environmentConfigOverridesPath, overrides: parameters.environmentConfigOverrides, context: .environmentConfiguration)
 
         // Toolchain override
         if let toolchain = self.parameters.toolchainOverride {

--- a/Tests/SWBCoreTests/SettingsTests.swift
+++ b/Tests/SWBCoreTests/SettingsTests.swift
@@ -6337,4 +6337,32 @@ import SWBTestSupport
             }
         }
     }
+
+    @Test
+    func commandLineXCConfigContentChangeInvalidatesCachedSettings() async throws {
+        try await withTemporaryDirectory { tmpDirPath in
+            let core = try await getCore()
+            let xcconfigPath = tmpDirPath.join("overrides.xcconfig")
+            try localFS.write(xcconfigPath, contents: "OTHER_CFLAGS = -DFIRST")
+
+            let workspace = try TestWorkspace(
+                "Workspace",
+                sourceRoot: tmpDirPath,
+                projects: [TestProject("aProject",
+                                       groupTree: TestGroup("SomeFiles"),
+                                       targets: [TestStandardTarget("anApp", type: .application)])]
+            ).load(core)
+            let workspaceContext = WorkspaceContext(core: core, workspace: workspace, fs: localFS, processExecutionCache: .sharedForTesting)
+            let parameters = BuildParameters(configuration: "Debug", commandLineConfigOverridesPath: xcconfigPath)
+            let project = workspace.projects[0]
+
+            let settings1 = BuildRequestContext(workspaceContext: workspaceContext).getCachedSettings(parameters, project: project)
+            #expect(settings1.globalScope.evaluate(BuiltinMacros.OTHER_CFLAGS) == ["-DFIRST"])
+
+            try localFS.write(xcconfigPath, contents: "OTHER_CFLAGS = -DSECOND")
+
+            let settings2 = BuildRequestContext(workspaceContext: workspaceContext).getCachedSettings(parameters, project: project)
+            #expect(settings2.globalScope.evaluate(BuiltinMacros.OTHER_CFLAGS) == ["-DSECOND"], "stale command-line xcconfig settings were served from the cache after the file's contents changed")
+        }
+    }
 }


### PR DESCRIPTION
Command line and environment override files weren't added to inputPathsAffectingSettings, so editing their contents didn't invalidate the settings cache.
